### PR TITLE
Improve non root error message [revision requested]

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -712,6 +712,11 @@ def main(cli_args=sys.argv[1:]):
     config = configuration.NamespaceConfig(args)
     zope.component.provideUtility(config)
 
+    # Check if running as root
+    if os.geteuid() != 0:
+        raise errors.Error(
+            "You need to have root privileges to run certbot.\nPlease try again, this time using 'sudo'. Exiting.")
+
     # Setup logging ASAP, otherwise "No handlers could be found for
     # logger ..." TODO: this should be done before plugins discovery
     for directory in config.config_dir, config.work_dir:

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -712,12 +712,6 @@ def main(cli_args=sys.argv[1:]):
     config = configuration.NamespaceConfig(args)
     zope.component.provideUtility(config)
 
-    # Check if running as root
-    if os.geteuid() != 0:
-        raise errors.Error(
-            "You need to have root privileges to run certbot. "
-            "Please try again, this time using 'sudo'. Exiting.")
-
     # Setup logging ASAP, otherwise "No handlers could be found for
     # logger ..." TODO: this should be done before plugins discovery
     for directory in config.config_dir, config.work_dir:

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -715,7 +715,8 @@ def main(cli_args=sys.argv[1:]):
     # Check if running as root
     if os.geteuid() != 0:
         raise errors.Error(
-            "You need to have root privileges to run certbot.\nPlease try again, this time using 'sudo'. Exiting.")
+            "You need to have root privileges to run certbot. "
+            "Please try again, this time using 'sudo'. Exiting.")
 
     # Setup logging ASAP, otherwise "No handlers could be found for
     # logger ..." TODO: this should be done before plugins discovery

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -115,6 +115,11 @@ class MakeOrVerifyDirTest(unittest.TestCase):
             makedirs.side_effect = OSError()
             self.assertRaises(OSError, self._call, "bar", 12312312)
 
+    def test_raises_root_error(self):
+        with mock.patch.object(os, "makedirs") as makedirs:
+            makedirs.side_effect = OSError(13)
+            self.assertRaises(errors.Error, self._call, "bar", 12312312)
+
 
 class CheckPermissionsTest(unittest.TestCase):
     """Tests for certbot.util.check_permissions.

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -117,7 +117,7 @@ class MakeOrVerifyDirTest(unittest.TestCase):
 
     def test_raises_root_error(self):
         with mock.patch.object(os, "makedirs") as makedirs:
-            makedirs.side_effect = OSError(13)
+            makedirs.side_effect = OSError(errno.EACCES, "Permission denied")
             self.assertRaises(errors.Error, self._call, "bar", 12312312)
 
 

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -112,6 +112,10 @@ def make_or_verify_dir(directory, mode=0o755, uid=0, strict=False):
                 raise errors.Error(
                     "%s exists, but it should be owned by user %d with"
                     "permissions %s" % (directory, uid, oct(mode)))
+        elif exception.errno == errno.EPERM or exception.errno == errno.EACCES:
+            raise errors.Error(
+                "You need to have root privileges to run certbot. "
+                "Please try again, this time using 'sudo'. Exiting.")
         else:
             raise
 


### PR DESCRIPTION
This PR aims to add a more verbose message when running certbot without root privileges, as mentioned in #2734.
