### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ systems have packages yet, we provide a temporary solution via the
 ``letsencrypt-auto`` wrapper script, which obtains some dependencies
 from your OS and puts others in a python virtual environment::
 
-  user@webserver:~$ git clone https://github.com/letsencrypt/letsencrypt
+  user@webserver:~$ git clone https://github.com/certbot/certbot
   user@webserver:~$ cd letsencrypt
   user@webserver:~/letsencrypt$ ./letsencrypt-auto --help
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/letsencrypt/letsencrypt | https://github.com/certbot/certbot 
