### PR TITLE
Allow tests to run when psutil isn't available

### DIFF
--- a/certbot/plugins/util_test.py
+++ b/certbot/plugins/util_test.py
@@ -4,13 +4,7 @@ import unittest
 import sys
 
 import mock
-
-try:
-    # Python 3.5+
-    from importlib import reload as refresh  # pylint: disable=no-name-in-module
-except ImportError:
-    # Python 2-3.4
-    from imp import reload as refresh
+from six.moves import reload_module  # pylint: disable=import-error
 
 
 class PathSurgeryTest(unittest.TestCase):
@@ -50,14 +44,14 @@ class AlreadyListeningTestNoPsutil(unittest.TestCase):
         sys.modules['psutil'] = None
         # Reload hackery to ensure getting non-psutil version
         # loaded to memory
-        refresh(certbot.plugins.util)
+        reload_module(certbot.plugins.util)
 
     def tearDown(self):
         # Need to reload the module to ensure
         # getting back to normal
         import certbot.plugins.util
         sys.modules["psutil"] = self.psutil
-        refresh(certbot.plugins.util)
+        reload_module(certbot.plugins.util)
 
     @mock.patch("certbot.plugins.util.zope.component.getUtility")
     def test_ports_available(self, mock_getutil):

--- a/certbot/plugins/util_test.py
+++ b/certbot/plugins/util_test.py
@@ -1,10 +1,15 @@
 """Tests for certbot.plugins.util."""
 import os
-import unittest
 import sys
 
 import mock
 from six.moves import reload_module  # pylint: disable=import-error
+
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest  # pylint: disable=import-error
+else:
+    import unittest
 
 
 class PathSurgeryTest(unittest.TestCase):
@@ -75,6 +80,22 @@ class AlreadyListeningTestNoPsutil(unittest.TestCase):
         self.assertEqual(mock_getutil.call_count, 2)
 
 
+def has_psutil():
+    """Checks if the psutil module is available.
+
+    :returns: True if psutil is installed, otherwise, False
+    :rtype: bool
+
+    """
+    try:
+        import psutil  # pylint: disable=unused-variable
+        return True
+    except ImportError:
+        return False
+
+
+@unittest.skipUnless(has_psutil(),
+                     "optional psutil dependency is not available")
 class AlreadyListeningTestPsutil(unittest.TestCase):
     """Tests for certbot.plugins.already_listening."""
     def _call(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ if sys.version_info < (2, 7):
         # only some distros recognize stdlib argparse as already satisfying
         'argparse',
         'mock<1.1.0',
+        'unittest2',
     ])
 else:
     install_requires.append('mock')


### PR DESCRIPTION
Fixes #3438.

This adds a dependency of `unittest2` on Python 2.6 systems which already exists indirectly due to `configargparse` ([source1](https://github.com/bw2/ConfigArgParse/blob/0.10.0/setup.py#L76) and [source2](https://github.com/certbot/certbot/blob/master/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt#L161)).