### PR TITLE
Automatically enable EPEL after prompting users

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -285,7 +285,7 @@ BootstrapRpmCommon() {
     yes_flag="-y"
   fi
 
-  if ! $SUDO $tool list *virtualenv > /dev/null 2>&1; then
+  if ! $SUDO $tool list *virtualenv >/dev/null 2>&1; then
     echo "To use Certbot, packages from the EPEL repository need to be installed."
     if [ "$ASSUME_YES" = 1 ]; then
         /bin/echo -n "Enabling the EPEL repository in 3 seconds..."

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -287,6 +287,10 @@ BootstrapRpmCommon() {
 
   if ! $SUDO $tool list *virtualenv >/dev/null 2>&1; then
     echo "To use Certbot, packages from the EPEL repository need to be installed."
+    if ! $SUDO $tool list epel-release >/dev/null 2>&1; then
+      echo "Please enable this repository and try running Certbot again."
+      exit 1
+    fi
     if [ "$ASSUME_YES" = 1 ]; then
         /bin/echo -n "Enabling the EPEL repository in 3 seconds..."
         sleep 1s

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -281,6 +281,26 @@ BootstrapRpmCommon() {
     exit 1
   fi
 
+  if [ "$ASSUME_YES" = 1 ]; then
+    yes_flag="-y"
+  fi
+
+  if ! $SUDO $tool list *virtualenv > /dev/null 2>&1; then
+    echo "To use Certbot, packages from the EPEL repository need to be installed."
+    if [ "$ASSUME_YES" = 1 ]; then
+        /bin/echo -n "Enabling the EPEL repository in 3 seconds..."
+        sleep 1s
+        /bin/echo -ne "\e[0K\rEnabling the EPEL repository in 2 seconds..."
+        sleep 1s
+        /bin/echo -e "\e[0K\rEnabling the EPEL repository in 1 seconds..."
+        sleep 1s
+    fi
+    if ! $SUDO $tool install $yes_flag epel-release; then
+      echo "Could not enable EPEL. Aborting bootstrap!"
+      exit 1
+    fi
+  fi
+
   pkgs="
     gcc
     dialog
@@ -316,10 +336,6 @@ BootstrapRpmCommon() {
     pkgs="$pkgs
       mod_ssl
     "
-  fi
-
-  if [ "$ASSUME_YES" = 1 ]; then
-    yes_flag="-y"
   fi
 
   if ! $SUDO $tool install $yes_flag $pkgs; then

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -17,6 +17,26 @@ BootstrapRpmCommon() {
     exit 1
   fi
 
+  if [ "$ASSUME_YES" = 1 ]; then
+    yes_flag="-y"
+  fi
+
+  if ! $SUDO $tool list *virtualenv > /dev/null 2>&1; then
+    echo "To use Certbot, packages from the EPEL repository need to be installed."
+    if [ "$ASSUME_YES" = 1 ]; then
+        /bin/echo -n "Enabling the EPEL repository in 3 seconds..."
+        sleep 1s
+        /bin/echo -ne "\e[0K\rEnabling the EPEL repository in 2 seconds..."
+        sleep 1s
+        /bin/echo -e "\e[0K\rEnabling the EPEL repository in 1 seconds..."
+        sleep 1s
+    fi
+    if ! $SUDO $tool install $yes_flag epel-release; then
+      echo "Could not enable EPEL. Aborting bootstrap!"
+      exit 1
+    fi
+  fi
+
   pkgs="
     gcc
     dialog
@@ -52,10 +72,6 @@ BootstrapRpmCommon() {
     pkgs="$pkgs
       mod_ssl
     "
-  fi
-
-  if [ "$ASSUME_YES" = 1 ]; then
-    yes_flag="-y"
   fi
 
   if ! $SUDO $tool install $yes_flag $pkgs; then

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -21,7 +21,7 @@ BootstrapRpmCommon() {
     yes_flag="-y"
   fi
 
-  if ! $SUDO $tool list *virtualenv > /dev/null 2>&1; then
+  if ! $SUDO $tool list *virtualenv >/dev/null 2>&1; then
     echo "To use Certbot, packages from the EPEL repository need to be installed."
     if [ "$ASSUME_YES" = 1 ]; then
         /bin/echo -n "Enabling the EPEL repository in 3 seconds..."

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -23,6 +23,10 @@ BootstrapRpmCommon() {
 
   if ! $SUDO $tool list *virtualenv >/dev/null 2>&1; then
     echo "To use Certbot, packages from the EPEL repository need to be installed."
+    if ! $SUDO $tool list epel-release >/dev/null 2>&1; then
+      echo "Please enable this repository and try running Certbot again."
+      exit 1
+    fi
     if [ "$ASSUME_YES" = 1 ]; then
         /bin/echo -n "Enabling the EPEL repository in 3 seconds..."
         sleep 1s


### PR DESCRIPTION
Fixes #2158.

I tested all branches of this on CentOS 6 and tested the script on CentOS 7 (EPEL doesn't need to be enabled on CentOS 7 so there's not much to test). I also tested this on the test farm, however, it appears EPEL is already enabled so I think the value of testing there is fairly minimal.