### PR TITLE
updating readme with free memory requirement [revised]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,18 +121,24 @@ email to client-dev+subscribe@letsencrypt.org)
 System Requirements
 ===================
 
-The Let's Encrypt Client presently only runs on Unix-ish OSes that include 
-Python 2.6 or 2.7; Python 3.x support will be added after the Public Beta 
-launch. The client may require at least 512MB of free memory in order to 
-properly initalize the cryptography libraries. The client requires root access 
-in order to write to ``/etc/letsencrypt``, ``/var/log/letsencrypt``, 
-``/var/lib/letsencrypt``; to bind to ports 80 and 443 (if you use the 
-``standalone`` plugin) and to read and modify webserver configurations (if you 
-use the ``apache`` or ``nginx`` plugins).  If none of these apply to you, it is 
-theoretically possible to run without root privileges, but for most users who 
-want to avoid running an ACME client as root, either `letsencrypt-nosudo 
-<https://github.com/diafygi/letsencrypt-nosudo>`_ or `simp_le 
+The Let's Encrypt Client presently only runs on Unix-ish OSes that include
+Python 2.6 or 2.7; Python 3.x support will be added after the Public Beta
+launch. The client requires root access in order to write to
+``/etc/letsencrypt``, ``/var/log/letsencrypt``, ``/var/lib/letsencrypt``; to
+bind to ports 80 and 443 (if you use the ``standalone`` plugin) and to read and
+modify webserver configurations (if you use the ``apache`` or ``nginx``
+plugins).  If none of these apply to you, it is theoretically possible to run
+without root privileges, but for most users who want to avoid running an ACME
+client as root, either `letsencrypt-nosudo
+<https://github.com/diafygi/letsencrypt-nosudo>`_ or `simp_le
 <https://github.com/kuba/simp_le>`_ are more appropriate choices.
+
+It is possible that running ``letsencrypt-auto`` may fail on machines with a low
+(< 512MB) amount of free memory, failing to compile ``python-cryptography``.
+Adding additional swap memory (or stopping memory hogging processes) can resolve
+this issue or, if your OS packages a recent copy of ``python-cryptography``, you
+may be able to run ``letsencrypt`` without the ``letsencrypt-auto`` wrapper,
+avoiding the compilation.
 
 The Apache plugin currently requires a Debian-based OS with augeas version
 1.0; this includes Ubuntu 12.04+ and Debian 7+.

--- a/README.rst
+++ b/README.rst
@@ -121,16 +121,17 @@ email to client-dev+subscribe@letsencrypt.org)
 System Requirements
 ===================
 
-The Let's Encrypt Client presently only runs on Unix-ish OSes that include
-Python 2.6 or 2.7; Python 3.x support will be added after the Public Beta
-launch. The client requires root access in order to write to
-``/etc/letsencrypt``, ``/var/log/letsencrypt``, ``/var/lib/letsencrypt``; to
-bind to ports 80 and 443 (if you use the ``standalone`` plugin) and to read and
-modify webserver configurations (if you use the ``apache`` or ``nginx``
-plugins).  If none of these apply to you, it is theoretically possible to run
-without root privileges, but for most users who want to avoid running an ACME
-client as root, either `letsencrypt-nosudo
-<https://github.com/diafygi/letsencrypt-nosudo>`_ or `simp_le
+The Let's Encrypt Client presently only runs on Unix-ish OSes that include 
+Python 2.6 or 2.7; Python 3.x support will be added after the Public Beta 
+launch. The client may require at least 512MB of free memory in order to 
+properly initalize the cryptography libraries. The client requires root access 
+in order to write to ``/etc/letsencrypt``, ``/var/log/letsencrypt``, 
+``/var/lib/letsencrypt``; to bind to ports 80 and 443 (if you use the 
+``standalone`` plugin) and to read and modify webserver configurations (if you 
+use the ``apache`` or ``nginx`` plugins).  If none of these apply to you, it is 
+theoretically possible to run without root privileges, but for most users who 
+want to avoid running an ACME client as root, either `letsencrypt-nosudo 
+<https://github.com/diafygi/letsencrypt-nosudo>`_ or `simp_le 
 <https://github.com/kuba/simp_le>`_ are more appropriate choices.
 
 The Apache plugin currently requires a Debian-based OS with augeas version


### PR DESCRIPTION
There is a non-obvious requirement for memory to be available for the crypto libraries on the client.  The readme's System Requirements section didn't reflect this.  On low-memory systems this crashes the client with an extremely verbose but not terribly useful error. 
See https://github.com/letsencrypt/letsencrypt/issues/1883#issuecomment-167276122
