### PR TITLE
Handle dns01 challenge into the manual plugin [see #3466]

### DIFF
--- a/certbot/plugins/manual.py
+++ b/certbot/plugins/manual.py
@@ -195,7 +195,7 @@ s.serve_forever()" """
                                               uri=uri,
                                               command=command)
 
-            self._ip_logging_permission(response, formated_message)
+            self._ip_logging_permission(formated_message)
 
         if not response.simple_verify(
                 achall.chall, achall.domain,
@@ -211,7 +211,7 @@ s.serve_forever()" """
             formated_message = message.format(validation=validation,
                                               domain=achall.domain,
                                               response=response)
-            self._ip_logging_permission(response, formated_message)
+            self._ip_logging_permission(formated_message)
 
         if not response.simple_verify(
                 achall.chall, achall.domain,
@@ -241,7 +241,7 @@ s.serve_forever()" """
         sys.stdout.write(message)
         six.moves.input("Press ENTER to continue")
 
-    def _ip_logging_permission(self, response, formated_message):
+    def _ip_logging_permission(self, formated_message):
         # pylint: disable=missing-docstring
         if not self.conf("public-ip-logging-ok"):
             if not zope.component.getUtility(interfaces.IDisplay).yesno(

--- a/certbot/plugins/manual.py
+++ b/certbot/plugins/manual.py
@@ -4,24 +4,28 @@ import logging
 import pipes
 import shutil
 import signal
-import socket
 import subprocess
 import sys
 import tempfile
-import time
 
 import six
 import zope.component
 import zope.interface
 
+from functools import partial
+
 from acme import challenges
 
 from certbot import errors
 from certbot import interfaces
-from certbot.plugins import common
+from certbot.plugins import common, util
+from certbot.util import busy_wait
 
 
 logger = logging.getLogger(__name__)
+
+
+SUPPORTED_CHALLENGES = [challenges.HTTP01, challenges.DNS01]
 
 
 @zope.interface.implementer(interfaces.IAuthenticator)
@@ -41,7 +45,16 @@ class Authenticator(common.Plugin):
 
     description = "Manually configure an HTTP server"
 
-    MESSAGE_TEMPLATE = """\
+    MESSAGE_TEMPLATE = {
+        "dns-01": """\
+Make sure your dns configuration content the following key before continuing:
+
+{validation}
+
+if you didn't, make sure to add the validation as TXT record into your domain
+configuration.
+""",
+        "http-01": """\
 Make sure your web server displays the following content at
 {uri} before continuing:
 
@@ -51,7 +64,7 @@ If you don't have HTTP server configured, you can run the following
 command on the target server (as root):
 
 {command}
-"""
+"""}
 
     # a disclaimer about your current IP being transmitted to Let's Encrypt's servers.
     IP_DISCLAIMER = """\
@@ -86,10 +99,23 @@ s.serve_forever()" """
 
     @classmethod
     def add_parser_arguments(cls, add):
+        validator = partial(util.supported_challenges_validator,
+                            supported=SUPPORTED_CHALLENGES)
+
         add("test-mode", action="store_true",
             help="Test mode. Executes the manual command in subprocess.")
         add("public-ip-logging-ok", action="store_true",
             help="Automatically allows public IP logging.")
+        add("supported-challenges",
+            help="Supported challenges. Preferred in the order they are listed.",
+            type=validator,
+            default="http-01")
+
+    @property
+    def supported_challenges(self):
+        """Challenges supported by this plugin."""
+        return [challenges.Challenge.TYPES[name] for name in
+                self.conf("supported-challenges").split(",")]
 
     def prepare(self):  # pylint: disable=missing-docstring,no-self-use
         if self.config.noninteractive_mode and not self.conf("test-mode"):
@@ -97,38 +123,35 @@ s.serve_forever()" """
 
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
         return ("This plugin requires user's manual intervention in setting "
-                "up an HTTP server for solving http-01 challenges and thus "
+                "up an HTTP server when solving http-01 challenges and thus "
                 "does not need to be run as a privileged process. "
                 "Alternatively shows instructions on how to use Python's "
-                "built-in HTTP server.")
+                "built-in HTTP server."
+                "When solving dns-01 challenges, it simply needs to wait for "
+                "the proper configuration of the domain's dns")
 
     def get_chall_pref(self, domain):
         # pylint: disable=missing-docstring,no-self-use,unused-argument
-        return [challenges.HTTP01]
+        return self.supported_challenges
 
-    def perform(self, achalls):  # pylint: disable=missing-docstring
+    def perform(self, achalls):
+        # pylint: disable=missing-docstring
+        mapping = {"http-01": self._perform_http01_challenge,
+                   "dns-01": self._perform_dns01_challenge}
         responses = []
         # TODO: group achalls by the same socket.gethostbyname(_ex)
         # and prompt only once per server (one "echo -n" per domain)
         for achall in achalls:
-            responses.append(self._perform_single(achall))
+            responses.append(mapping[achall.typ](achall))
         return responses
 
-    @classmethod
-    def _test_mode_busy_wait(cls, port):
-        while True:
-            time.sleep(1)
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                sock.connect(("localhost", port))
-            except socket.error:  # pragma: no cover
-                pass
-            else:
-                break
-            finally:
-                sock.close()
+    def cleanup(self, achalls):
+        # pylint: disable=missing-docstring
+        for achall in achalls:
+            if isinstance(achall.chall, challenges.HTTP01):
+                self._cleanup_http01_challenge(achall)
 
-    def _perform_single(self, achall):
+    def _perform_http01_challenge(self, achall):
         # same path for each challenge response would be easier for
         # users, but will not work if multiple domains point at the
         # same server: default command doesn't support virtual hosts
@@ -161,7 +184,8 @@ s.serve_forever()" """
             logger.debug("Manual command running as PID %s.", self._httpd.pid)
             # give it some time to bootstrap, before we try to verify
             # (cert generation in case of simpleHttpS might take time)
-            self._test_mode_busy_wait(port)
+            busy_wait(port)
+
             if self._httpd.poll() is not None:
                 raise errors.Error("Couldn't execute manual command")
         else:
@@ -171,10 +195,14 @@ s.serve_forever()" """
                         cli_flag="--manual-public-ip-logging-ok"):
                     raise errors.PluginError("Must agree to IP logging to proceed")
 
-            self._notify_and_wait(self.MESSAGE_TEMPLATE.format(
-                validation=validation, response=response,
+            message = self._get_message(achall)
+
+            self._notify_and_wait(message.format(
+                validation=validation,
+                response=response,
                 uri=achall.chall.uri(achall.domain),
-                command=command))
+                command=command
+            ))
 
         if not response.simple_verify(
                 achall.chall, achall.domain,
@@ -183,15 +211,30 @@ s.serve_forever()" """
 
         return response
 
-    def _notify_and_wait(self, message):  # pylint: disable=no-self-use
-        # TODO: IDisplay wraps messages, breaking the command
-        #answer = zope.component.getUtility(interfaces.IDisplay).notification(
-        #    message=message, height=25, pause=True)
-        sys.stdout.write(message)
-        six.moves.input("Press ENTER to continue")
+    def _perform_dns01_challenge(self, achall):
+        response, validation = achall.response_and_validation()
+        if not self.conf("test-mode"):
+            if not self.conf("public-ip-logging-ok"):
+                if not zope.component.getUtility(interfaces.IDisplay).yesno(
+                        self.IP_DISCLAIMER, "Yes", "No",
+                        cli_flag="--manual-public-ip-logging-ok"):
+                    raise errors.PluginError("Must agree to IP logging to proceed")
 
-    def cleanup(self, achalls):
-        # pylint: disable=missing-docstring,no-self-use,unused-argument
+            message = self._get_message(achall)
+            formated_message = message.format(validation=validation,
+                                              response=response)
+
+            self._notify_and_wait(formated_message)
+
+        if not response.simple_verify(
+                achall.chall, achall.domain,
+                achall.account_key.public_key()):
+            logger.warning("Self-verify of challenge failed.")
+
+        return response
+
+    def _cleanup_http01_challenge(self, achall):
+        # pylint: disable=missing-docstring,unused-argument
         if self.conf("test-mode"):
             assert self._httpd is not None, (
                 "cleanup() must be called after perform()")
@@ -202,3 +245,14 @@ s.serve_forever()" """
                 logger.debug("Manual command process already terminated "
                              "with %s code", self._httpd.returncode)
             shutil.rmtree(self._root)
+
+    def _notify_and_wait(self, message):  # pylint: disable=no-self-use
+        # TODO: IDisplay wraps messages, breaking the command
+        #answer = zope.component.getUtility(interfaces.IDisplay).notification(
+        #    message=message, height=25, pause=True)
+        sys.stdout.write(message)
+        six.moves.input("Press ENTER to continue")
+
+    def _get_message(self, achall):
+        # pylint: disable=missing-docstring,no-self-use,unused-argument
+        return self.MESSAGE_TEMPLATE.get(achall.chall.typ, "")

--- a/certbot/plugins/standalone_test.py
+++ b/certbot/plugins/standalone_test.py
@@ -1,5 +1,4 @@
 """Tests for certbot.plugins.standalone."""
-import argparse
 import socket
 import unittest
 
@@ -62,33 +61,6 @@ class ServerManagerTest(unittest.TestCase):
             errors.StandaloneBindError, self.mgr.run, port,
             challenge_type=challenges.HTTP01)
         self.assertEqual(self.mgr.running(), {})
-
-
-class SupportedChallengesValidatorTest(unittest.TestCase):
-    """Tests for plugins.standalone.supported_challenges_validator."""
-
-    def _call(self, data):
-        from certbot.plugins.standalone import (
-            supported_challenges_validator)
-        return supported_challenges_validator(data)
-
-    def test_correct(self):
-        self.assertEqual("tls-sni-01", self._call("tls-sni-01"))
-        self.assertEqual("http-01", self._call("http-01"))
-        self.assertEqual("tls-sni-01,http-01", self._call("tls-sni-01,http-01"))
-        self.assertEqual("http-01,tls-sni-01", self._call("http-01,tls-sni-01"))
-
-    def test_unrecognized(self):
-        assert "foo" not in challenges.Challenge.TYPES
-        self.assertRaises(argparse.ArgumentTypeError, self._call, "foo")
-
-    def test_not_subset(self):
-        self.assertRaises(argparse.ArgumentTypeError, self._call, "dns")
-
-    def test_dvsni(self):
-        self.assertEqual("tls-sni-01", self._call("dvsni"))
-        self.assertEqual("http-01,tls-sni-01", self._call("http-01,dvsni"))
-        self.assertEqual("tls-sni-01,http-01", self._call("dvsni,http-01"))
 
 
 class AuthenticatorTest(unittest.TestCase):

--- a/certbot/tests/acme_util.py
+++ b/certbot/tests/acme_util.py
@@ -17,9 +17,9 @@ HTTP01 = challenges.HTTP01(
     token=b"evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+oA")
 TLSSNI01 = challenges.TLSSNI01(
     token=jose.b64decode(b"evaGxfADs6pSRb2LAv9IZf17Dt3juxGJyPCt92wrDoA"))
-DNS = challenges.DNS(token=b"17817c66b60ce2e4012dfad92657527a")
+DNS01 = challenges.DNS01(token=b"17817c66b60ce2e4012dfad92657527a")
 
-CHALLENGES = [HTTP01, TLSSNI01, DNS]
+CHALLENGES = [HTTP01, TLSSNI01, DNS01]
 
 
 def gen_combos(challbs):
@@ -45,9 +45,9 @@ def chall_to_challb(chall, status):  # pylint: disable=redefined-outer-name
 # Pending ChallengeBody objects
 TLSSNI01_P = chall_to_challb(TLSSNI01, messages.STATUS_PENDING)
 HTTP01_P = chall_to_challb(HTTP01, messages.STATUS_PENDING)
-DNS_P = chall_to_challb(DNS, messages.STATUS_PENDING)
+DNS01_P = chall_to_challb(DNS01, messages.STATUS_PENDING)
 
-CHALLENGES_P = [HTTP01_P, TLSSNI01_P, DNS_P]
+CHALLENGES_P = [HTTP01_P, TLSSNI01_P, DNS01_P]
 
 
 def gen_authzr(authz_status, domain, challs, statuses, combos=True):

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -111,7 +111,7 @@ class GetAuthorizationsTest(unittest.TestCase):
 
         mock_poll.side_effect = self._validate_all
         self.mock_auth.get_chall_pref.return_value.append(challenges.HTTP01)
-        self.mock_auth.get_chall_pref.return_value.append(challenges.DNS)
+        self.mock_auth.get_chall_pref.return_value.append(challenges.DNS01)
 
         authzr = self.handler.get_authorizations(["0"])
 
@@ -125,7 +125,7 @@ class GetAuthorizationsTest(unittest.TestCase):
         self.assertEqual(self.mock_auth.cleanup.call_count, 1)
         # Test if list first element is TLSSNI01, use typ because it is an achall
         for achall in self.mock_auth.cleanup.call_args[0][0]:
-            self.assertTrue(achall.typ in ["tls-sni-01", "http-01", "dns"])
+            self.assertTrue(achall.typ in ["tls-sni-01", "http-01", "dns-01"])
 
         # Length of authorizations list
         self.assertEqual(len(authzr), 1)
@@ -240,7 +240,7 @@ class PollChallengesTest(unittest.TestCase):
         from certbot.auth_handler import challb_to_achall
         self.mock_net.poll.side_effect = self._mock_poll_solve_one_valid
         self.chall_update[self.doms[0]].append(
-            challb_to_achall(acme_util.DNS_P, "key", self.doms[0]))
+            challb_to_achall(acme_util.DNS01_P, "key", self.doms[0]))
         self.assertRaises(
             errors.AuthorizationError, self.handler._poll_challenges,
             self.chall_update, False)
@@ -342,7 +342,7 @@ class GenChallengePathTest(unittest.TestCase):
         self.assertTrue(self._call(challbs[::-1], prefs, None))
 
     def test_not_supported(self):
-        challbs = (acme_util.DNS_P, acme_util.TLSSNI01_P)
+        challbs = (acme_util.DNS01_P, acme_util.TLSSNI01_P)
         prefs = [challenges.TLSSNI01]
         combos = ((0, 1),)
 

--- a/certbot/tests/errors_test.py
+++ b/certbot/tests/errors_test.py
@@ -16,12 +16,12 @@ class FaiiledChallengesTest(unittest.TestCase):
         from certbot.errors import FailedChallenges
         self.error = FailedChallenges(set([achallenges.DNS(
             domain="example.com", challb=messages.ChallengeBody(
-                chall=acme_util.DNS, uri=None,
+                chall=acme_util.DNS01, uri=None,
                 error=messages.Error(typ="tls", detail="detail")))]))
 
     def test_str(self):
         self.assertTrue(str(self.error).startswith(
-            "Failed authorization procedure. example.com (dns): tls"))
+            "Failed authorization procedure. example.com (dns-01): tls"))
 
 
 class StandaloneBindErrorTest(unittest.TestCase):

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -14,6 +14,7 @@ import socket
 import stat
 import subprocess
 import sys
+import time
 
 import configargparse
 
@@ -474,3 +475,23 @@ def get_strict_version(normalized):
     # strict version ending with "a" and a number designates a pre-release
     # pylint: disable=no-member
     return distutils.version.StrictVersion(normalized.replace(".dev", "a"))
+
+
+def busy_wait(port, host="localhost"):
+    """Artificialy wait a fixed amount of time on a specific host and port
+
+    :param str port: port of the connection
+    :param str host: hostname of the connection, "localhost" if None
+
+    """
+    while True:
+        time.sleep(1)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.connect((host, port))
+        except socket.error:  # pragma: no cover
+            pass
+        else:
+            break
+        finally:
+            sock.close()


### PR DESCRIPTION
Following changes made by @bmw at https://github.com/certbot/certbot/pull/2061

I really needed to be able to use the `dns-01` challenge using the manual mode.

Since `dns-01` challenge is now supported by the `acme` client of `certbot` this PR is making use of the challenge by adding a new command line argument called `supported-challenges`.

 