### PR TITLE
Nginx charset_map and ${VARIABLE_SUBSTITUTION} parsing

### DIFF
--- a/certbot-compatibility-test/nginx/nginx-roundtrip-testdata/chive/chive-nginx-master/win-utf
+++ b/certbot-compatibility-test/nginx/nginx-roundtrip-testdata/chive/chive-nginx-master/win-utf
@@ -2,7 +2,6 @@
 # This map is not a full windows-1251 <> utf8 map: it does not
 # contain Serbian and Macedonian letters.  If you need a full map,
 # use contrib/unicode2nginx/win-utf map instead.
-#
 
 charset_map  windows-1251  utf-8 {
 

--- a/certbot-compatibility-test/nginx/nginx-roundtrip-testdata/chive/chive-nginx-master/win-utf
+++ b/certbot-compatibility-test/nginx/nginx-roundtrip-testdata/chive/chive-nginx-master/win-utf
@@ -2,6 +2,7 @@
 # This map is not a full windows-1251 <> utf8 map: it does not
 # contain Serbian and Macedonian letters.  If you need a full map,
 # use contrib/unicode2nginx/win-utf map instead.
+#
 
 charset_map  windows-1251  utf-8 {
 

--- a/certbot-nginx/certbot_nginx/nginxparser.py
+++ b/certbot-nginx/certbot_nginx/nginxparser.py
@@ -63,11 +63,11 @@ class RawNginxParser(object):
     # key could for instance be "server" or "http", or "location" (in which case
     # location_statement needs to have a non-empty location)
 
-    block_begin = (Group(space + key + location_statement) ^ 
+    block_begin = (Group(space + key + location_statement) ^
                    Group(if_statement) ^
                    Group(charset_map_statement)).leaveWhitespace()
 
-    block_innards = Group(ZeroOrMore(Group(comment | assignment) | block | map_block) 
+    block_innards = Group(ZeroOrMore(Group(comment | assignment) | block | map_block)
                           + space).leaveWhitespace()
 
     block << Group(block_begin + left_bracket + block_innards + right_bracket)

--- a/certbot-nginx/certbot_nginx/nginxparser.py
+++ b/certbot-nginx/certbot_nginx/nginxparser.py
@@ -73,15 +73,10 @@ class RawNginxParser(object):
     block << Group(block_begin + left_bracket + block_innards + right_bracket)
 
     script = OneOrMore(Group(comment | assignment) ^ block ^ map_block) + space + stringEnd
-    script.parseWithTabs()
-    testLine = OneOrMore(Group(space + key + location_statement)).leaveWhitespace()
-    testTwo = OneOrMore(block)
+    script.parseWithTabs().leaveWhitespace()
 
     def __init__(self, source):
         self.source = source
-
-    def test(self):
-        return self.testLine.parseString(self.source)
 
     def parse(self):
         """Returns the parsed tree."""


### PR DESCRIPTION
This PR fixes the parsing of the character set examples in the nginx compatibility dataset (`certbot-compatibility-test/nginx/nginx-roundtrip-testdata/chive/chive-nginx-master/koi-utf`, `certbot-compatibility-test/nginx/nginx-roundtrip-testdata/chive/chive-nginx-master/koi-win`, and `certbot-compatibility-test/nginx/nginx-roundtrip-testdata/chive/chive-nginx-master/win-utf`) by:

* adding a new case for parsing `charset_map` blocks (these take two arguments, not zero or one like other blocks)
* preserve whitespace before comments at the beginning of a conf file