### PR TITLE
Explain the most likely cause of a missing replay nonce error

### DIFF
--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -49,7 +49,7 @@ class MissingNonce(NonceError):
 
     def __str__(self):
         return ('Server {0} response did not include a replay '
-                'nonce, headers: {1}\n(This may be a service outage)'.format(
+                'nonce, headers: {1} (This may be a service outage)'.format(
                     self.response.request.method, self.response.headers))
 
 

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -49,7 +49,7 @@ class MissingNonce(NonceError):
 
     def __str__(self):
         return ('Server {0} response did not include a replay '
-                'nonce, headers: {1}'.format(
+                'nonce, headers: {1}\n(This may be a service outage)'.format(
                     self.response.request.method, self.response.headers))
 
 


### PR DESCRIPTION
People have gotten this error because Akamai keeps answering during boulder outages, and it's pretty mysterious.