### PR TITLE
Don't call os.pid() the default kwargs to atexit_print_messages

### DIFF
--- a/certbot/reporter.py
+++ b/certbot/reporter.py
@@ -16,6 +16,11 @@ from certbot import le_util
 
 logger = logging.getLogger(__name__)
 
+# Store the pid of the process that first imported this module so that
+# atexit_print_messages side-effects such as error reporting can be limited to
+# this process and not any fork()'d children.
+INITIAL_PID = os.getpid()
+
 
 @zope.interface.implementer(interfaces.IReporter)
 class Reporter(object):
@@ -55,12 +60,14 @@ class Reporter(object):
         self.messages.put(self._msg_type(priority, msg, on_crash))
         logger.info("Reporting to user: %s", msg)
 
-    def atexit_print_messages(self, pid=os.getpid()):
+    def atexit_print_messages(self, pid=None):
         """Function to be registered with atexit to print messages.
 
         :param int pid: Process ID
 
         """
+        if pid is None:
+            pid = INITIAL_PID
         # This ensures that messages are only printed from the process that
         # created the Reporter.
         if pid == os.getpid():


### PR DESCRIPTION
Whilst it has no side-effects, this results in non-reproducible output when
generating the certbot documentation:

    http://i.imgur.com/Q6VGi9S.jpg

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>