### PR TITLE
Python 3 support for certonly

### DIFF
--- a/certbot/auth_handler.py
+++ b/certbot/auth_handler.py
@@ -1,8 +1,8 @@
 """ACME AuthHandler."""
-import itertools
 import logging
 import time
 
+import six
 import zope.component
 
 from acme import challenges
@@ -141,7 +141,7 @@ class AuthHandler(object):
 
         """
         active_achalls = []
-        for achall, resp in itertools.izip(achalls, resps):
+        for achall, resp in six.moves.zip(achalls, resps):
             # This line needs to be outside of the if block below to
             # ensure failed challenges are cleaned up correctly
             active_achalls.append(achall)
@@ -472,7 +472,7 @@ def _report_failed_challs(failed_achalls):
             problems.setdefault(achall.error.typ, []).append(achall)
 
     reporter = zope.component.getUtility(interfaces.IReporter)
-    for achalls in problems.itervalues():
+    for achalls in six.itervalues(problems):
         reporter.add_message(
             _generate_failed_chall_msg(achalls), reporter.MEDIUM_PRIORITY)
 

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -343,8 +343,10 @@ class HelpfulArgumentParser(object):
         self.determine_verb()
         help1 = self.prescan_for_flag("-h", self.help_topics)
         help2 = self.prescan_for_flag("--help", self.help_topics)
-        assert max(True, "a") == "a", "Gravity changed direction"
-        self.help_arg = max(help1, help2)
+        if isinstance(help1, bool) and isinstance(help2, bool):
+            self.help_arg = help1 or help2
+        else:
+            self.help_arg = help1 if isinstance(help1, str) else help2
         if self.help_arg is True:
             # just --help with no topic; avoid argparse altogether
             print(usage)

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -18,7 +18,7 @@ CLI_DEFAULTS = dict(
         os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"),
                      "letsencrypt", "cli.ini"),
     ],
-    verbose_count=-(logging.INFO / 10),
+    verbose_count=-int(logging.INFO / 10),
     server="https://acme-v01.api.letsencrypt.org/directory",
     rsa_key_size=2048,
     rollback_checkpoints=1,

--- a/certbot/plugins/disco.py
+++ b/certbot/plugins/disco.py
@@ -3,6 +3,7 @@ import collections
 import itertools
 import logging
 import pkg_resources
+import six
 
 import zope.interface
 import zope.interface.verify
@@ -194,12 +195,12 @@ class PluginsRegistry(collections.Mapping):
     def init(self, config):
         """Initialize all plugins in the registry."""
         return [plugin_ep.init(config) for plugin_ep
-                in self._plugins.itervalues()]
+                in six.itervalues(self._plugins)]
 
     def filter(self, pred):
         """Filter plugins based on predicate."""
         return type(self)(dict((name, plugin_ep) for name, plugin_ep
-                               in self._plugins.iteritems() if pred(plugin_ep)))
+                               in six.iteritems(self._plugins) if pred(plugin_ep)))
 
     def visible(self):
         """Filter plugins based on visibility."""
@@ -216,7 +217,7 @@ class PluginsRegistry(collections.Mapping):
 
     def prepare(self):
         """Prepare all plugins in the registry."""
-        return [plugin_ep.prepare() for plugin_ep in self._plugins.itervalues()]
+        return [plugin_ep.prepare() for plugin_ep in six.itervalues(self._plugins)]
 
     def available(self):
         """Filter plugins based on availability."""
@@ -238,7 +239,7 @@ class PluginsRegistry(collections.Mapping):
 
         """
         # use list instead of set because PluginEntryPoint is not hashable
-        candidates = [plugin_ep for plugin_ep in self._plugins.itervalues()
+        candidates = [plugin_ep for plugin_ep in six.itervalues(self._plugins)
                       if plugin_ep.initialized and plugin_ep.init() is plugin]
         assert len(candidates) <= 1
         if candidates:
@@ -249,7 +250,7 @@ class PluginsRegistry(collections.Mapping):
     def __repr__(self):
         return "{0}({1})".format(
             self.__class__.__name__, ','.join(
-                repr(p_ep) for p_ep in self._plugins.itervalues()))
+                repr(p_ep) for p_ep in six.itervalues(self._plugins)))
 
     def __str__(self):
         if not self._plugins:

--- a/certbot/plugins/manual.py
+++ b/certbot/plugins/manual.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import time
 
+import six
 import zope.component
 import zope.interface
 
@@ -187,7 +188,7 @@ s.serve_forever()" """
         #answer = zope.component.getUtility(interfaces.IDisplay).notification(
         #    message=message, height=25, pause=True)
         sys.stdout.write(message)
-        raw_input("Press ENTER to continue")
+        six.moves.input("Press ENTER to continue")
 
     def cleanup(self, achalls):
         # pylint: disable=missing-docstring,no-self-use,unused-argument

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -84,7 +84,7 @@ def pick_plugin(config, default, plugins, question, ifaces):
         else:
             return plugin_ep.init()
     elif len(prepared) == 1:
-        plugin_ep = prepared.values()[0]
+        plugin_ep = list(prepared.values())[0]
         logger.debug("Single candidate plugin: %s", plugin_ep)
         if plugin_ep.misconfigured:
             return None

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -409,6 +409,9 @@ def enforce_domain_sanity(domain):
         else:
             raise errors.ConfigurationError(str(error_fmt).format(domain))
 
+    if six.PY3:
+        domain = domain.decode('ascii')
+
     # Remove trailing dot
     domain = domain[:-1] if domain.endswith('.') else domain
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ install_requires = [
     'psutil>=2.2.1',  # 2.1.0 for net_connections and 2.2.1 resolves #1080
     'PyOpenSSL',
     'pyrfc3339',
-    'python2-pythondialog>=3.2.2rc1',  # Debian squeeze support, cf. #280
     'pytz',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
@@ -52,6 +51,12 @@ install_requires = [
     'zope.component',
     'zope.interface',
 ]
+
+# Debian squeeze support, cf. #280
+if sys.version_info[0] == 2:
+    install_requires.append('python2-pythondialog>=3.2.2rc1')
+else:
+    install_requires.append('pythondialog>=3.2.2rc1')
 
 # env markers in extras_require cause problems with older pip: #517
 # Keep in sync with conditional_requirements.py.


### PR DESCRIPTION
Ref: #3179

It's far from complete, just a quick try. Only these command is tested:
```
$ certbot --help
$ certbot --help all
$ certbot --logs-dir logs --config-dir config --work-dir certbot-workdir certonly --manual --domains my.domain.name --email my.email@some.company.com --agree-tos --manual-public-ip-logging-ok
```