### PR TITLE
Error/Warning with build docker container from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /opt/certbot
 # If <dest> doesn't exist, it is created along with all missing
 # directories in its path.
 
+ENV DEBIAN_FRONTEND=noninteractive
 
 COPY letsencrypt-auto-source/letsencrypt-auto /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto
 RUN /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto --os-packages-only && \


### PR DESCRIPTION
When I try to build container I see in logs 
```
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
```

`DEBIAN_FRONTEND=noninteractive` fixed this warning

docker version - 1.11.1.