### PR TITLE
Fix Debian/Red Hat Packaging Problems

### DIFF
--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -572,7 +572,7 @@ class ClientNetworkTest(unittest.TestCase):
         sess = mock.MagicMock()
         self.net.session = sess
         del self.net
-        sess.close.assert_called_once()
+        sess.close.assert_called_once_with()
 
     @mock.patch('acme.client.requests')
     def test_requests_error_passthrough(self, mock_requests):


### PR DESCRIPTION
Fixes #3098.

`mock` is more liberal in modern versions, treating `assert_called_once()` as a mocked out call instead of an assertion. This isn't true with older versions of `mock` packaged on Debian/Red Hat.