### PR TITLE
Fix Nginx reversion

### DIFF
--- a/certbot-nginx/certbot_nginx/tests/tls_sni_01_test.py
+++ b/certbot-nginx/certbot_nginx/tests/tls_sni_01_test.py
@@ -80,7 +80,7 @@ class TlsSniPerformTest(util.NginxTest):
 
         mock_setup_cert.assert_called_once_with(self.achalls[0])
         self.assertEqual([response], responses)
-        self.assertEqual(mock_save.call_count, 2)
+        self.assertEqual(mock_save.call_count, 1)
 
         # Make sure challenge config is included in main config
         http = self.sni.configurator.parser.parsed[

--- a/certbot-nginx/certbot_nginx/tls_sni_01.py
+++ b/certbot-nginx/certbot_nginx/tls_sni_01.py
@@ -46,8 +46,6 @@ class NginxTlsSni01(common.TLSSNI01):
         if not self.achalls:
             return []
 
-        self.configurator.save()
-
         addresses = []
         default_addr = "{0} default_server ssl".format(
             self.configurator.config.tls_sni_01_port)


### PR DESCRIPTION
Fixes #1977.

After auditing the code for creating/modifying/removing files, proper reverter use, etc., it turns out this was trivial. The problem occurred when the Nginx plugin was performing a challenge. Before setting up the challenge, it would create a permanent checkpoint and write out the Nginx config. It is not expected that a checkpoint is created here so when rolling back, the client always rolled back one too few checkpoints.

It turns out that no changes are made before this save point so I deleted it (although if you break after the save in `master` you'll likely see a lot of changes, but that's only because your configuration has been normalized). The reason it was even there in the first place is the Nginx plugin is modeled after the Apache plugin which makes a temporary save at this point (the save used to be permanent in Apache).

Using this PR, you should ALWAYS be able to revert your Nginx configuration to a previous state. This can be accomplished using `certbot rollback`. Furthermore, Certbot should revert in progress changes if it is interrupted. This includes hitting ctrl+c at any point during the program.

NOTE: If it's interrupted when enabling a redirect but already successfully installed your cert, only the redirect changes are reverted. This is the desired behavior and is mentioned in the program output after handling this case. You can rollback all the way using `certbot rollback`.

The big caveat here is it's possible to interrupt the code rolling back your changes. For example, if you hit ctrl+c once to trigger the error handling code and then hit ctrl+c again, you'll interrupt the error handler and your changes might not be reverted. With that said, even if you interrupt the error handler, `certbot rollback` will still work.

With all that said, I encourage you to try and break this PR. I tried and couldn't but this will certainly benefit from additional testing, including the certbot-compatibility-test.