### PR TITLE
Check if ports are available at an earlier point in time (fixes #1216)

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -37,6 +37,7 @@ from letsencrypt import storage
 from letsencrypt.display import util as display_util
 from letsencrypt.display import ops as display_ops
 from letsencrypt.plugins import disco as plugins_disco
+from letsencrypt.plugins.standalone import Authenticator as StandaloneAuthenticator
 
 logger = logging.getLogger(__name__)
 
@@ -380,7 +381,7 @@ def diagnose_configurator_problem(cfg_type, requested, plugins):
     raise errors.PluginSelectionError(msg)
 
 
-def choose_configurator_plugins(args, config, plugins, verb):
+def choose_configurator_plugins(args, config, plugins, verb):  # pylint: disable=too-many-branches
     """
     Figure out which configurator we're going to use
 
@@ -422,6 +423,11 @@ def choose_configurator_plugins(args, config, plugins, verb):
         if need_auth:
             authenticator = display_ops.pick_authenticator(config, req_auth, plugins)
     logger.debug("Selected authenticator %s and installer %s", authenticator, installer)
+
+    # StandaloneAuthenticator needs certain required ports to be available
+    if isinstance(authenticator, StandaloneAuthenticator):
+        # If a port is already in use, this will throw an MisconfigurationError
+        authenticator.check_required_ports()
 
     # Report on any failures
     if need_inst and not installer:

--- a/letsencrypt/plugins/standalone.py
+++ b/letsencrypt/plugins/standalone.py
@@ -202,11 +202,15 @@ class Authenticator(common.Plugin):
         random.shuffle(chall_pref)  # 50% for each challenge
         return chall_pref
 
-    def perform(self, achalls):  # pylint: disable=missing-docstring
+    def check_required_ports(self):
+        """Check if required ports are available, else raise an Error."""
         if any(util.already_listening(port) for port in self._necessary_ports):
             raise errors.MisconfigurationError(
                 "At least one of the (possibly) required ports is "
                 "already taken.")
+
+    def perform(self, achalls):  # pylint: disable=missing-docstring
+        self.check_required_ports()
 
         try:
             return self.perform2(achalls)


### PR DESCRIPTION
Minor modification of `cli.py` to show an error asap if the user chose StandaloneAuthenticator but the ports are not available.