### PR TITLE
Only write nginx config files if they've been modified

### DIFF
--- a/certbot-nginx/certbot_nginx/nginxparser.py
+++ b/certbot-nginx/certbot_nginx/nginxparser.py
@@ -1,4 +1,5 @@
 """Very low-level nginx config parser based on pyparsing."""
+# Forked from https://github.com/fatiherikli/nginxparser (MIT Licensed)
 import copy
 import logging
 import string
@@ -81,8 +82,7 @@ class RawNginxDumper(object):
                 yield b.pop(0) # indentation
                 if not b:
                     continue
-            key = b.pop(0)
-            values = b.pop(0)
+            key, values = b.pop(0), b.pop(0)
 
             if isinstance(key, list):
                 yield "".join(key) + '{'
@@ -91,9 +91,9 @@ class RawNginxDumper(object):
                         yield line
                 yield '}'
             else:
-                if isinstance(key, str) and key.strip() == '#':
+                if isinstance(key, str) and key.strip() == '#':  # comment
                     yield key + values
-                else:
+                else:                                            # assignment
                     gap = ""
                     # Sometimes the parser has stuck some gap whitespace in here;
                     # if so rotate it into gap

--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -205,11 +205,12 @@ class NginxParser(object):
         raise errors.NoInstallationError(
             "Could not find configuration root")
 
-    def filedump(self, ext='tmp'):
+    def filedump(self, ext='tmp', lazy=True):
         """Dumps parsed configurations into files.
 
         :param str ext: The file extension to use for the dumped files. If
             empty, this overrides the existing conf files.
+        :param bool lazy: Only write files that have been modified
 
         """
         # Best-effort atomicity is enforced above us by reverter.py
@@ -218,6 +219,8 @@ class NginxParser(object):
             if ext:
                 filename = filename + os.path.extsep + ext
             try:
+                if lazy and not tree.is_dirty():
+                    continue
                 out = nginxparser.dumps(tree)
                 logger.debug('Writing nginx conf tree to %s:\n%s', filename, out)
                 with open(filename, 'w') as _file:

--- a/certbot-nginx/certbot_nginx/tests/nginxparser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/nginxparser_test.py
@@ -231,6 +231,17 @@ class TestUnspacedList(unittest.TestCase):
         del ul3[2]
         self.assertEqual(ul3, ["some", "things", "why", "did", "whether"])
 
+    def test_is_dirty(self):
+        self.assertEqual(False, self.ul2.is_dirty())
+        ul3 = UnspacedList([])
+        ul3.append(self.ul)
+        self.assertEqual(False, self.ul.is_dirty())
+        self.assertEqual(True, ul3.is_dirty())
+        ul4 = UnspacedList([[1], [2, 3, 4]])
+        self.assertEqual(False, ul4.is_dirty())
+        ul4[1][2] = 5
+        self.assertEqual(True, ul4.is_dirty())
+
 
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -66,7 +66,7 @@ class NginxParserTest(util.NginxTest):
 
     def test_filedump(self):
         nparser = parser.NginxParser(self.config_path, self.ssl_options)
-        nparser.filedump('test')
+        nparser.filedump('test', lazy=False)
         # pylint: disable=protected-access
         parsed = nparser._parse_files(nparser.abs_path(
             'sites-enabled/example.com.test'))


### PR DESCRIPTION
We keep a dirty bit for each node in the parse tree, and walk it to implement a `.is_dirty()` method.  That's not very efficient, but is no more inefficient than having to perform elaborate the deepcopying that a `.top` attribute on each node of the tree would require.

Fixes: #3205