### PR TITLE
Make certbot-auto quieter without implementing --quiet

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -899,13 +899,12 @@ UNLIKELY_EOF
     echo "Installation succeeded."
   fi
   echo "Requesting root privileges to run certbot..."
+  echo "  $VENV_BIN/letsencrypt" "$@"
   if [ -z "$SUDO_ENV" ] ; then
     # SUDO is su wrapper / noop
-    echo "  " $SUDO "$VENV_BIN/letsencrypt" "$@"
     $SUDO "$VENV_BIN/letsencrypt" "$@"
   else
     # sudo
-    echo "  " $SUDO "$SUDO_ENV" "$VENV_BIN/letsencrypt" "$@"
     $SUDO "$SUDO_ENV" "$VENV_BIN/letsencrypt" "$@"
   fi
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -898,8 +898,11 @@ UNLIKELY_EOF
     fi
     echo "Installation succeeded."
   fi
-  echo "Requesting root privileges to run certbot..."
-  echo "  $VENV_BIN/letsencrypt" "$@"
+  if [ -n "$SUDO" ]; then
+    # SUDO is su wrapper or sudo
+    echo "Requesting root privileges to run certbot..."
+    echo "  $VENV_BIN/letsencrypt" "$@"
+  fi
   if [ -z "$SUDO_ENV" ] ; then
     # SUDO is su wrapper / noop
     $SUDO "$VENV_BIN/letsencrypt" "$@"

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -452,6 +452,11 @@ BootstrapMac() {
   fi
 }
 
+BootstrapSmartOS() {
+  pkgin update
+  pkgin -y install 'gcc49' 'py27-augeas' 'py27-virtualenv'
+}
+
 
 # Install required OS packages:
 Bootstrap() {
@@ -484,8 +489,10 @@ Bootstrap() {
     ExperimentalBootstrap "FreeBSD" BootstrapFreeBsd
   elif uname | grep -iq Darwin ; then
     ExperimentalBootstrap "Mac OS X" BootstrapMac
-  elif grep -iq "Amazon Linux" /etc/issue ; then
+  elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
     ExperimentalBootstrap "Amazon Linux" BootstrapRpmCommon
+  elif [ -f /etc/product ] && grep -q "Joyent Instance" /etc/product ; then
+    ExperimentalBootstrap "Joyent SmartOS Zone" BootstrapSmartOS
   else
     echo "Sorry, I don't know how to bootstrap Certbot on your operating system!"
     echo

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -931,7 +931,6 @@ else
   fi
 
   if [ "$NO_SELF_UPGRADE" != 1 ]; then
-    echo "Checking for new version..."
     TEMP_DIR=$(TempDir)
     # ---------------------------------------------------------------------------
     cat << "UNLIKELY_EOF" > "$TEMP_DIR/fetch.py"

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -68,6 +68,12 @@ for arg in "$@" ; do
   esac
 done
 
+if [ $BASENAME = "letsencrypt-auto" ]; then
+  # letsencrypt-auto does not respect --help or --yes for backwards compatibility
+  ASSUME_YES=1
+  HELP=0
+fi
+
 # certbot-auto needs root access to bootstrap OS dependencies, and
 # certbot itself needs root access for almost all modes of operation
 # The "normal" case is that sudo is used for the steps that need root, but
@@ -105,12 +111,6 @@ if test "`id -u`" -ne "0" ; then
   fi
 else
   SUDO=
-fi
-
-if [ $BASENAME = "letsencrypt-auto" ]; then
-  # letsencrypt-auto does not respect --help or --yes for backwards compatibility
-  ASSUME_YES=1
-  HELP=0
 fi
 
 ExperimentalBootstrap() {

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -256,13 +256,12 @@ UNLIKELY_EOF
     echo "Installation succeeded."
   fi
   echo "Requesting root privileges to run certbot..."
+  echo "  $VENV_BIN/letsencrypt" "$@"
   if [ -z "$SUDO_ENV" ] ; then
     # SUDO is su wrapper / noop
-    echo "  " $SUDO "$VENV_BIN/letsencrypt" "$@"
     $SUDO "$VENV_BIN/letsencrypt" "$@"
   else
     # sudo
-    echo "  " $SUDO "$SUDO_ENV" "$VENV_BIN/letsencrypt" "$@"
     $SUDO "$SUDO_ENV" "$VENV_BIN/letsencrypt" "$@"
   fi
 

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -255,8 +255,11 @@ UNLIKELY_EOF
     fi
     echo "Installation succeeded."
   fi
-  echo "Requesting root privileges to run certbot..."
-  echo "  $VENV_BIN/letsencrypt" "$@"
+  if [ -n "$SUDO" ]; then
+    # SUDO is su wrapper or sudo
+    echo "Requesting root privileges to run certbot..."
+    echo "  $VENV_BIN/letsencrypt" "$@"
+  fi
   if [ -z "$SUDO_ENV" ] ; then
     # SUDO is su wrapper / noop
     $SUDO "$VENV_BIN/letsencrypt" "$@"

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -288,7 +288,6 @@ else
   fi
 
   if [ "$NO_SELF_UPGRADE" != 1 ]; then
-    echo "Checking for new version..."
     TEMP_DIR=$(TempDir)
     # ---------------------------------------------------------------------------
     cat << "UNLIKELY_EOF" > "$TEMP_DIR/fetch.py"

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -68,6 +68,12 @@ for arg in "$@" ; do
   esac
 done
 
+if [ $BASENAME = "letsencrypt-auto" ]; then
+  # letsencrypt-auto does not respect --help or --yes for backwards compatibility
+  ASSUME_YES=1
+  HELP=0
+fi
+
 # certbot-auto needs root access to bootstrap OS dependencies, and
 # certbot itself needs root access for almost all modes of operation
 # The "normal" case is that sudo is used for the steps that need root, but
@@ -105,12 +111,6 @@ if test "`id -u`" -ne "0" ; then
   fi
 else
   SUDO=
-fi
-
-if [ $BASENAME = "letsencrypt-auto" ]; then
-  # letsencrypt-auto does not respect --help or --yes for backwards compatibility
-  ASSUME_YES=1
-  HELP=0
 fi
 
 ExperimentalBootstrap() {


### PR DESCRIPTION
Fixes #2990. I think this PR should be preferred to one that adds `certbot-auto` support for `--quiet`.

Initially, I planned to provide `--quiet` support for the whole script, including bootstrapping and setting up the `virtualenv`. The problem with this is these steps don't happen very often and the output is often something the user should care about.

With this in mind, I set out to only implement `--quiet` support for the non-upgrading case. I did this in #3015 and then realized there are only two places where we output anything.

1. We output "Checking for new version..." on every single run. This seems very excessive. I believe we are very clear that `certbot-auto` is a self updating script and this output is just clutter. I removed it entirely.
2. We output "Requesting root privileges to run certbot..." on every run, even if we already have root. After fixing the bug of always showing this prompt, I hid it when using `--quiet`, however, if we're about use su/sudo to run `certbot`, we will likely be prompting you to enter a password. Asking for a `sudo` password with no context is a bad idea and isn't likely to be useful in the renewal case either. Therefore, to fix this problem, I only print these messages if we're about to use su/sudo.

And...that fixes the problem! The fact we were able to do this without further complicated our temporary `certbot-auto` script is a win in my opinion and there is little to nothing to be gained by implementing `--quiet` on top of this PR.

Please let me know if you disagree!

EDIT: I didn't list it explicitly, but we also output if we're going to use `su` instead of `sudo`. Again, if we're using `su`, we're likely going to prompt so I didn't see this as a problem.