### PR TITLE
Initialize Augeas in a different method to be able to react to ImportError

### DIFF
--- a/certbot-apache/certbot_apache/augeas_configurator.py
+++ b/certbot-apache/certbot_apache/augeas_configurator.py
@@ -28,6 +28,18 @@ class AugeasConfigurator(common.Plugin):
     def __init__(self, *args, **kwargs):
         super(AugeasConfigurator, self).__init__(*args, **kwargs)
 
+        # Placeholder for augeas
+        self.aug = None
+
+        self.save_notes = ""
+
+        # See if any temporary changes need to be recovered
+        # This needs to occur before VirtualHost objects are setup...
+        # because this will change the underlying configuration and potential
+        # vhosts
+        self.reverter = reverter.Reverter(self.config)
+        self.recovery_routine()
+
     def init_augeas(self):
         """ Initialize the actual Augeas instance """
         import augeas
@@ -37,14 +49,6 @@ class AugeasConfigurator(common.Plugin):
             # Do not save backup (we do it ourselves), do not load
             # anything by default
             flags=(augeas.Augeas.NONE | augeas.Augeas.NO_MODL_AUTOLOAD))
-        self.save_notes = ""
-
-        # See if any temporary changes need to be recovered
-        # This needs to occur before VirtualHost objects are setup...
-        # because this will change the underlying configuration and potential
-        # vhosts
-        self.reverter = reverter.Reverter(self.config)
-        self.recovery_routine()
 
     def check_parsing_errors(self, lens):
         """Verify Augeas can parse all of the lens files.

--- a/certbot-apache/certbot_apache/augeas_configurator.py
+++ b/certbot-apache/certbot_apache/augeas_configurator.py
@@ -38,7 +38,6 @@ class AugeasConfigurator(common.Plugin):
         # because this will change the underlying configuration and potential
         # vhosts
         self.reverter = reverter.Reverter(self.config)
-        self.recovery_routine()
 
     def init_augeas(self):
         """ Initialize the actual Augeas instance """
@@ -49,6 +48,7 @@ class AugeasConfigurator(common.Plugin):
             # Do not save backup (we do it ourselves), do not load
             # anything by default
             flags=(augeas.Augeas.NONE | augeas.Augeas.NO_MODL_AUTOLOAD))
+        self.recovery_routine()
 
     def check_parsing_errors(self, lens):
         """Verify Augeas can parse all of the lens files.

--- a/certbot-apache/certbot_apache/augeas_configurator.py
+++ b/certbot-apache/certbot_apache/augeas_configurator.py
@@ -1,7 +1,6 @@
 """Class of Augeas Configurators."""
 import logging
 
-import augeas
 
 from certbot import errors
 from certbot import reverter
@@ -29,6 +28,9 @@ class AugeasConfigurator(common.Plugin):
     def __init__(self, *args, **kwargs):
         super(AugeasConfigurator, self).__init__(*args, **kwargs)
 
+    def init_augeas(self):
+        """ Initialize the actual Augeas instance """
+        import augeas
         self.aug = augeas.Augeas(
             # specify a directory to load our preferred lens from
             loadpath=constants.AUGEAS_LENS_DIR,

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -150,6 +150,12 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         :raises .errors.PluginError: If there is any other error
 
         """
+        # Perform the actual Augeas initialization to be able to react
+        try:
+            self.init_augeas()
+        except ImportError:
+            raise errors.NoInstallationError("Problem in Augeas installation")
+
         # Verify Apache is installed
         if not util.exe_exists(constants.os_constant("restart_cmd")[0]):
             raise errors.NoInstallationError

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -55,6 +55,14 @@ class MultipleVhostsTest(util.ApacheTest):
         self.assertRaises(
             errors.NoInstallationError, self.config.prepare)
 
+    @mock.patch("certbot_apache.augeas_configurator.AugeasConfigurator.init_augeas")
+    def test_prepare_no_augeas(self, mock_init_augeas):
+        def side_effect_error(*args, **kwargs):
+            raise ImportError
+        mock_init_augeas.side_effect = side_effect_error
+        self.assertRaises(
+            errors.NoInstallationError, self.config.prepare)
+
     @mock.patch("certbot_apache.parser.ApacheParser")
     @mock.patch("certbot_apache.configurator.util.exe_exists")
     def test_prepare_version(self, mock_exe_exists, _):

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -57,7 +57,9 @@ class MultipleVhostsTest(util.ApacheTest):
 
     @mock.patch("certbot_apache.augeas_configurator.AugeasConfigurator.init_augeas")
     def test_prepare_no_augeas(self, mock_init_augeas):
-        def side_effect_error(*args, **kwargs):
+        """ Test augeas initialization ImportError """
+        def side_effect_error():
+            """ Side effect error for the test """
             raise ImportError
         mock_init_augeas.side_effect = side_effect_error
         self.assertRaises(


### PR DESCRIPTION
Handle augeas initialization in a separate method to be able to call it from inside prepare(), and react to the possible ImportError by reporting Apache plugin unavailable and letting user to choose out of the other possibilities.

Mitigates #1173 