### PR TITLE
Randomize serial numbers of DVSNI challenge certificates.

### DIFF
--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -203,12 +203,10 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-
     try:
         cert.set_serial_number(int(OpenSSL.rand.bytes(16).encode("hex"), 16))
     except AttributeError:
-        cert.set_serial_number(int.from_bytes(OpenSSL.rand.bytes(16),'big'))
-
+        cert.set_serial_number(int.from_bytes(OpenSSL.rand.bytes(16), 'big'))
     cert.set_version(2)
 
     extensions = [

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -203,7 +203,7 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    cert.set_serial_number(int(OpenSSL.rand.bytes(16).encode("hex"), 16))
+    cert.set_serial_number(int.from_bytes(OpenSSL.rand.bytes(16),'big'))
     cert.set_version(2)
 
     extensions = [

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -206,6 +206,7 @@ def gen_ss_cert(key, domains, not_before=None,
     try:
         cert.set_serial_number(int(OpenSSL.rand.bytes(16).encode("hex"), 16))
     except AttributeError:
+        # pylint: disable=E1101
         cert.set_serial_number(int.from_bytes(OpenSSL.rand.bytes(16), 'big'))
     cert.set_version(2)
 

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -203,7 +203,12 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    cert.set_serial_number(int.from_bytes(OpenSSL.rand.bytes(16),'big'))
+
+    try:
+        cert.set_serial_number(int(OpenSSL.rand.bytes(16).encode("hex"), 16))
+    except AttributeError:
+        cert.set_serial_number(int.from_bytes(OpenSSL.rand.bytes(16),'big'))
+
     cert.set_version(2)
 
     extensions = [

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -1,4 +1,5 @@
 """Crypto utilities."""
+import binascii
 import contextlib
 import logging
 import re
@@ -203,11 +204,7 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    try:
-        cert.set_serial_number(int(OpenSSL.rand.bytes(16).encode("hex"), 16))
-    except AttributeError:
-        # pylint: disable=E1101
-        cert.set_serial_number(int.from_bytes(OpenSSL.rand.bytes(16), 'big'))
+    cert.set_serial_number(int(binascii.hexlify(OpenSSL.rand.bytes(16)), 16))
     cert.set_version(2)
 
     extensions = [

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -203,7 +203,7 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    cert.set_serial_number(1337)
+    cert.set_serial_number(int(OpenSSL.rand.bytes(16).encode("hex"), 16))
     cert.set_version(2)
 
     extensions = [

--- a/acme/acme/crypto_util_test.py
+++ b/acme/acme/crypto_util_test.py
@@ -132,18 +132,18 @@ class RandomSnTest(unittest.TestCase):
     """Test for random certificate serial numbers."""
 
     def setUp(self):
-        self.certCount = 5
-        self.serialNum = []
+        self.cert_count = 5
+        self.serial_num = []
         self.key = OpenSSL.crypto.PKey()
         self.key.generate_key(OpenSSL.crypto.TYPE_RSA, 2048)
 
     def test_sn_collisions(self):
         from acme.crypto_util import gen_ss_cert
 
-        for _ in range(self.certCount):
+        for _ in range(self.cert_count):
             cert = gen_ss_cert(self.key, ['dummy'], force_san=True)
-            self.serialNum.append(cert.get_serial_number())
-        self.assertTrue(len(set(self.serialNum)) > 1)
+            self.serial_num.append(cert.get_serial_number())
+        self.assertTrue(len(set(self.serial_num)) > 1)
 
 
 if __name__ == '__main__':

--- a/acme/acme/crypto_util_test.py
+++ b/acme/acme/crypto_util_test.py
@@ -8,6 +8,8 @@ import unittest
 import six
 from six.moves import socketserver  # pylint: disable=import-error
 
+import OpenSSL
+
 from acme import errors
 from acme import jose
 from acme import test_util
@@ -124,6 +126,24 @@ class PyOpenSSLCertOrReqSANTest(unittest.TestCase):
     def test_csr_idn_sans(self):
         self.assertEqual(self._call_csr('csr-idnsans.pem'),
                          self._get_idn_names())
+
+
+class RandomSnTest(unittest.TestCase):
+    """Test for random certificate serial numbers."""
+
+    def setUp(self):
+        self.certCount = 5
+        self.serialNum = []
+        self.key = OpenSSL.crypto.PKey()
+        self.key.generate_key(OpenSSL.crypto.TYPE_RSA, 2048)
+
+    def test_sn_collisions(self):
+        from acme.crypto_util import gen_ss_cert
+
+        for _ in range(self.certCount):
+            cert = gen_ss_cert(self.key, ['dummy'], force_san=True)
+            self.serialNum.append(cert.get_serial_number())
+        self.assertTrue(len(set(self.serialNum)) > 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Setting all DVSNI challenge certificates to the same serial number (1337) requires the TLS speaking application to load multiple instances of the _same certificate_ (issuer + s/n should uniquely identify a certificate). [Some TLS speakers](http://www.cisco.com/c/en/us/products/security/asa-firepower-services/index.html) aren't happy about this. Discussion on the client forum [here](https://community.letsencrypt.org/t/serial-numbers-of-dvsni-challenge-certificates-are-a-problem).