### PR TITLE
Pull request to fix newline in user agent bug. 

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -609,6 +609,10 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
                       method, url, args, kwargs)
         kwargs['verify'] = self.verify_ssl
         kwargs.setdefault('headers', {})
+        """
+          PULL REQUEST: fix bug where newline creeps in.
+        """
+        self.user_agent = self.user_agent.replace( '\n', '' )
         kwargs['headers'].setdefault('User-Agent', self.user_agent)
         response = self.session.request(method, url, *args, **kwargs)
         logging.debug('Received %s. Headers: %s. Content: %r',

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -57,6 +57,11 @@ def _determine_user_agent(config):
                        config.authenticator, config.installer)
     else:
         ua = config.user_agent
+    """
+      PULL REQUEST: Fix an error where somehow a newline crept in
+      resulting in an exception being thrown as the request is sent.
+    """
+    ua = ua.replace( '\n', '' )
     return ua
 
 

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -19,7 +19,7 @@ XDG_DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
 VENV_NAME="letsencrypt"
 VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
 VENV_BIN="$VENV_PATH/bin"
-LE_AUTO_VERSION="0.7.0"
+LE_AUTO_VERSION="0.8.0"
 BASENAME=$(basename $0)
 USAGE="Usage: $BASENAME [OPTIONS]
 A self-updating wrapper script for the Certbot ACME client. When run, updates
@@ -713,24 +713,21 @@ zope.interface==4.1.3 \
 mock==1.0.1 \
     --hash=sha256:b839dd2d9c117c701430c149956918a423a9863b48b09c90e30a6013e7d2f44f \
     --hash=sha256:8f83080daa249d036cbccfb8ae5cc6ff007b88d6d937521371afabe7b19badbc
-
-# THE LINES BELOW ARE EDITED BY THE RELEASE SCRIPT; ADD ALL DEPENDENCIES ABOVE.
-
-acme==0.7.0 \
-    --hash=sha256:6e61dba343806ad4cb27af84628152abc9e83a0fa24be6065587d2b46f340d7a \
-    --hash=sha256:9f75a1947978402026b741bdee8a18fc5a1cfd539b78e523b7e5f279bf18eeb9
-certbot==0.7.0 \
-    --hash=sha256:55604e43d231ac226edefed8dc110d792052095c3d75ad0e4a228ae0989fe5fd \
-    --hash=sha256:ad5083d75e16d1ab806802d3a32f34973b6d7adaf083aee87e07a6c1359efe88
-certbot-apache==0.7.0 \
-    --hash=sha256:5ab5ed9b2af6c7db9495ce1491122798e9d0764e3df8f0843d11d89690bf7f88 \
-    --hash=sha256:1ddbfaf01bcb0b05c0dcc8b2ebd37637f080cf798151e8140c20c9f5fe7bae75
 letsencrypt==0.7.0 \
     --hash=sha256:105a5fb107e45bcd0722eb89696986dcf5f08a86a321d6aef25a0c7c63375ade \
     --hash=sha256:c36e532c486a7e92155ee09da54b436a3c420813ec1c590b98f635d924720de9
-letsencrypt-apache==0.7.0 \
-    --hash=sha256:10445980a6afc810325ea22a56e269229999120848f6c0b323b00275696b5c80 \
-    --hash=sha256:3f4656088a18e4efea7cd7eb4965e14e8d901f3b64f4691e79cafd0bb91890f0
+
+# THE LINES BELOW ARE EDITED BY THE RELEASE SCRIPT; ADD ALL DEPENDENCIES ABOVE.
+
+acme==0.8.0 \
+    --hash=sha256:8561d590e496afb41a8ff2dac389199661d9cd785b1636ae08325771511189af \
+    --hash=sha256:dfa86b547628b231f275c7e0efc7a09bec5dfaec866f89f5c5b59b78c14564da
+certbot==0.8.0 \
+    --hash=sha256:395c5840ff6b75aa51ee6449c86d016c14c5f65a71281e7bcef5feecac6a3293 \
+    --hash=sha256:3c3c70b484fb3243a166515adc81ae0401c5d687a2763c75b40df9d8241a4314
+certbot-apache==0.8.0 \
+    --hash=sha256:f4d4fc962ecc19646f6745d49c62a265d26e5b2df3acf34ef4865351594156e3 \
+    --hash=sha256:cfb211debbcb0d0645c88d7e8bb38c591fca263bfdb5337242c023956055e268
 
 UNLIKELY_EOF
     # -------------------------------------------------------------------------


### PR DESCRIPTION
A new line can creep into the user agent. Observe this log:

```
2016-06-04 16:54:31,737:DEBUG:certbot.main:Exiting abnormally:
Traceback (most recent call last):
  File "/Users/dosaygo/.local/share/letsencrypt/bin/letsencrypt", line 11, in <module>
    sys.exit(main())
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/certbot/main.py", line 735, in main
    return config.func(config, plugins)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/certbot/main.py", line 549, in obtain_cert
    le_client = _init_le_client(config, auth, installer)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/certbot/main.py", line 366, in _init_le_client
    return client.Client(config, acc, authenticator, installer, acme=acme)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/certbot/client.py", line 184, in __init__
    acme = acme_from_config_key(config, self.account.key)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/certbot/client.py", line 42, in acme_from_config_key
    return acme_client.Client(config.server, key=key, net=net)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/acme/client.py", line 63, in __init__
    self.net.get(directory).json())
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/acme/client.py", line 631, in get
    self._send_request('GET', url, **kwargs), content_type=content_type)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/acme/client.py", line 613, in _send_request
    response = self.session.request(method, url, *args, **kwargs)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/requests/sessions.py", line 468, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/requests/adapters.py", line 376, in send
    timeout=timeout
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 559, in urlopen
    body=body, headers=headers)
  File "/Users/dosaygo/.local/share/letsencrypt/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 353, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/httplib.py", line 1057, in request
    self._send_request(method, url, body, headers)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/httplib.py", line 1096, in _send_request
    self.putheader(hdr, value)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/httplib.py", line 1035, in putheader
    raise ValueError('Invalid header value %r' % (one_value,))
ValueError: Invalid header value 'CertbotACMEClient/0.8.0 (darwin 10.11.5\n) Authenticator/manual Installer/None'
```

Two modifications made, in certbot/client.py and acme/client.py, to do this : 

```
ua = ua.replace( '\n', '' )
```

I got this to work on my own system doing the modification of the `.local/share/` site packages *AFTER initial install*, and *NOT* when modifying the branch directly, *before* running letsencrypt-auto the first time, which I assume is because, upon running first time and performing initial install of site packages, the client pulls site package files from the certbot repo and not from its own local copy.

