### PR TITLE
Check for pip-installed virtualenv (ie. not pyenv shims)

### DIFF
--- a/bootstrap/mac.sh
+++ b/bootstrap/mac.sh
@@ -4,15 +4,15 @@ if ! hash brew 2>/dev/null; then
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
-brew install augeas
-brew install dialog
+brew --prefix augeas &>/dev/null || brew install augeas
+brew --prefix dialog &>/dev/null || brew install dialog
 
 if ! hash pip 2>/dev/null; then
     echo "pip Not Installed\nInstalling python from Homebrew..."
     brew install python
 fi
 
-if ! hash virtualenv 2>/dev/null; then
+if ! pip list | grep 'virtualenv\s' &>/dev/null then
     echo "virtualenv Not Installed\nInstalling with pip"
     pip install virtualenv
 fi


### PR DESCRIPTION
I ran into a small hiccup when trying to run `letsencrypt-auto` on OS X. Because `pyenv-virtualenv` installs shims for the real `virtualenv`, running `hash virtualenv` will always succeed, even if it's not really installed for the currently active pyenv (`system`, in this case).

This changes the `mac.sh` script to ensure `virtualenv` is a pip-installed package. I also added a check to only install brew packages that aren't already installed (`augeas`, `dialog`).
