### PR TITLE
Allow unrecognized fields in Directory object

### DIFF
--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -143,12 +143,6 @@ class Directory(jose.JSONDeSerializable):
 
     def __init__(self, jobj):
         canon_jobj = util.map_keys(jobj, self._canon_key)
-        if not set(canon_jobj).issubset(
-                set(self._REGISTERED_TYPES).union(['meta'])):
-            # TODO: acme-spec is not clear about this: 'It is a JSON
-            # dictionary, whose keys are the "resource" values listed
-            # in {{https-requests}}'
-            raise ValueError('Wrong directory fields')
         # TODO: check that everything is an absolute URL; acme-spec is
         # not clear on that
         self._jobj = canon_jobj
@@ -171,10 +165,7 @@ class Directory(jose.JSONDeSerializable):
     @classmethod
     def from_json(cls, jobj):
         jobj['meta'] = cls.Meta.from_json(jobj.pop('meta', {}))
-        try:
-            return cls(jobj)
-        except ValueError as error:
-            raise jose.DeserializationError(str(error))
+        return cls(jobj)
 
 
 class Resource(jose.JSONObjectWithFields):

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -97,9 +97,9 @@ class DirectoryTest(unittest.TestCase):
             ),
         })
 
-    def test_init_wrong_key_value_error(self):
+    def test_init_wrong_key_value_success(self):  # pylint: disable=no-self-use
         from acme.messages import Directory
-        self.assertRaises(ValueError, Directory, {'foo': 'bar'})
+        Directory({'foo': 'bar'})
 
     def test_getitem(self):
         self.assertEqual('reg', self.dir['new-reg'])
@@ -127,10 +127,9 @@ class DirectoryTest(unittest.TestCase):
             },
         })
 
-    def test_from_json_deserialization_error_on_wrong_key(self):
+    def test_from_json_deserialization_unknown_key_success(self):  # pylint: disable=no-self-use
         from acme.messages import Directory
-        self.assertRaises(
-            jose.DeserializationError, Directory.from_json, {'foo': 'bar'})
+        Directory.from_json({'foo': 'bar'})
 
 
 class RegistrationTest(unittest.TestCase):


### PR DESCRIPTION
This is necessary for forward API compatibility, for instance implementing the `authorizations` and `certificates` fields on the Boulder side.

Fixes #2965