### PR TITLE
If Nginx does not found vhost info, does not create it

### DIFF
--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -219,17 +219,13 @@ class NginxConfigurator(common.Plugin):
         :rtype: :class:`~letsencrypt_nginx.obj.VirtualHost`
 
         """
-        vhost = None
-
         matches = self._get_ranked_matches(target_name)
         if not matches:
-            # No matches. Create a new vhost with this name in nginx.conf.
-            filep = self.parser.loc["root"]
-            new_block = [['server'], [['server_name', target_name]]]
-            self.parser.add_http_directives(filep, new_block)
-            vhost = obj.VirtualHost(filep, set([]), False, True,
-                                    set([target_name]), list(new_block[1]))
-        elif matches[0]['rank'] in xrange(2, 6):
+            logger.info("Virtual Host not found for %s", target_name)
+            return None
+
+
+        if matches[0]['rank'] in xrange(2, 6):
             # Wildcard match - need to find the longest one
             rank = matches[0]['rank']
             wildcards = [x for x in matches if x['rank'] == rank]
@@ -237,9 +233,8 @@ class NginxConfigurator(common.Plugin):
         else:
             vhost = matches[0]['vhost']
 
-        if vhost is not None:
-            if not vhost.ssl:
-                self._make_server_ssl(vhost)
+        if not vhost.ssl:
+            self._make_server_ssl(vhost)
 
         return vhost
 

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -612,15 +612,20 @@ class NginxConfigurator(common.Plugin):
         outstanding challenges will have to be designed better.
 
         """
-        self._chall_out += len(achalls)
-        responses = [None] * len(achalls)
         chall_doer = tls_sni_01.NginxTlsSni01(self)
 
         for i, achall in enumerate(achalls):
             # Currently also have chall_doer hold associated index of the
             # challenge. This helps to put all of the responses back together
             # when they are all complete.
-            chall_doer.add_chall(achall, i)
+            # As we does not create vhost when it isn't found in the current configuration,
+            # we will filter out this domains before to perform TLS challenge
+            if self.choose_vhost(achall.domain) is not None:
+                chall_doer.add_chall(achall, i)
+
+        count_achalls = len(chall_doer.achalls)
+        self._chall_out += count_achalls
+        responses = [None] * count_achalls
 
         sni_response = chall_doer.perform()
         # Must restart in order to activate the challenges.

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -153,7 +153,7 @@ class NginxConfigurator(common.Plugin):
 
         vhost = self.choose_vhost(domain)
         if vhost is None:
-          raise errors.PluginError("Virtual Host not found for domain: " + domain)
+            raise errors.PluginError("Virtual Host not found for domain: " + domain)
 
         cert_directives = [['ssl_certificate', fullchain_path],
                            ['ssl_certificate_key', key_path]]
@@ -376,12 +376,12 @@ class NginxConfigurator(common.Plugin):
             documentation for appropriate parameter.
 
         """
-        vhost = self.choose_vhost(domain, options)
+        vhost = self.choose_vhost(domain)
         if vhost is None:
-          raise errors.PluginError("Virtual Host not found for domain: " + domain)
+            raise errors.PluginError("Virtual Host not found for domain: " + domain)
 
         try:
-            return self._enhance_func[enhancement](vhost)
+            return self._enhance_func[enhancement](vhost, options)
         except (KeyError, ValueError):
             raise errors.PluginError(
                 "Unsupported enhancement: {0}".format(enhancement))
@@ -630,8 +630,8 @@ class NginxConfigurator(common.Plugin):
                 chall_doer.add_chall(achall, i)
             else:
               # TODO: Handle feedback about domain without vhost
-              logger.info("As was not found a virtual host for domain %s, "
-                          "it will be ignored", achalls.domain)
+                logger.info("As was not found a virtual host for domain %s, "
+                            "it will be ignored", achall.domain)
 
         count_achalls = len(chall_doer.achalls)
         self._chall_out += count_achalls

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -224,7 +224,9 @@ class NginxConfigurator(common.Plugin):
         """
         matches = self._get_ranked_matches(target_name)
         if not matches:
-            logger.info("Virtual Host not found for %s", target_name)
+            logger.info("Virtual Host not found for %s. "
+                        "Are you sure you're really serving that domain name?",
+                        target_name)
             return None
 
 

--- a/letsencrypt-nginx/letsencrypt_nginx/configurator.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/configurator.py
@@ -630,7 +630,7 @@ class NginxConfigurator(common.Plugin):
                 chall_doer.add_chall(achall, i)
             else:
               # TODO: Handle feedback about domain without vhost
-                logger.info("As was not found a virtual host for domain %s, "
+                logger.info("As we couldn't find a virtual host for domain %s, "
                             "it will be ignored", achall.domain)
 
         count_achalls = len(chall_doer.achalls)

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
@@ -122,18 +122,12 @@ class NginxConfiguratorTest(util.NginxTest):
                    'abc.www.foo.com': "etc_nginx/foo.conf",
                    'www.bar.co.uk': "etc_nginx/nginx.conf"}
 
-        bad_results = ['www.foo.com', 'example', 't.www.bar.co',
-                       '69.255.225.155']
-
         for name in results:
             vhost = self.config.choose_vhost(name)
             path = os.path.relpath(vhost.filep, self.temp_dir)
 
             self.assertEqual(results[name], vhost.names)
             self.assertEqual(conf_path[name], path)
-
-        for name in bad_results:
-            self.assertEqual(set([name]), self.config.choose_vhost(name).names)
 
     def test_more_info(self):
         self.assertTrue('nginx.conf' in self.config.more_info())

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
@@ -311,6 +311,7 @@ class NginxConfiguratorTest(util.NginxTest):
         responses = self.config.perform([achall1, achall_invalid])
         self.assertEqual(1, len(responses))
         self.assertEqual(mock_perform.call_count, 1)
+        self.assertEqual(mock_restart.call_count, 1)
 
     @mock.patch("letsencrypt_nginx.configurator.subprocess.Popen")
     def test_get_version(self, mock_popen):

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/configurator_test.py
@@ -287,6 +287,31 @@ class NginxConfiguratorTest(util.NginxTest):
         self.assertEqual(responses, expected)
         self.assertEqual(mock_restart.call_count, 1)
 
+    @mock.patch("letsencrypt_nginx.configurator.NginxConfigurator.restart")
+    @mock.patch("letsencrypt_nginx.configurator.tls_sni_01.NginxTlsSni01.perform")
+    @mock.patch("letsencrypt_nginx.configurator.NginxConfigurator.choose_vhost")
+    def test_perform_does_not_process_domains_without_vhost(self, mock_choose_vhost,
+                                                            mock_perform, mock_restart):
+        achall1 = achallenges.KeyAuthorizationAnnotatedChallenge(
+            challb=messages.ChallengeBody(
+                chall=challenges.TLSSNI01(token="kNdwjwOeX0I_A8DXt9Msmg"),
+                uri="https://ca.org/chall0_uri",
+                status=messages.Status("pending"),
+            ), domain="localhost", account_key=self.rsa512jwk)
+        achall_invalid = achallenges.KeyAuthorizationAnnotatedChallenge(
+            challb=messages.ChallengeBody(
+                chall=challenges.TLSSNI01(token="m8TdO1qik4JVFtgPPurJmg"),
+                uri="https://ca.org/chall1_uri",
+                status=messages.Status("pending"),
+            ), domain="invalid_vhost", account_key=self.rsa512jwk)
+
+        mock_choose_vhost.side_effect = ["vhost", None]
+        mock_perform.return_value = [achall1.response(self.rsa512jwk)]
+
+        responses = self.config.perform([achall1, achall_invalid])
+        self.assertEqual(1, len(responses))
+        self.assertEqual(mock_perform.call_count, 1)
+
     @mock.patch("letsencrypt_nginx.configurator.subprocess.Popen")
     def test_get_version(self, mock_popen):
         mock_popen().communicate.return_value = (

--- a/letsencrypt-nginx/letsencrypt_nginx/tests/tls_sni_01_test.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tests/tls_sni_01_test.py
@@ -20,26 +20,26 @@ class TlsSniPerformTest(util.NginxTest):
     """Test the NginxTlsSni01 challenge."""
 
     account_key = common_test.TLSSNI01Test.auth_key
-    achalls = [
-        achallenges.KeyAuthorizationAnnotatedChallenge(
-            challb=acme_util.chall_to_challb(
-                challenges.TLSSNI01(token="kNdwjwOeX0I_A8DXt9Msmg"), "pending"),
-            domain="www.example.com", account_key=account_key),
-        achallenges.KeyAuthorizationAnnotatedChallenge(
-            challb=acme_util.chall_to_challb(
-                challenges.TLSSNI01(
-                    token="\xba\xa9\xda?<m\xaewmx\xea\xad\xadv\xf4\x02\xc9y"
-                          "\x80\xe2_X\t\xe7\xc7\xa4\t\xca\xf7&\x945"
-                ), "pending"),
-            domain="blah", account_key=account_key),
-        achallenges.KeyAuthorizationAnnotatedChallenge(
-            challb=acme_util.chall_to_challb(
-                challenges.TLSSNI01(
-                    token="\x8c\x8a\xbf_-f\\cw\xee\xd6\xf8/\xa5\xe3\xfd"
-                          "\xeb9\xf1\xf5\xb9\xefVM\xc9w\xa4u\x9c\xe1\x87\xb4"
-                ), "pending"),
-            domain="www.example.org", account_key=account_key),
-    ]
+    dot_com_achall = achallenges.KeyAuthorizationAnnotatedChallenge(
+        challb=acme_util.chall_to_challb(
+            challenges.TLSSNI01(token="kNdwjwOeX0I_A8DXt9Msmg"), "pending"),
+            domain="www.example.com",
+            account_key=account_key)
+
+    dot_org_achall = achallenges.KeyAuthorizationAnnotatedChallenge(
+        challb=acme_util.chall_to_challb(
+            challenges.TLSSNI01(
+                token="\x8c\x8a\xbf_-f\\cw\xee\xd6\xf8/\xa5\xe3\xfd"
+                    "\xeb9\xf1\xf5\xb9\xefVM\xc9w\xa4u\x9c\xe1\x87\xb4"), "pending"),
+            domain="www.example.org",
+            account_key=account_key)
+    vhost_not_configured_achall = achallenges.KeyAuthorizationAnnotatedChallenge(
+        challb=acme_util.chall_to_challb(
+            challenges.TLSSNI01(
+                token="\xba\xa9\xda?<m\xaewmx\xea\xad\xadv\xf4\x02\xc9y"
+                    "\x80\xe2_X\t\xe7\xc7\xa4\t\xca\xf7&\x945"), "pending"),
+            domain="vhost_not_configured",
+            account_key=account_key)
 
     def setUp(self):
         super(TlsSniPerformTest, self).setUp()
@@ -57,20 +57,20 @@ class TlsSniPerformTest(util.NginxTest):
 
     @mock.patch("letsencrypt_nginx.configurator"
                 ".NginxConfigurator.choose_vhost")
-    def test_perform(self, mock_choose):
-        self.sni.add_chall(self.achalls[1])
+    def test_perform_returns_none_when_vhost_not_found(self, mock_choose):
+        self.sni.add_chall(self.vhost_not_configured_achall)
         mock_choose.return_value = None
         result = self.sni.perform()
         self.assertTrue(result is None)
 
-    def test_perform0(self):
+    def test_perform_returns_empty_when_does_not_have_chall(self):
         responses = self.sni.perform()
         self.assertEqual([], responses)
 
     @mock.patch("letsencrypt_nginx.configurator.NginxConfigurator.save")
-    def test_perform1(self, mock_save):
-        self.sni.add_chall(self.achalls[0])
-        response = self.achalls[0].response(self.account_key)
+    def test_perform_single_domain(self, mock_save):
+        self.sni.add_chall(self.dot_com_achall)
+        response = self.dot_com_achall.response(self.account_key)
         mock_setup_cert = mock.MagicMock(return_value=response)
 
         # pylint: disable=protected-access
@@ -78,7 +78,7 @@ class TlsSniPerformTest(util.NginxTest):
 
         responses = self.sni.perform()
 
-        mock_setup_cert.assert_called_once_with(self.achalls[0])
+        mock_setup_cert.assert_called_once_with(self.dot_com_achall)
         self.assertEqual([response], responses)
         self.assertEqual(mock_save.call_count, 2)
 
@@ -88,37 +88,33 @@ class TlsSniPerformTest(util.NginxTest):
         self.assertTrue(
             util.contains_at_depth(http, ['include', self.sni.challenge_conf], 1))
 
-    def test_perform2(self):
+    def test_perform_multiple_domain(self):
         acme_responses = []
-        for achall in self.achalls:
-            self.sni.add_chall(achall)
-            acme_responses.append(achall.response(self.account_key))
+        self.sni.add_chall(self.dot_com_achall)
+        acme_responses.append(self.dot_com_achall.response(self.account_key))
+        self.sni.add_chall(self.dot_org_achall)
+        acme_responses.append(self.dot_org_achall.response(self.account_key))
 
         mock_setup_cert = mock.MagicMock(side_effect=acme_responses)
         # pylint: disable=protected-access
         self.sni._setup_challenge_cert = mock_setup_cert
 
         sni_responses = self.sni.perform()
+        self.assertEqual(len(sni_responses), 2)
+        self.assertEqual(sni_responses, acme_responses)
 
-        self.assertEqual(mock_setup_cert.call_count, 3)
-
-        for index, achall in enumerate(self.achalls):
-            self.assertEqual(
-                mock_setup_cert.call_args_list[index], mock.call(achall))
+        self.assertEqual(mock_setup_cert.call_count, 2)
+        mock_setup_cert.assert_any_call(self.dot_com_achall)
+        mock_setup_cert.assert_any_call(self.dot_org_achall)
 
         http = self.sni.configurator.parser.parsed[
             self.sni.configurator.parser.loc["root"]][-1]
-        self.assertTrue(['include', self.sni.challenge_conf] in http[1])
         self.assertTrue(
-            util.contains_at_depth(http, ['server_name', 'blah'], 3))
-
-        self.assertEqual(len(sni_responses), 3)
-        for i in xrange(3):
-            self.assertEqual(sni_responses[i], acme_responses[i])
+            util.contains_at_depth(http, ['include', self.sni.challenge_conf], 1))
 
     def test_mod_config(self):
-        self.sni.add_chall(self.achalls[0])
-        self.sni.add_chall(self.achalls[2])
+        self.sni.add_chall(self.dot_com_achall)
+        self.sni.add_chall(self.dot_org_achall)
 
         v_addr1 = [obj.Addr("69.50.225.155", "9000", True, False),
                    obj.Addr("127.0.0.1", "", False, False)]
@@ -139,9 +135,9 @@ class TlsSniPerformTest(util.NginxTest):
 
         for vhost in vhs:
             if vhost.addrs == set(v_addr1):
-                response = self.achalls[0].response(self.account_key)
+                response = self.dot_com_achall.response(self.account_key)
             else:
-                response = self.achalls[2].response(self.account_key)
+                response = self.dot_org_achall.response(self.account_key)
                 self.assertEqual(vhost.addrs, set(v_addr2))
             self.assertEqual(vhost.names, set([response.z_domain]))
 

--- a/letsencrypt-nginx/letsencrypt_nginx/tls_sni_01.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tls_sni_01.py
@@ -65,8 +65,8 @@ class NginxTlsSni01(common.TLSSNI01):
                 if addr.default:
                     addresses.append([obj.Addr.fromstring(default_addr)])
                     break
-            else:
-                addresses.append(list(vhost.addrs))
+                else:
+                    addresses.append(list(vhost.addrs))
 
         # Create challenge certs
         responses = [self._setup_challenge_cert(x) for x in self.achalls]

--- a/letsencrypt-nginx/letsencrypt_nginx/tls_sni_01.py
+++ b/letsencrypt-nginx/letsencrypt_nginx/tls_sni_01.py
@@ -65,8 +65,8 @@ class NginxTlsSni01(common.TLSSNI01):
                 if addr.default:
                     addresses.append([obj.Addr.fromstring(default_addr)])
                     break
-                else:
-                    addresses.append(list(vhost.addrs))
+
+            addresses.append(list(vhost.addrs))
 
         # Create challenge certs
         responses = [self._setup_challenge_cert(x) for x in self.achalls]

--- a/letsencrypt-nginx/tests/boulder-integration.conf.sh
+++ b/letsencrypt-nginx/tests/boulder-integration.conf.sh
@@ -55,6 +55,8 @@ http {
 
     root $root/webroot;
 
+    server_name nginx.wtf;
+
     location / {
       # First attempt to serve request as file, then as directory, then fall
       # back to index.html.


### PR DESCRIPTION
For issue like #925 was created the PR #2097, but looks like the dir structure for each platform is different :disappointed: 

So, for now if we didn't find vhost in the config files, weren't create it. 

