### PR TITLE
apt-get install libaugeas0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Apache, though we will be expanding it to other platforms.
 
 ```
 sudo apt-get install python python-setuptools python-virtualenv \
-  python-dev gcc swig dialog libssl-dev
+  python-dev gcc swig dialog libaugeas0 libssl-dev
 virtualenv --no-site-packages venv
 ./venv/bin/python setup.py install
 sudo ./venv/bin/letsencrypt


### PR DESCRIPTION
libaugeas0 is still required, despite python-augeas from PyPI
