### PR TITLE
Strip "\n" from end of OS version string for OS X.

### DIFF
--- a/certbot/util.py
+++ b/certbot/util.py
@@ -325,7 +325,7 @@ def get_python_os_info():
         os_ver = subprocess.Popen(
             ["sw_vers", "-productVersion"],
             stdout=subprocess.PIPE
-        ).communicate()[0]
+        ).communicate()[0].rstrip('\n')
     elif os_type.startswith('freebsd'):
         # eg "9.3-RC3-p1"
         os_ver = os_ver.partition("-")[0]


### PR DESCRIPTION
If you don't, it ends up in the UserAgent header and you get an error
like:
Invalid header value 'CertbotACMEClient/0.8.0 (darwin 10.10.5\n)...'