### PR TITLE
Updating broken link to Google Python Style guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -297,7 +297,7 @@ Please:
 4. Remember to use ``pylint``.
 
 .. _Google Python Style Guide:
-  https://google-styleguide.googlecode.com/svn/trunk/pyguide.html
+  https://google.github.io/styleguide/pyguide.html
 .. _Sphinx-style: http://sphinx-doc.org/
 .. _PEP 8 - Style Guide for Python Code:
   https://www.python.org/dev/peps/pep-0008


### PR DESCRIPTION
Old link: https://google-styleguide.googlecode.com/svn/trunk/pyguide.html
New link: https://google.github.io/styleguide/pyguide.html