### PR TITLE
Make return type of certbot.interfaces.IInstaller.get_all_keys_certs() an iterator

### DIFF
--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -1503,7 +1503,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         :rtype: list
 
         """
-        c_k = set()
 
         for vhost in self.vhosts:
             if vhost.ssl:
@@ -1517,11 +1516,10 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 if cert_path and key_path:
                     cert = os.path.abspath(self.parser.get_arg(cert_path[-1]))
                     key = os.path.abspath(self.parser.get_arg(key_path[-1]))
-                    c_k.add((cert, key, get_file_path(cert_path[-1])))
+                    yield (cert, key, get_file_path(cert_path[-1]))
                 else:
                     logger.warning(
                         "Invalid VirtualHost configuration - %s", vhost.filep)
-        return c_k
 
     def is_site_enabled(self, avail_fp):
         """Checks to see if the given site is enabled.

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -1496,11 +1496,11 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         Retrieve all certs and keys set in VirtualHosts on the Apache server
 
-        :returns: list of tuples with form [(cert, key, path)]
+        :returns: iterator that returns tuples with form (cert, key, path)
             cert - str path to certificate file
             key - str path to associated key file
             path - File path to configuration file.
-        :rtype: list
+        :rtype: iterator
 
         """
 

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -786,9 +786,9 @@ class MultipleVhostsTest(util.ApacheTest):
     def test_get_all_certs_keys_malformed_conf(self):
         self.config.parser.find_dir = mock.Mock(
             side_effect=[["path"], [], ["path"], [], ["path"], []])
-        c_k = self.config.get_all_certs_keys()
+        c_k = set(self.config.get_all_certs_keys())
 
-        self.assertIsNone(c_k)
+        self.assertEqual(set(c_k), set([]))
 
     def test_more_info(self):
         self.assertTrue(self.config.more_info())

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -776,9 +776,9 @@ class MultipleVhostsTest(util.ApacheTest):
                           self.config.config_test)
 
     def test_get_all_certs_keys(self):
-        c_k = self.config.get_all_certs_keys()
-        self.assertEqual(len(list(c_k)), 3)
-        cert, key, path = next(c_k)
+        c_k = set(self.config.get_all_certs_keys())
+        self.assertEqual(len(c_k), 3)
+        cert, key, path = next(iter(c_k))
         self.assertTrue("cert" in cert)
         self.assertTrue("key" in key)
         self.assertTrue("default-ssl" in path or "ocsp-ssl" in path)

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -777,8 +777,8 @@ class MultipleVhostsTest(util.ApacheTest):
 
     def test_get_all_certs_keys(self):
         c_k = self.config.get_all_certs_keys()
-        self.assertEqual(len(c_k), 3)
-        cert, key, path = next(iter(c_k))
+        self.assertEqual(len(list(c_k)), 3)
+        cert, key, path = next(c_k)
         self.assertTrue("cert" in cert)
         self.assertTrue("key" in key)
         self.assertTrue("default-ssl" in path or "ocsp-ssl" in path)
@@ -788,7 +788,7 @@ class MultipleVhostsTest(util.ApacheTest):
             side_effect=[["path"], [], ["path"], [], ["path"], []])
         c_k = self.config.get_all_certs_keys()
 
-        self.assertFalse(c_k)
+        self.assertIsNone(c_k)
 
     def test_more_info(self):
         self.assertTrue(self.config.more_info())

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -353,11 +353,11 @@ class NginxConfigurator(common.Plugin):
     def get_all_certs_keys(self):
         """Find all existing keys, certs from configuration.
 
-        :returns: list of tuples with form [(cert, key, path)]
+        :returns: iterator that returns tuples with form (cert, key, path)
             cert - str path to certificate file
             key - str path to associated key file
             path - File path to configuration file.
-        :rtype: set
+        :rtype: iterator
 
         """
         return self.parser.get_all_certs_keys()

--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -312,7 +312,6 @@ class NginxParser(object):
         :rtype: set
 
         """
-        c_k = set()
         vhosts = self.get_vhosts()
         for vhost in vhosts:
             tup = [None, None, vhost.filep]
@@ -323,8 +322,7 @@ class NginxParser(object):
                     elif directive[0] == 'ssl_certificate_key':
                         tup[1] = directive[1]
             if tup[0] is not None and tup[1] is not None:
-                c_k.add(tuple(tup))
-        return c_k
+                yield tuple(tup)
 
 
 def _do_for_subarray(entry, condition, func):

--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -305,11 +305,11 @@ class NginxParser(object):
     def get_all_certs_keys(self):
         """Gets all certs and keys in the nginx config.
 
-        :returns: list of tuples with form [(cert, key, path)]
+        :returns: iterator that returns tuples with form (cert, key, path)
             cert - str path to certificate file
             key - str path to associated key file
             path - File path to configuration file.
-        :rtype: set
+        :rtype: iterator
 
         """
         vhosts = self.get_vhosts()

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -261,7 +261,7 @@ class NginxConfiguratorTest(util.NginxTest):
         self.assertEqual(set([
             ('example/fullchain.pem', 'example/key.pem', example_conf),
             ('/etc/nginx/fullchain.pem', '/etc/nginx/key.pem', nginx_conf),
-        ]), self.config.get_all_certs_keys())
+        ]), set(self.config.get_all_certs_keys()))
 
     @mock.patch("certbot_nginx.configurator.tls_sni_01.NginxTlsSni01.perform")
     @mock.patch("certbot_nginx.configurator.NginxConfigurator.restart")

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -226,7 +226,7 @@ class NginxParserTest(util.NginxTest):
                                        ['listen', '443 ssl']],
                                       replace=False)
         c_k = nparser.get_all_certs_keys()
-        self.assertEqual(set([('foo.pem', 'bar.key', filep)]), c_k)
+        self.assertEqual(set([('foo.pem', 'bar.key', filep)]), next(c_k))
 
     def test_parse_server_ssl(self):
         server = parser.parse_server([

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -226,7 +226,7 @@ class NginxParserTest(util.NginxTest):
                                        ['listen', '443 ssl']],
                                       replace=False)
         c_k = nparser.get_all_certs_keys()
-        self.assertEqual(set([('foo.pem', 'bar.key', filep)]), next(c_k))
+        self.assertEqual(set([('foo.pem', 'bar.key', filep)]), set(c_k))
 
     def test_parse_server_ssl(self):
         server = parser.parse_server([

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -300,13 +300,13 @@ class IInstaller(IPlugin):
     def get_all_certs_keys():
         """Retrieve all certs and keys set in configuration.
 
-        :returns: tuples with form `[(cert, key, path)]`, where:
-
+        :returns: An iterator that returns `(cert, key, path)` for every
+            iteration, where:
             - `cert` - str path to certificate file
             - `key` - str path to associated key file
             - `path` - file path to configuration file
 
-        :rtype: list
+        :rtype: iterator
 
         """
 

--- a/certbot/plugins/null.py
+++ b/certbot/plugins/null.py
@@ -41,7 +41,7 @@ class Installer(common.Plugin):
         return []
 
     def get_all_certs_keys(self):
-        return []
+        return iter([])
 
     def save(self, title=None, temporary=False):
         pass  # pragma: no cover

--- a/certbot/plugins/null_test.py
+++ b/certbot/plugins/null_test.py
@@ -15,7 +15,7 @@ class InstallerTest(unittest.TestCase):
         self.assertTrue(isinstance(self.installer.more_info(), str))
         self.assertEqual([], self.installer.get_all_names())
         self.assertEqual([], self.installer.supported_enhancements())
-        self.assertEqual([], self.installer.get_all_certs_keys())
+        self.assertEqual(iter([]), self.installer.get_all_certs_keys())
 
 
 if __name__ == "__main__":

--- a/certbot/plugins/null_test.py
+++ b/certbot/plugins/null_test.py
@@ -16,8 +16,11 @@ class InstallerTest(unittest.TestCase):
         self.assertEqual([], self.installer.get_all_names())
         self.assertEqual([], self.installer.supported_enhancements())
         self.assertEqual(set([]), set(self.installer.get_all_certs_keys()))
-        with self.assertRaises(StopIteration):
-            next(self.installer.get_all_certs_keys())
+        self.assertRaises(
+            StopIteration,
+            next,
+            self.installer.get_all_certs_keys()
+        )
 
 
 if __name__ == "__main__":

--- a/certbot/plugins/null_test.py
+++ b/certbot/plugins/null_test.py
@@ -15,7 +15,9 @@ class InstallerTest(unittest.TestCase):
         self.assertTrue(isinstance(self.installer.more_info(), str))
         self.assertEqual([], self.installer.get_all_names())
         self.assertEqual([], self.installer.supported_enhancements())
-        self.assertEqual(iter([]), self.installer.get_all_certs_keys())
+        self.assertEqual(set([]), set(self.installer.get_all_certs_keys()))
+        with self.assertRaises(StopIteration):
+            next(self.installer.get_all_certs_keys())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We're developing a plugin for certbot called certbot-haproxy, for HAProxy as the name implies. There are 2 likely scenario's we are considering for the development of the plugin. 
1. HAProxy is used as a load-balancer/high availability proxy for a single or a few large websites with multiple back-ends.
2. HAProxy is used as a load-balancer/high availability proxy for many websites (up to thousands of websites) with multiple back-ends.

Our use case is the latter. Because we are dealing with bigger numbers we need to be careful not to create stuff that does not perform well when run repeatedly like in for loops.

We have a working proof of concept, that implements the interfaces specified by Certbot and is capable of authorisation and installation of certificates. It looks like it will scale pretty well too. 

There is however 1 thing that does not perform well when the amount of certificates goes beyond a thousand or so. It's `cerbot.interfaces.IInstaller.get_all_certs_keys()` ([link](https://github.com/certbot/certbot/blob/5d8744bf7cd62d999ed130f912bf50c72d2c2de1/certbot/interfaces.py#L300)), which is supposed to return a `list` of `tuple`'s containing the path of the certificate, key and configuration file.

``` python
def get_all_certs_keys():
    """Retrieve all certs and keys set in configuration.
    :returns: tuples with form `[(cert, key, path)]`, where:
    - `cert` - str path to certificate file
    - `key` - str path to associated key file
    - `path` - file path to configuration file
    :rtype: list
    """
```

HAProxy does know the concept of "VirtualHost" (Apache) or "server" (nginx), instead we rely on ACL's to pass the requests for each website to the correct back-end. These ACL's do not relate to the configured certificates in the configuration file. Which means we can not implement this function the conventional way i.e.: find all VirtualHost's and parse them to find paths to certificates. We have to inspect our certificate directory instead, parsing each certificate to check that they are in fact certificates issued by Let's Encrypt. This has to be done for every certificate every time the method is called since we need to return a `list` of `tuple`'s. Performance is still mostly linear per call, but decreases with every issued certificate, which is not a best practice for software development.

We therefore want to propose a change in the interface:

``` python
def get_all_certs_keys():
    """Retrieve all certs and keys set in configuration.

    :returns: An iterator that returns `(cert, key, path)` for every
        iteration, where:
        - `cert` - str path to certificate file
        - `key` - str path to associated key file
        - `path` - file path to configuration file

    :rtype: iterator

    """
```

**Pro's**
- Performance is slightly increased regardless of the plugin because: 
  - Memory use is decreased, even if only **very slightly** in most cases.
  - If the first or one of the first keys is the one you are looking for, the others don't even need to be parsed.

**Cons**
- The interface is already defined and implementations already exist, maybe we can come up with a workaround that allows both a `list` or an `iterator`? But this would depend on the purpose of this method, which at this point is not very clear to me.
  - It seems a non-issue since it's only used in unittests.
  - I have updated all unittests and `get_all_certs_keys()` implementations that are in certbot-apache and certbot-nginx in my pull-request.

**Questions**
- We aren't aware if there is any specific reasoning for this to return a `list` instead of an `iterator`, is there?
- We couldn't really find any call to this method other than in the unittests, is this a future use kind of thing?

I ran the tox tests according to the contribution guidelines, <s>it doesn't seem any issues arose from my changes</s>. Had a few issues with Python 2.6 compatibility, fixed that along with some obvious errors, now all tests seem to pass.
