### PR TITLE
#3408: Made Gentoo bootstrapping asking before performing any changes

### DIFF
--- a/letsencrypt-auto-source/pieces/bootstrappers/gentoo_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/gentoo_common.sh
@@ -9,15 +9,20 @@ BootstrapGentooCommon() {
     app-misc/ca-certificates
     virtual/pkgconfig"
 
+  local ASK_OPTION="--ask"
+  if [ "$ASSUME_YES" = 1 ]; then
+    ASK_OPTION=""
+  fi
+
   case "$PACKAGE_MANAGER" in
     (paludis)
       $SUDO cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
       ;;
     (pkgcore)
-      $SUDO pmerge --noreplace --oneshot $PACKAGES
+      $SUDO pmerge --noreplace --oneshot $ASK_OPTION $PACKAGES
       ;;
     (portage|*)
-      $SUDO emerge --noreplace --oneshot $PACKAGES
+      $SUDO emerge --noreplace --oneshot $ASK_OPTION $PACKAGES
       ;;
   esac
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/gentoo_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/gentoo_common.sh
@@ -9,7 +9,7 @@ BootstrapGentooCommon() {
     app-misc/ca-certificates
     virtual/pkgconfig"
 
-  local ASK_OPTION="--ask"
+  ASK_OPTION="--ask"
   if [ "$ASSUME_YES" = 1 ]; then
     ASK_OPTION=""
   fi


### PR DESCRIPTION
Made Gentoo bootstrapping asking the user before performing any changes. This works for emerge and pmerge. Cave has been left out, since it has no equivalent option (or at least I do not know any). Overriding this behaviour using the `--non-interactive` option is possible.
