### PR TITLE
Add privacy information to the Subscriber Agreement question

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -37,11 +37,11 @@ def acme_from_config_key(config, key):
     "Wrangle ACME client construction"
     # TODO: Allow for other alg types besides RS256
     net = acme_client.ClientNetwork(key, verify_ssl=(not config.no_verify_ssl),
-                                    user_agent=_determine_user_agent(config))
+                                    user_agent=determine_user_agent(config))
     return acme_client.Client(config.server, key=key, net=net)
 
 
-def _determine_user_agent(config):
+def determine_user_agent(config):
     """
     Set a user_agent string in the config based on the choice of plugins.
     (this wasn't knowable at construction time)
@@ -51,7 +51,7 @@ def _determine_user_agent(config):
     """
 
     if config.user_agent is None:
-        ua = "CertbotACMEClient/{0} ({1}) Authenticator/{2} Installer/{3}"
+        ua = "Certbot/{0} ({1}) Authenticator/{2} Installer/{3}"
         ua = ua.format(certbot.__version__, " ".join(le_util.get_os_info()),
                        config.authenticator, config.installer)
     else:

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -329,10 +329,15 @@ def _determine_account(config):
             def _tos_cb(regr):
                 if config.tos:
                     return True
-                msg = ("Please read the Terms of Service at {0}. You "
-                       "must agree in order to register with the ACME "
-                       "server at {1}".format(
-                           regr.terms_of_service, config.server))
+                msg = ("Please read the Terms of Service and privacy information at {0}. You must agree in order "
+                       "to register with the ACME server at {1}.\n\n"
+                       "Note that Certbot sends the following information to ACME servers:\n\n"
+                       "* contact email (optional but recommended);\n"
+                       "* requested domain names;\n"
+                       "* IP address of the machine it's run on (normally public anyway);\n" 
+                       "* User Agent information, eg:\n    {2}".format(
+                           regr.terms_of_service, config.server, 
+                           client.determine_user_agent(config)))
                 obj = zope.component.getUtility(interfaces.IDisplay)
                 return obj.yesno(msg, "Agree", "Cancel", cli_flag="--agree-tos")
 


### PR DESCRIPTION
Currently the Subscriber Agreement agreement interaction in the client does not address privacy issues directly (though they are part of Let's Encrypt's Subscriber Agreement).  This PR attempts to make Certbot's privacy stance clear in the same screen.  Not sure yet if this is too wordy, but it may be the best way forward.