### PR TITLE
Use the right URL for the project

### DIFF
--- a/EULA
+++ b/EULA
@@ -2,4 +2,4 @@ This is a PREVIEW RELEASE of a client application for the Let's Encrypt certific
 
 Until publicly-trusted certificates can be issued by Let's Encrypt, this software CANNOT OBTAIN A PUBLICLY-TRUSTED CERTIFICATE FOR YOUR WEB SERVER.  You should only use this program if you are a developer interested in experimenting with the ACME protocol or in helping to improve this software.  If you want to configure your web site with HTTPS in the meantime, please obtain a certificate from a different authority.
 
-For updates on the status of Let's Encrypt, please visit the Let's Encrypt home page at https://www.lets-encrypt.org/.
+For updates on the status of Let's Encrypt, please visit the Let's Encrypt home page at https://www.letsencrypt.org/.

--- a/letsencrypt/client/schemata/challengeobject.json
+++ b/letsencrypt/client/schemata/challengeobject.json
@@ -1,5 +1,5 @@
 {
-    "id": "https://lets-encrypt.org/schema/01/challengeobject#",
+    "id": "https://letsencrypt.org/schema/01/challengeobject#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "Subschema for an individual challenge (within challenge)",
     "anyOf": [

--- a/letsencrypt/client/schemata/jwk.json
+++ b/letsencrypt/client/schemata/jwk.json
@@ -1,5 +1,5 @@
 {
-    "id": "https://lets-encrypt.org/schema/01/jwk#",
+    "id": "https://letsencrypt.org/schema/01/jwk#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "Schema for a jwk (**kty RSA/e=65537 ONLY**)",
     "type": "object",

--- a/letsencrypt/client/schemata/responseobject.json
+++ b/letsencrypt/client/schemata/responseobject.json
@@ -1,5 +1,5 @@
 {
-    "id": "https://lets-encrypt.org/schema/01/responseobject#",
+    "id": "https://letsencrypt.org/schema/01/responseobject#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "Subschema for an individual challenge response (within authorizationRequest)",
     "anyOf": [

--- a/letsencrypt/client/schemata/signature.json
+++ b/letsencrypt/client/schemata/signature.json
@@ -1,5 +1,5 @@
 {
-    "id": "https://lets-encrypt.org/schema/01/signature#",
+    "id": "https://letsencrypt.org/schema/01/signature#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "Schema for a signature (alg RS256/e=65537 or P-256 ONLY)",
     "type": "object",


### PR DESCRIPTION
`lets-encrypt.org` doesn't work but `letsencrypt.org` does so use that.
