### PR TITLE
Don't fail authentication when vhost cannot be found

### DIFF
--- a/certbot-apache/certbot_apache/tests/tls_sni_01_test.py
+++ b/certbot-apache/certbot_apache/tests/tls_sni_01_test.py
@@ -4,6 +4,7 @@ import shutil
 
 import mock
 
+from certbot import errors
 from certbot.plugins import common_test
 
 from certbot_apache import obj
@@ -131,6 +132,16 @@ class TlsSniPerformTest(util.ApacheTest):
                 set([obj.Addr.fromstring("_default_:443")]),
                 False, False)
         )
+
+        # pylint: disable=protected-access
+        self.assertEqual(
+            set([obj.Addr.fromstring("*:443")]),
+            self.sni._get_addrs(self.achalls[0]))
+
+    def test_get_addrs_no_vhost_found(self):
+        self.sni.configurator.choose_vhost = mock.Mock(
+            side_effect=errors.MissingCommandlineFlag(
+                "Failed to run Apache plugin non-interactively"))
 
         # pylint: disable=protected-access
         self.assertEqual(

--- a/certbot-apache/certbot_apache/tls_sni_01.py
+++ b/certbot-apache/certbot_apache/tls_sni_01.py
@@ -4,7 +4,7 @@ import os
 import logging
 
 from certbot.plugins import common
-from certbot.errors import PluginError
+from certbot.errors import PluginError, MissingCommandlineFlag
 
 from certbot_apache import obj
 from certbot_apache import parser
@@ -124,7 +124,7 @@ class ApacheTlsSni01(common.TLSSNI01):
 
         try:
             vhost = self.configurator.choose_vhost(achall.domain, temp=True)
-        except PluginError:
+        except (PluginError, MissingCommandlineFlag):
             # We couldn't find the virtualhost for this domain, possibly
             # because it's a new vhost that's not configured yet (GH #677),
             # or perhaps because there were multiple <VirtualHost> sections


### PR DESCRIPTION
It's rather annoying when you cannot renew a certificate LetsEncrypt generated
for you, because the newer version is pickier about parsing Apache config files
and fails to understand typical setups like
```apache
<VirtualHost *:80>
    ServerName example.com
    Redirect permanent / https://example.com
</VirtualHost>
<VirtualHost *:433>
    ServerName example.com
    SSLEngine on
    SSLCertificateFile /etc/letsencrypt/live/example.com/fullchain.pem
    SSLCertificateKeyFile /etc/letsencrypt/live/example.com/privkey.pem
    ...
</VirtualHost>
```
because there are multiple VirtualHost sections in one config file (#1042).

This PR attempts to work around the problem by allowing the Apache
authenticator to proceed without understanding the existing virtual hosts, by
falling back to a sensible default (listen on *:443) when it cannot figure out
what ports were used for the virtual hosts you're trying to authenticate.

Should fix #677 and #2600.

~~I don't expect this PR to be merged as-is, since it lacks tests, but I hope to
push the two bugs mentioned above closer to resolution.  (I can try to add the
tests, with some help perhaps, if the approach seems acceptable to the
LetsEncrypt maintainers.)~~  There are even tests now ;)