### PR TITLE
Use kill instead of killpg. [needs revision]

### DIFF
--- a/certbot/plugins/manual.py
+++ b/certbot/plugins/manual.py
@@ -196,7 +196,7 @@ s.serve_forever()" """
                 "cleanup() must be called after perform()")
             if self._httpd.poll() is None:
                 logger.debug("Terminating manual command process")
-                os.killpg(self._httpd.pid, signal.SIGTERM)
+                os.kill(self._httpd.pid, signal.SIGTERM)
             else:
                 logger.debug("Manual command process already terminated "
                              "with %s code", self._httpd.returncode)

--- a/certbot/plugins/manual_test.py
+++ b/certbot/plugins/manual_test.py
@@ -100,13 +100,13 @@ class AuthenticatorTest(unittest.TestCase):
         httpd.poll.return_value = 0
         self.auth_test_mode.cleanup(self.achalls)
 
-    @mock.patch("certbot.plugins.manual.os.killpg", autospec=True)
-    def test_cleanup_test_mode_kills_still_running(self, mock_killpg):
+    @mock.patch("certbot.plugins.manual.os.kill", autospec=True)
+    def test_cleanup_test_mode_kills_still_running(self, mock_kill):
         # pylint: disable=protected-access
         self.auth_test_mode._httpd = httpd = mock.Mock(pid=1234)
         httpd.poll.return_value = None
         self.auth_test_mode.cleanup(self.achalls)
-        mock_killpg.assert_called_once_with(1234, signal.SIGTERM)
+        mock_kill.assert_called_once_with(1234, signal.SIGTERM)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Killpg kills an entire process group and produces unexpected results when run as
part of integration tests running in a noninteractive shell. Specifically, it
kills the entire test rather than just the httpd process.

This was causing problems running Boulder integration tests inside of Docker
with an unprivileged user, because `su buser -c ...` creates a noninteractive
shell. So the integration test would always exit with status 143 after printing
"Terminating manual command process."
