### PR TITLE
Fix symlink webroot paths

### DIFF
--- a/letsencrypt/plugins/webroot.py
+++ b/letsencrypt/plugins/webroot.py
@@ -155,5 +155,8 @@ to serve all files under specified web root ({0})."""
                     elif exc.errno == errno.EACCES:
                         logger.debug("Challenges cleaned up but no permissions for %s",
                                      root_path)
+                    elif exc.errno == errno.ENOENT:
+                        logger.debug("Challenges cleaned up, %s does not exists",
+                                     root_path)
                     else:
                         raise

--- a/letsencrypt/plugins/webroot_test.py
+++ b/letsencrypt/plugins/webroot_test.py
@@ -176,10 +176,23 @@ class AuthenticatorTest(unittest.TestCase):
         self.auth.perform([self.achall])
 
         os_error = OSError()
-        os_error.errno = errno.ENOENT
+        os_error.errno = errno.EPERM
         mock_rmdir.side_effect = os_error
 
         self.assertRaises(OSError, self.auth.cleanup, [self.achall])
+        self.assertFalse(os.path.exists(self.validation_path))
+        self.assertTrue(os.path.exists(self.root_challenge_path))
+
+    @mock.patch('os.rmdir')
+    def test_cleanup_file_not_exists(self, mock_rmdir):
+        self.auth.prepare()
+        self.auth.perform([self.achall])
+
+        os_error = OSError()
+        os_error.errno = errno.ENOENT
+        mock_rmdir.side_effect = os_error
+
+        self.auth.cleanup([self.achall])
         self.assertFalse(os.path.exists(self.validation_path))
         self.assertTrue(os.path.exists(self.root_challenge_path))
 


### PR DESCRIPTION
When using symlinks for webroot folders and requesting SSL for same websites with symlink domains.
The challenges files and acme-challenge directory are removed on the first domain and on second domain the
acme-challenge directory is already removed and tries to remove it again.