### PR TITLE
Fix ValueError: Invalid header value on OS X

### DIFF
--- a/certbot/util.py
+++ b/certbot/util.py
@@ -325,7 +325,7 @@ def get_python_os_info():
         os_ver = subprocess.Popen(
             ["sw_vers", "-productVersion"],
             stdout=subprocess.PIPE
-        ).communicate()[0]
+        ).communicate()[0].strip()
     elif os_type.startswith('freebsd'):
         # eg "9.3-RC3-p1"
         os_ver = os_ver.partition("-")[0]


### PR DESCRIPTION
The OS X user agent header contained a `\n` which didn't pass the validation:
````
'CertbotACMEClient/0.8.0 (darwin 10.11.5\n) Authenticator/standalone Installer/None'
````