### PR TITLE
fix #3347 - quote domain name [needs revision]

### DIFF
--- a/certbot/util.py
+++ b/certbot/util.py
@@ -451,7 +451,8 @@ def enforce_domain_sanity(domain):
     # FQDN checks according to RFC 2181: domain name should be less than 255
     # octets (inclusive). And each label is 1 - 63 octets (inclusive).
     # https://tools.ietf.org/html/rfc2181#section-11
-    msg = "Requested domain {0} is not a FQDN because ".format(domain)
+    # quoted domain just in case the domain is empty - see issue #3347
+    msg = "Requested domain \"{0}\" is not a FQDN because ".format(domain)
     labels = domain.split('.')
     for l in labels:
         if not 0 < len(l) < 64:


### PR DESCRIPTION
This makes it more clear when passing an empty domain name leads to the error:

```
Requested domain  is not a FQDN because label is either empty or too long.
```

now has become

```
Requested domain "" is not a FQDN because label is either empty or too long.
```
