### PR TITLE
Errors when run without root

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -36,9 +36,10 @@ from certbot.plugins import disco as plugins_disco
 from certbot.plugins import selection as plug_sel
 
 
-_PERM_ERR_FMT = ("An error occurred while trying to create or modify {0}. To "
-                 "run as non-root, set --config-dir, --logs-dir, and "
-                 "--work-dir to writeable paths.")
+_PERM_ERR_FMT = os.linesep.join((
+    "The following error was encountered:", "{0}",
+    "If running as non-root, set --config-dir, "
+    "--logs-dir, and --work-dir to writeable paths."))
 
 
 logger = logging.getLogger(__name__)
@@ -601,8 +602,8 @@ def setup_log_file_handler(config, logfile, fmt):
     try:
         handler = logging.handlers.RotatingFileHandler(
             log_file_path, maxBytes=2 ** 20, backupCount=10)
-    except IOError:
-        raise errors.Error(_PERM_ERR_FMT.format(log_file_path))
+    except IOError as error:
+        raise errors.Error(_PERM_ERR_FMT.format(error))
     # rotate on each invocation, rollover only possible when maxBytes
     # is nonzero and backupCount is nonzero, so we set maxBytes as big
     # as possible not to overrun in single CLI invocation (1MB).
@@ -715,8 +716,8 @@ def make_or_verify_core_dir(directory, mode, uid, strict):
     """
     try:
         util.make_or_verify_dir(directory, mode, uid, strict)
-    except OSError:
-        raise errors.Error(_PERM_ERR_FMT.format(directory))
+    except OSError as error:
+        raise errors.Error(_PERM_ERR_FMT.format(error))
 
 
 def main(cli_args=sys.argv[1:]):

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 import atexit
 import dialog
-import errno
 import functools
 import logging.handlers
 import os
@@ -602,13 +601,8 @@ def setup_log_file_handler(config, logfile, fmt):
     try:
         handler = logging.handlers.RotatingFileHandler(
             log_file_path, maxBytes=2 ** 20, backupCount=10)
-    except IOError as e:
-        if e.errno == errno.EACCES:
-            msg = ("Access denied writing to {0}. To run as non-root, set " +
-                "--logs-dir, --config-dir, --work-dir to writable paths.")
-            raise errors.Error(msg.format(log_file_path))
-        else:
-            raise
+    except IOError:
+        raise errors.Error(_PERM_ERR_FMT.format(log_file_path))
     # rotate on each invocation, rollover only possible when maxBytes
     # is nonzero and backupCount is nonzero, so we set maxBytes as big
     # as possible not to overrun in single CLI invocation (1MB).

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -36,6 +36,12 @@ from certbot.display import util as display_util, ops as display_ops
 from certbot.plugins import disco as plugins_disco
 from certbot.plugins import selection as plug_sel
 
+
+_PERM_ERR_FMT = ("An error occurred while trying to create or modify {0}. To "
+                 "run as non-root, set --config-dir, --logs-dir, and "
+                 "--work-dir to writeable paths.")
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1,9 +1,7 @@
 """Tests for certbot.main."""
 import unittest
 
-
 import mock
-
 
 from certbot import cli
 from certbot import configuration

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -95,6 +95,7 @@ def make_or_verify_dir(directory, mode=0o755, uid=0, strict=False):
     :param str directory: Path to a directory.
     :param int mode: Directory mode.
     :param int uid: Directory owner.
+    :param bool strict: require directory to be owned by current user
 
     :raises .errors.Error: if a directory already exists,
         but has wrong permissions or owner


### PR DESCRIPTION
Fixes #2306, #2734 

All `OSError` and `IOError` exceptions that occur in the relevant sections will include a message about root. I did this due to the variety of errno types that occur across different systems, like we saw with the `webroot` directory.

An example error message looks like this:
```
The following error was encountered:
[Errno 13] Permission denied: '/etc/letsencrypt'
If running as non-root, set --config-dir, --logs-dir, and --work-dir to writeable paths.
```