### PR TITLE
Fixing package names for Debian Jessie

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -460,7 +460,7 @@ repo, if you have not already done so. Then run:
 
 .. code-block:: shell
 
-   sudo apt-get install certbot python-certbot-apache -t jessie-backports
+   sudo apt-get install letsencrypt python-letsencrypt-apache -t jessie-backports
 
 **Fedora**
 


### PR DESCRIPTION
Certbot packages don't exist in Jessie backports