### PR TITLE
Use correct Content-Types in headers.

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -495,6 +495,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
 class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
     """Client network."""
     JSON_CONTENT_TYPE = 'application/json'
+    JOSE_CONTENT_TYPE = 'application/jose+json'
     JSON_ERROR_CONTENT_TYPE = 'application/problem+json'
     REPLAY_NONCE_HEADER = 'Replay-Nonce'
 
@@ -641,9 +642,10 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
             self._add_nonce(self.head(url))
         return self._nonces.pop()
 
-    def post(self, url, obj, content_type=JSON_CONTENT_TYPE, **kwargs):
+    def post(self, url, obj, content_type=JOSE_CONTENT_TYPE, **kwargs):
         """POST object wrapped in `.JWS` and check response."""
         data = self._wrap_in_jws(obj, self._get_nonce(url))
+        kwargs.setdefault('headers', {'Content-Type': content_type})
         response = self._send_request('POST', url, data=data, **kwargs)
         self._add_nonce(response)
         return self._check_response(response, content_type=content_type)

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -630,6 +630,10 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
         self.send_request.assert_called_once_with(
             'GET', 'http://example.com/', bar='baz')
 
+    def test_post_no_content_type(self):
+        self.content_type = self.net.JOSE_CONTENT_TYPE
+        self.assertEqual(self.checked_response, self.net.post('uri', self.obj))
+
     def test_post(self):
         # pylint: disable=protected-access
         self.assertEqual(self.checked_response, self.net.post(


### PR DESCRIPTION
This closes https://github.com/certbot/certbot/issues/3555

The content type for all posts requests is now `application/jose+json`, which is in compliance with the latest ACME spec. https://tools.ietf.org/html/draft-ietf-acme-acme-03