### PR TITLE
.gitattributes: EOL=LF overrides auto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,15 @@
-* text=auto eol=lf
+#Default, normalize CRLF into LF in non-binary files
+# Files identified as binary by Git are not changed
+* crlf=auto
 
 # special files
+*.sh crlf=input
+*.py crlf=input
+
 *.bat text eol=crlf
+
+*.der binary
+*.gz binary
 *.jpeg binary
 *.jpg binary
 *.png binary


### PR DESCRIPTION
The line
* text=auto eol=lf
in .gitattributes does not work as expected:
setting eol=lf overrides text=auto, and works as
* eol=lf
or
* text eol=lf

This is not what is intended, as binary files like *.gz go through
a CRLF -> LF conversion at commit time.

Use
* crlf=auto
instead (which is even understood by older Git versions, which are still in use)