### PR TITLE
Specify minimum parsedatetime version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     'ConfigArgParse>=0.9.3',
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
-    'parsedatetime',
+    'parsedatetime>=1.3',  # Calendar.parseDT
     'psutil>=2.1.0',  # net_connections introduced in 2.1.0
     'PyOpenSSL',
     'pyrfc3339',


### PR DESCRIPTION
Fixes #2934. Versions of `parsedatetime` before 1.3 will fail with:
```
Traceback (most recent call last):
  File "/home/bmw/Code/letsencrypt/certbot/renewal.py", line 339, in renew_all_lineages
    if should_renew(lineage_config, renewal_candidate):
  File "/home/bmw/Code/letsencrypt/certbot/renewal.py", line 198, in should_renew
    if lineage.should_autorenew(interactive=True):
  File "/home/bmw/Code/letsencrypt/certbot/storage.py", line 718, in should_autorenew
    if expiry < add_time_interval(now, interval):
  File "/home/bmw/Code/letsencrypt/certbot/storage.py", line 50, in add_time_interval
    return textparser.parseDT(interval, base_time, tzinfo=tzinfo)[0]
AttributeError: Calendar instance has no attribute 'parseDT'
```