### PR TITLE
FreeBSD port is now py-certbot

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -428,7 +428,7 @@ Operating System Packages
 
 **FreeBSD**
 
-  * Port: ``cd /usr/ports/security/py-letsencrypt && make install clean``
+  * Port: ``cd /usr/ports/security/py-certbot && make install clean``
   * Package: ``pkg install py27-letsencrypt``
 
 **OpenBSD**


### PR DESCRIPTION
https://www.freebsd.org/cgi/ports.cgi?query=certbot&stype=all

Although it appears the package is still named `letsencrypt` (and is stuck on 0.4.1).