### PR TITLE
If lineages are in an inconsistent (non-deployed) state, deploy them

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -166,9 +166,9 @@ def _handle_identical_cert_request(config, lineage):
 
     """
     if lineage.has_pending_deployment():
-        lineage.update_all_links_to(lineage.latest_common_version())
         logger.warn("Found a new cert /archive/ that was not linked to in /live/; "
                     "fixing and reinstalling..")
+        lineage.update_all_links_to(lineage.latest_common_version())
         return "reinstall", lineage
     if renewal.should_renew(config, lineage):
         return "renew", lineage

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -187,7 +187,7 @@ def _handle_identical_cert_request(config, lineage):
     elif config.verb == "certonly":
         keep_opt = "Keep the existing certificate for now"
     choices = [keep_opt,
-               "Renew & replace the lineage (limit ~5 per 7 days)"]
+               "Renew & replace the cert (limit ~5 per 7 days)"]
 
     display = zope.component.getUtility(interfaces.IDisplay)
     response = display.menu(question, choices, "OK", "Cancel", default=0)

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -579,6 +579,7 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         chain_path = '/etc/letsencrypt/live/foo.bar/fullchain.pem'
         mock_lineage = mock.MagicMock(cert=cert_path, fullchain=chain_path)
         mock_lineage.should_autorenew.return_value = due_for_renewal
+        mock_lineage.has_pending_deployment.return_value = False
         mock_certr = mock.MagicMock()
         mock_key = mock.MagicMock(pem='pem_key')
         mock_client = mock.MagicMock()

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -18,12 +18,13 @@ class MainTest(unittest.TestCase):
         pass
 
     @mock.patch("certbot.main.logger")
-    def test_handle_identical_cert_request_pending(self, mock_logger):
+    def test_handle_identical_cert_request_pending(self, _mock_logger):
         # For now, just test has_pending_deployment_branch; other
         # coverage is in cli_test.py...
         from certbot import main
         mock_lineage = mock.Mock()
         mock_lineage.has_pending_deployment.return_value = True
+        # pylint: disable=protected-access
         ret = main._handle_identical_cert_request(mock.Mock(), mock_lineage)
         self.assertEqual(ret, ("reinstall", mock_lineage))
         self.assertEqual(mock_lineage.update_all_links_to.call_count, 1)

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -11,6 +11,22 @@ from certbot import configuration
 from certbot import errors
 from certbot.plugins import disco as plugins_disco
 
+class MainTest(unittest.TestCase):
+    def setUp(self):
+        pass
+    def tearDown(self):
+        pass
+
+    @mock.patch("certbot.main.logger")
+    def test_handle_identical_cert_request_pending(self, mock_logger):
+        # For now, just test has_pending_deployment_branch; other
+        # coverage is in cli_test.py...
+        from certbot import main
+        mock_lineage = mock.Mock()
+        mock_lineage.has_pending_deployment.return_value = True
+        ret = main._handle_identical_cert_request(mock.Mock(), mock_lineage)
+        self.assertEqual(ret, ("reinstall", mock_lineage))
+        self.assertEqual(mock_lineage.update_all_links_to.call_count, 1)
 
 class ObtainCertTest(unittest.TestCase):
     """Tests for certbot.main.obtain_cert."""


### PR DESCRIPTION
Fixes:  #3497. Probably also fixes: #3366.