### PR TITLE
Fix Unix signal handling in certbot.error_handler.ErrorHandler [minor revision]

### DIFF
--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -112,7 +112,8 @@ class ErrorHandler(object):
         self.prev_handlers.clear()
 
     def _signal_handler(self, signum, unused_frame):
-        """Stores the recieved signal.
+        """Stores the recieved signal. If we are executing the code block in
+        the body of the context manager, stop by raising signal exit.
 
         :param int signum: number of current signal
 

--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -115,7 +115,9 @@ class ErrorHandler(object):
         self.prev_handlers.clear()
 
     def _signal_handler(self, signum, unused_frame):
-        """Stores the recieved signal. If we are executing the code block in
+        """Replacement function for handling recieved signals.
+
+        Store the recieved signal. If we are executing the code block in
         the body of the context manager, stop by raising signal exit.
 
         :param int signum: number of current signal

--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -75,10 +75,10 @@ class ErrorHandler(object):
                     traceback.format_exception(exec_type, exec_value, trace)))
 
             self._call_registered()
-            self._call_signals()
             return retval
         finally:
-            self._reset_signal_handlers()
+            prev_handlers = self._reset_signal_handlers()
+            self._call_signals(prev_handlers)
 
     def register(self, func, *args, **kwargs):
         """Sets func to be called with *args and **kwargs during cleanup
@@ -112,7 +112,9 @@ class ErrorHandler(object):
         """Resets signal handlers for signals in _SIGNALS."""
         for signum in self.prev_handlers:
             signal.signal(signum, self.prev_handlers[signum])
+        out = dict((k, v) for k, v in self.prev_handlers.items())
         self.prev_handlers.clear()
+        return out
 
     def _signal_handler(self, signum, unused_frame):
         """Replacement function for handling recieved signals.
@@ -127,7 +129,7 @@ class ErrorHandler(object):
         if not self.body_executed:
             raise errors.SignalExit
 
-    def _call_signals(self):
+    def _call_signals(self, prev_handlers):
         """Finally call the deferred signals.
 
         :param int signum: signal number
@@ -135,5 +137,5 @@ class ErrorHandler(object):
         """
         for signum in self.received_signals:
             logger.debug("Calling signal %s", signum)
-            signal.signal(signum, self.prev_handlers[signum])
+            signal.signal(signum, prev_handlers[signum])
             os.kill(os.getpid(), signum)

--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -5,6 +5,7 @@ import os
 import signal
 import traceback
 
+from certbot import errors
 
 logger = logging.getLogger(__name__)
 
@@ -17,14 +18,6 @@ logger = logging.getLogger(__name__)
 _SIGNALS = ([signal.SIGTERM] if os.name == "nt" else
             [signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT,
              signal.SIGXCPU, signal.SIGXFSZ])
-
-
-class SignalExit(Exception):
-    """This exception is used stop of execution of the code in the body of the
-    ErrorHandler context manager.
-
-    """
-    pass
 
 
 class ErrorHandler(object):
@@ -62,7 +55,7 @@ class ErrorHandler(object):
     def __exit__(self, exec_type, exec_value, trace):
         self.body_executed = True
         retval = False
-        if exec_type is SignalExit:
+        if exec_type is errors.SignalExit:
             logger.debug("Encountered signals: %s", self.received_signals)
             self.call_registered()
             for signum in self.received_signals:
@@ -120,7 +113,7 @@ class ErrorHandler(object):
         """
         self.received_signals.append(signum)
         if not self.body_executed:
-            raise SignalExit
+            raise errors.SignalExit
 
     def call_signal(self, signum):
         """Calls the signal given by signum.

--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -50,6 +50,7 @@ class ErrorHandler(object):
             self.register(func, *args, **kwargs)
 
     def __enter__(self):
+        self.body_executed = False
         self.set_signal_handlers()
 
     def __exit__(self, exec_type, exec_value, trace):

--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -77,8 +77,8 @@ class ErrorHandler(object):
             self._call_registered()
             return retval
         finally:
-            prev_handlers = self._reset_signal_handlers()
-            self._call_signals(prev_handlers)
+            self._reset_signal_handlers()
+            self._call_signals()
 
     def register(self, func, *args, **kwargs):
         """Sets func to be called with *args and **kwargs during cleanup
@@ -112,9 +112,7 @@ class ErrorHandler(object):
         """Resets signal handlers for signals in _SIGNALS."""
         for signum in self.prev_handlers:
             signal.signal(signum, self.prev_handlers[signum])
-        out = dict((k, v) for k, v in self.prev_handlers.items())
         self.prev_handlers.clear()
-        return out
 
     def _signal_handler(self, signum, unused_frame):
         """Replacement function for handling recieved signals.
@@ -129,13 +127,8 @@ class ErrorHandler(object):
         if not self.body_executed:
             raise errors.SignalExit
 
-    def _call_signals(self, prev_handlers):
-        """Finally call the deferred signals.
-
-        :param int signum: signal number
-
-        """
+    def _call_signals(self):
+        """Finally call the deferred signals."""
         for signum in self.received_signals:
             logger.debug("Calling signal %s", signum)
-            signal.signal(signum, prev_handlers[signum])
             os.kill(os.getpid(), signum)

--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -128,7 +128,7 @@ class ErrorHandler(object):
             raise errors.SignalExit
 
     def _call_signals(self):
-        """Calls the signal given by signum.
+        """Finally call the deferred signals.
 
         :param int signum: signal number
 

--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -21,19 +21,26 @@ _SIGNALS = ([signal.SIGTERM] if os.name == "nt" else
 
 
 class ErrorHandler(object):
-    """Registers functions to be called if an exception or signal occurs.
+    """Context manager for running code that must be cleaned up on failure.
 
-    This class allows you to register functions that will be called when
-    an exception (excluding SystemExit) or signal is encountered. The
-    class works best as a context manager. For example:
+    The context manager allows you to register functions that will be called
+    when an exception (excluding SystemExit) or signal is encountered. Usage:
 
-    with ErrorHandler(cleanup_func):
+    handler = ErrorHandler(cleanup1_func, *cleanup1_args, **cleanup1_kwargs)
+    handler.register(cleanup2_func, *cleanup2_args, **cleanup2_kwargs)
+
+    with handler:
         do_something()
 
-    If an exception is raised out of do_something, cleanup_func will be
-    called. The exception is not caught by the ErrorHandler. Similarly,
-    if a signal is encountered, cleanup_func is called followed by the
-    previously registered signal handler.
+    Or for one cleanup function:
+
+    with ErrorHandler(func, args, kwargs):
+        do_something()
+
+    If an exception is raised out of do_something, the cleanup functions will
+    be called in last in first out order. Then the exception is raised.
+    Similarly, if a signal is encountered, the cleanup functions are called
+    followed by the previously received signal handler.
 
     Each registered cleanup function is called exactly once. If a registered
     function raises an exception, it is logged and the next function is called.

--- a/certbot/error_handler.py
+++ b/certbot/error_handler.py
@@ -61,24 +61,22 @@ class ErrorHandler(object):
         self._set_signal_handlers()
 
     def __exit__(self, exec_type, exec_value, trace):
-        try:
-            self.body_executed = True
-            retval = False
-            # SystemExit is ignored to properly handle forks that don't exec
-            if exec_type in (None, SystemExit):
-                return retval
-            elif exec_type is errors.SignalExit:
-                logger.debug("Encountered signals: %s", self.received_signals)
-                retval = True
-            else:
-                logger.debug("Encountered exception:\n%s", "".join(
-                    traceback.format_exception(exec_type, exec_value, trace)))
-
-            self._call_registered()
+        self.body_executed = True
+        retval = False
+        # SystemExit is ignored to properly handle forks that don't exec
+        if exec_type in (None, SystemExit):
             return retval
-        finally:
-            self._reset_signal_handlers()
-            self._call_signals()
+        elif exec_type is errors.SignalExit:
+            logger.debug("Encountered signals: %s", self.received_signals)
+            retval = True
+        else:
+            logger.debug("Encountered exception:\n%s", "".join(
+                traceback.format_exception(exec_type, exec_value, trace)))
+
+        self._call_registered()
+        self._reset_signal_handlers()
+        self._call_signals()
+        return retval
 
     def register(self, func, *args, **kwargs):
         """Sets func to be called with *args and **kwargs during cleanup

--- a/certbot/errors.py
+++ b/certbot/errors.py
@@ -29,6 +29,10 @@ class HookCommandNotFound(Error):
     """Failed to find a hook command in the PATH."""
 
 
+class SignalExit(Error):
+    """A Unix signal was recieved while in the ErrorHandler context manager."""
+
+
 # Auth Handler Errors
 class AuthorizationError(Error):
     """Authorization error."""

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -3,12 +3,12 @@ import os
 import signal
 import sys
 import unittest
-from contextlib import contextmanager
+import contextlib
 
 import mock
 
 
-@contextmanager
+@contextlib.contextmanager
 def signal_receiver(signums):
     """Context manager to catch signals"""
     signals = []

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -68,7 +68,7 @@ class ErrorHandlerTest(unittest.TestCase):
     def test_bad_recovery(self):
         bad_func = mock.MagicMock(side_effect=[ValueError])
         self.handler.register(bad_func)
-        self.handler.call_registered()
+        self.handler._call_registered()
         self.init_func.assert_called_once_with(*self.init_args,
                                                **self.init_kwargs)
         bad_func.assert_called_once_with()

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -46,7 +46,9 @@ class ErrorHandlerTest(unittest.TestCase):
             with self.handler:
                 raise ValueError
         except ValueError:
-            pass
+            exception_raised = True
+
+        self.assertTrue(exception_raised)
         self.init_func.assert_called_once_with(*self.init_args,
                                                **self.init_kwargs)
 

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -11,13 +11,11 @@ import mock
 @contextmanager
 def signal_receiver(signums):
     """Context manager to catch signals"""
-    def receiver(signum, unused_frame):
-        signals.append(signum)
     signals = []
     prev_handlers = {}
     for signum in signums:
         prev_handlers[signum] = signal.getsignal(signum)
-        signal.signal(signum, receiver)
+        signal.signal(signum, lambda signum, _: signals.append(signum))
     yield signals
     for signum in signums:
         signal.signal(signum, prev_handlers[signum])

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -1,9 +1,9 @@
 """Tests for certbot.error_handler."""
+import contextlib
 import os
 import signal
 import sys
 import unittest
-import contextlib
 
 import mock
 

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -70,7 +70,11 @@ class ErrorHandlerTest(unittest.TestCase):
     def test_bad_recovery(self):
         bad_func = mock.MagicMock(side_effect=[ValueError])
         self.handler.register(bad_func)
-        self.handler._call_registered()
+        try:
+            with self.handler:
+                raise ValueError
+        except ValueError:
+            pass
         self.init_func.assert_called_once_with(*self.init_args,
                                                **self.init_kwargs)
         bad_func.assert_called_once_with()

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -14,7 +14,8 @@ def get_signals(signums):
 
 def set_signals(sig_handler_dict):
     """Set the signal (keys) with the handler (values) from the input dict."""
-    tuple(signal.signal(s, h) for (s, h) in sig_handler_dict.items())
+    for s, h in sig_handler_dict.items():
+        signal.signal(s, h)
 
 
 @contextlib.contextmanager
@@ -25,7 +26,7 @@ def signal_receiver(signums):
     prev_handlers = get_signals(signums)
     set_signals(dict((s, lambda s, _: signals.append(s)) for s in signums))
     yield signals
-    set_signals(dict((s, prev_handlers[s]) for s in signums))
+    set_signals(prev_handlers)
 
 
 def send_signal(signum):

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -42,6 +42,7 @@ class ErrorHandlerTest(unittest.TestCase):
         self.signals = error_handler._SIGNALS
 
     def test_context_manager(self):
+        exception_raised = False
         try:
             with self.handler:
                 raise ValueError

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -66,6 +66,9 @@ class ErrorHandlerTest(unittest.TestCase):
         # assert the error handling function was just called once
         self.init_func.assert_called_once_with(*self.init_args,
                                                **self.init_kwargs)
+        for signum in self.signals:
+            sig = signal.getsignal(signum)
+            self.assertTrue((sig == signal.SIG_DFL) or (sig == signal.SIG_IGN))
 
     def test_bad_recovery(self):
         bad_func = mock.MagicMock(side_effect=[ValueError])


### PR DESCRIPTION
Closes #3219 and #3215 

This tweaks how Unix signals are managed by `certbot.error_handler.ErrorHandler`.

Previously, signals sent while `ErrorHandler`'s cleanup functions were running would cause the functions to get run again.

Now all signals are deferred until after the cleanup functions are run.