### PR TITLE
Add MacPorts support to Mac bootstrap [needs revision]

### DIFF
--- a/bootstrap/mac.sh
+++ b/bootstrap/mac.sh
@@ -1,8 +1,11 @@
-#!/bin/sh -e
+#! /bin/bash
+#
 OSX_PM_="no_package_manager" # OS X Package Manager
 if hash port 2>/dev/null; then
+    echo "Found Mac Ports package manager."
     OSX_PM_="sudo port"
 elif hash brew 2>/dev/null; then
+    echo "Found HomeBrew package manager."
     OSX_PM_="brew"
 elif ! hash brew 2>/dev/null; then
     echo "Homebrew Not Installed\nDownloading..."

--- a/bootstrap/mac.sh
+++ b/bootstrap/mac.sh
@@ -1,15 +1,26 @@
 #!/bin/sh -e
-if ! hash brew 2>/dev/null; then
+OSX_PM_="no_package_manager" # OS X Package Manager
+if hash port 2>/dev/null; then
+    OSX_PM_="sudo port"
+elif hash brew 2>/dev/null; then
+    OSX_PM_="brew"
+elif ! hash brew 2>/dev/null; then
     echo "Homebrew Not Installed\nDownloading..."
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    OSX_PM_="brew"
 fi
 
-brew install augeas
-brew install dialog
+${OSX_PM_} install augeas
+${OSX_PM_} install dialog
 
 if ! hash pip 2>/dev/null; then
-    echo "pip Not Installed\nInstalling python from Homebrew..."
-    brew install python
+    if [ "${OSX_PM_}" == "sudo port" ]; then
+      echo "pip Not Installed\nInstalling python from Mac Ports ..."
+      ${OSX_PM_} install python27
+    else
+      echo "pip Not Installed\nInstalling python from Homebrew..."
+      ${OSX_PM_} install python
+    fi
 fi
 
 if ! hash virtualenv 2>/dev/null; then


### PR DESCRIPTION
Why? MacPorts is a popular and venerable package manager for OS X.
LetsEncrypt should use it if it is already installed.

This change modifies the Mac bootstrap script to add support for
MacPorts package manager. HomeBrew support remains, and if neither
package manager is installed, the bootstrap script will still
default to installing HomeBrew.