### PR TITLE
Release script prep

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -188,9 +188,10 @@ while ! openssl dgst -sha256 -verify $RELEASE_OPENSSL_PUBKEY -signature \
 done
 
 # copy leauto to the root, overwriting the previous release version
+cp -p letsencrypt-auto-source/letsencrypt-auto certbot-auto
 cp -p letsencrypt-auto-source/letsencrypt-auto letsencrypt-auto
 
-git add letsencrypt-auto letsencrypt-auto-source
+git add certbot-auto letsencrypt-auto letsencrypt-auto-source
 git diff --cached
 git commit --gpg-sign="$RELEASE_GPG_KEY" -m "Release $version"
 git tag --local-user "$RELEASE_GPG_KEY" --sign --message "Release $version" "$tag"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -45,7 +45,7 @@ export GPG_TTY=$(tty)
 PORT=${PORT:-1234}
 
 # subpackages to be released
-SUBPKGS=${SUBPKGS:-"acme certbot-apache certbot-nginx letshelp-certbot"}
+SUBPKGS=${SUBPKGS:-"acme certbot-apache certbot-nginx letshelp-certbot letsencrypt letsencrypt-apache letsencrypt-nginx letshelp-letsencrypt"}
 subpkgs_modules="$(echo $SUBPKGS | sed s/-/_/g)"
 # certbot_compatibility_test is not packaged because:
 # - it is not meant to be used by anyone else than Certbot devs
@@ -162,12 +162,12 @@ done
 deactivate
 
 # pin pip hashes of the things we just built
-for pkg in acme certbot certbot-apache ; do
+for pkg in acme certbot certbot-apache letsencrypt letsencrypt-apache ; do
     echo $pkg==$version \\
     pip hash dist."$version/$pkg"/*.{whl,gz} | grep "^--hash" | python2 -c 'from sys import stdin; input = stdin.read(); print "   ", input.replace("\n--hash", " \\\n    --hash"),'
 done > /tmp/hashes.$$
 
-if ! wc -l /tmp/hashes.$$ | grep -qE "^\s*9 " ; then
+if ! wc -l /tmp/hashes.$$ | grep -qE "^\s*15 " ; then
     echo Unexpected pip hash output
     exit 1
 fi


### PR DESCRIPTION
This release script can be used for the next two releases. After that, we should be able to stop building and releasing shim packages.