### PR TITLE
Support both invalidEmail and invalidContact errors

### DIFF
--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -27,6 +27,8 @@ class Error(jose.JSONObjectWithFields, errors.Error):
             ('dnssec', 'The server could not validate a DNSSEC signed domain'),
             ('invalidEmail',
              'The provided email for a registration was invalid'),
+            ('invalidContact',
+             'The provided email for a registration was invalid'),
             ('malformed', 'The request message was malformed'),
             ('rateLimited', 'There were too many requests of a given type'),
             ('serverInternal', 'The server experienced an internal error'),

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -28,7 +28,7 @@ class Error(jose.JSONObjectWithFields, errors.Error):
             ('invalidEmail',
              'The provided email for a registration was invalid'),
             ('invalidContact',
-             'The provided email for a registration was invalid'),
+             'The provided contact URI was invalid'),
             ('malformed', 'The request message was malformed'),
             ('rateLimited', 'There were too many requests of a given type'),
             ('serverInternal', 'The server experienced an internal error'),

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -149,7 +149,7 @@ def perform_registration(acme, config):
     try:
         return acme.register(messages.NewRegistration.from_data(email=config.email))
     except messages.Error as e:
-        if e.typ == "urn:acme:error:invalidEmail":
+        if e.typ == "urn:acme:error:invalidEmail" or e.typ == "urn:acme:error:invalidContact":
             if config.noninteractive_mode:
                 msg = ("The ACME server believes %s is an invalid email address. "
                        "Please ensure it is a valid email and attempt "

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -65,7 +65,7 @@ class RegisterTest(unittest.TestCase):
         from acme import messages
         self.config.noninteractive_mode = False
         msg = "DNS problem: NXDOMAIN looking up MX for example.com"
-        mx_err = messages.Error(detail=msg, typ="urn:acme:error:invalidEmail")
+        mx_err = messages.Error(detail=msg, typ="urn:acme:error:invalidContact")
         with mock.patch("certbot.client.acme_client.Client") as mock_client:
             mock_client().register.side_effect = [mx_err, mock.MagicMock()]
             self._call()
@@ -75,7 +75,7 @@ class RegisterTest(unittest.TestCase):
     def test_email_invalid_noninteractive(self, _rep):
         from acme import messages
         msg = "DNS problem: NXDOMAIN looking up MX for example.com"
-        mx_err = messages.Error(detail=msg, typ="urn:acme:error:invalidEmail")
+        mx_err = messages.Error(detail=msg, typ="urn:acme:error:invalidContact")
         with mock.patch("certbot.client.acme_client.Client") as mock_client:
             mock_client().register.side_effect = [mx_err, mock.MagicMock()]
             self.assertRaises(errors.Error, self._call)


### PR DESCRIPTION
With the switch to the proper ACME error coming sometime in the future (letsencrypt/boulder#2140) Certbot should support both types in the interim.