### PR TITLE
added support for authentication via FTP and SFTP

### DIFF
--- a/letsencrypt/cli.py
+++ b/letsencrypt/cli.py
@@ -510,6 +510,8 @@ def choose_configurator_plugins(args, config, plugins, verb):  # pylint: disable
         req_auth = set_configurator(req_auth, "webroot")
     if args.manual:
         req_auth = set_configurator(req_auth, "manual")
+    if args.ftp:
+        req_auth = set_configurator(req_auth, "ftp")
     logger.debug("Requested authenticator %s and installer %s", req_auth, req_inst)
 
     # Try to meet the user's request and/or ask them to pick plugins
@@ -1178,6 +1180,8 @@ def _plugins_parsing(helpful, plugins):
                 help='Obtain certs using a "standalone" webserver.')
     helpful.add("plugins", "--manual", action="store_true",
                 help='Provide laborious manual instructions for obtaining a cert')
+    helpful.add("plugins", "--ftp", action="store_true",
+                help='Obtain certs by FTPing files to a webroot directory.')
     helpful.add("plugins", "--webroot", action="store_true",
                 help='Obtain certs by placing files in a webroot directory.')
 
@@ -1186,6 +1190,8 @@ def _plugins_parsing(helpful, plugins):
     # specific groups (so that plugins_group.description makes sense)
 
     helpful.add_plugin_args(plugins)
+
+    parse_dict = lambda s: dict(json.loads(s))
 
     # These would normally be a flag within the webroot plugin, but because
     # they are parsed in conjunction with --domains, they live here for
@@ -1196,10 +1202,50 @@ def _plugins_parsing(helpful, plugins):
                      "handle different domains; each domain will have the webroot path that"
                      " preceded it.  For instance: `-w /var/www/example -d example.com -d "
                      "www.example.com -w /var/www/thing -d thing.net -d m.thing.net`")
-    parse_dict = lambda s: dict(json.loads(s))
     # --webroot-map still has some awkward properties, so it is undocumented
     helpful.add("webroot", "--webroot-map", default={}, type=parse_dict,
                 help=argparse.SUPPRESS)
+
+    # These would normally be a flag within the FTP plugin, but because
+    # they are parsed in conjunction with --domains, they live here for
+    # legibility. helpful.add_plugin_ags must be called first to add the
+    # "ftp" topic
+    helpful.add("ftp", "-W", "--ftp-webroot-path", action=FTPWebrootPathProcessor,
+                help="public_html / webroot path. This can be specified multiple times to "
+                     "handle different domains; each domain will have the webroot path that"
+                     " preceded it.  For instance: `-W username@host:/var/www/example "
+                     "-d example.com -d www.example.com -W username@host:/var/www/thing "
+                     "-d thing.net -d m.thing.net`")
+    # --ftp-webroot-map still has some awkward properties, so it is undocumented
+    helpful.add("ftp", "--ftp-webroot-map", default={}, type=parse_dict,
+                help=argparse.SUPPRESS)
+
+
+class FTPWebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring
+    def __init__(self, *args, **kwargs):
+        self.domain_before_webroot = False
+        argparse.Action.__init__(self, *args, **kwargs)
+
+    def __call__(self, parser, config, webroot, option_string=None):
+        """
+        Keep a record of --ftp-webroot-path / -w flags during processing, so that
+        we know which apply to which -d flags
+        """
+        if config.ftp_webroot_path is None:      # first -w flag encountered
+            config.ftp_webroot_path = []
+            # if any --domain flags preceded the first --ftp-webroot-path flag,
+            # apply that webroot path to those; subsequent entries in
+            # config.ftp_webroot_map are filled in by cli.DomainFlagProcessor
+            if config.domains:
+                self.domain_before_webroot = True
+                for d in config.domains:
+                    config.ftp_webroot_map.setdefault(d, webroot)
+        elif self.domain_before_webroot:
+            # FIXME if you set domains in a config file, you should get a different error
+            # here, pointing you to --ftp-webroot-map
+            raise errors.Error("If you specify multiple FTP webroot paths, one of "
+                               "them must precede all domain flags")
+        config.ftp_webroot_path.append(webroot)
 
 
 class WebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring
@@ -1232,8 +1278,8 @@ class WebrootPathProcessor(argparse.Action): # pylint: disable=missing-docstring
 class DomainFlagProcessor(argparse.Action): # pylint: disable=missing-docstring
     def __call__(self, parser, config, domain_arg, option_string=None):
         """
-        Process a new -d flag, helping the webroot plugin construct a map of
-        {domain : webrootpath} if -w / --webroot-path is in use
+        Process a new -d flag, helping the webroot and ftp plugins construct a
+        map of {domain : webrootpath} if -w / --webroot-path is in use
         """
         for domain in (d.strip() for d in domain_arg.split(",")):
             if domain not in config.domains:
@@ -1241,6 +1287,10 @@ class DomainFlagProcessor(argparse.Action): # pylint: disable=missing-docstring
                 # Each domain has a webroot_path of the most recent -w flag
                 if config.webroot_path:
                     config.webroot_map[domain] = config.webroot_path[-1]
+                # Each domain has an ftp_webroot_path of the most recent
+                # --ftp-webroot-path flag
+                if config.ftp_webroot_path:
+                    config.ftp_webroot_map[domain] = config.ftp_webroot_path[-1]
 
 
 def setup_log_file_handler(args, logfile, fmt):

--- a/letsencrypt/plugins/ftp.py
+++ b/letsencrypt/plugins/ftp.py
@@ -1,0 +1,180 @@
+"""FTP and SFTP plugin."""
+
+import ftputil
+import logging
+import os
+import pysftp
+import shutil
+import tempfile
+import urlparse
+
+import zope.component
+import zope.interface
+
+from acme import challenges
+
+from letsencrypt import errors
+from letsencrypt import interfaces
+from letsencrypt.plugins import common
+
+
+logger = logging.getLogger(__name__)
+
+
+class Authenticator(common.Plugin):
+    """FTP and SFTP Authenticator.
+
+    This plugin uploads the challenge responses required by the ACME
+    protocol to a remote server using FTP or SFTP.
+
+    .. todo:: Support for `~.challenges.TLSSNI01`.
+
+    """
+    zope.interface.implements(interfaces.IAuthenticator)
+    zope.interface.classProvides(interfaces.IPluginFactory)
+    hidden = True
+
+    description = "Configure an HTTP server using FTP or SFTP"
+
+    # a disclaimer about your current IP being transmitted to Let's
+    # Encrypt's servers.
+    IP_DISCLAIMER = """\
+NOTE: The IP of this machine will be publicly logged as having \
+requested this certificate. If you're running letsencrypt in FTP mode \
+on a machine that is not your server, please ensure you're okay with that.
+
+Are you OK with your IP being logged?
+"""
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+        self.full_roots = {}
+        self._cleanup_funcs = []
+        self._tmpdir = tempfile.mkdtemp()
+
+    @classmethod
+    def add_parser_arguments(cls, add):
+        # --webroot-path and --webroot-map are added in cli.py because they
+        # are parsed in conjunction with --domains
+        add("public-ip-logging-ok", action="store_true",
+            help="Automatically allows public IP logging.")
+
+    def prepare(self):  # pylint: disable=missing-docstring
+        path_map = self.conf("webroot-map")
+
+        if not path_map:
+            raise errors.PluginError("--{0} must be set".format(
+                self.option_name("webroot-path")))
+        for name, path in path_map.items():
+            self.full_roots[name] = os.path.join(
+                path, challenges.HTTP01.URI_ROOT_PATH)
+
+    def more_info(self):  # pylint: disable=missing-docstring,no-self-use
+        return ("This plugin tries to solve http-01 challenges automatically "
+                "by copying files using FTP or SFTP to the webroot of a "
+                "remote HTTP server.")
+
+    def get_chall_pref(self, domain):
+        # pylint: disable=missing-docstring,no-self-use,unused-argument
+        return [challenges.HTTP01]
+
+    def perform(self, achalls):  # pylint: disable=missing-docstring
+        assert self.full_roots, \
+            "FTP plugin appears to be missing FTP webroot map"
+
+        if achalls and not self.conf("public-ip-logging-ok"):
+            if not zope.component.getUtility(interfaces.IDisplay).yesno(
+                    self.IP_DISCLAIMER, "Yes", "No"):
+                raise errors.PluginError("Must agree to IP logging to proceed")
+
+        return [self._perform_single(achall) for achall in achalls]
+
+    def _path_for_achall(self, achall):
+        try:
+            path = self.full_roots[achall.domain]
+        except IndexError:
+            raise errors.PluginError(
+                "Missing --ftp-webroot-path for domain: {1}".format(
+                    achall.domain))
+        return os.path.join(path, achall.chall.encode("token"))
+
+    def _perform_single(self, achall):
+        path = self._path_for_achall(achall)
+        path_parts = self._split_path(path)
+
+        if path_parts.scheme == "sftp":
+            return self._perform_single_sftp(achall, path_parts)
+        elif path_parts.scheme == "ftp":
+            return self._perform_single_ftp(achall, path_parts)
+        else:
+            raise errors.PluginError(
+                "unknown webroot URI scheme: {0.scheme}".format(path_parts)
+            )
+
+    def _perform_single_ftp(self, achall, path_parts):
+        hostname = path_parts.hostname
+        username = path_parts.username
+        password = path_parts.password
+        path = path_parts.path
+        if path[0] == '/':
+            path = path[1:]
+
+        response, validation = achall.response_and_validation()
+
+        dirname, filename = os.path.split(path)
+        tmpfile = os.path.join(self._tmpdir, filename)
+        with open(tmpfile, "w") as fp:
+            fp.write(validation.encode())
+
+        with ftputil.FTPHost(hostname, username, password) as ftp:
+            ftp.makedirs(dirname)
+            ftp.chdir(dirname)
+            ftp.upload(tmpfile, filename)
+
+        def cleanup():
+            with ftputil.FTPHost(hostname, username, password) as ftp:
+                ftp.unlink(path)
+
+        self._register_cleanup_func(cleanup)
+        return response
+
+    def _perform_single_sftp(self, achall, path_parts):
+        hostname = path_parts.hostname
+        username = path_parts.username
+        path = path_parts.path
+        if path[0] == '/':
+            path = path[1:]
+
+        response, validation = achall.response_and_validation()
+
+        dirname, filename = os.path.split(path)
+        tmpfile = os.path.join(self._tmpdir, filename)
+        with open(tmpfile, "w") as fp:
+            fp.write(validation.encode())
+
+        with pysftp.Connection(hostname, username=username) as sftp:
+            sftp.makedirs(dirname, mode=022)
+            with sftp.cd(dirname):
+                sftp.put(tmpfile)
+
+        # TODO: register a cleanup function
+        return response
+
+    def _register_cleanup_func(self, func):
+        """Registers a new cleanup function to be executed when the
+        plugin has finished its job.
+        """
+        self._cleanup_funcs.append(func)
+
+    def _split_path(self, path):
+        parts = urlparse.urlparse(path)
+        if not parts.scheme:
+            # No scheme was given, assume sftp
+            return urlparse.urlparse("sftp://" + path)
+        return parts
+
+    def cleanup(self, achalls):
+        # pylint: disable=missing-docstring,no-self-use,unused-argument
+        for func in reversed(self._cleanup_funcs):
+            func()
+        shutil.rmtree(self._tmpdir)

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,12 @@ install_requires = [
     'acme=={0}'.format(version),
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
+    'ftputil',
     'parsedatetime',
     'psutil>=2.1.0',  # net_connections introduced in 2.1.0
     'PyOpenSSL',
     'pyrfc3339',
+    'pysftp',
     'python2-pythondialog>=3.2.2rc1',  # Debian squeeze support, cf. #280
     'pytz',
     'setuptools',  # pkg_resources
@@ -135,6 +137,7 @@ setup(
         'letsencrypt.plugins': [
             'manual = letsencrypt.plugins.manual:Authenticator',
             'null = letsencrypt.plugins.null:Installer',
+            'ftp = letsencrypt.plugins.ftp:Authenticator',
             'standalone = letsencrypt.plugins.standalone:Authenticator',
             'webroot = letsencrypt.plugins.webroot:Authenticator',
         ],


### PR DESCRIPTION
I have created a plugin for my own purposes that allows the user to proceed through the authentication by FTP-ing files to a remote server.

This is useful for shared web hosting providers where the hosting company does not provide full SSH access but allows FTP and/or SFTP (like mine). The plugin is similar to the `webroot` plugin in the sense that the user must define "web roots" for the domains and the plugin will create files there to make the server pass the authentication step. I know that this could probably have been solved using FUSE with `curlftpfs`, but the advantage of this method is that there is no need to mount a file system on the local machine (for which the user might not have privileges anyway), and it works out-of-the-box on a vanilla Mac where FUSE is uncommon.

The plugin is not feature-complete yet and there are no tests specific to the FTP/SFTP functionality, but I thought I'd share it anyway to gauge whether there's any interest for such a plugin. If there is, I am happy to keep on working on the code until it is of acceptable quality.