### PR TITLE
Mention Python venv setup in certbot-auto --help

### DIFF
--- a/certbot-auto
+++ b/certbot-auto
@@ -35,6 +35,7 @@ Help for certbot itself cannot be provided until it is installed.
   --no-self-upgrade                         do not download updates
   --os-packages-only                        install OS dependencies and exit
   -v, --verbose                             provide more output
+  --version                                 install certbot and print version
 
 All arguments are accepted and forwarded to the Certbot client when run."
 
@@ -967,7 +968,7 @@ else
 
     # Print latest released version of LE to stdout:
     python fetch.py --latest-version
-    
+
     # Download letsencrypt-auto script from git tag v1.2.3 into the folder I'm
     # in, and make sure its signature verifies:
     python fetch.py --le-auto-script v1.2.3


### PR DESCRIPTION
Please see #3512 and #3472 for context. This one-liner allow users of certbot-auto to figure out how to do `--setup-and-then-stop` or `--venv-only` that should not be added.