### PR TITLE
Tweak for Travis performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,7 @@ matrix:
         - sudo cat /var/log/mysql/error.log
         - ps aux | grep mysql
     - python: "2.7"
-      env: TOXENV=apacheconftest
-      sudo: required
-    - python: "2.7"
-      env: TOXENV=nginxroundtrip
-    - python: "2.7"
-      env: TOXENV=py27 BOULDER_INTEGRATION=1
+      env: TOXENV=cover BOULDER_INTEGRATION=1
       sudo: true
       after_failure:
         - sudo cat /var/log/mysql/error.log
@@ -48,6 +43,11 @@ matrix:
       after_failure:
         - sudo cat /var/log/mysql/error.log
         - ps aux | grep mysql
+    - sudo: required
+      env: TOXENV=nginx_compat
+      services: docker
+      before_install:
+      addons:
     - python: "2.7"
       env: TOXENV=lint
     - sudo: required
@@ -60,19 +60,18 @@ matrix:
       services: docker
       before_install:
       addons:
-    - sudo: required
-      env: TOXENV=nginx_compat
-      services: docker
-      before_install:
-      addons:
-    - python: "2.7"
-      env: TOXENV=cover
     - python: "3.3"
       env: TOXENV=py33
     - python: "3.4"
       env: TOXENV=py34
     - python: "3.5"
       env: TOXENV=py35
+    - python: "2.7"
+      env: TOXENV=apacheconftest
+      sudo: required
+    - python: "2.7"
+      env: TOXENV=nginxroundtrip
+
 
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-`. This reduces the number of simultaneous Travis runs, which speeds

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,20 @@ env:
 
 matrix:
   include:
+    - python: "2.7"
+      env: TOXENV=cover BOULDER_INTEGRATION=1
+      sudo: true
+      after_failure:
+        - sudo cat /var/log/mysql/error.log
+        - ps aux | grep mysql
+    - python: "2.7"
+      env: TOXENV=lint
+    - python: "2.7"
+      env: TOXENV=py27-oldest BOULDER_INTEGRATION=1
+      sudo: true
+      after_failure:
+        - sudo cat /var/log/mysql/error.log
+        - ps aux | grep mysql
     - python: "2.6"
       env: TOXENV=py26 BOULDER_INTEGRATION=1
       sudo: true
@@ -31,25 +45,11 @@ matrix:
       after_failure:
         - sudo cat /var/log/mysql/error.log
         - ps aux | grep mysql
-    - python: "2.7"
-      env: TOXENV=cover BOULDER_INTEGRATION=1
-      sudo: true
-      after_failure:
-        - sudo cat /var/log/mysql/error.log
-        - ps aux | grep mysql
-    - python: "2.7"
-      env: TOXENV=py27-oldest BOULDER_INTEGRATION=1
-      sudo: true
-      after_failure:
-        - sudo cat /var/log/mysql/error.log
-        - ps aux | grep mysql
     - sudo: required
       env: TOXENV=nginx_compat
       services: docker
       before_install:
       addons:
-    - python: "2.7"
-      env: TOXENV=lint
     - sudo: required
       env: TOXENV=le_auto
       services: docker


### PR DESCRIPTION
 - merge `cover` and `py27 BOULDER_INTEGRATION` into one matrix entry
 - re-order to put the fastest environments last, improving average
   case parallelism
 - but ensure that the most likely-to-break tests (cover, lint) start first to fail early.