### PR TITLE
Merge Augeas fix for escaped spaces in arguments

### DIFF
--- a/certbot-apache/certbot_apache/augeas_lens/httpd.aug
+++ b/certbot-apache/certbot_apache/augeas_lens/httpd.aug
@@ -58,8 +58,8 @@ let empty               = Util.empty_dos
 let indent              = Util.indent
 
 (* borrowed from shellvars.aug *)
-let char_arg_dir  = /([^\\ '"{\t\r\n]|[^ '"{\t\r\n]+[^\\ \t\r\n])|\\\\"|\\\\'/
-let char_arg_sec  = /([^\\ '"\t\r\n>]|[^ '"\t\r\n>]+[^\\ \t\r\n>])|\\\\"|\\\\'/
+let char_arg_dir  = /([^\\ '"{\t\r\n]|[^ '"{\t\r\n]+[^\\ \t\r\n])|\\\\"|\\\\'|\\\\ /
+let char_arg_sec  = /([^\\ '"\t\r\n>]|[^ '"\t\r\n>]+[^\\ \t\r\n>])|\\\\"|\\\\'|\\\\ /
 let char_arg_wl   = /([^\\ '"},\t\r\n]|[^ '"},\t\r\n]+[^\\ '"},\t\r\n])/
 
 let cdot = /\\\\./

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/passing/escaped-space-arguments-2735.conf
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/passing/escaped-space-arguments-2735.conf
@@ -1,0 +1,2 @@
+RewriteCond %{HTTP:Content-Disposition} \.php [NC]
+RewriteCond %{THE_REQUEST} ^[A-Z]{3,9}\ /.+/trackback/?\ HTTP/ [NC]


### PR DESCRIPTION
From https://github.com/hercules-team/augeas/commit/f741b8b4f23dd9372dcdea18383ef9138f9c161e

Fixes #2735