### PR TITLE
Remove dangling footnote

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -552,10 +552,3 @@ Beyond the methods discussed here, other methods may be possible, such as
 installing Certbot directly with pip from PyPI or downloading a ZIP
 archive from GitHub may be technically possible but are not presently
 recommended or supported.
-
-
-.. rubric:: Footnotes
-
-.. [#venv] By using this virtualized Python environment (`virtualenv
-           <https://virtualenv.pypa.io>`_) we don't pollute the main
-           OS space with packages from PyPI!


### PR DESCRIPTION
This footnote has no references!

I checked by searching for `#venv`, since [the ReST docs](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#footnotes) tell me a reference ought to look like `[#venv]_`.