### PR TITLE
Fix local tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     py{26,27}-oldest: psutil==2.1.0
     py{26,27}-oldest: PyOpenSSL==0.13
     py{26,27}-oldest: python2-pythondialog==3.2.2rc1
+    py{26,27}-oldest: dnspython>=1.12
 
 [testenv:py33]
 commands =


### PR DESCRIPTION
The acme dns dependency was missing from tox.ini, causing acme tests to fail on local env.