### PR TITLE
Randomize serial numbers of DVSNI challenge certificates. [needs revision]

### DIFF
--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -203,7 +203,7 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    cert.set_serial_number(1337)
+    cert.set_serial_number(OpenSSL.rand.bytes(16))
     cert.set_version(2)
 
     extensions = [


### PR DESCRIPTION
Background here:
https://community.letsencrypt.org/t/serial-numbers-of-dvsni-challenge-certificates-are-a-problem/14317/5