### PR TITLE
Do not install mod_ssl [needs revisions]

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -262,6 +262,14 @@ BootstrapRpmCommon() {
       echo "Could not install additional dependencies. Aborting bootstrap!"
       exit 1
   fi
+
+
+  if $SUDO $tool list installed "httpd" >/dev/null 2>&1; then
+    if ! $SUDO $tool install -y mod_ssl
+    then
+      echo "Apache found, but mod_ssl could not be installed."
+    fi
+  fi
 }
 
 BootstrapSuseCommon() {

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -262,14 +262,6 @@ BootstrapRpmCommon() {
       echo "Could not install additional dependencies. Aborting bootstrap!"
       exit 1
   fi
-
-
-  if $SUDO $tool list installed "httpd" >/dev/null 2>&1; then
-    if ! $SUDO $tool install -y mod_ssl
-    then
-      echo "Apache found, but mod_ssl could not be installed."
-    fi
-  fi
 }
 
 BootstrapSuseCommon() {

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -50,12 +50,4 @@ BootstrapRpmCommon() {
       echo "Could not install additional dependencies. Aborting bootstrap!"
       exit 1
   fi
-
-
-  if $SUDO $tool list installed "httpd" >/dev/null 2>&1; then
-    if ! $SUDO $tool install -y mod_ssl
-    then
-      echo "Apache found, but mod_ssl could not be installed."
-    fi
-  fi
 }


### PR DESCRIPTION
Fixes #2589 

Installing mod_ssl on some servers triggers a change in Apache behaviour - it starts listening on port 443. This is not a desired change for me and I don't believe it would be for other people.
