### PR TITLE
Stop packaging shim packages

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -713,6 +713,9 @@ zope.interface==4.1.3 \
 mock==1.0.1 \
     --hash=sha256:b839dd2d9c117c701430c149956918a423a9863b48b09c90e30a6013e7d2f44f \
     --hash=sha256:8f83080daa249d036cbccfb8ae5cc6ff007b88d6d937521371afabe7b19badbc
+letsencrypt==0.7.0 \
+    --hash=sha256:105a5fb107e45bcd0722eb89696986dcf5f08a86a321d6aef25a0c7c63375ade \
+    --hash=sha256:c36e532c486a7e92155ee09da54b436a3c420813ec1c590b98f635d924720de9
 
 # THE LINES BELOW ARE EDITED BY THE RELEASE SCRIPT; ADD ALL DEPENDENCIES ABOVE.
 
@@ -725,12 +728,6 @@ certbot==0.7.0 \
 certbot-apache==0.7.0 \
     --hash=sha256:5ab5ed9b2af6c7db9495ce1491122798e9d0764e3df8f0843d11d89690bf7f88 \
     --hash=sha256:1ddbfaf01bcb0b05c0dcc8b2ebd37637f080cf798151e8140c20c9f5fe7bae75
-letsencrypt==0.7.0 \
-    --hash=sha256:105a5fb107e45bcd0722eb89696986dcf5f08a86a321d6aef25a0c7c63375ade \
-    --hash=sha256:c36e532c486a7e92155ee09da54b436a3c420813ec1c590b98f635d924720de9
-letsencrypt-apache==0.7.0 \
-    --hash=sha256:10445980a6afc810325ea22a56e269229999120848f6c0b323b00275696b5c80 \
-    --hash=sha256:3f4656088a18e4efea7cd7eb4965e14e8d901f3b64f4691e79cafd0bb91890f0
 
 UNLIKELY_EOF
     # -------------------------------------------------------------------------

--- a/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
+++ b/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
@@ -175,6 +175,9 @@ zope.interface==4.1.3 \
 mock==1.0.1 \
     --hash=sha256:b839dd2d9c117c701430c149956918a423a9863b48b09c90e30a6013e7d2f44f \
     --hash=sha256:8f83080daa249d036cbccfb8ae5cc6ff007b88d6d937521371afabe7b19badbc
+letsencrypt==0.7.0 \
+    --hash=sha256:105a5fb107e45bcd0722eb89696986dcf5f08a86a321d6aef25a0c7c63375ade \
+    --hash=sha256:c36e532c486a7e92155ee09da54b436a3c420813ec1c590b98f635d924720de9
 
 # THE LINES BELOW ARE EDITED BY THE RELEASE SCRIPT; ADD ALL DEPENDENCIES ABOVE.
 
@@ -187,9 +190,3 @@ certbot==0.7.0 \
 certbot-apache==0.7.0 \
     --hash=sha256:5ab5ed9b2af6c7db9495ce1491122798e9d0764e3df8f0843d11d89690bf7f88 \
     --hash=sha256:1ddbfaf01bcb0b05c0dcc8b2ebd37637f080cf798151e8140c20c9f5fe7bae75
-letsencrypt==0.7.0 \
-    --hash=sha256:105a5fb107e45bcd0722eb89696986dcf5f08a86a321d6aef25a0c7c63375ade \
-    --hash=sha256:c36e532c486a7e92155ee09da54b436a3c420813ec1c590b98f635d924720de9
-letsencrypt-apache==0.7.0 \
-    --hash=sha256:10445980a6afc810325ea22a56e269229999120848f6c0b323b00275696b5c80 \
-    --hash=sha256:3f4656088a18e4efea7cd7eb4965e14e8d901f3b64f4691e79cafd0bb91890f0

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -45,7 +45,7 @@ export GPG_TTY=$(tty)
 PORT=${PORT:-1234}
 
 # subpackages to be released
-SUBPKGS=${SUBPKGS:-"acme certbot-apache certbot-nginx letsencrypt letsencrypt-apache letsencrypt-nginx"}
+SUBPKGS=${SUBPKGS:-"acme certbot-apache certbot-nginx"}
 subpkgs_modules="$(echo $SUBPKGS | sed s/-/_/g)"
 # certbot_compatibility_test is not packaged because:
 # - it is not meant to be used by anyone else than Certbot devs
@@ -164,19 +164,19 @@ for module in certbot $subpkgs_modules ; do
 done
 
 # pin pip hashes of the things we just built
-for pkg in acme certbot certbot-apache letsencrypt letsencrypt-apache ; do
+for pkg in acme certbot certbot-apache ; do
     echo $pkg==$version \\
     pip hash dist."$version/$pkg"/*.{whl,gz} | grep "^--hash" | python2 -c 'from sys import stdin; input = stdin.read(); print "   ", input.replace("\n--hash", " \\\n    --hash"),'
 done > /tmp/hashes.$$
 deactivate
 
-if ! wc -l /tmp/hashes.$$ | grep -qE "^\s*15 " ; then
+if ! wc -l /tmp/hashes.$$ | grep -qE "^\s*9 " ; then
     echo Unexpected pip hash output
     exit 1
 fi
 
 # perform hideous surgery on requirements.txt...
-head -n -15 letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt > /tmp/req.$$
+head -n -9 letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt > /tmp/req.$$
 cat /tmp/hashes.$$ >> /tmp/req.$$
 cp /tmp/req.$$ letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
 


### PR DESCRIPTION
This PR stops packaging shim packages but continues to have `certbot-auto` install the `letsencrypt` package for backwards compatibility with people running `letsencrypt` manually from the venv.