### PR TITLE
Include log retention count to 1000.

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -601,7 +601,7 @@ def setup_log_file_handler(config, logfile, fmt):
     log_file_path = os.path.join(config.logs_dir, logfile)
     try:
         handler = logging.handlers.RotatingFileHandler(
-            log_file_path, maxBytes=2 ** 20, backupCount=10)
+            log_file_path, maxBytes=2 ** 20, backupCount=1000)
     except IOError as error:
         raise errors.Error(_PERM_ERR_FMT.format(error))
     # rotate on each invocation, rollover only possible when maxBytes


### PR DESCRIPTION
This is a quick fix to https://github.com/certbot/certbot/issues/3382, so that
Python log rotation is less likely to delete files before logrotate can get to
them. Specifically, if logrotate's config says to preserve fewer than 1000 logs,
it will do the right thing.