### PR TITLE
Official npm installer

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+# Keep out unused files in our npm package
+# See: https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
+####
+
+docs/
+examples/
+tests/
+tools
+.dockerignore
+.gitattributes
+.travis.yml
+.docker-compose.yml
+Dockerfile
+Dockerfile-dev
+readthedocs.org.requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,20 @@ Encrypt CA (or any other CA that speaks the `ACME
 protocol) that can automate the tasks of obtaining certificates and
 configuring webservers to use them.
 
+
+
 Installation
 ------------
+
+**Using npm:*
+
+  user@webserver:~$ npm i -g @letsencrypt/letsencrypt
+
+The installer will install 'letsencrypt' into your path automatically and will
+be available as `letsencrypt <arg(s)>`. For the available arguments, see below.
+
+
+**Using Git:**
 
 If ``letsencrypt`` is packaged for your OS, you can install it from there, and
 run it by typing ``letsencrypt``.  Because not all operating systems have

--- a/bin/npm-cli
+++ b/bin/npm-cli
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bin_dir="`dirname $(readlink -f ${0})`/"
+parent_dir="`dirname ${bin_dir}`"
+
+for args in "$*"
+do
+    ${parent_dir}/letsencrypt-auto ${args}
+done
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "letsencrypt",
+  "version": "0.1.2",
+  "description": "Let's Encrypt is an ACME client that can obtain certs and extensibly update server configurations",
+  "bin": {
+    "letsencrypt": "./bin/npm-cli"
+  },
+  "scripts": {
+    "postinstall": "letsencrypt-auto --help"
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letsencrypt/letsencrypt"
+  },
+  "bugs": {
+    "url": "https://github.com/letsencrypt/letsencrypt/issues"
+  },
+  "keywords": {
+    "ssl", "certificate", "encrypt", "letsencrypt"
+  },
+  "author": "Jason Robert O'Kennedy",
+  "contributors": [{
+    "name": "celticparser",
+    "email": "jason.okennedy@codepile.io"
+  }],
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {},
+  "preferGlobal": true
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "letsencrypt": "./bin/npm-cli"
   },
   "scripts": {
-    "postinstall": "letsencrypt-auto --help"
+    "postinstall": "letsencrypt-auto --help",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -16,9 +16,9 @@
   "bugs": {
     "url": "https://github.com/letsencrypt/letsencrypt/issues"
   },
-  "keywords": {
+  "keywords": [
     "ssl", "certificate", "encrypt", "letsencrypt"
-  },
+  ],
   "author": "Jason Robert O'Kennedy",
   "contributors": [{
     "name": "celticparser",


### PR DESCRIPTION
**Allows User's to download and install using an official npm package.**

#### Why is this Proposal Necessary?

From what I can find there is no official 'letsencrypt' package on npm. There are a
few variations by the works of [@coolaj86](https://www.npmjs.com/~coolaj86). However, they are written in js and "over-built"
by requiring several `dependencies` equating to over a hundred sub-dependencies. This is
not necessary and node can utilized the current scripts in this repository to do the job.

#### How does this request address the issue?

 1. Create an node package.json in the root
 2. Add a '.npmignore' to eliminate bloat
 3. Add a simple 'npm-cli' binary that executes './letsencrypt' and passes the args to it
 4. Create an 'official' "letsencrypt" organization and package(s) on npm

#### Changes to be committed:

 * new file:   .npmignore
 * modified:   README.rst
 * new file:   bin/npm-cli
 * new file:   package.json

#### Usage:

 * Installation:

   user@webserver:~$ npm i -g @letsencrypt/letsencrypt

 > The normally used './letsencrypt-auto <arg(s)>' command can be now executed globally
 > using `letsencrypt <arg(s)>' in a node environment.

 > **_NOTE:_** A user will have to manually symlink the downloaded certs (See TODO).

#### What side effects does this change have?

 * Repo maintainers will have to update the 'version' key within the 'package.json'
   file with each release (_there are tool that can automate this_)
 * A npm organization will need to be created/maintained by this repo's owners

#### Conclusion

This will allow node users to easily install the "Let's Encrypt" software via a npm
package that is officially maintained by it's creators and insuring that there are no
dependencies that can become outdated or have vulnerabilities.

 > TODO: [npm-cli] Add function to take an arg to instruct where to symlink the certs taken
from the command args. e.g --nginx