### PR TITLE
Run Boulder via docker-compose in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 # test has failed
 env:
   global:
-    - BOULDERPATH=$GOPATH/src/github.com/letsencrypt/boulder/
+    - BOULDERPATH=$PWD/boulder/
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,18 @@ cache:
     directories:
         - $HOME/.cache/pip
 
-services:
-  - rabbitmq
-  - mariadb
-  # apacheconftest
-  #- apache2
+# This makes sure we get a host with docker-compose present.
+dist: trusty
 
-# http://docs.travis-ci.com/user/ci-environment/#CI-environment-OS
-# gimme has to be kept in sync with Boulder's Go version setting in .travis.yml
 before_install:
   - 'dpkg -s libaugeas0'
-  - '[ "xxx$BOULDER_INTEGRATION" = "xxx" ] || eval "$(gimme 1.5.1)"'
 
 # using separate envs with different TOXENVs creates 4x1 Travis build
 # matrix, which allows us to clearly distinguish which component under
 # test has failed
 env:
   global:
-    - GOPATH=/tmp/go
-    - PATH=$GOPATH/bin:$PATH
-    - GO15VENDOREXPERIMENT=1  # Fixes problems with vendor directories
+    - BOULDERPATH=$GOPATH/src/github.com/letsencrypt/boulder/
 
 matrix:
   include:
@@ -93,7 +85,6 @@ addons:
     - boulder
     - boulder-mysql
     - boulder-rabbitmq
-  mariadb: "10.0"
   apt:
     sources:
     - augeas
@@ -109,13 +100,11 @@ addons:
     # For certbot-nginx integration testing
     - nginx-light
     - openssl
-    # For Boulder integration testing
-    - rsyslog
     # for apacheconftest
-    #- apache2
-    #- libapache2-mod-wsgi
-    #- libapache2-mod-macro
-    #- sudo
+    - apache2
+    - libapache2-mod-wsgi
+    - libapache2-mod-macro
+    - sudo
 
 install: "travis_retry pip install tox coveralls"
 script: 'travis_retry tox && ([ "xxx$BOULDER_INTEGRATION" = "xxx" ] || ./tests/travis-integration.sh)'

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -1,40 +1,10 @@
 #!/bin/bash
 # Download and run Boulder instance for integration testing
-
-# ugh, go version output is like:
-# go version go1.4.2 linux/amd64
-GOVER=`go version | cut -d" " -f3 | cut -do -f2`
-
-# version comparison
-function verlte {
-  #OS X doesn't support version sorting; emulate with sed
-  if [ `uname` == 'Darwin' ]; then
-    [ "$1" = "`echo -e \"$1\n$2\" |  sed 's/\b\([0-9]\)\b/0\1/g' \
-      | sort | sed 's/\b0\([0-9]\)/\1/g' | head -n1`" ]
-  else
-    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
-  fi
-}
-
-if ! verlte 1.5 "$GOVER" ; then
-  echo "We require go version 1.5 or later; you have... $GOVER"
-  exit 1
-fi
-
 set -xe
 
-# `/...` avoids `no buildable Go source files` errors, for more info
-# see `go help packages`
-go get -d github.com/letsencrypt/boulder/...
-cd $GOPATH/src/github.com/letsencrypt/boulder
-# goose is needed for ./test/create_db.sh
-wget https://github.com/jsha/boulder-tools/raw/master/goose.gz && \
-  mkdir $GOPATH/bin && \
-  zcat goose.gz > $GOPATH/bin/goose && \
-  chmod +x $GOPATH/bin/goose
-./test/create_db.sh
-go run cmd/rabbitmq-setup/main.go -server amqp://localhost
-# listenbuddy is needed for ./start.py
-go get github.com/jsha/listenbuddy
-cd -
+# Check out special branch until latest docker changes land in Boulder master.
+git clone -b rev-rev https://github.com/letsencrypt/boulder $BOULDERPATH
+cd $BOULDERPATH
+sed -i 's/FAKE_DNS: .*/FAKE_DNS: 172.17.42.1/' docker-compose.yml
+docker-compose up -d
 

--- a/tests/letstest/scripts/boulder_install.sh
+++ b/tests/letstest/scripts/boulder_install.sh
@@ -2,27 +2,8 @@
 
 # >>>> only tested on Ubuntu 14.04LTS <<<<
 
-# non-interactive install of mariadb and other dependencies
-export DEBIAN_FRONTEND=noninteractive
-sudo debconf-set-selections <<< 'mariadb-server mysql-server/root_password password PASS'
-sudo debconf-set-selections <<< 'mariadb-server mysql-server/root_password_again password PASS'
-apt-get -y --no-upgrade install git make libltdl3-dev mariadb-server rabbitmq-server
-sudo mysql -uroot -pPASS -e "SET PASSWORD = PASSWORD(\'\');"
-
-# install go
-wget https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz
-tar xzvf go1.5.1.linux-amd64.tar.gz
-mkdir gocode
-echo "export GOROOT=/home/ubuntu/go \n\
-      export GOPATH=/home/ubuntu/gocode\n\
-      export PATH=/home/ubuntu/go/bin:/home/ubuntu/gocode/bin:$PATH" >> .bashrc
-
-# install boulder and its go dependencies
-go get -d github.com/letsencrypt/boulder/...
-cd $GOPATH/src/github.com/letsencrypt/boulder
-wget https://github.com/jsha/boulder-tools/raw/master/goose.gz
-mkdir $GOPATH/bin
-zcat goose.gz > $GOPATH/bin/goose
-chmod +x $GOPATH/bin/goose
-./test/create_db.sh
-go get github.com/jsha/listenbuddy
+# Check out special branch until latest docker changes land in Boulder master.
+git clone -b rev-rev https://github.com/letsencrypt/boulder $BOULDERPATH
+cd $BOULDERPATH
+sed -i 's/FAKE_DNS: .*/FAKE_DNS: 172.17.42.1/' docker-compose.yml
+docker-compose up -d

--- a/tests/travis-integration.sh
+++ b/tests/travis-integration.sh
@@ -6,14 +6,9 @@ set -o errexit
 
 source .tox/$TOXENV/bin/activate
 
-export CERTBOT_PATH=`pwd`
+until curl http://boulder:4000/directory 2>/dev/null; do
+  echo waiting for boulder
+  sleep 1
+done
 
-cd $GOPATH/src/github.com/letsencrypt/boulder/
-
-# boulder's integration-test.py has code that knows to start and wait for the
-# boulder processes to start reliably and then will run the certbot
-# boulder-interation.sh on its own. The --certbot flag says to run only the
-# certbot tests (instead of any other client tests it might run). We're
-# going to want to define a more robust interaction point between the boulder
-# and certbot tests, but that will be better built off of this.
-python test/integration-test.py --certbot
+./tests/boulder-integration.sh


### PR DESCRIPTION
This removes a lot of setup code we used to need in order to get Boulder to run,
and should reduce brittleness of tests based on Boulder changes.

This also unblocks Boulder from upgrading to MariaDB 10.1 in integration tests,
since changing to 10.1 syntax for user creation would break the current certbot
integration tests (which run 10.0).

Note: the apacheconftest task was failing until I uncommented the .travis.yml section that installs apache. Is that correct?