### PR TITLE
Revert "Pin old pkginfo version"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ dev_extras = [
     'nose',
     'nosexcover',
     'pep8',
-    'pkginfo<=1.2.1',
     'pylint==1.4.2',  # upstream #248
     'tox',
     'twine',


### PR DESCRIPTION
This reverts commit 4919814dd17bdb8a7b0100ac89a5196cb4766310.

`pkginfo` has a new release fixing the problem.