### PR TITLE
Add dns-01 challenge support to the ACME client

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -207,7 +207,7 @@ class KeyAuthorizationChallenge(_TokenChallenge):
 
 @ChallengeResponse.register
 class DNS01Response(KeyAuthorizationChallengeResponse):
-    """ACME "dns-01" challenge response."""
+    """ACME dns-01 challenge response."""
     typ = "dns-01"
 
     def simple_verify(self, chall, domain, account_public_key):
@@ -215,7 +215,7 @@ class DNS01Response(KeyAuthorizationChallengeResponse):
 
         :param challenges.DNS01 chall: Corresponding challenge.
         :param unicode domain: Domain name being verified.
-        :param account_public_key: Public key for the key pair
+        :param JWK account_public_key: Public key for the key pair
             being authorized.
 
         :returns: ``True`` iff validation with the TXT records resolved from a
@@ -247,7 +247,7 @@ class DNS01Response(KeyAuthorizationChallengeResponse):
 
 @Challenge.register  # pylint: disable=too-many-ancestors
 class DNS01(KeyAuthorizationChallenge):
-    """ACME "dns-01" challenge."""
+    """ACME dns-01 challenge."""
     response_cls = DNS01Response
     typ = response_cls.typ
 
@@ -298,7 +298,7 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
             being authorized.
         :param int port: Port used in the validation.
 
-        :returns: ``True`` iff validation of the files currently server by the
+        :returns: ``True`` iff validation with the files currently served by the
             HTTP server is successful.
         :rtype: bool
 

--- a/acme/acme/dns_resolver.py
+++ b/acme/acme/dns_resolver.py
@@ -1,0 +1,28 @@
+"""DNS Resolver for ACME client.
+Required only for local validation of 'dns-01' challenges.
+"""
+import logging
+
+import dns.resolver
+import dns.exception
+
+logger = logging.getLogger(__name__)
+
+
+def txt_records_for_name(name):
+    """Resolve the name and return the TXT records.
+
+    :param unicode name: Domain name being verified.
+
+    :returns: A list of txt records, if empty the name could not be resolved
+    :rtype: list of unicode
+
+    """
+    try:
+        dns_response = dns.resolver.query(name, 'TXT')
+    except dns.resolver.NXDOMAIN as error:
+        return []
+    except dns.exception.DNSException as error:
+        logger.error("Error resolving %s: %s", name, str(error))
+        return []
+    return [txt_rec for rdata in dns_response for txt_rec in rdata.strings]

--- a/acme/acme/dns_resolver.py
+++ b/acme/acme/dns_resolver.py
@@ -25,4 +25,6 @@ def txt_records_for_name(name):
     except dns.exception.DNSException as error:
         logger.error("Error resolving %s: %s", name, str(error))
         return []
-    return [txt_rec for rdata in dns_response for txt_rec in rdata.strings]
+
+    return [txt_rec.decode("utf-8") for rdata in dns_response
+            for txt_rec in rdata.strings]

--- a/acme/acme/dns_resolver_test.py
+++ b/acme/acme/dns_resolver_test.py
@@ -1,0 +1,53 @@
+"""Tests for acme.dns_resolver."""
+import unittest
+import mock
+
+from acme import dns_resolver
+
+try:
+    import dns
+except ImportError:  # pragma: no cover
+    dns = None
+
+
+def create_txt_response(name, txt_records):
+    """
+    Returns an RRSet containing the 'txt_records' as the result of a DNS
+    query for 'name'.
+
+    This takes advantage of the fact that an Answer object mostly behaves
+    like an RRset.
+    """
+    return dns.rrset.from_text_list(name, 60, "IN", "TXT", txt_records)
+
+
+class TxtRecordsForNameTest(unittest.TestCase):
+
+    @mock.patch("acme.dns_resolver.dns.resolver.query")
+    def test_txt_records_for_name_with_single_response(self, mock_dns):
+        mock_dns.return_value = create_txt_response('name', ['response'])
+        self.assertEqual(['response'],
+                         dns_resolver.txt_records_for_name('name'))
+
+    @mock.patch("acme.dns_resolver.dns.resolver.query")
+    def test_txt_records_for_name_with_multiple_responses(self, mock_dns):
+        mock_dns.return_value = create_txt_response(
+            'name', ['response1', 'response2'])
+        self.assertEqual(['response1', 'response2'],
+                         dns_resolver.txt_records_for_name('name'))
+
+    @mock.patch("acme.dns_resolver.dns.resolver.query")
+    def test_txt_records_for_name_domain_not_found(self, mock_dns):
+        mock_dns.side_effect = dns.resolver.NXDOMAIN
+        self.assertEquals([], dns_resolver.txt_records_for_name('name'))
+
+    @mock.patch("acme.dns_resolver.dns.resolver.query")
+    def test_txt_records_for_name_domain_other_error(self, mock_dns):
+        mock_dns.side_effect = dns.exception.DNSException
+        self.assertEquals([], dns_resolver.txt_records_for_name('name'))
+
+    def run(self, result=None):
+        if dns is None:  # pragma: no cover
+            print(self, "... SKIPPING, no dnspython available")
+            return
+        super(TxtRecordsForNameTest, self).run(result)

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -35,6 +35,15 @@ if sys.version_info < (2, 7):
 else:
     install_requires.append('mock')
 
+if sys.version_info < (3, 0):
+    dns_extras = [
+        'dnspython',
+    ]
+else:
+    dns_extras = [
+        'dnspython3',
+    ]
+
 dev_extras = [
     'nose',
     'pep8',
@@ -76,6 +85,7 @@ setup(
     include_package_data=True,
     install_requires=install_requires,
     extras_require={
+        'dns': dns_extras,
         'dev': dev_extras,
         'docs': docs_extras,
     },

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -35,14 +35,10 @@ if sys.version_info < (2, 7):
 else:
     install_requires.append('mock')
 
-if sys.version_info < (3, 0):
-    dns_extras = [
-        'dnspython',
-    ]
-else:
-    dns_extras = [
-        'dnspython3',
-    ]
+# dnspython 1.12 is required to support both Python 2 and Python 3.
+dns_extras = [
+    'dnspython>=1.12',
+]
 
 dev_extras = [
     'nose',

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = py{26,33,34,35},cover,lint
 # packages installed separately to ensure that downstream deps problems
 # are detected, c.f. #1002
 commands =
-    pip install -e acme[dev]
+    pip install -e acme[dns,dev]
     nosetests -v acme
     pip install -e .[dev]
     nosetests -v certbot
@@ -38,23 +38,23 @@ deps =
 
 [testenv:py33]
 commands =
-    pip install -e acme[dev]
+    pip install -e acme[dns,dev]
     nosetests -v acme
 
 [testenv:py34]
 commands =
-    pip install -e acme[dev]
+    pip install -e acme[dns,dev]
     nosetests -v acme
 
 [testenv:py35]
 commands =
-    pip install -e acme[dev]
+    pip install -e acme[dns,dev]
     nosetests -v acme
 
 [testenv:cover]
 basepython = python2.7
 commands =
-    pip install -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e letshelp-certbot
+    pip install -e acme[dns,dev] -e .[dev] -e certbot-apache -e certbot-nginx -e letshelp-certbot
     ./tox.cover.sh
 
 [testenv:lint]
@@ -64,7 +64,7 @@ basepython = python2.7
 # duplicate code checking; if one of the commands fails, others will
 # continue, but tox return code will reflect previous error
 commands =
-    pip install -q -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-compatibility-test -e letshelp-certbot
+    pip install -q -e acme[dns,dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-compatibility-test -e letshelp-certbot
     ./pep8.travis.sh
     pylint --reports=n --rcfile=.pylintrc certbot
     pylint --reports=n --rcfile=acme/.pylintrc acme/acme


### PR DESCRIPTION
Tested against a local dev version of the non-spec server, should also work against the soon-to-be-updated staging server.