### PR TITLE
Improve user experience for linting.

### DIFF
--- a/acme/.pylintrc
+++ b/acme/.pylintrc
@@ -21,12 +21,6 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=linter_plugin
 
-# DEPRECATED
-include-ids=no
-
-# DEPRECATED
-symbols=no
-
 # Use multiple processes to speed up Pylint.
 jobs=1
 

--- a/pep8.travis.sh
+++ b/pep8.travis.sh
@@ -2,16 +2,4 @@
 
 set -e  # Fail fast
 
-# PEP8 is not ignored in ACME
 pep8 --config=acme/.pep8 acme
-
-pep8 \
-  setup.py \
-  certbot \
-  certbot-apache \
-  certbot-nginx \
-  certbot-compatibility-test \
-  letshelp-certbot \
-  || echo "PEP8 checking failed, but it's ignored in Travis"
-
-# echo exits with 0

--- a/tox.ini
+++ b/tox.ini
@@ -64,14 +64,14 @@ basepython = python2.7
 # duplicate code checking; if one of the commands fails, others will
 # continue, but tox return code will reflect previous error
 commands =
-    pip install -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-compatibility-test -e letshelp-certbot
+    pip install -q -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-compatibility-test -e letshelp-certbot
     ./pep8.travis.sh
-    pylint --rcfile=.pylintrc certbot
-    pylint --rcfile=acme/.pylintrc acme/acme
-    pylint --rcfile=.pylintrc certbot-apache/certbot_apache
-    pylint --rcfile=.pylintrc certbot-nginx/certbot_nginx
-    pylint --rcfile=.pylintrc certbot-compatibility-test/certbot_compatibility_test
-    pylint --rcfile=.pylintrc letshelp-certbot/letshelp_certbot
+    pylint --reports=n --rcfile=.pylintrc certbot
+    pylint --reports=n --rcfile=acme/.pylintrc acme/acme
+    pylint --reports=n --rcfile=.pylintrc certbot-apache/certbot_apache
+    pylint --reports=n --rcfile=.pylintrc certbot-nginx/certbot_nginx
+    pylint --reports=n --rcfile=.pylintrc certbot-compatibility-test/certbot_compatibility_test
+    pylint --reports=n --rcfile=.pylintrc letshelp-certbot/letshelp_certbot
 
 [testenv:apacheconftest]
 #basepython = python2.7


### PR DESCRIPTION
Don't run pep8 for directories that we don't actually enforce pep8 on.
Install dependencies with -q.
Don't print reports, they make it hard to find the actual errors.
Remove deprecated fields from acme .pylintrc, they cause unnecessary messages
about deprecation.