### PR TITLE
Mention that the domain is used to choose filename [revision requested]

### DIFF
--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -65,7 +65,9 @@ optional arguments:
   -d DOMAIN, --domains DOMAIN, --domain DOMAIN
                         Domain names to apply. For multiple domains you can
                         use multiple -d flags or enter a comma separated list
-                        of domains as a parameter. (default: [])
+                        of domains as a parameter. The first domain in the list
+                        will be used to decide where to store the new certificate,
+                        unless otherwise specified. (default: [])
   --user-agent USER_AGENT
                         Set a custom user agent string for the client. User
                         agent strings allow the CA to collect high level


### PR DESCRIPTION
The cert filename is chosen based on the first domain listed. With certs with overlapping domains or where some domains are less canonical, it's therefore useful to put the most canonical/unique domain first. This updates the help text to inform users of this fact.

When I used certbot for the first time, I didn't realize this, and ended up with a somewhat poorly named cert directory.
