### PR TITLE
Fix the links for #3416 and align `README.rst` & `docs/resources.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,11 @@ If you'd like to contribute to this project please read `Developer Guide
 Installation
 ------------
 
-The easiest way to install Certbot is by visiting https://certbot.eff.org, where you can 
+The easiest way to install Certbot is by visiting `certbot.eff.org`_, where you can
 find the correct installation instructions for many web server and OS combinations.
 For more information, see the `User Guide <https://certbot.eff.org/docs/using.html#getting-certbot>`_.
+
+.. _certbot.eff.org: https://certbot.eff.org/
 
 How to run the client
 ---------------------
@@ -93,6 +95,10 @@ ACME working area in github: https://github.com/ietf-wg-acme/acme
 
 Mailing list: `client-dev`_ (to subscribe without a Google account, send an
 email to client-dev+subscribe@letsencrypt.org)
+
+.. _Freenode: https://webchat.freenode.net?channels=%23letsencrypt
+.. _OFTC: https://webchat.oftc.net?channels=%23certbot
+.. _client-dev: https://groups.google.com/a/letsencrypt.org/forum/#!forum/client-dev
 
 |build-status| |coverage| |docs| |container|
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -24,6 +24,10 @@ ACME working area in github: https://github.com/ietf-wg-acme/acme
 Mailing list: `client-dev`_ (to subscribe without a Google account, send an
 email to client-dev+subscribe@letsencrypt.org)
 
+.. _Freenode: https://webchat.freenode.net?channels=%23letsencrypt
+.. _OFTC: https://webchat.oftc.net?channels=%23certbot
+.. _client-dev: https://groups.google.com/a/letsencrypt.org/forum/#!forum/client-dev
+
 |build-status| |coverage| |docs| |container|
 
 
@@ -45,10 +49,6 @@ email to client-dev+subscribe@letsencrypt.org)
    :alt: Docker Repository on Quay.io
 
 .. _`installation instructions`:
-   https://letsencrypt.readthedocs.org/en/latest/using.html
+   https://letsencrypt.readthedocs.org/en/latest/using.html#getting-certbot
 
 .. _watch demo video: https://www.youtube.com/watch?v=Gas_sSB-5SU
-
-.. _Freenode: https://webchat.freenode.net?channels=%23letsencrypt
-.. _OFTC: https://webchat.oftc.net?channels=%23certbot
-.. _client-dev: https://groups.google.com/a/letsencrypt.org/forum/#!forum/client-dev


### PR DESCRIPTION
Fix the links for #3416 and align content of in README.rst and docs/resources.rst so it's easier to later de-dupe

(I've not done this now as in README.rst does too much tag: fiddling and I'm not sure how that will work out if the fiddling is not aware of .. include::.