### PR TITLE
Hook validation: skip leading spaces/newlines

### DIFF
--- a/certbot/hooks.py
+++ b/certbot/hooks.py
@@ -27,7 +27,7 @@ def _validate_hook(shell_cmd, hook_name):
     :raises .errors.HookCommandNotFound: if the command is not found
     """
     if shell_cmd:
-        cmd = shell_cmd.partition(" ")[0]
+        cmd = shell_cmd.split(None, 1)[0]
         if not _prog(cmd):
             path = os.environ["PATH"]
             msg = "Unable to find {2}-hook command {0} in the PATH.\n(PATH is {1})".format(


### PR DESCRIPTION
Improves the situation with #3020 a bit.

Does nothing about other valid shell commands that the current validation would reject:

  - shell builtins like `--post-hook 'if [ -x /my/script ]; then /my/script; fi'`
  - variable assignments like `--post-hook 'ENV_VAR=value command'`
  - comments
  - redirections like `--post-hook '<infile command'`
  - I'm sure I'm missing many other exciting possibilities

Still, I believe this is a step in the right direction and therefore ask you to please merge it (assuming I haven't broken any tests).