### PR TITLE
certbot-auto

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -650,9 +650,6 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         help="(letsencrypt-auto only) prevent the letsencrypt-auto script from"
              " upgrading itself to newer released versions")
     helpful.add(
-        "automation", "--yes", action="store_true",
-        help="(letsencrypt-auto only) assume yes is the answer to all prompts")
-    helpful.add(
         "automation", "-q", "--quiet", dest="quiet", action="store_true",
         help="Silence all output except errors. Useful for automation via cron."
              " Implies --non-interactive.")

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -650,6 +650,9 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         help="(letsencrypt-auto only) prevent the letsencrypt-auto script from"
              " upgrading itself to newer released versions")
     helpful.add(
+        "automation", "--yes", action="store_true",
+        help="(letsencrypt-auto only) assume yes is the answer to all prompts")
+    helpful.add(
         "automation", "-q", "--quiet", dest="quiet", action="store_true",
         help="Silence all output except errors. Useful for automation via cron."
              " Implies --non-interactive.")

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -307,7 +307,12 @@ BootstrapRpmCommon() {
 BootstrapSuseCommon() {
   # SLE12 don't have python-virtualenv
 
-  $SUDO zypper -nq in -l \
+  if [ "$ASSUME_YES" = 1 ]; then
+    zypper_flags="-nq"
+    install_flags="-l"
+  fi
+
+  $SUDO zypper $zypper_flags in $install_flags \
     python \
     python-devel \
     python-virtualenv \

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -183,26 +183,34 @@ BootstrapDebCommon() {
       # ARGS:
       BACKPORT_NAME="$1"
       BACKPORT_SOURCELINE="$2"
+      echo "To use the Apache Certbot plugin, augeas needs to be installed from $BACKPORT_NAME."
       if ! grep -v -e ' *#' /etc/apt/sources.list | grep -q "$BACKPORT_NAME" ; then
           # This can theoretically error if sources.list.d is empty, but in that case we don't care.
           if ! grep -v -e ' *#' /etc/apt/sources.list.d/* 2>/dev/null | grep -q "$BACKPORT_NAME"; then
-              /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
-              sleep 1s
-              /bin/echo -ne "\e[0K\rInstalling augeas from $BACKPORT_NAME in 2 seconds..."
-              sleep 1s
-              /bin/echo -e "\e[0K\rInstalling augeas from $BACKPORT_NAME in 1 second ..."
-              sleep 1s
               if echo $BACKPORT_NAME | grep -q wheezy ; then
-                  /bin/echo '(Backports are only installed if explicitly requested via "apt-get install -t wheezy-backports")'
+                  echo 'Backports are only installed if explicitly requested via "apt-get install -t wheezy-backports"'
               fi
-
-              $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
-              $SUDO apt-get update
+              if [ "$ASSUME_YES" = 1 ]; then
+                  add_backports=1
+              else
+                  read -p "Would you like to enable the $BACKPORT_NAME repository [Y/n]? " response
+                  case $response in
+                      [yY][eE][sS]|[yY]|"")
+                          add_backports=1;;
+                      *)
+                          add_backports=0;;
+                  esac
+              fi
+              if [ "$add_backports" = 1 ]; then
+                  $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
+                  $SUDO apt-get update
+              fi
           fi
       fi
-      $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
-      augeas_pkg=
-
+      if [ "$add_backports" != 0 ]; then
+          $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
+          augeas_pkg=
+      fi
   }
 
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Download and run the latest release version of the Let's Encrypt client.
+# Download and run the latest release version of the Certbot client.
 #
 # NOTE: THIS SCRIPT IS AUTO-GENERATED AND SELF-UPDATING
 #
@@ -21,7 +21,7 @@ VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN="$VENV_PATH/bin"
 LE_AUTO_VERSION="0.6.0.dev0"
 
-# This script takes the same arguments as the main letsencrypt program, but it
+# This script takes the same arguments as the main certbot program, but it
 # additionally responds to --verbose (more output) and --debug (allow support
 # for experimental platforms)
 for arg in "$@" ; do
@@ -45,8 +45,8 @@ for arg in "$@" ; do
   esac
 done
 
-# letsencrypt-auto needs root access to bootstrap OS dependencies, and
-# letsencrypt itself needs root access for almost all modes of operation
+# certbot-auto needs root access to bootstrap OS dependencies, and
+# certbot itself needs root access for almost all modes of operation
 # The "normal" case is that sudo is used for the steps that need root, but
 # this script *can* be run as root (not recommended), or fall back to using
 # `su`
@@ -186,7 +186,7 @@ BootstrapDebCommon() {
           AddBackportRepo precise-backports "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse"
       else
           echo "No libaugeas0 version is available that's new enough to run the"
-          echo "Let's Encrypt apache plugin..."
+          echo "Certbot apache plugin..."
       fi
       # XXX add a case for ubuntu PPAs
   fi
@@ -426,7 +426,7 @@ Bootstrap() {
   elif grep -iq "Amazon Linux" /etc/issue ; then
     ExperimentalBootstrap "Amazon Linux" BootstrapRpmCommon
   else
-    echo "Sorry, I don't know how to bootstrap Let's Encrypt on your operating system!"
+    echo "Sorry, I don't know how to bootstrap Certbot on your operating system!"
     echo
     echo "You will need to bootstrap, configure virtualenv, and run pip install manually."
     echo "Please see https://letsencrypt.readthedocs.org/en/latest/contributing.html#prerequisites"
@@ -446,7 +446,8 @@ if [ "$1" = "--le-auto-phase2" ]; then
   shift 1  # the --le-auto-phase2 arg
   if [ -f "$VENV_BIN/letsencrypt" ]; then
     # --version output ran through grep due to python-cryptography DeprecationWarnings
-    INSTALLED_VERSION=$("$VENV_BIN/letsencrypt" --version 2>&1 | grep ^letsencrypt | cut -d " " -f 2)
+    # grep for both certbot and letsencrypt until certbot and shim packages have been released
+    INSTALLED_VERSION=$("$VENV_BIN/letsencrypt" --version 2>&1 | grep "^certbot\|^letsencrypt" | cut -d " " -f 2)
   else
     INSTALLED_VERSION="none"
   fi
@@ -465,8 +466,8 @@ if [ "$1" = "--le-auto-phase2" ]; then
     # There is no $ interpolation due to quotes on starting heredoc delimiter.
     # -------------------------------------------------------------------------
     cat << "UNLIKELY_EOF" > "$TEMP_DIR/letsencrypt-auto-requirements.txt"
-# This is the flattened list of packages letsencrypt-auto installs. To generate
-# this, do `pip install --no-cache-dir -e acme -e . -e letsencrypt-apache`, and
+# This is the flattened list of packages certbot-auto installs. To generate
+# this, do `pip install --no-cache-dir -e acme -e . -e certbot-apache`, and
 # then use `hashin` or a more secure method to gather the hashes.
 
 argparse==1.4.0 \
@@ -823,16 +824,16 @@ UNLIKELY_EOF
     fi
     echo "Installation succeeded."
   fi
-  echo "Requesting root privileges to run letsencrypt..."
+  echo "Requesting root privileges to run certbot..."
   echo "  " $SUDO "$VENV_BIN/letsencrypt" "$@"
   $SUDO "$VENV_BIN/letsencrypt" "$@"
 else
-  # Phase 1: Upgrade letsencrypt-auto if neceesary, then self-invoke.
+  # Phase 1: Upgrade certbot-auto if neceesary, then self-invoke.
   #
   # Each phase checks the version of only the thing it is responsible for
   # upgrading. Phase 1 checks the version of the latest release of
-  # letsencrypt-auto (which is always the same as that of the letsencrypt
-  # package). Phase 2 checks the version of the locally installed letsencrypt.
+  # certbot-auto (which is always the same as that of the certbot
+  # package). Phase 2 checks the version of the locally installed certbot.
 
   if [ ! -f "$VENV_BIN/letsencrypt" ]; then
     # If it looks like we've never bootstrapped before, bootstrap:
@@ -953,7 +954,7 @@ def verified_new_le_auto(get, tag, temp_dir):
                        stderr=dev_null)
     except CalledProcessError as exc:
         raise ExpectedError("Couldn't verify signature of downloaded "
-                            "letsencrypt-auto.", exc)
+                            "certbot-auto.", exc)
 
 
 def main():
@@ -980,27 +981,24 @@ UNLIKELY_EOF
     DeterminePythonVersion
     REMOTE_VERSION=`"$LE_PYTHON" "$TEMP_DIR/fetch.py" --latest-version`
     if [ "$LE_AUTO_VERSION" != "$REMOTE_VERSION" ]; then
-      echo "Upgrading letsencrypt-auto $LE_AUTO_VERSION to $REMOTE_VERSION..."
+      echo "Upgrading certbot-auto $LE_AUTO_VERSION to $REMOTE_VERSION..."
 
       # Now we drop into Python so we don't have to install even more
       # dependencies (curl, etc.), for better flow control, and for the option of
       # future Windows compatibility.
       "$LE_PYTHON" "$TEMP_DIR/fetch.py" --le-auto-script "v$REMOTE_VERSION"
 
-      # Install new copy of letsencrypt-auto.
+      # Install new copy of certbot-auto.
       # TODO: Deal with quotes in pathnames.
-      echo "Replacing letsencrypt-auto..."
+      echo "Replacing certbot-auto..."
       # Clone permissions with cp. chmod and chown don't have a --reference
       # option on OS X or BSD, and stat -c on Linux is stat -f on OS X and BSD:
-      echo "  " $SUDO cp -p "$0" "$TEMP_DIR/letsencrypt-auto.permission-clone"
       $SUDO cp -p "$0" "$TEMP_DIR/letsencrypt-auto.permission-clone"
-      echo "  " $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$TEMP_DIR/letsencrypt-auto.permission-clone"
       $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$TEMP_DIR/letsencrypt-auto.permission-clone"
       # Using mv rather than cp leaves the old file descriptor pointing to the
       # original copy so the shell can continue to read it unmolested. mv across
       # filesystems is non-atomic, doing `rm dest, cp src dest, rm src`, but the
       # cp is unlikely to fail (esp. under sudo) if the rm doesn't.
-      echo "  " $SUDO mv -f "$TEMP_DIR/letsencrypt-auto.permission-clone" "$0"
       $SUDO mv -f "$TEMP_DIR/letsencrypt-auto.permission-clone" "$0"
       # TODO: Clean up temp dir safely, even if it has quotes in its path.
       rm -rf "$TEMP_DIR"

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -191,6 +191,12 @@ BootstrapDebCommon() {
                   echo 'Backports are only installed if explicitly requested via "apt-get install -t wheezy-backports"'
               fi
               if [ "$ASSUME_YES" = 1 ]; then
+                  /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
+                  sleep 1s
+                  /bin/echo -ne "\e[0K\rInstalling augeas from $BACKPORT_NAME in 2 seconds..."
+                  sleep 1s
+                  /bin/echo -e "\e[0K\rInstalling augeas from $BACKPORT_NAME in 1 second ..."
+                  sleep 1s
                   add_backports=1
               else
                   read -p "Would you like to enable the $BACKPORT_NAME repository [Y/n]? " response

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -240,9 +240,10 @@ BootstrapDebCommon() {
 
 BootstrapRpmCommon() {
   # Tested with:
-  #   - Fedora 22, 23 (x64)
+  #   - Fedora 20, 21, 22, 23 (x64)
   #   - Centos 7 (x64: on DigitalOcean droplet)
   #   - CentOS 7 Minimal install in a Hyper-V VM
+  #   - CentOS 6 (EPEL must be installed manually)
 
   if type dnf 2>/dev/null
   then
@@ -256,47 +257,50 @@ BootstrapRpmCommon() {
     exit 1
   fi
 
+  pkgs="
+    gcc
+    dialog
+    augeas-libs
+    openssl
+    openssl-devel
+    libffi-devel
+    redhat-rpm-config
+    ca-certificates
+  "
+
   # Some distros and older versions of current distros use a "python27"
   # instead of "python" naming convention. Try both conventions.
-  if ! $SUDO $tool install -y \
-         python \
-         python-devel \
-         python-virtualenv \
-         python-tools \
-         python-pip
-  then
-    if ! $SUDO $tool install -y \
-           python27 \
-           python27-devel \
-           python27-virtualenv \
-           python27-tools \
-           python27-pip
-    then
-      echo "Could not install Python dependencies. Aborting bootstrap!"
-      exit 1
-    fi
+  if $SUDO $tool list python >/dev/null 2>&1; then
+    pkgs="$pkgs
+      python
+      python-devel
+      python-virtualenv
+      python-tools
+      python-pip
+    "
+  else
+    pkgs="$pkgs
+      python27
+      python27-devel
+      python27-virtualenv
+      python27-tools
+      python27-pip
+    "
   fi
-
-  if ! $SUDO $tool install -y \
-         gcc \
-         dialog \
-         augeas-libs \
-         openssl \
-         openssl-devel \
-         libffi-devel \
-         redhat-rpm-config \
-         ca-certificates
-  then
-      echo "Could not install additional dependencies. Aborting bootstrap!"
-      exit 1
-  fi
-
 
   if $SUDO $tool list installed "httpd" >/dev/null 2>&1; then
-    if ! $SUDO $tool install -y mod_ssl
-    then
-      echo "Apache found, but mod_ssl could not be installed."
-    fi
+    pkgs="$pkgs
+      mod_ssl
+    "
+  fi
+
+  if [ "$ASSUME_YES" = 1 ]; then
+    yes_flag="-y"
+  fi
+
+  if ! $SUDO $tool install $yes_flag $pkgs; then
+      echo "Could not install OS dependencies. Aborting bootstrap!"
+      exit 1
   fi
 }
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -175,6 +175,10 @@ BootstrapDebCommon() {
   augeas_pkg="libaugeas0 augeas-lenses"
   AUGVERSION=`apt-cache show --no-all-versions libaugeas0 | grep ^Version: | cut -d" " -f2`
 
+  if [ "$ASSUME_YES" = 1 ]; then
+    YES_FLAG="-y"
+  fi
+
   AddBackportRepo() {
       # ARGS:
       BACKPORT_NAME="$1"
@@ -196,7 +200,7 @@ BootstrapDebCommon() {
               $SUDO apt-get update
           fi
       fi
-      $SUDO apt-get install -y --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
+      $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
       augeas_pkg=
 
   }
@@ -215,7 +219,7 @@ BootstrapDebCommon() {
       # XXX add a case for ubuntu PPAs
   fi
 
-  $SUDO apt-get install -y --no-install-recommends \
+  $SUDO apt-get install $YES_FLAG --no-install-recommends \
     python \
     python-dev \
     $virtualenv \
@@ -334,8 +338,12 @@ BootstrapArchCommon() {
   # pacman -T exits with 127 if there are missing dependencies
   missing=$($SUDO pacman -T $deps) || true
 
+  if [ "$ASSUME_YES" = 1 ]; then
+    noconfirm="--noconfirm"
+  fi
+
   if [ "$missing" ]; then
-    $SUDO pacman -S --needed $missing
+    $SUDO pacman -S --needed $missing $noconfirm
   fi
 }
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -21,11 +21,11 @@ VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN="$VENV_PATH/bin"
 LE_AUTO_VERSION="0.6.0.dev0"
 BASENAME=$(basename $0)
-USAGE="Usage: $BASENAME [OPTION]
+USAGE="Usage: $BASENAME [OPTIONS]
 A self-updating wrapper script for the Certbot ACME client. When run, updates
 to both this script and certbot will be downloaded and installed. After
 ensuring you have the latest versions installed, certbot will be invoked with
-all arguments you provided.
+all arguments you have provided.
 
 Help for certbot itself cannot be provided until it is installed.
 
@@ -860,6 +860,10 @@ else
   # package). Phase 2 checks the version of the locally installed certbot.
 
   if [ ! -f "$VENV_BIN/letsencrypt" ]; then
+    if [ "$HELP" = 1 ]; then
+      echo "$USAGE"
+      exit 0
+    fi
     # If it looks like we've never bootstrapped before, bootstrap:
     Bootstrap
   fi

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -34,6 +34,10 @@ for arg in "$@" ; do
       # Do not upgrade this script (also prevents client upgrades, because each
       # copy of the script pins a hash of the python client)
       NO_SELF_UPGRADE=1;;
+    --help)
+      HELP=1;;
+    --yes)
+      ASSUME_YES=1;;
     --verbose)
       VERBOSE=1;;
     [!-]*|-*[!v]*|-)
@@ -79,6 +83,12 @@ if test "`id -u`" -ne "0" ; then
   fi
 else
   SUDO=
+fi
+
+if [ $(basename $0) = "letsencrypt-auto" ]; then
+  # letsencrypt-auto does not respect --help or --yes for backwards compatibility
+  ASSUME_YES=1
+  HELP=0
 fi
 
 ExperimentalBootstrap() {

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -192,9 +192,6 @@ BootstrapDebCommon() {
       if ! grep -v -e ' *#' /etc/apt/sources.list | grep -q "$BACKPORT_NAME" ; then
           # This can theoretically error if sources.list.d is empty, but in that case we don't care.
           if ! grep -v -e ' *#' /etc/apt/sources.list.d/* 2>/dev/null | grep -q "$BACKPORT_NAME"; then
-              if echo $BACKPORT_NAME | grep -q wheezy ; then
-                  echo 'Backports are only installed if explicitly requested via "apt-get install -t wheezy-backports"'
-              fi
               if [ "$ASSUME_YES" = 1 ]; then
                   /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
                   sleep 1s

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -20,10 +20,24 @@ VENV_NAME="letsencrypt"
 VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN="$VENV_PATH/bin"
 LE_AUTO_VERSION="0.6.0.dev0"
+BASENAME=$(basename $0)
+USAGE="Usage: $BASENAME [OPTION]
+A self-updating wrapper script for the Certbot ACME client. When run, updates
+to both this script and certbot will be downloaded and installed. After
+ensuring you have the latest versions installed, certbot will be invoked with
+all arguments you provided.
 
-# This script takes the same arguments as the main certbot program, but it
-# additionally responds to --verbose (more output) and --debug (allow support
-# for experimental platforms)
+Help for certbot itself cannot be provided until it is installed.
+
+  --debug               attempt installation on experimental platforms
+  --help                print this help
+  --no-self-upgrade     do not download updates for certbot or certbot-auto
+  --os-packages-only    install OS dependencies and exit
+  -v, --verbose         provide more output
+  --yes                 assume yes is the answer to all prompts
+
+All arguments are accepted and forwarded to the Certbot client when run."
+
 for arg in "$@" ; do
   case "$arg" in
     --debug)
@@ -85,7 +99,7 @@ else
   SUDO=
 fi
 
-if [ $(basename $0) = "letsencrypt-auto" ]; then
+if [ $BASENAME = "letsencrypt-auto" ]; then
   # letsencrypt-auto does not respect --help or --yes for backwards compatibility
   ASSUME_YES=1
   HELP=0

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -29,14 +29,25 @@ all arguments you have provided.
 
 Help for certbot itself cannot be provided until it is installed.
 
-  --debug               attempt installation on experimental platforms
-  --help                print this help
-  --no-self-upgrade     do not download updates for certbot or certbot-auto
-  --os-packages-only    install OS dependencies and exit
-  -v, --verbose         provide more output
-  --yes                 assume yes is the answer to all prompts
+  --debug                                   attempt experimental installation
+  -h, --help                                print this help
+  -n, --non-interactive, --noninteractive   run without asking for user input
+  --no-self-upgrade                         do not download updates
+  --os-packages-only                        install OS dependencies and exit
+  -v, --verbose                             provide more output
 
 All arguments are accepted and forwarded to the Certbot client when run."
+
+while getopts ":hnv" arg; do
+    case $arg in
+        h)
+            HELP=1;;
+        n)
+            ASSUME_YES=1;;
+        v)
+            VERBOSE=1;;
+    esac
+done
 
 for arg in "$@" ; do
   case "$arg" in
@@ -50,15 +61,9 @@ for arg in "$@" ; do
       NO_SELF_UPGRADE=1;;
     --help)
       HELP=1;;
-    --yes)
+    --noninteractive|--non-interactive)
       ASSUME_YES=1;;
     --verbose)
-      VERBOSE=1;;
-    [!-]*|-*[!v]*|-)
-      # Anything that isn't -v, -vv, etc.: that is, anything that does not
-      # start with a -, contains anything that's not a v, or is just "-"
-      ;;
-    *)  # -v+ remains.
       VERBOSE=1;;
   esac
 done

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -20,10 +20,24 @@ VENV_NAME="letsencrypt"
 VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN="$VENV_PATH/bin"
 LE_AUTO_VERSION="{{ LE_AUTO_VERSION }}"
+BASENAME=$(basename $0)
+USAGE="Usage: $BASENAME [OPTION]
+A self-updating wrapper script for the Certbot ACME client. When run, updates
+to both this script and certbot will be downloaded and installed. After
+ensuring you have the latest versions installed, certbot will be invoked with
+all arguments you provided.
 
-# This script takes the same arguments as the main certbot program, but it
-# additionally responds to --verbose (more output) and --debug (allow support
-# for experimental platforms)
+Help for certbot itself cannot be provided until it is installed.
+
+  --debug               attempt installation on experimental platforms
+  --help                print this help
+  --no-self-upgrade     do not download updates for certbot or certbot-auto
+  --os-packages-only    install OS dependencies and exit
+  -v, --verbose         provide more output
+  --yes                 assume yes is the answer to all prompts
+
+All arguments are accepted and forwarded to the Certbot client when run."
+
 for arg in "$@" ; do
   case "$arg" in
     --debug)
@@ -85,7 +99,7 @@ else
   SUDO=
 fi
 
-if [ $(basename $0) = "letsencrypt-auto" ]; then
+if [ $BASENAME = "letsencrypt-auto" ]; then
   # letsencrypt-auto does not respect --help or --yes for backwards compatibility
   ASSUME_YES=1
   HELP=0

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -34,6 +34,10 @@ for arg in "$@" ; do
       # Do not upgrade this script (also prevents client upgrades, because each
       # copy of the script pins a hash of the python client)
       NO_SELF_UPGRADE=1;;
+    --help)
+      HELP=1;;
+    --yes)
+      ASSUME_YES=1;;
     --verbose)
       VERBOSE=1;;
     [!-]*|-*[!v]*|-)
@@ -79,6 +83,12 @@ if test "`id -u`" -ne "0" ; then
   fi
 else
   SUDO=
+fi
+
+if [ $(basename $0) = "letsencrypt-auto" ]; then
+  # letsencrypt-auto does not respect --help or --yes for backwards compatibility
+  ASSUME_YES=1
+  HELP=0
 fi
 
 ExperimentalBootstrap() {

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -21,7 +21,7 @@ VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN="$VENV_PATH/bin"
 LE_AUTO_VERSION="{{ LE_AUTO_VERSION }}"
 
-# This script takes the same arguments as the main letsencrypt program, but it
+# This script takes the same arguments as the main certbot program, but it
 # additionally responds to --verbose (more output) and --debug (allow support
 # for experimental platforms)
 for arg in "$@" ; do
@@ -45,7 +45,7 @@ for arg in "$@" ; do
   esac
 done
 
-# letsencrypt-auto needs root access to bootstrap OS dependencies, and
+# certbot-auto needs root access to bootstrap OS dependencies, and
 # certbot itself needs root access for almost all modes of operation
 # The "normal" case is that sudo is used for the steps that need root, but
 # this script *can* be run as root (not recommended), or fall back to using
@@ -177,7 +177,8 @@ if [ "$1" = "--le-auto-phase2" ]; then
   shift 1  # the --le-auto-phase2 arg
   if [ -f "$VENV_BIN/letsencrypt" ]; then
     # --version output ran through grep due to python-cryptography DeprecationWarnings
-    INSTALLED_VERSION=$("$VENV_BIN/letsencrypt" --version 2>&1 | grep ^letsencrypt | cut -d " " -f 2)
+    # grep for both certbot and letsencrypt until certbot and shim packages have been released
+    INSTALLED_VERSION=$("$VENV_BIN/letsencrypt" --version 2>&1 | grep "^certbot\|^letsencrypt" | cut -d " " -f 2)
   else
     INSTALLED_VERSION="none"
   fi
@@ -223,11 +224,11 @@ UNLIKELY_EOF
   echo "  " $SUDO "$VENV_BIN/letsencrypt" "$@"
   $SUDO "$VENV_BIN/letsencrypt" "$@"
 else
-  # Phase 1: Upgrade letsencrypt-auto if neceesary, then self-invoke.
+  # Phase 1: Upgrade certbot-auto if neceesary, then self-invoke.
   #
   # Each phase checks the version of only the thing it is responsible for
   # upgrading. Phase 1 checks the version of the latest release of
-  # letsencrypt-auto (which is always the same as that of the certbot
+  # certbot-auto (which is always the same as that of the certbot
   # package). Phase 2 checks the version of the locally installed certbot.
 
   if [ ! -f "$VENV_BIN/letsencrypt" ]; then
@@ -250,27 +251,24 @@ UNLIKELY_EOF
     DeterminePythonVersion
     REMOTE_VERSION=`"$LE_PYTHON" "$TEMP_DIR/fetch.py" --latest-version`
     if [ "$LE_AUTO_VERSION" != "$REMOTE_VERSION" ]; then
-      echo "Upgrading letsencrypt-auto $LE_AUTO_VERSION to $REMOTE_VERSION..."
+      echo "Upgrading certbot-auto $LE_AUTO_VERSION to $REMOTE_VERSION..."
 
       # Now we drop into Python so we don't have to install even more
       # dependencies (curl, etc.), for better flow control, and for the option of
       # future Windows compatibility.
       "$LE_PYTHON" "$TEMP_DIR/fetch.py" --le-auto-script "v$REMOTE_VERSION"
 
-      # Install new copy of letsencrypt-auto.
+      # Install new copy of certbot-auto.
       # TODO: Deal with quotes in pathnames.
-      echo "Replacing letsencrypt-auto..."
+      echo "Replacing certbot-auto..."
       # Clone permissions with cp. chmod and chown don't have a --reference
       # option on OS X or BSD, and stat -c on Linux is stat -f on OS X and BSD:
-      echo "  " $SUDO cp -p "$0" "$TEMP_DIR/letsencrypt-auto.permission-clone"
       $SUDO cp -p "$0" "$TEMP_DIR/letsencrypt-auto.permission-clone"
-      echo "  " $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$TEMP_DIR/letsencrypt-auto.permission-clone"
       $SUDO cp "$TEMP_DIR/letsencrypt-auto" "$TEMP_DIR/letsencrypt-auto.permission-clone"
       # Using mv rather than cp leaves the old file descriptor pointing to the
       # original copy so the shell can continue to read it unmolested. mv across
       # filesystems is non-atomic, doing `rm dest, cp src dest, rm src`, but the
       # cp is unlikely to fail (esp. under sudo) if the rm doesn't.
-      echo "  " $SUDO mv -f "$TEMP_DIR/letsencrypt-auto.permission-clone" "$0"
       $SUDO mv -f "$TEMP_DIR/letsencrypt-auto.permission-clone" "$0"
       # TODO: Clean up temp dir safely, even if it has quotes in its path.
       rm -rf "$TEMP_DIR"

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -21,11 +21,11 @@ VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN="$VENV_PATH/bin"
 LE_AUTO_VERSION="{{ LE_AUTO_VERSION }}"
 BASENAME=$(basename $0)
-USAGE="Usage: $BASENAME [OPTION]
+USAGE="Usage: $BASENAME [OPTIONS]
 A self-updating wrapper script for the Certbot ACME client. When run, updates
 to both this script and certbot will be downloaded and installed. After
 ensuring you have the latest versions installed, certbot will be invoked with
-all arguments you provided.
+all arguments you have provided.
 
 Help for certbot itself cannot be provided until it is installed.
 
@@ -256,6 +256,10 @@ else
   # package). Phase 2 checks the version of the locally installed certbot.
 
   if [ ! -f "$VENV_BIN/letsencrypt" ]; then
+    if [ "$HELP" = 1 ]; then
+      echo "$USAGE"
+      exit 0
+    fi
     # If it looks like we've never bootstrapped before, bootstrap:
     Bootstrap
   fi

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -29,14 +29,25 @@ all arguments you have provided.
 
 Help for certbot itself cannot be provided until it is installed.
 
-  --debug               attempt installation on experimental platforms
-  --help                print this help
-  --no-self-upgrade     do not download updates for certbot or certbot-auto
-  --os-packages-only    install OS dependencies and exit
-  -v, --verbose         provide more output
-  --yes                 assume yes is the answer to all prompts
+  --debug                                   attempt experimental installation
+  -h, --help                                print this help
+  -n, --non-interactive, --noninteractive   run without asking for user input
+  --no-self-upgrade                         do not download updates
+  --os-packages-only                        install OS dependencies and exit
+  -v, --verbose                             provide more output
 
 All arguments are accepted and forwarded to the Certbot client when run."
+
+while getopts ":hnv" arg; do
+    case $arg in
+        h)
+            HELP=1;;
+        n)
+            ASSUME_YES=1;;
+        v)
+            VERBOSE=1;;
+    esac
+done
 
 for arg in "$@" ; do
   case "$arg" in
@@ -50,15 +61,9 @@ for arg in "$@" ; do
       NO_SELF_UPGRADE=1;;
     --help)
       HELP=1;;
-    --yes)
+    --noninteractive|--non-interactive)
       ASSUME_YES=1;;
     --verbose)
-      VERBOSE=1;;
-    [!-]*|-*[!v]*|-)
-      # Anything that isn't -v, -vv, etc.: that is, anything that does not
-      # start with a -, contains anything that's not a v, or is just "-"
-      ;;
-    *)  # -v+ remains.
       VERBOSE=1;;
   esac
 done

--- a/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
@@ -21,7 +21,11 @@ BootstrapArchCommon() {
   # pacman -T exits with 127 if there are missing dependencies
   missing=$($SUDO pacman -T $deps) || true
 
+  if [ "$ASSUME_YES" = 1 ]; then
+    noconfirm="--noconfirm"
+  fi
+
   if [ "$missing" ]; then
-    $SUDO pacman -S --needed $missing
+    $SUDO pacman -S --needed $missing $noconfirm
   fi
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -46,9 +46,6 @@ BootstrapDebCommon() {
       if ! grep -v -e ' *#' /etc/apt/sources.list | grep -q "$BACKPORT_NAME" ; then
           # This can theoretically error if sources.list.d is empty, but in that case we don't care.
           if ! grep -v -e ' *#' /etc/apt/sources.list.d/* 2>/dev/null | grep -q "$BACKPORT_NAME"; then
-              if echo $BACKPORT_NAME | grep -q wheezy ; then
-                  echo 'Backports are only installed if explicitly requested via "apt-get install -t wheezy-backports"'
-              fi
               if [ "$ASSUME_YES" = 1 ]; then
                   /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
                   sleep 1s

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -34,6 +34,10 @@ BootstrapDebCommon() {
   augeas_pkg="libaugeas0 augeas-lenses"
   AUGVERSION=`apt-cache show --no-all-versions libaugeas0 | grep ^Version: | cut -d" " -f2`
 
+  if [ "$ASSUME_YES" = 1 ]; then
+    YES_FLAG="-y"
+  fi
+
   AddBackportRepo() {
       # ARGS:
       BACKPORT_NAME="$1"
@@ -55,7 +59,7 @@ BootstrapDebCommon() {
               $SUDO apt-get update
           fi
       fi
-      $SUDO apt-get install -y --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
+      $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
       augeas_pkg=
 
   }
@@ -74,7 +78,7 @@ BootstrapDebCommon() {
       # XXX add a case for ubuntu PPAs
   fi
 
-  $SUDO apt-get install -y --no-install-recommends \
+  $SUDO apt-get install $YES_FLAG --no-install-recommends \
     python \
     python-dev \
     $virtualenv \

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -50,6 +50,12 @@ BootstrapDebCommon() {
                   echo 'Backports are only installed if explicitly requested via "apt-get install -t wheezy-backports"'
               fi
               if [ "$ASSUME_YES" = 1 ]; then
+                  /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
+                  sleep 1s
+                  /bin/echo -ne "\e[0K\rInstalling augeas from $BACKPORT_NAME in 2 seconds..."
+                  sleep 1s
+                  /bin/echo -e "\e[0K\rInstalling augeas from $BACKPORT_NAME in 1 second ..."
+                  sleep 1s
                   add_backports=1
               else
                   read -p "Would you like to enable the $BACKPORT_NAME repository [Y/n]? " response

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -42,26 +42,34 @@ BootstrapDebCommon() {
       # ARGS:
       BACKPORT_NAME="$1"
       BACKPORT_SOURCELINE="$2"
+      echo "To use the Apache Certbot plugin, augeas needs to be installed from $BACKPORT_NAME."
       if ! grep -v -e ' *#' /etc/apt/sources.list | grep -q "$BACKPORT_NAME" ; then
           # This can theoretically error if sources.list.d is empty, but in that case we don't care.
           if ! grep -v -e ' *#' /etc/apt/sources.list.d/* 2>/dev/null | grep -q "$BACKPORT_NAME"; then
-              /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
-              sleep 1s
-              /bin/echo -ne "\e[0K\rInstalling augeas from $BACKPORT_NAME in 2 seconds..."
-              sleep 1s
-              /bin/echo -e "\e[0K\rInstalling augeas from $BACKPORT_NAME in 1 second ..."
-              sleep 1s
               if echo $BACKPORT_NAME | grep -q wheezy ; then
-                  /bin/echo '(Backports are only installed if explicitly requested via "apt-get install -t wheezy-backports")'
+                  echo 'Backports are only installed if explicitly requested via "apt-get install -t wheezy-backports"'
               fi
-
-              $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
-              $SUDO apt-get update
+              if [ "$ASSUME_YES" = 1 ]; then
+                  add_backports=1
+              else
+                  read -p "Would you like to enable the $BACKPORT_NAME repository [Y/n]? " response
+                  case $response in
+                      [yY][eE][sS]|[yY]|"")
+                          add_backports=1;;
+                      *)
+                          add_backports=0;;
+                  esac
+              fi
+              if [ "$add_backports" = 1 ]; then
+                  $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
+                  $SUDO apt-get update
+              fi
           fi
       fi
-      $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
-      augeas_pkg=
-
+      if [ "$add_backports" != 0 ]; then
+          $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
+          augeas_pkg=
+      fi
   }
 
 

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -1,8 +1,9 @@
 BootstrapRpmCommon() {
   # Tested with:
-  #   - Fedora 22, 23 (x64)
+  #   - Fedora 20, 21, 22, 23 (x64)
   #   - Centos 7 (x64: on DigitalOcean droplet)
   #   - CentOS 7 Minimal install in a Hyper-V VM
+  #   - CentOS 6 (EPEL must be installed manually)
 
   if type dnf 2>/dev/null
   then
@@ -16,46 +17,49 @@ BootstrapRpmCommon() {
     exit 1
   fi
 
+  pkgs="
+    gcc
+    dialog
+    augeas-libs
+    openssl
+    openssl-devel
+    libffi-devel
+    redhat-rpm-config
+    ca-certificates
+  "
+
   # Some distros and older versions of current distros use a "python27"
   # instead of "python" naming convention. Try both conventions.
-  if ! $SUDO $tool install -y \
-         python \
-         python-devel \
-         python-virtualenv \
-         python-tools \
-         python-pip
-  then
-    if ! $SUDO $tool install -y \
-           python27 \
-           python27-devel \
-           python27-virtualenv \
-           python27-tools \
-           python27-pip
-    then
-      echo "Could not install Python dependencies. Aborting bootstrap!"
-      exit 1
-    fi
+  if $SUDO $tool list python >/dev/null 2>&1; then
+    pkgs="$pkgs
+      python
+      python-devel
+      python-virtualenv
+      python-tools
+      python-pip
+    "
+  else
+    pkgs="$pkgs
+      python27
+      python27-devel
+      python27-virtualenv
+      python27-tools
+      python27-pip
+    "
   fi
-
-  if ! $SUDO $tool install -y \
-         gcc \
-         dialog \
-         augeas-libs \
-         openssl \
-         openssl-devel \
-         libffi-devel \
-         redhat-rpm-config \
-         ca-certificates
-  then
-      echo "Could not install additional dependencies. Aborting bootstrap!"
-      exit 1
-  fi
-
 
   if $SUDO $tool list installed "httpd" >/dev/null 2>&1; then
-    if ! $SUDO $tool install -y mod_ssl
-    then
-      echo "Apache found, but mod_ssl could not be installed."
-    fi
+    pkgs="$pkgs
+      mod_ssl
+    "
+  fi
+
+  if [ "$ASSUME_YES" = 1 ]; then
+    yes_flag="-y"
+  fi
+
+  if ! $SUDO $tool install $yes_flag $pkgs; then
+      echo "Could not install OS dependencies. Aborting bootstrap!"
+      exit 1
   fi
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/suse_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/suse_common.sh
@@ -1,7 +1,12 @@
 BootstrapSuseCommon() {
   # SLE12 don't have python-virtualenv
 
-  $SUDO zypper -nq in -l \
+  if [ "$ASSUME_YES" = 1 ]; then
+    zypper_flags="-nq"
+    install_flags="-l"
+  fi
+
+  $SUDO zypper $zypper_flags in $install_flags \
     python \
     python-devel \
     python-virtualenv \

--- a/letsencrypt-auto-source/pieces/fetch.py
+++ b/letsencrypt-auto-source/pieces/fetch.py
@@ -103,7 +103,7 @@ def verified_new_le_auto(get, tag, temp_dir):
                        stderr=dev_null)
     except CalledProcessError as exc:
         raise ExpectedError("Couldn't verify signature of downloaded "
-                            "letsencrypt-auto.", exc)
+                            "certbot-auto.", exc)
 
 
 def main():

--- a/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
+++ b/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
@@ -1,4 +1,4 @@
-# This is the flattened list of packages letsencrypt-auto installs. To generate
+# This is the flattened list of packages certbot-auto installs. To generate
 # this, do `pip install --no-cache-dir -e acme -e . -e certbot-apache`, and
 # then use `hashin` or a more secure method to gather the hashes.
 

--- a/letsencrypt-auto-source/tests/auto_test.py
+++ b/letsencrypt-auto-source/tests/auto_test.py
@@ -231,7 +231,7 @@ class AutoTests(TestCase):
     * The OpenSSL sig mismatches.
 
     For tests which get to the end, we run merely ``letsencrypt --version``.
-    The functioning of the rest of the letsencrypt script is covered by other
+    The functioning of the rest of the certbot script is covered by other
     test suites.
 
     """
@@ -277,7 +277,7 @@ class AutoTests(TestCase):
                 ok_(re.match(r'letsencrypt \d+\.\d+\.\d+',
                              err.strip().splitlines()[-1]))
                 # Make a few assertions to test the validity of the next tests:
-                self.assertIn('Upgrading letsencrypt-auto ', out)
+                self.assertIn('Upgrading certbot-auto ', out)
                 self.assertIn('Creating virtual environment...', out)
 
                 # Now we have le-auto 99.9.9  and LE 99.9.9 installed. This
@@ -286,14 +286,14 @@ class AutoTests(TestCase):
                 # Test when neither phase-1 upgrade nor phase-2 upgrade is
                 # needed (probably a common case):
                 out, err = run_letsencrypt_auto()
-                self.assertNotIn('Upgrading letsencrypt-auto ', out)
+                self.assertNotIn('Upgrading certbot-auto ', out)
                 self.assertNotIn('Creating virtual environment...', out)
 
                 # Test when a phase-1 upgrade is not needed but a phase-2
                 # upgrade is:
                 set_le_script_version(venv_dir, '0.0.1')
                 out, err = run_letsencrypt_auto()
-                self.assertNotIn('Upgrading letsencrypt-auto ', out)
+                self.assertNotIn('Upgrading certbot-auto ', out)
                 self.assertIn('Creating virtual environment...', out)
 
     def test_openssl_failure(self):
@@ -312,10 +312,10 @@ class AutoTests(TestCase):
                 except CalledProcessError as exc:
                     eq_(exc.returncode, 1)
                     self.assertIn("Couldn't verify signature of downloaded "
-                                  "letsencrypt-auto.",
+                                  "certbot-auto.",
                                   exc.output)
                 else:
-                    self.fail('Signature check on letsencrypt-auto erroneously passed.')
+                    self.fail('Signature check on certbot-auto erroneously passed.')
 
     def test_pip_failure(self):
         """Make sure pip stops us if there is a hash mismatch."""


### PR DESCRIPTION
Fixes #1337, #1903, #2821, and #2848.

`certbot-auto` and `letsencrypt-auto` are the same file by request so that we only have to sign one script during releases. The script changes its behavior based upon the value of `$0`. If `basename $0` is `letsencrypt-auto`, the old behavior is preserved.

I only modified the bootstrap scripts that are officially supported (the ones that are not behind a call to `ExperimentalBootstrap`). It is difficult to test many of the 3rd party bootstrap scripts so I left their behavior the same instead of potentially breaking them. Perhaps we can add support for `--yes` into these scripts at a later date. Since the only way to access them is by using a `--debug` flag, there is less of a promise of the stability.

I unfortunately did not have time to write automated tests for these changes. I was also struggling to run test farm tests, however, I tested every change using docker.

I also did not modify the `letsencrypt-auto-source` directory layout (#2877), point the script to the `certbot` PyPI packages (#2839), or modify the embedded GitHub URL (#2884). I think these changes should occur later, in a subsequent PR.