### PR TITLE
Fixed hash_bucket_size detection for nginx

### DIFF
--- a/certbot-nginx/certbot_nginx/tls_sni_01.py
+++ b/certbot-nginx/certbot_nginx/tls_sni_01.py
@@ -101,7 +101,7 @@ class NginxTlsSni01(common.TLSSNI01):
             if key == ['http']:
                 found_bucket = False
                 for k, _ in body:
-                    if k == bucket_directive[0]:
+                    if k == bucket_directive[1]:
                         found_bucket = True
                 if not found_bucket:
                     body.insert(0, bucket_directive)


### PR DESCRIPTION
bucket_directive[0] is '\n', bucket_directive[1] is 'server_names_hash_bucket_size'

The code shouldn't search for \n when trying to find the bucket_size option.