### PR TITLE
Randomize DVSNI challenge certificate serial number, now for python 3.3.

### DIFF
--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -203,7 +203,7 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    cert.set_serial_number(int(OpenSSL.rand.bytes(16).encode("hex"), 16))
+    cert.set_serial_number(int.from_bytes(OpenSSL.rand.bytes(16),'big'))
     cert.set_version(2)
 
     extensions = [

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -203,7 +203,7 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    cert.set_serial_number(1337)
+    cert.set_serial_number(int(OpenSSL.rand.bytes(16).encode("hex"), 16))
     cert.set_version(2)
 
     extensions = [


### PR DESCRIPTION
Today's earlier attempt wasn't python 3.3 friendly. Is a new pull request the right way to handle such a revision? I've no idea. I'm sorry for the clutter, especially if it's the wrong way to go.

Setting all DVSNI challenge certificates to the same serial number (1337) requires the TLS speaking application to load multiple instances of the same certificate (issuer + s/n should uniquely identify a certificate). Some TLS speakers aren't happy about this. Discussion on the client forum [here](https://community.letsencrypt.org/t/serial-numbers-of-dvsni-challenge-certificates-are-a-problem/).