### PR TITLE
Prevent bootstrap-issue on Debian systems with virtualenv package

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -172,7 +172,7 @@ BootstrapDebCommon() {
   # distro version (#346)
 
   virtualenv=
-  if apt-cache show virtualenv > /dev/null 2>&1; then
+  if apt-cache show virtualenv > /dev/null 2>&1 && ! apt-cache --quiet=0 show virtualenv 2>&1 | grep -q 'No packages found'; then
     virtualenv="virtualenv"
   fi
 

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -23,7 +23,7 @@ BootstrapDebCommon() {
   # distro version (#346)
 
   virtualenv=
-  if apt-cache show virtualenv > /dev/null 2>&1; then
+  if apt-cache show virtualenv > /dev/null 2>&1 && ! apt-cache --quiet=0 show virtualenv 2>&1 | grep -q 'No packages found'; then
     virtualenv="virtualenv"
   fi
 


### PR DESCRIPTION
On Debian 7 (and probably relative distro's) `aptitude show virtualenv` exits
with 0, since it is a virtual package. However, it doesn't have any installation
candidates, so filter on this case before trying to install `virtualenv` to
prevent installation-errors while bootstrapping.

NB, to make this clear:

	(0)#: apt-cache show virtualenv
	N: Can't select versions from package 'virtualenv' as it is purely virtual
	N: No packages found
	(0)#: echo $?
	0

Furthermore, --quiet=0 is necessary, to be able to grep through `apt-cache`'s
output via a pipe. More details on
http://unix.stackexchange.com/questions/201869/why-isnt-apt-cache-policy-output-piped/202041#202041.