### PR TITLE
Allow validation of cross-domain redirects

### DIFF
--- a/certbot-compatibility-test/certbot_compatibility_test/validator.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/validator.py
@@ -41,7 +41,11 @@ class Validator(object):
 
         redirect_location = response.headers.get("location", "")
         if not redirect_location.startswith("https://"):
-            return False
+            if not redirect_location.startswith("http://"):
+                return False
+            else:
+                if redirect_location[len("http://"):] == name:
+                    return False
 
         if response.status_code != 301:
             logger.error("Server did not redirect with permanent code")

--- a/certbot-compatibility-test/certbot_compatibility_test/validator.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/validator.py
@@ -40,6 +40,9 @@ class Validator(object):
             return False
 
         redirect_location = response.headers.get("location", "")
+        # We're checking that the redirect we added behaves correctly.
+        # It's okay for some server configuration to redirect to an
+        # http URL, as long as it's on some other domain.
         if not redirect_location.startswith("https://"):
             if not redirect_location.startswith("http://"):
                 return False


### PR DESCRIPTION
Update compatibility validator to pass redirect check when redirecting to a different domain, whether http or https.