### PR TITLE
Use -p python2 when creating virtualenv

### DIFF
--- a/tools/dev-release.sh
+++ b/tools/dev-release.sh
@@ -23,7 +23,7 @@ mv "dist.$version" "dist.$version.$(date +%s).bak" || true
 git tag --delete "$tag" || true
 
 tmpvenv=$(mktemp -d)
-virtualenv --no-site-packages $tmpvenv
+virtualenv --no-site-packages -p python2 $tmpvenv
 . $tmpvenv/bin/activate
 # update setuptools/pip just like in other places in the repo
 pip install -U setuptools


### PR DESCRIPTION
Since `virtualenv --no-site-packages` creates a Python3 virtualenv on my Arch laptop, the current `tools/dev-release.sh` doesn't work for me. This change fixes the problem and should only cause new problems if someone is trying to do a release from OS X or Debian Squeeze (which is not likely).

cc @kuba
