### PR TITLE
0.7.0 release script prep

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -176,7 +176,7 @@ if ! wc -l /tmp/hashes.$$ | grep -qE "^\s*15 " ; then
 fi
 
 # perform hideous surgery on requirements.txt...
-head -n -9 letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt > /tmp/req.$$
+head -n -15 letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt > /tmp/req.$$
 cat /tmp/hashes.$$ >> /tmp/req.$$
 cp /tmp/req.$$ letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -45,7 +45,7 @@ export GPG_TTY=$(tty)
 PORT=${PORT:-1234}
 
 # subpackages to be released
-SUBPKGS=${SUBPKGS:-"acme certbot-apache certbot-nginx letshelp-certbot letsencrypt letsencrypt-apache letsencrypt-nginx letshelp-letsencrypt"}
+SUBPKGS=${SUBPKGS:-"acme certbot-apache certbot-nginx letsencrypt letsencrypt-apache letsencrypt-nginx"}
 subpkgs_modules="$(echo $SUBPKGS | sed s/-/_/g)"
 # certbot_compatibility_test is not packaged because:
 # - it is not meant to be used by anyone else than Certbot devs

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -162,13 +162,13 @@ for module in certbot $subpkgs_modules ; do
     echo testing $module
     nosetests $module
 done
-deactivate
 
 # pin pip hashes of the things we just built
 for pkg in acme certbot certbot-apache letsencrypt letsencrypt-apache ; do
     echo $pkg==$version \\
     pip hash dist."$version/$pkg"/*.{whl,gz} | grep "^--hash" | python2 -c 'from sys import stdin; input = stdin.read(); print "   ", input.replace("\n--hash", " \\\n    --hash"),'
 done > /tmp/hashes.$$
+deactivate
 
 if ! wc -l /tmp/hashes.$$ | grep -qE "^\s*15 " ; then
     echo Unexpected pip hash output


### PR DESCRIPTION
Turns out not much had to be done. This makes the release script a little more convenient, stop packaging `letshelp-*`, and properly update `letsencrypt-auto-requirements.txt`.

@pde, it's probably best if you can review this, but the changes are very simple if anyone else wants to take a crack at it.