### PR TITLE
add -D/--webroot-delay-auth option

### DIFF
--- a/certbot/plugins/webroot.py
+++ b/certbot/plugins/webroot.py
@@ -29,6 +29,12 @@ class Authenticator(common.Plugin):
 
     description = "Place files in webroot directory"
 
+    MSG_AUTH_DELAYED = """\
+Authentication delayed. Deploy the {0}/.well-known directory to \
+your webroot now.
+
+Press ENTER to continue to the validation process."""
+
     MORE_INFO = """\
 Authenticator plugin that performs http-01 challenge by saving
 necessary validation resources to appropriate paths on the file
@@ -82,7 +88,9 @@ to serve all files under specified web root ({0})."""
         responses = [self._perform_single(achall) for achall in achalls]
 
         if self.conf("delay-auth"):
-            six.moves.input("Press ENTER to continue authentication...")
+            path = self.conf("path")[0]
+            display = zope.component.getUtility(interfaces.IDisplay)
+            display.notification(self.MSG_AUTH_DELAYED.format(path))
 
         return responses
 

--- a/certbot/plugins/webroot.py
+++ b/certbot/plugins/webroot.py
@@ -55,6 +55,12 @@ to serve all files under specified web root ({0})."""
                  "-d entries. At present, if you put webroot-map in a config "
                  "file, it needs to be on a single line, like: webroot-map = "
                  '{"example.com":"/var/www"}.')
+        add("delay-auth", "-D", action="store_true",
+            help="Wait until the user presses ENTER before the "
+                 "authentication process kicks in. This is useful when "
+                 "proposing the challenges from a foreign machine to be "
+                 "able to copy the files to the real webserver before "
+                 "the challenges are verified.")
 
     def get_chall_pref(self, domain):  # pragma: no cover
         # pylint: disable=missing-docstring,no-self-use,unused-argument
@@ -73,7 +79,12 @@ to serve all files under specified web root ({0})."""
 
         self._create_challenge_dirs()
 
-        return [self._perform_single(achall) for achall in achalls]
+        responses = [self._perform_single(achall) for achall in achalls]
+
+        if self.conf("delay-auth"):
+            six.moves.input("Press ENTER to continue authentication...")
+
+        return responses
 
     def _set_webroots(self, achalls):
         if self.conf("path"):


### PR DESCRIPTION
With this new option enabled, the "webroot" plugin will wait for user
input before the challanges will be verified.

This is useful for creating certificates for shared hosting plans
without root (or even no SSH access at all): The challenges can be
proposed from a foreign machine, and with this option, the user has
the time to copy the validation files to the actual webserver before
the challanges are verified.
