### PR TITLE
Replace '-' with '_' before filtering plugin settings

### DIFF
--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -143,6 +143,7 @@ def _restore_plugin_configs(config, renewalparams):
     if renewalparams.get("installer", None) is not None:
         plugin_prefixes.append(renewalparams["installer"])
     for plugin_prefix in set(plugin_prefixes):
+        plugin_prefix = plugin_prefix.replace('-', '_')
         for config_item, config_value in six.iteritems(renewalparams):
             if config_item.startswith(plugin_prefix + "_") and not cli.set_by_cli(config_item):
                 # Values None, True, and False need to be treated specially,


### PR DESCRIPTION
This bug notably occurs when renewing certs for with the plugin `letsencrypt-s3front`

Fixes: #3380 