### PR TITLE
Remove reference to letsencrypt-auto in error message [revision requested]

### DIFF
--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -267,7 +267,7 @@ def diagnose_configurator_problem(cfg_type, requested, plugins):
         else:
             # XXX update this logic as we make progress on #788 and nginx support
             msg = ('No installers are available on your OS yet; try running '
-                   '"letsencrypt-auto certonly" to get a cert you can install manually')
+                   '"certbot-auto certonly" to get a cert you can install manually')
     else:
         msg = "{0} could not be determined or is not installed".format(cfg_type)
     raise errors.PluginSelectionError(msg)


### PR DESCRIPTION
Ran into this on FreeBSD. Quick fix although it'd probably be better to set it up so that it uses the name of the script being run rather than hardcoding a name.
