### PR TITLE
certonly subcommand - If cert_path provided - do not uniquify  it

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -292,7 +292,6 @@ class Client(object):
                 key.pem, crypto_util.dump_pyopenssl_chain(chain),
                 configuration.RenewerConfiguration(self.config.namespace))
 
-           
     def save_certificate(self, certr, chain_cert,
                          cert_path, chain_path, fullchain_path):
         """Saves the certificate received from the ACME server.

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -569,12 +569,22 @@ def view_config_changes(config, num=None):
     rev.view_config_changes(num)
 
 def _open_pem_file(cli_arg_path, pem_path):
+    """Open a pem file.
+
+    If cli_arg_path was set by the client, open that.
+    Otherwise, uniquify the file path.
+
+    :param str cli_arg_path: the cli arg name, e.g. cert_path
+    :param str pem_path: the pem file path to open
+
+    :returns a file object
+    """
     if cli.set_by_cli(cli_arg_path):
         return le_util.safe_open(pem_path, chmod=0o644),\
             os.path.abspath(pem_path)
     else:
         uniq = le_util.unique_file(pem_path, 0o644)
-        return uniq[0], os.path.abspath(uniq)
+        return uniq[0], os.path.abspath(uniq[1])
 
 def _save_chain(chain_pem, chain_file):
     """Saves chain_pem at a unique path based on chain_path.

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -580,7 +580,8 @@ def _open_pem_file(cli_arg_path, pem_path):
     :param str cli_arg_path: the cli arg name, e.g. cert_path
     :param str pem_path: the pem file path to open
 
-    :returns a file object
+    :returns: a tuple of file object and its absolute file path
+
     """
     if cli.set_by_cli(cli_arg_path):
         return le_util.safe_open(pem_path, chmod=0o644),\

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -338,7 +338,7 @@ class Client(object):
                     _open_pem_file('fullchain_path', fullchain_path)
 
             _save_chain(chain_pem, chain_file)
-            _save_chain(cert_pem + chain_pem, fullchain_file
+            _save_chain(cert_pem + chain_pem, fullchain_file)
 
         return abs_cert_path, abs_chain_path, abs_fullchain_path
 

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -328,7 +328,9 @@ class Client(object):
         logger.info("Server issued certificate; certificate written to %s",
                     abs_cert_path)
 
-        if chain_cert:
+        if not chain_cert:
+            return abs_cert_path, None, None
+        else:
             chain_pem = crypto_util.dump_pyopenssl_chain(chain_cert)
 
             chain_file, abs_chain_path =\
@@ -339,7 +341,7 @@ class Client(object):
             _save_chain(chain_pem, chain_file)
             _save_chain(cert_pem + chain_pem, fullchain_file)
 
-        return abs_cert_path, abs_chain_path, abs_fullchain_path
+            return abs_cert_path, abs_chain_path, abs_fullchain_path
 
     def deploy_certificate(self, domains, privkey_path,
                            cert_path, chain_path, fullchain_path):

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -24,6 +24,7 @@ from certbot import interfaces
 from certbot import le_util
 from certbot import reverter
 from certbot import storage
+from certbot import cli
 
 from certbot.display import ops as display_ops
 from certbot.display import enhancements
@@ -318,7 +319,7 @@ class Client(object):
         cert_pem = OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_PEM, certr.body.wrapped)
 
-        if cert_path != constants.CLI_DEFAULTS['auth_cert_path']:
+        if cli.set_by_cli('cert_path'):
             cert_file = le_util.safe_open(cert_path, chmod=0o644)
             act_cert_path = cert_path
         else:

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -292,6 +292,7 @@ class Client(object):
                 key.pem, crypto_util.dump_pyopenssl_chain(chain),
                 configuration.RenewerConfiguration(self.config.namespace))
 
+           
     def save_certificate(self, certr, chain_cert,
                          cert_path, chain_path, fullchain_path):
         """Saves the certificate received from the ACME server.
@@ -318,12 +319,15 @@ class Client(object):
 
         cert_pem = OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_PEM, certr.body.wrapped)
-
+        """
         if cli.set_by_cli('cert_path'):
             cert_file = le_util.safe_open(cert_path, chmod=0o644)
             act_cert_path = cert_path
         else:
             cert_file, act_cert_path = le_util.unique_file(cert_path, 0o644)
+        """
+        cert_file, act_cert_path = _open_pem_file('cert_path', cert_path)
+        #import ipdb; ipdb.set_trace
 
         try:
             cert_file.write(cert_pem)
@@ -331,7 +335,14 @@ class Client(object):
             cert_file.close()
         logger.info("Server issued certificate; certificate written to %s",
                     act_cert_path)
-
+        
+        if cli.set_by_cli('chain_path'):
+            #import ipdb; ipdb.set_trace()
+            pass
+        if cli.set_by_cli('fullchain_path'):
+            #import ipdb; ipdb.set_trace()
+            pass
+        
         cert_chain_abspath = None
         fullchain_abspath = None
         if chain_cert:
@@ -569,6 +580,11 @@ def view_config_changes(config, num=None):
     rev.recovery_routine()
     rev.view_config_changes(num)
 
+def _open_pem_file(cli_arg_path, pem_path):
+    if cli.set_by_cli(cli_arg_path):
+        return le_util.safe_open(pem_path, chmod=0o644), pem_path 
+    else:
+        return le_util.unique_file(pem_path, 0o644)
 
 def _save_chain(chain_pem, chain_path):
     """Saves chain_pem at a unique path based on chain_path.

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -317,7 +317,13 @@ class Client(object):
 
         cert_pem = OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_PEM, certr.body.wrapped)
-        cert_file, act_cert_path = le_util.unique_file(cert_path, 0o644)
+
+        if cert_path != constants.CLI_DEFAULTS['auth_cert_path']:
+            cert_file = le_util.safe_open(cert_path, chmod=0o644)
+            act_cert_path = cert_path
+        else:
+            cert_file, act_cert_path = le_util.unique_file(cert_path, 0o644)
+
         try:
             cert_file.write(cert_pem)
         finally:

--- a/certbot/le_util.py
+++ b/certbot/le_util.py
@@ -151,7 +151,8 @@ def _unique_file(path, filename_pat, count, mode):
     while True:
         current_path = os.path.join(path, filename_pat(count))
         try:
-            return safe_open(current_path, chmod=mode), current_path
+            return safe_open(current_path, chmod=mode),\
+                os.path.abspath(current_path)
         except OSError as err:
             # "File exists," is okay, try a different name.
             if err.errno != errno.EEXIST:

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -221,7 +221,9 @@ class ClientTest(unittest.TestCase):
             mock.sentinel.key, domains, self.config.csr_dir)
         self._check_obtain_certificate()
 
-    def test_save_certificate(self):
+    @mock.patch("certbot.cli.helpful_parser")
+    def test_save_certificate(self, mock_parser):
+        # pylint: disable=too-many-locals
         certs = ["matching_cert.pem", "cert.pem", "cert-san.pem"]
         tmp_path = tempfile.mkdtemp()
         os.chmod(tmp_path, 0o755)  # TODO: really??
@@ -232,6 +234,10 @@ class ClientTest(unittest.TestCase):
         candidate_cert_path = os.path.join(tmp_path, "certs", "cert.pem")
         candidate_chain_path = os.path.join(tmp_path, "chains", "chain.pem")
         candidate_fullchain_path = os.path.join(tmp_path, "chains", "fullchain.pem")
+        mock_parser.verb = "certonly"
+        mock_parser.args = ["--cert-path", candidate_cert_path,
+                "--chain-path", candidate_chain_path,
+                "--fullchain-path", candidate_fullchain_path]
 
         cert_path, chain_path, fullchain_path = self.client.save_certificate(
             certr, chain_cert, candidate_cert_path, candidate_chain_path,

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -44,7 +44,7 @@ common auth --csr "$CSR_PATH" \
        --cert-path "${root}/csr/cert.pem" \
        --chain-path "${root}/csr/chain.pem"
 openssl x509 -in "${root}/csr/cert.pem" -text
-openssl x509 -in "${root}/csr/0000_chain.pem" -text
+openssl x509 -in "${root}/csr/chain.pem" -text
 
 common --domains le3.wtf install \
        --cert-path "${root}/csr/cert.pem" \

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -43,7 +43,7 @@ export CSR_PATH="${root}/csr.der" KEY_PATH="${root}/key.pem" \
 common auth --csr "$CSR_PATH" \
        --cert-path "${root}/csr/cert.pem" \
        --chain-path "${root}/csr/chain.pem"
-openssl x509 -in "${root}/csr/0000_cert.pem" -text
+openssl x509 -in "${root}/csr/cert.pem" -text
 openssl x509 -in "${root}/csr/0000_chain.pem" -text
 
 common --domains le3.wtf install \


### PR DESCRIPTION
Fixes #1505. 
`certbot` will now uniquify (prepend a number to the file) the cert_path only if it wasn't specifically provided by the client.
