### PR TITLE
Change "hacking" to "getting started" in the docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,9 +6,9 @@ Developer Guide
    :local:
 
 
-.. _hacking:
+.. _getting_started:
 
-Hacking
+Getting Started
 =======
 
 Running a local copy of the client


### PR DESCRIPTION
I think this more accurately reflects the purpose of this section, while "hacking" is mostly redundant with the title of the page, "Developer Guide."