### PR TITLE
Check out Boulder master instead of branch.

### DIFF
--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # Check out special branch until latest docker changes land in Boulder master.
-git clone -b rev-rev https://github.com/letsencrypt/boulder $BOULDERPATH
+git clone https://github.com/letsencrypt/boulder $BOULDERPATH
 cd $BOULDERPATH
 sed -i 's/FAKE_DNS: .*/FAKE_DNS: 172.17.42.1/' docker-compose.yml
 docker-compose up -d

--- a/tests/letstest/scripts/boulder_install.sh
+++ b/tests/letstest/scripts/boulder_install.sh
@@ -3,7 +3,7 @@
 # >>>> only tested on Ubuntu 14.04LTS <<<<
 
 # Check out special branch until latest docker changes land in Boulder master.
-git clone -b rev-rev https://github.com/letsencrypt/boulder $BOULDERPATH
+git clone https://github.com/letsencrypt/boulder $BOULDERPATH
 cd $BOULDERPATH
 sed -i 's/FAKE_DNS: .*/FAKE_DNS: 172.17.42.1/' docker-compose.yml
 docker-compose up -d


### PR DESCRIPTION
We temporarily had the integration tests checking out a branch of Boulder while we waited to land some code. Now that code is in master and we can remove the branch flag.