### PR TITLE
Changed Gentoo os_info string

### DIFF
--- a/certbot-apache/certbot_apache/constants.py
+++ b/certbot-apache/certbot_apache/constants.py
@@ -81,6 +81,7 @@ CLI_DEFAULTS = {
     "rhel": CLI_DEFAULTS_CENTOS,
     "amazon": CLI_DEFAULTS_CENTOS,
     "gentoo": CLI_DEFAULTS_GENTOO,
+    "gentoo base system": CLI_DEFAULTS_GENTOO,
     "darwin": CLI_DEFAULTS_DARWIN,
 }
 """CLI defaults."""

--- a/certbot-apache/certbot_apache/constants.py
+++ b/certbot-apache/certbot_apache/constants.py
@@ -80,7 +80,7 @@ CLI_DEFAULTS = {
     "red hat enterprise linux server": CLI_DEFAULTS_CENTOS,
     "rhel": CLI_DEFAULTS_CENTOS,
     "amazon": CLI_DEFAULTS_CENTOS,
-    "gentoo base system": CLI_DEFAULTS_GENTOO,
+    "gentoo": CLI_DEFAULTS_GENTOO,
     "darwin": CLI_DEFAULTS_DARWIN,
 }
 """CLI defaults."""


### PR DESCRIPTION
Gentoo's os_info is not what is expected in constants.py, resulting in certbot-apache systematic failure.
See bug #3091