### PR TITLE
Fixes Certbot for OS X

### DIFF
--- a/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
@@ -16,12 +16,11 @@ BootstrapMac() {
 
   $pkgcmd augeas
   $pkgcmd dialog
-  if [ "$(which python)" = "/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python" ]; then
-    # We want to avoid using the system Python because it requires root to use pip.
-    # python.org, MacPorts or HomeBrew Python installations should all be OK.
-    echo "Installing python..."
-    $pkgcmd python
-  fi
+
+  # We want to avoid using the system Python because it requires root to use pip.
+  # python.org, MacPorts or HomeBrew Python installations should all be OK.
+  echo "Installing python..."
+  $pkgcmd python
 
   # Workaround for _dlopen not finding augeas on OS X
   if [ "$pkgman" = "port" ] && ! [ -e "/usr/local/lib/libaugeas.dylib" ] && [ -e "/opt/local/lib/libaugeas.dylib" ]; then


### PR DESCRIPTION
This commit removes the condition that checks for Python's path. The hard-coded path is incorrect since in OS X 10.11 Python is installed in /usr/bin/python. Removing the condition makes sense because any of the software we use to install Python should return a "Already installed" message if Python is installed.