### PR TITLE
Add a "KeyAlreadyRegistered" exception for Client.register [needs revision]

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -100,8 +100,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
             response = self.net.post(self.directory[new_reg], new_reg)
         except errors.ClientError as error:
             # TODO: More complete error handling
-            if (error.response is not None and
-                error.response.status_code == http_client.CONFLICT):
+            if error.response.status_code == http_client.CONFLICT:
                 existing_registration_url = error.response.headers.get('Location')
                 raise errors.KeyAlreadyRegistered(existing_registration_url)
             raise error
@@ -556,8 +555,8 @@ class ClientNetwork(object):
                         'Ignoring wrong Content-Type (%r) for JSON Error',
                         response_ct)
                 try:
-                    raise errors.ClientError(
-                        response, error=messages.Error.from_json(jobj))
+                    raise errors.ClientErrorWithDetails(
+                        response, messages.Error.from_json(jobj))
                 except jose.DeserializationError as error:
                     # Couldn't deserialize JSON object
                     raise errors.ClientError(response, error)

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -100,7 +100,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
             response = self.net.post(self.directory[new_reg], new_reg)
         except errors.ClientError as error:
             # TODO: More complete error handling
-            if error.response is not None and
+            if (error.response is not None and
                 error.response.status_code == http_client.CONFLICT):
                 existing_registration_url = error.response.headers.get('Location')
                 raise errors.KeyAlreadyRegistered(existing_registration_url)

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -100,7 +100,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
             response = self.net.post(self.directory[new_reg], new_reg)
         except errors.ClientError as error:
             # TODO: More complete error handling
-            if (error.response is not None and
+            if error.response is not None and
                 error.response.status_code == http_client.CONFLICT):
                 existing_registration_url = error.response.headers.get('Location')
                 raise errors.KeyAlreadyRegistered(existing_registration_url)
@@ -486,8 +486,8 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
                                  messages.Revocation(certificate=cert),
                                  content_type=None)
         if response.status_code != http_client.OK:
-            raise errors.ClientError(response,
-                'Successful revocation must return HTTP OK status')
+            raise errors.ClientError(
+                response, 'Successful revocation must return HTTP OK status')
 
 
 class ClientNetwork(object):
@@ -571,8 +571,9 @@ class ClientNetwork(object):
                     'response', response_ct)
 
             if content_type == cls.JSON_CONTENT_TYPE and jobj is None:
-                raise errors.ClientError(response,
-                    'Unexpected response Content-Type: {0}'.format(response_ct))
+                raise errors.ClientError(
+                    response, 'Unexpected response Content-Type: {0}'.format(
+                        response_ct))
 
         return response
 

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -108,9 +108,12 @@ class ClientTest(unittest.TestCase):
         self.response.status_code = http_client.CONFLICT
         self.response.headers['Location'] = 'EXISTING'
 
-        with self.assertRaises(errors.KeyAlreadyRegistered) as cm:
+        self.assertRaises(
+            errors.KeyAlreadyRegistered, self.client.register, self.new_reg)
+        try:
             self.client.register(self.new_reg)
-        self.assertEquals(cm.exception.existing_registration_uri, 'EXISTING')
+        except errors.KeyAlreadyRegistered as error:
+            self.assertEquals(error.existing_registration_uri, 'EXISTING')
 
     def test_register_missing_next(self):
         self.response.status_code = http_client.CREATED

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -471,13 +471,14 @@ class ClientNetworkTest(unittest.TestCase):
         self.response.json.return_value = net_error.to_json()
         # pylint: disable=protected-access
         self.assertRaises(
-            errors.ClientError, self.net._check_response, self.response)
+            errors.ClientErrorWithDetails, self.net._check_response,
+            self.response)
         try:
             # pylint: disable=no-value-for-parameter
             self.net._check_response(self.response)
-        except errors.ClientError as error:
+        except errors.ClientErrorWithDetails as error:
             self.assertEqual(self.response, error.response)
-            self.assertEqual(net_error, error.error)
+            self.assertEqual(net_error, error.details)
 
     def test_check_response_not_ok_no_jobj(self):
         self.response.ok = False

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -104,6 +104,14 @@ class ClientTest(unittest.TestCase):
         self.assertRaises(
             errors.UnexpectedUpdate, self.client.register, self.new_reg)
 
+    def test_register_existing(self):
+        self.response.status_code = http_client.CONFLICT
+        self.response.headers['Location'] = 'EXISTING'
+
+        with self.assertRaises(errors.KeyAlreadyRegistered) as cm:
+            self.client.register(self.new_reg)
+        self.assertEquals(cm.exception.existing_registration_uri, 'EXISTING')
+
     def test_register_missing_next(self):
         self.response.status_code = http_client.CREATED
         self.assertRaises(

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -12,15 +12,29 @@ class SchemaValidationError(jose_errors.DeserializationError):
 
 class ClientError(Error):
     """Network error or unexpected client response."""
-    def __init__(self, response, error=None, *args, **kwargs):
+    def __init__(self, response, *args, **kwargs):
+        """
+        :param requests.Response details: The response object that caused the
+            exception to be thrown.
+        """
         super(ClientError, self).__init__(*args, **kwargs)
-        self.error = error
         self.response = response
 
+
+class ClientErrorWithDetails(ClientError):
+    """Network error."""
+    def __init__(self, response, details, *args, **kwargs):
+        """
+        :param requests.Response details: The response object that caused the
+            exception to be thrown.
+        :param acme.messages.Error details: The details of the error as transmitted
+            by the server.
+        """
+        super(ClientErrorWithDetails, self).__init__(response, *args, **kwargs)
+        self.details = details
+
     def __str__(self):
-        if self.error is None:
-            return super(ClientError, self).__str__()
-        return 'Client error: {0}'.format(self.error)
+        return 'Client error: {0}'.format(self.details)
 
 
 class UnexpectedUpdate(ClientError):

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -18,6 +18,17 @@ class UnexpectedUpdate(ClientError):
     """Unexpected update error."""
 
 
+class KeyAlreadyRegistered(Exception):
+    """Key used in registration is already registered"""
+    def __init__(self, existing_registration_url, *args, **kwargs):
+        super(KeyAlreadyRegistered, self).__init__(*args, **kwargs)
+        self.existing_registration_url = existing_registration_url
+
+    def __str__(self):
+        return 'Key already registered at server: {0}'.format(
+            self.existing_registration_url)
+
+
 class NonceError(ClientError):
     """Server response nonce error."""
 

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -20,13 +20,13 @@ class UnexpectedUpdate(ClientError):
 
 class KeyAlreadyRegistered(Exception):
     """Key used in registration is already registered"""
-    def __init__(self, existing_registration_url, *args, **kwargs):
+    def __init__(self, existing_registration_uri, *args, **kwargs):
         super(KeyAlreadyRegistered, self).__init__(*args, **kwargs)
-        self.existing_registration_url = existing_registration_url
+        self.existing_registration_uri = existing_registration_uri
 
     def __str__(self):
         return 'Key already registered at server: {0}'.format(
-            self.existing_registration_url)
+            self.existing_registration_uri)
 
 
 class NonceError(ClientError):

--- a/acme/acme/errors_test.py
+++ b/acme/acme/errors_test.py
@@ -23,14 +23,23 @@ class ClientErrorTest(unittest.TestCase):
 
     def setUp(self):
         from acme.errors import ClientError
-        from acme.messages import Error
-        self.unspecified_error = ClientError(None)
-        self.network_error = ClientError(None,
-                                         Error(typ='TYP', detail='DETAIL'))
+        self.error = ClientError(None)
 
     def test_str(self):
-        self.assertEqual("", str(self.unspecified_error))
-        self.assertEqual("Client error: TYP :: DETAIL", str(self.network_error))
+        self.assertEqual("", str(self.error))
+
+
+class ClientErrorWithDetailsTest(unittest.TestCase):
+    """Tests for acme.errors.ClientErrorWithDetails."""
+
+    def setUp(self):
+        from acme.errors import ClientErrorWithDetails
+        from acme.messages import Error
+        self.error = ClientErrorWithDetails(
+            None, Error(typ='TYP', detail='DETAIL'))
+
+    def test_str(self):
+        self.assertEqual("Client error: TYP :: DETAIL", str(self.error))
 
 
 class BadNonceTest(unittest.TestCase):

--- a/acme/acme/errors_test.py
+++ b/acme/acme/errors_test.py
@@ -63,8 +63,8 @@ class PollErrorTest(unittest.TestCase):
 
     def setUp(self):
         from acme.errors import PollError
-        self.timeout = PollError(None,
-            waiting=[(datetime.datetime(2015, 11, 29), mock.sentinel.AR)],
+        self.timeout = PollError(
+            None, waiting=[(datetime.datetime(2015, 11, 29), mock.sentinel.AR)],
             updated={})
         self.invalid = PollError(None, waiting=[], updated={
             mock.sentinel.AR: mock.sentinel.AR2})

--- a/acme/acme/errors_test.py
+++ b/acme/acme/errors_test.py
@@ -18,12 +18,27 @@ class KeyAlreadyRegisteredTest(unittest.TestCase):
                          str(self.error))
 
 
+class ClientErrorTest(unittest.TestCase):
+    """Tests for acme.errors.ClientError."""
+
+    def setUp(self):
+        from acme.errors import ClientError
+        from acme.messages import Error
+        self.unspecified_error = ClientError(None)
+        self.network_error = ClientError(None,
+                                         Error(typ='TYP', detail='DETAIL'))
+
+    def test_str(self):
+        self.assertEqual("", str(self.unspecified_error))
+        self.assertEqual("Client error: TYP :: DETAIL", str(self.network_error))
+
+
 class BadNonceTest(unittest.TestCase):
     """Tests for acme.errors.BadNonce."""
 
     def setUp(self):
         from acme.errors import BadNonce
-        self.error = BadNonce(nonce="xxx", error="error")
+        self.error = BadNonce(None, nonce="xxx", nonce_error="error")
 
     def test_str(self):
         self.assertEqual("Invalid nonce ('xxx'): error", str(self.error))
@@ -48,10 +63,10 @@ class PollErrorTest(unittest.TestCase):
 
     def setUp(self):
         from acme.errors import PollError
-        self.timeout = PollError(
+        self.timeout = PollError(None,
             waiting=[(datetime.datetime(2015, 11, 29), mock.sentinel.AR)],
             updated={})
-        self.invalid = PollError(waiting=[], updated={
+        self.invalid = PollError(None, waiting=[], updated={
             mock.sentinel.AR: mock.sentinel.AR2})
 
     def test_timeout(self):

--- a/acme/acme/errors_test.py
+++ b/acme/acme/errors_test.py
@@ -1,8 +1,21 @@
+
 """Tests for acme.errors."""
 import datetime
 import unittest
 
 import mock
+
+
+class KeyAlreadyRegisteredTest(unittest.TestCase):
+    """Tests for acme.errors.KeyAlreadyRegistered."""
+
+    def setUp(self):
+        from acme.errors import KeyAlreadyRegistered
+        self.error = KeyAlreadyRegistered("EXISTING")
+
+    def test_str(self):
+        self.assertEqual("Key already registered at server: EXISTING",
+                         str(self.error))
 
 
 class BadNonceTest(unittest.TestCase):

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -8,7 +8,7 @@ from acme import jose
 from acme import util
 
 
-class Error(jose.JSONObjectWithFields, errors.Error):
+class Error(jose.JSONObjectWithFields):
     """ACME error.
 
     https://tools.ietf.org/html/draft-ietf-appsawg-http-problem-00

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -2,7 +2,6 @@
 import collections
 
 from acme import challenges
-from acme import errors
 from acme import fields
 from acme import jose
 from acme import util

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -13,6 +13,7 @@ class Error(jose.JSONObjectWithFields, errors.Error):
 
     https://tools.ietf.org/html/draft-ietf-appsawg-http-problem-00
 
+    :ivar int status:
     :ivar unicode typ:
     :ivar unicode title:
     :ivar unicode detail:
@@ -35,6 +36,7 @@ class Error(jose.JSONObjectWithFields, errors.Error):
         )
     )
 
+    status = jose.Field('status', omitempty=True)
     typ = jose.Field('type')
     title = jose.Field('title', omitempty=True)
     detail = jose.Field('detail')

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -18,8 +18,9 @@ class ErrorTest(unittest.TestCase):
 
     def setUp(self):
         from acme.messages import Error
-        self.error = Error(status=409, detail='foo',
-            typ='urn:acme:error:malformed', title='title')
+        self.error = Error(
+            status=409, detail='foo', typ='urn:acme:error:malformed',
+            title='title')
         self.jobj = {
             'status': 409,
             'detail': 'foo',

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -18,15 +18,15 @@ class ErrorTest(unittest.TestCase):
 
     def setUp(self):
         from acme.messages import Error
-        self.error = Error(
-            detail='foo', typ='urn:acme:error:malformed', title='title')
+        self.error = Error(status=409, detail='foo',
+            typ='urn:acme:error:malformed', title='title')
         self.jobj = {
+            'status': 409,
             'detail': 'foo',
             'title': 'some title',
             'type': 'urn:acme:error:malformed',
         }
         self.error_custom = Error(typ='custom', detail='bar')
-        self.jobj_cusom = {'type': 'custom', 'detail': 'bar'}
 
     def test_from_json_hashable(self):
         from acme.messages import Error
@@ -36,6 +36,10 @@ class ErrorTest(unittest.TestCase):
         self.assertEqual(
             'The request message was malformed', self.error.description)
         self.assertTrue(self.error_custom.description is None)
+
+    def test_status(self):
+        self.assertEqual(409, self.error.status)
+        self.assertEqual(None, self.error_custom.status)
 
     def test_str(self):
         self.assertEqual(

--- a/acme/examples/example_client.py
+++ b/acme/examples/example_client.py
@@ -43,6 +43,6 @@ csr = OpenSSL.crypto.load_certificate_request(
         'acme', os.path.join('testdata', 'csr.der')))
 try:
     acme.request_issuance(csr, (authzr,))
-except messages.Error as error:
+except errors.ClientError as error:
     print ("This script is doomed to fail as no authorization "
            "challenges are ever solved. Error from server: {0}".format(error))

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -147,8 +147,8 @@ def perform_registration(acme, config):
     """
     try:
         return acme.register(messages.NewRegistration.from_data(email=config.email))
-    except acme_errors.ClientError, e:
-        err = str(e)
+    except acme_errors.ClientErrorWithDetails, e:
+        err = repr(e.details)
         if "MX record" in err or "Validation of contact mailto" in err:
             config.namespace.email = display_ops.get_email(more=True, invalid=True)
             return perform_registration(acme, config)

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -8,6 +8,7 @@ import OpenSSL
 import zope.component
 
 from acme import client as acme_client
+from acme import errors as acme_errors
 from acme import jose
 from acme import messages
 
@@ -146,8 +147,8 @@ def perform_registration(acme, config):
     """
     try:
         return acme.register(messages.NewRegistration.from_data(email=config.email))
-    except errors.ClientError, e:
-        err = repr(e)
+    except acme_errors.ClientError, e:
+        err = str(e)
         if "MX record" in err or "Validation of contact mailto" in err:
             config.namespace.email = display_ops.get_email(more=True, invalid=True)
             return perform_registration(acme, config)

--- a/letsencrypt/client.py
+++ b/letsencrypt/client.py
@@ -146,7 +146,7 @@ def perform_registration(acme, config):
     """
     try:
         return acme.register(messages.NewRegistration.from_data(email=config.email))
-    except messages.Error, e:
+    except errors.ClientError, e:
         err = repr(e)
         if "MX record" in err or "Validation of contact mailto" in err:
             config.namespace.email = display_ops.get_email(more=True, invalid=True)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -520,7 +520,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
                            title='beta'))
         args = mock.MagicMock(debug=False, verbose_count=-3)
         cli._handle_exception(
-            errors.ClientError exc_value=exception, trace=None, args=args)
+            errors.ClientError, exc_value=exception, trace=None, args=args)
         error_msg = mock_sys.exit.call_args_list[-1][0][0]
         self.assertTrue('unexpected error' in error_msg)
         self.assertTrue('acme:error' not in error_msg)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -490,6 +490,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
     @mock.patch('letsencrypt.cli.sys')
     def test_handle_exception(self, mock_sys):
         # pylint: disable=protected-access
+        from acme import errors as acme_errors
         from acme import messages
 
         args = mock.MagicMock()
@@ -514,13 +515,13 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             mock_sys.exit.assert_any_call(''.join(
                 traceback.format_exception_only(errors.Error, error)))
 
-        exception = errors.ClientError(
+        exception = acme_errors.ClientError(
             None,
             messages.Error(detail='alpha', typ='urn:acme:error:triffid',
                            title='beta'))
         args = mock.MagicMock(debug=False, verbose_count=-3)
         cli._handle_exception(
-            errors.ClientError, exc_value=exception, trace=None, args=args)
+            acme_errors.ClientError, exc_value=exception, trace=None, args=args)
         error_msg = mock_sys.exit.call_args_list[-1][0][0]
         self.assertTrue('unexpected error' in error_msg)
         self.assertTrue('acme:error' not in error_msg)
@@ -528,7 +529,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue('beta' in error_msg)
         args = mock.MagicMock(debug=False, verbose_count=1)
         cli._handle_exception(
-            errors.ClientError, exc_value=exception, trace=None, args=args)
+            acme_errors.ClientError, exc_value=exception, trace=None, args=args)
         error_msg = mock_sys.exit.call_args_list[-1][0][0]
         self.assertTrue('unexpected error' in error_msg)
         self.assertTrue('acme:error' in error_msg)

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -515,7 +515,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             mock_sys.exit.assert_any_call(''.join(
                 traceback.format_exception_only(errors.Error, error)))
 
-        exception = acme_errors.ClientError(
+        exception = acme_errors.ClientErrorWithDetails(
             None,
             messages.Error(detail='alpha', typ='urn:acme:error:triffid',
                            title='beta'))

--- a/letsencrypt/tests/cli_test.py
+++ b/letsencrypt/tests/cli_test.py
@@ -514,11 +514,13 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             mock_sys.exit.assert_any_call(''.join(
                 traceback.format_exception_only(errors.Error, error)))
 
-        exception = messages.Error(detail='alpha', typ='urn:acme:error:triffid',
-                                   title='beta')
+        exception = errors.ClientError(
+            None,
+            messages.Error(detail='alpha', typ='urn:acme:error:triffid',
+                           title='beta'))
         args = mock.MagicMock(debug=False, verbose_count=-3)
         cli._handle_exception(
-            messages.Error, exc_value=exception, trace=None, args=args)
+            errors.ClientError exc_value=exception, trace=None, args=args)
         error_msg = mock_sys.exit.call_args_list[-1][0][0]
         self.assertTrue('unexpected error' in error_msg)
         self.assertTrue('acme:error' not in error_msg)
@@ -526,7 +528,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertTrue('beta' in error_msg)
         args = mock.MagicMock(debug=False, verbose_count=1)
         cli._handle_exception(
-            messages.Error, exc_value=exception, trace=None, args=args)
+            errors.ClientError, exc_value=exception, trace=None, args=args)
         error_msg = mock_sys.exit.call_args_list[-1][0][0]
         self.assertTrue('unexpected error' in error_msg)
         self.assertTrue('acme:error' in error_msg)

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -62,9 +62,10 @@ class RegisterTest(unittest.TestCase):
     @mock.patch("letsencrypt.account.report_new_account")
     @mock.patch("letsencrypt.client.display_ops.get_email")
     def test_email_retry(self, _rep, mock_get_email):
+        from acme import errors as acme_errors
         from acme import messages
         msg = "Validation of contact mailto:sousaphone@improbablylongggstring.tld failed"
-        mx_err = ClientError(
+        mx_err = acme_errors.ClientError(
             None, error=messages.Error(detail=msg, typ="malformed", title="title"))
         with mock.patch("letsencrypt.client.acme_client.Client") as mock_client:
             mock_client().register.side_effect = [mx_err, mock.MagicMock()]

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -65,8 +65,8 @@ class RegisterTest(unittest.TestCase):
         from acme import errors as acme_errors
         from acme import messages
         msg = "Validation of contact mailto:sousaphone@improbablylongggstring.tld failed"
-        mx_err = acme_errors.ClientError(
-            None, error=messages.Error(detail=msg, typ="malformed", title="title"))
+        mx_err = acme_errors.ClientErrorWithDetails(
+            None, messages.Error(detail=msg, typ="malformed", title="title"))
         with mock.patch("letsencrypt.client.acme_client.Client") as mock_client:
             mock_client().register.side_effect = [mx_err, mock.MagicMock()]
             self._call()

--- a/letsencrypt/tests/client_test.py
+++ b/letsencrypt/tests/client_test.py
@@ -64,7 +64,8 @@ class RegisterTest(unittest.TestCase):
     def test_email_retry(self, _rep, mock_get_email):
         from acme import messages
         msg = "Validation of contact mailto:sousaphone@improbablylongggstring.tld failed"
-        mx_err = messages.Error(detail=msg, typ="malformed", title="title")
+        mx_err = ClientError(
+            None, error=messages.Error(detail=msg, typ="malformed", title="title"))
         with mock.patch("letsencrypt.client.acme_client.Client") as mock_client:
             mock_client().register.side_effect = [mx_err, mock.MagicMock()]
             self._call()


### PR DESCRIPTION
Add a specific KeyAlreadyRegistered exception that contains the previous registration URL.

This includes adding the response object to the ClientError exception.  It also includes returning the mesages.Error parsed from a non-success response in a field of ClientError instead of as a separate exception.
