### PR TITLE
Travis tweaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,15 +60,15 @@ matrix:
       services: docker
       before_install:
       addons:
+    - python: "2.7"
+      env: TOXENV=apacheconftest
+      sudo: required
     - python: "3.3"
       env: TOXENV=py33
     - python: "3.4"
       env: TOXENV=py34
     - python: "3.5"
       env: TOXENV=py35
-    - python: "2.7"
-      env: TOXENV=apacheconftest
-      sudo: required
     - python: "2.7"
       env: TOXENV=nginxroundtrip
 


### PR DESCRIPTION
One more tiny tweak, placing the slower `sudo` environments back up the list. I expect this should save us another 10-20 seconds.