### PR TITLE
Remove pointless question

### DIFF
--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -103,12 +103,8 @@ def choose_names(installer):
     names = get_valid_domains(domains)
 
     if not names:
-        server = ""
-        if hasattr(installer, "name") and installer.name:
-            server = "{0} ".format(installer.name)
-            server = server[0].upper() + server[1:] # capitalise server name
         return _choose_names_manually(
-            "No names were found in your {0}configuration files. ".format(server))
+            "No names were found in your configuration files. ")
 
     code, names = _filter_names(names)
     if code == display_util.OK and names:

--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -103,7 +103,8 @@ def choose_names(installer):
     names = get_valid_domains(domains)
 
     if not names:
-        return _choose_names_manually()
+        return _choose_names_manually(
+            "No names were found in your configuration files. ")
 
     code, names = _filter_names(names)
     if code == display_util.OK and names:
@@ -146,10 +147,17 @@ def _filter_names(names):
     return code, [str(s) for s in names]
 
 
-def _choose_names_manually():
-    """Manually input names for those without an installer."""
+def _choose_names_manually(prompt_prefix=""):
+    """Manually input names for those without an installer.
 
+    :param str prompt_prefix: string to prepend to prompt for domains
+
+    :returns: list of provided names
+    :rtype: `list` of `str`
+
+    """
     code, input_ = z_util(interfaces.IDisplay).input(
+        prompt_prefix +
         "Please enter in your domain name(s) (comma and/or space separated) ",
         cli_flag="--domains")
 

--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -103,18 +103,7 @@ def choose_names(installer):
     names = get_valid_domains(domains)
 
     if not names:
-        manual = z_util(interfaces.IDisplay).yesno(
-            "No names were found in your configuration files.{0}You should "
-            "specify ServerNames in your config files in order to allow for "
-            "accurate installation of your certificate.{0}"
-            "If you do use the default vhost, you may specify the name "
-            "manually. Would you like to continue?{0}".format(os.linesep),
-            default=True)
-
-        if manual:
-            return _choose_names_manually()
-        else:
-            return []
+        return _choose_names_manually()
 
     code, names = _filter_names(names)
     if code == display_util.OK and names:

--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -103,8 +103,12 @@ def choose_names(installer):
     names = get_valid_domains(domains)
 
     if not names:
+        server = ""
+        if hasattr(installer, "name") and installer.name:
+            server = "{0} ".format(installer.name)
+            server = server[0].upper() + server[1:] # capitalise server name
         return _choose_names_manually(
-            "No names were found in your configuration files. ")
+            "No names were found in your {0}configuration files. ".format(server))
 
     code, names = _filter_names(names)
     if code == display_util.OK and names:

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -206,20 +206,12 @@ class ChooseNamesTest(unittest.TestCase):
     @mock.patch("certbot.display.ops.z_util")
     def test_no_names_choose(self, mock_util):
         self.mock_install().get_all_names.return_value = set()
-        mock_util().yesno.return_value = True
         domain = "example.com"
         mock_util().input.return_value = (display_util.OK, domain)
 
         actual_doms = self._call(self.mock_install)
         self.assertEqual(mock_util().input.call_count, 1)
         self.assertEqual(actual_doms, [domain])
-
-    @mock.patch("certbot.display.ops.z_util")
-    def test_no_names_quit(self, mock_util):
-        self.mock_install().get_all_names.return_value = set()
-        mock_util().yesno.return_value = False
-
-        self.assertEqual(self._call(self.mock_install), [])
 
     @mock.patch("certbot.display.ops.z_util")
     def test_filter_names_valid_return(self, mock_util):

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -212,6 +212,8 @@ class ChooseNamesTest(unittest.TestCase):
         actual_doms = self._call(self.mock_install)
         self.assertEqual(mock_util().input.call_count, 1)
         self.assertEqual(actual_doms, [domain])
+        self.assertTrue(
+            "configuration files" in mock_util().input.call_args[0][0])
 
     @mock.patch("certbot.display.ops.z_util")
     def test_filter_names_valid_return(self, mock_util):


### PR DESCRIPTION
Fixes #3509.

I feel that the best approach here is to simply remove this question. First, I thought we wanted Nginx to error out if `get_all_names` returns an empty list but that's not correct. For instance, the user could have
```
server_name *.example.org;
```
We will not suggest this domain (it won't be in the return value for `get_all_names`), but if the user manually requests `www.example.org`, the Nginx plugin will/should work.

Additionally, I feel that the question itself was a little silly. You may not have to specify `ServerName` directives in your config, for instance, the Apache plugin will do this for you now. It also discusses default vhosts which may not be relevant (see above example) and may be more detail about server configuration than is needed for most users.

If there's a problem later, we should error out with the appropriate error message, but I feel like this question doesn't add much/any value for users.