### PR TITLE
Joyent SmartOS Zone Bootstrap Support [revised]

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -154,7 +154,7 @@ Bootstrap() {
     ExperimentalBootstrap "FreeBSD" BootstrapFreeBsd
   elif uname | grep -iq Darwin ; then
     ExperimentalBootstrap "Mac OS X" BootstrapMac
-  elif grep -iq "Amazon Linux" /etc/issue ; then
+  elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
     ExperimentalBootstrap "Amazon Linux" BootstrapRpmCommon
   else
     echo "Sorry, I don't know how to bootstrap Certbot on your operating system!"

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -122,6 +122,7 @@ DeterminePythonVersion() {
 {{ bootstrappers/gentoo_common.sh }}
 {{ bootstrappers/free_bsd.sh }}
 {{ bootstrappers/mac.sh }}
+{{ bootstrappers/smartos.sh }}
 
 # Install required OS packages:
 Bootstrap() {
@@ -156,6 +157,8 @@ Bootstrap() {
     ExperimentalBootstrap "Mac OS X" BootstrapMac
   elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
     ExperimentalBootstrap "Amazon Linux" BootstrapRpmCommon
+  elif [ -f /etc/product ] && grep -q "Joyent Instance" /etc/product ; then
+    ExperimentalBootstrap "Joyent SmartOS Zone" BootstrapSmartOS
   else
     echo "Sorry, I don't know how to bootstrap Certbot on your operating system!"
     echo

--- a/letsencrypt-auto-source/pieces/bootstrappers/smartos.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/smartos.sh
@@ -1,0 +1,4 @@
+BootstrapSmartOS() {
+  pkgin update
+  pkgin -y install 'gcc49' 'py27-augeas' 'py27-virtualenv'
+}


### PR DESCRIPTION
Initial support for bootstrapping on Joyent SmartOS Zones.

Testing with image: 088b97b0-e1a1-11e5-b895-9baa2086eb33 base-64-lts 15.4.1 smartos zone-dataset 2016-03-04

Also, a small bug fix for Amazon EC2 detection. /etc/issue doesn't exist on some machines. Prior to this patch, smartos zones would print an error message from the grep command.