### PR TITLE
docs: Fix generation of manpage 'certbot.1'.

### DIFF
--- a/docs/man/certbot.rst
+++ b/docs/man/certbot.rst
@@ -1,1 +1,1 @@
-.. literalinclude:: cli-help.txt
+.. literalinclude:: ../cli-help.txt


### PR DESCRIPTION
* docs/man/certbot.rst: Fix path to resource file.

Without this change, the manpage build process cannot find 'docs/cli-help.txt',
and the resulting certbot.1 includes only the header and footer, but no actual
documentation.