### PR TITLE
Adding OS X 10.11 test to Travis [revision requested]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
       env: TOXENV=cover
       before_install:
         - "travis_retry brew update"
-        - "travis_retry brew install python augeas dialog"
+        - "travis_retry brew install augeas dialog"
 
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-`. This reduces the number of simultaneous Travis runs, which speeds

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,10 +92,14 @@ matrix:
     - python: "2.7"
       env: TOXENV=nginxroundtrip
     - os: osx
+      # Cryptography no longer supports OpenSSL 0.9.8, which
+      # is the versionprovided by the default OS X image
       osx_image: xcode7.3
       language: generic
       env: TOXENV=cover
-      before_install: "travis_retry brew install python augeas dialog"
+      before_install:
+        - "travis_retry brew update"
+        - "travis_retry brew install python augeas dialog"
 
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-`. This reduces the number of simultaneous Travis runs, which speeds

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,12 +93,9 @@ matrix:
       env: TOXENV=nginxroundtrip
     - os: osx
       osx_image: xcode7.3
-      sudo: required
       language: generic
       env: TOXENV=cover
       before_install: "travis_retry brew install python augeas dialog"
-      install: "travis_retry pip install tox coveralls"
-      script: 'travis_retry tox && ([ "xxx$BOULDER_INTEGRATION" = "xxx" ] || ./tests/travis-integration.sh)'
 
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-`. This reduces the number of simultaneous Travis runs, which speeds

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,14 @@ matrix:
       env: TOXENV=py36
     - python: "2.7"
       env: TOXENV=nginxroundtrip
-
+    - os: osx
+      osx_image: xcode7.3
+      sudo: required
+      language: generic
+      env: TOXENV=cover
+      before_install: "travis_retry brew install python augeas dialog"
+      install: "travis_retry pip install tox coveralls"
+      script: 'travis_retry tox && ([ "xxx$BOULDER_INTEGRATION" = "xxx" ] || ./tests/travis-integration.sh)'
 
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-`. This reduces the number of simultaneous Travis runs, which speeds

--- a/acme/acme/standalone_test.py
+++ b/acme/acme/standalone_test.py
@@ -137,7 +137,6 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
         )
         self.old_cwd = os.getcwd()
         os.chdir(self.test_cwd)
-        self.thread.start()
 
     def tearDown(self):
         os.chdir(self.old_cwd)
@@ -146,6 +145,8 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
 
     def test_it(self):
         max_attempts = 5
+        started = False
+
         while max_attempts:
             max_attempts -= 1
             try:
@@ -153,7 +154,12 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
                     b'localhost', b'0.0.0.0', self.port)
             except errors.Error:
                 self.assertTrue(max_attempts > 0, "Timeout!")
-                time.sleep(1)  # wait until thread starts
+                if started:
+                    # Wait until thread starts
+                    time.sleep(1)
+                else:
+                    self.thread.start()
+                    started = True
             else:
                 self.assertEqual(jose.ComparableX509(cert),
                                  test_util.load_comparable_cert(

--- a/acme/acme/standalone_test.py
+++ b/acme/acme/standalone_test.py
@@ -154,12 +154,12 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
                     b'localhost', b'0.0.0.0', self.port)
             except errors.Error:
                 self.assertTrue(max_attempts > 0, "Timeout!")
-                if started:
-                    # Wait until thread starts
-                    time.sleep(1)
-                else:
+                if not started:
                     self.thread.start()
                     started = True
+                # Wait until thread starts. This line should remain outside
+                # the if condition to avoid coverage missing line false positive
+                time.sleep(1)
             else:
                 self.assertEqual(jose.ComparableX509(cert),
                                  test_util.load_comparable_cert(

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -589,14 +589,14 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 if realpath not in vhost_paths.keys():
                     vhs.append(new_vhost)
                     vhost_paths[realpath] = new_vhost.filep
-                elif realpath == new_vhost.filep:
+                elif not os.path.islink(new_vhost.filep):
                     # Prefer "real" vhost paths instead of symlinked ones
                     # ex: sites-enabled/vh.conf -> sites-available/vh.conf
 
                     # remove old (most likely) symlinked one
                     vhs = [v for v in vhs if v.filep != vhost_paths[realpath]]
                     vhs.append(new_vhost)
-                    vhost_paths[realpath] = realpath
+                    vhost_paths[realpath] = new_vhost.filep
 
         return vhs
 


### PR DESCRIPTION
The tests currently don't work because the exception raised here https://github.com/certbot/certbot/blob/master/acme/acme/crypto_util.py#L134 and the code written here https://github.com/certbot/certbot/blob/master/acme/acme/standalone_test.py#L146 isn't executed.

Adding tests that provoke an error never work for some reason. I'm testing on OS X, and after adding the following after the `test_it` function in `standalone_test.py`, the tests kept running forever.

``` python
    def test_failure(self):
        self.assertRaises(errors.Error, crypto_util.probe_sni, b'localhost', b'0.0.0.0', 1235)
```

I have absolutely no idea why does that happen. Even setting the port to the default 1234 doesn't work, and the tests keep running forever.

Furthermore, the tests fail on order versions of OS X because of the outdated `setuptools` package. That's why I'm forced the use of OS X 10.11 for now at least.

PR addresses issue #2978 
