### PR TITLE
Fixed small typo in usage()

### DIFF
--- a/letsencrypt.py
+++ b/letsencrypt.py
@@ -96,7 +96,7 @@ def usage():
     s = "Available options: --text, --privkey=, --csr=, --server=, "
     s += "--rollback=, --view-checkpoints, --revoke, --agree-eula, --redirect,"
     s += " --no-redirect, --help"
-    print str
+    print s
 
 def print_options():
     print "\nsudo ./letsencrypt.py (default authentication mode using pythondialog)"


### PR DESCRIPTION
While scrolling through letsencrypt.py I spotted a typo. `usage()` now prints the string built in it, instead of builtin function `str()`
