### PR TITLE
Typo: too many self's

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -500,7 +500,7 @@ class DNS(_TokenChallenge):
 
         """
         return DNSResponse(validation=self.gen_validation(
-            self, account_key, **kwargs))
+            account_key, **kwargs))
 
     def validation_domain_name(self, name):
         """Domain name for TXT validation record.


### PR DESCRIPTION
The extra self will push along the arguments, resulting in the accurate but not very helpful error message: "AttributeError: 'JWKRSA' object has no attribute 'kty'"