### PR TITLE
Refactored get_file_path

### DIFF
--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -1801,25 +1801,17 @@ def get_file_path(vhost_path):
     :rtype: str
 
     """
-    # Strip off /files
-    avail_fp = vhost_path[6:]
-    # This can be optimized...
-    while True:
-        # Cast all to lowercase to be case insensitive
-        find_if = avail_fp.lower().find("/ifmodule")
-        if find_if != -1:
-            avail_fp = avail_fp[:find_if]
-            continue
-        find_vh = avail_fp.lower().find("/virtualhost")
-        if find_vh != -1:
-            avail_fp = avail_fp[:find_vh]
-            continue
-        find_macro = avail_fp.lower().find("/macro")
-        if find_macro != -1:
-            avail_fp = avail_fp[:find_macro]
-            continue
-        break
-    return avail_fp
+    # Strip off /files/
+    avail_fp = vhost_path[7:].split("/")
+    last_good = ""
+    # Loop through the path parts and validate after every addition
+    for p in avail_fp:
+        cur_path = last_good+"/"+p
+        if os.path.exists(cur_path):
+            last_good = cur_path
+        else:
+            break
+    return last_good
 
 
 def install_ssl_options_conf(options_ssl):

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -1806,9 +1806,14 @@ def get_file_path(vhost_path):
     """
     # Strip off /files/
     try:
-        avail_fp = vhost_path[7:].split("/")
-    except TypeError:
+        if vhost_path.startswith("/files/"):
+            avail_fp = vhost_path[7:].split("/")
+        else:
+            return None
+    except AttributeError:
+        # If we recieved a None path
         return None
+
     last_good = ""
     # Loop through the path parts and validate after every addition
     for p in avail_fp:

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -538,6 +538,9 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 is_ssl = True
 
         filename = get_file_path(self.aug.get("/augeas/files%s/path" % get_file_path(path)))
+        if filename is None:
+            return None
+
         if self.conf("handle-sites"):
             is_enabled = self.is_site_enabled(filename)
         else:
@@ -1802,7 +1805,10 @@ def get_file_path(vhost_path):
 
     """
     # Strip off /files/
-    avail_fp = vhost_path[7:].split("/")
+    try:
+        avail_fp = vhost_path[7:].split("/")
+    except TypeError:
+        return None
     last_good = ""
     # Loop through the path parts and validate after every addition
     for p in avail_fp:

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -128,7 +128,7 @@ class MultipleVhostsTest(util.ApacheTest):
     def test_get_bad_path(self):
         from certbot_apache.configurator import get_file_path
         self.assertEqual(get_file_path(None), None)
-        self.assertEqual(self.config._create_vhost("nonexistent"), None)
+        self.assertEqual(self.config._create_vhost("nonexistent"), None) # pylint: disable=protected-access
 
     def test_bad_servername_alias(self):
         ssl_vh1 = obj.VirtualHost(

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -125,6 +125,10 @@ class MultipleVhostsTest(util.ApacheTest):
         self.assertTrue("google.com" in names)
         self.assertTrue("certbot.demo" in names)
 
+    def test_get_bad_path(self):
+        from certbot_apache.configurator import get_file_path
+        self.assertEqual(get_file_path(None), None)
+
     def test_bad_servername_alias(self):
         ssl_vh1 = obj.VirtualHost(
             "fp1", "ap1", set([obj.Addr(("*", "443"))]),

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -128,6 +128,7 @@ class MultipleVhostsTest(util.ApacheTest):
     def test_get_bad_path(self):
         from certbot_apache.configurator import get_file_path
         self.assertEqual(get_file_path(None), None)
+        self.assertEqual(self.config._create_vhost("nonexistent"), None)
 
     def test_bad_servername_alias(self):
         ssl_vh1 = obj.VirtualHost(

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -128,6 +128,7 @@ class MultipleVhostsTest(util.ApacheTest):
     def test_get_bad_path(self):
         from certbot_apache.configurator import get_file_path
         self.assertEqual(get_file_path(None), None)
+        self.assertEqual(get_file_path("nonexistent"), None)
         self.assertEqual(self.config._create_vhost("nonexistent"), None) # pylint: disable=protected-access
 
     def test_bad_servername_alias(self):


### PR DESCRIPTION
Instead of fiddling with predefined apache statement strings, do an actual file path verification for augeas paths. 

This eliminates the problem of having to predefine all possible Apache configuration file categories.

Also even though nobody(?) has hit it before, allows people to use vhost config file names starting with strings "ifmodule", "virtualhost" and "macro".

Fixes: #3377 #3319 