### PR TITLE
Remove unused nosexcover dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ dev_extras = [
     'astroid==1.3.5',
     'coverage',
     'nose',
-    'nosexcover',
     'pep8',
     'pylint==1.4.2',  # upstream #248
     'tox',


### PR DESCRIPTION
`nosexcover` hasn't been used since dfd7e142c143e8f3f92541dfd02349592caf4de3.