### PR TITLE
Cleanup dev setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+# show lines missing coverage in output
+show_missing = True

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ dev_extras = [
     'astroid==1.3.5',
     'coverage',
     'nose',
-    'nosexcover',
     'pep8',
     'pylint==1.4.2',  # upstream #248
     'tox',


### PR DESCRIPTION
The addition of `.coveragerc` fixes #3172 ([source](https://stackoverflow.com/questions/37733194/python-nosetests-with-coverage-no-longer-shows-missing-lines)).

`nosexcover` hasn't been used since dfd7e142c143e8f3f92541dfd02349592caf4de3.

~~PyCQA/pylint#248 has been resolved.~~

~~Lastly, the specific problem identified with using `astroid` in #289 appears to have been resolved. I didn't find the specific issue/PR on their repo, but `astroid` is only used for testing and all tests pass without pinning `astroid`.~~

EDIT: Turns out the `astroid`/`pylint` problems only shows up on some systems including Travis. I removed those changes.