### PR TITLE
Make Docker changes to allow use in tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ RUN /opt/certbot/venv/bin/python /opt/certbot/src/pipstrap.py && \
     -e /opt/certbot/src \
     -e /opt/certbot/src/certbot-apache \
     -e /opt/certbot/src/certbot-nginx
+COPY tests /opt/certbot/src/tests
+COPY examples /opt/certbot/src/examples
 
 # install in editable mode (-e) to save space: it's not possible to
 # "rm -rf /opt/certbot/src" (it's stays in the underlaying image);

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -8,6 +8,8 @@
 #
 # Note: this script is called by Boulder integration test suite!
 
+cd $(basename $0)/..
+
 . ./tests/integration/_common.sh
 export PATH="/usr/sbin:$PATH"  # /usr/sbin/nginx
 


### PR DESCRIPTION
For Boulder we're starting to move towards using Docker images to run our tests.
The certbot Docker image almost has what we need, but we need the test directory
too.