### PR TITLE
Adding sensible UI logging for typical user

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -282,7 +282,7 @@ class Client(object):
                 "by your operating system package manager")
 
         if self.config.dry_run:
-            logger.info("Dry run: Skipping creating new lineage for %s",
+            logger.debug("Dry run: Skipping creating new lineage for %s",
                         domains[0])
             return None
         else:

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -18,7 +18,7 @@ CLI_DEFAULTS = dict(
         os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"),
                      "letsencrypt", "cli.ini"),
     ],
-    verbose_count=-(logging.WARNING / 10),
+    verbose_count=-(logging.INFO / 10),
     server="https://acme-v01.api.letsencrypt.org/directory",
     rsa_key_size=2048,
     rollback_checkpoints=1,

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -615,11 +615,12 @@ def _cli_log_handler(config, level, fmt):
 
 def setup_logging(config, cli_handler_factory, logfile):
     """Setup logging."""
-    fmt = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
+    file_fmt = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
+    cli_fmt = "%(message)s"
     level = -config.verbose_count * 10
     file_handler, log_file_path = setup_log_file_handler(
-        config, logfile=logfile, fmt=fmt)
-    cli_handler = cli_handler_factory(config, level, fmt)
+        config, logfile=logfile, fmt=file_fmt)
+    cli_handler = cli_handler_factory(config, level, cli_fmt)
 
     # TODO: use fileConfig?
 

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -525,7 +525,7 @@ def _csr_obtain_cert(config, le_client):
     csr, typ = config.actual_csr
     certr, chain = le_client.obtain_certificate_from_csr(config.domains, csr, typ)
     if config.dry_run:
-        logger.info(
+        logger.debug(
             "Dry run: skipping saving certificate to %s", config.cert_path)
     else:
         cert_path, _, cert_fullchain = le_client.save_certificate(

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -107,7 +107,7 @@ def _restore_webroot_config(config, renewalparams):
         if not cli.set_by_cli("webroot_map"):
             config.namespace.webroot_map = renewalparams["webroot_map"]
     elif "webroot_path" in renewalparams:
-        logger.info("Ancient renewal conf file without webroot-map, restoring webroot-path")
+        logger.debug("Ancient renewal conf file without webroot-map, restoring webroot-path")
         wp = renewalparams["webroot_path"]
         if isinstance(wp, str):  # prior to 0.1.0, webroot_path was a string
             wp = [wp]
@@ -193,7 +193,7 @@ def _restore_required_config_elements(config, renewalparams):
 def should_renew(config, lineage):
     "Return true if any of the circumstances for automatic renewal apply."
     if config.renew_by_default:
-        logger.info("Auto-renewal forced with --force-renewal...")
+        logger.debug("Auto-renewal forced with --force-renewal...")
         return True
     if lineage.should_autorenew(interactive=True):
         logger.info("Cert is due for renewal, auto-renewing...")
@@ -235,7 +235,7 @@ def renew_cert(config, domains, le_client, lineage):
     _avoid_invalidating_lineage(config, lineage, original_server)
     new_certr, new_chain, new_key, _ = le_client.obtain_certificate(domains)
     if config.dry_run:
-        logger.info("Dry run: skipping updating lineage at %s",
+        logger.debug("Dry run: skipping updating lineage at %s",
                     os.path.dirname(lineage.cert))
     else:
         prior_version = lineage.latest_common_version()

--- a/certbot/reporter.py
+++ b/certbot/reporter.py
@@ -58,7 +58,7 @@ class Reporter(object):
         """
         assert self.HIGH_PRIORITY <= priority <= self.LOW_PRIORITY
         self.messages.put(self._msg_type(priority, msg, on_crash))
-        logger.info("Reporting to user: %s", msg)
+        logger.debug("Reporting to user: %s", msg)
 
     def atexit_print_messages(self, pid=None):
         """Function to be registered with atexit to print messages.


### PR DESCRIPTION
Closes #599 

There are 2 rules I followed when adjusting the logging level of certain messages.

First, I refrained from changing messages from info to warning (although some messages seemed like they belong more to warning, but that could be done in another PR).

And second, I tried to make it as possible to what a normal user would understand, without the messages being pedantic.