### PR TITLE
Allow tests to pass without dnspython

### DIFF
--- a/acme/acme/test_util.py
+++ b/acme/acme/test_util.py
@@ -5,6 +5,7 @@
 """
 import os
 import pkg_resources
+import unittest
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -73,3 +74,24 @@ def load_pyopenssl_private_key(*names):
     loader = _guess_loader(
         names[-1], OpenSSL.crypto.FILETYPE_PEM, OpenSSL.crypto.FILETYPE_ASN1)
     return OpenSSL.crypto.load_privatekey(loader, load_vector(*names))
+
+
+def skip_unless(condition, reason):  # pragma: no cover
+    """Skip tests unless a condition holds.
+
+    This implements the basic functionality of unittest.skipUnless
+    which is only available on Python 2.7+.
+
+    :param bool condition: If ``False``, the test will be skipped
+    :param str reason: the reason for skipping the test
+
+    :rtype: callable
+    :returns: decorator that hides tests unless condition is ``True``
+
+    """
+    if hasattr(unittest, "skipUnless"):
+        return unittest.skipUnless(condition, reason)
+    elif condition:
+        return lambda cls: cls
+    else:
+        return lambda cls: None

--- a/certbot/plugins/util_test.py
+++ b/certbot/plugins/util_test.py
@@ -6,6 +6,8 @@ import sys
 import mock
 from six.moves import reload_module  # pylint: disable=import-error
 
+from certbot.tests import test_util
+
 
 class PathSurgeryTest(unittest.TestCase):
     """Tests for certbot.plugins.path_surgery."""
@@ -89,28 +91,8 @@ def psutil_available():
     return True
 
 
-def skipUnless(condition, reason):
-    """Skip tests unless a condition holds.
-
-    This implements the basic functionality of unittest.skipUnless
-    which is only available on Python 2.7+.
-
-    :param bool condition: If ``False``, the test will be skipped
-    :param str reason: the reason for skipping the test
-
-    :rtype: callable
-    :returns: decorator that hides tests unless condition is ``True``
-
-    """
-    if hasattr(unittest, "skipUnless"):
-        return unittest.skipUnless(condition, reason)
-    elif condition:
-        return lambda cls: cls
-    else:
-        return lambda cls: None
-
-
-@skipUnless(psutil_available(), "optional dependency psutil is not available")
+@test_util.skipUnless(psutil_available(),
+                      "optional dependency psutil is not available")
 class AlreadyListeningTestPsutil(unittest.TestCase):
     """Tests for certbot.plugins.already_listening."""
     def _call(self, *args, **kwargs):

--- a/certbot/plugins/util_test.py
+++ b/certbot/plugins/util_test.py
@@ -91,8 +91,8 @@ def psutil_available():
     return True
 
 
-@test_util.skipUnless(psutil_available(),
-                      "optional dependency psutil is not available")
+@test_util.skip_unless(psutil_available(),
+                       "optional dependency psutil is not available")
 class AlreadyListeningTestPsutil(unittest.TestCase):
     """Tests for certbot.plugins.already_listening."""
     def _call(self, *args, **kwargs):

--- a/certbot/tests/test_util.py
+++ b/certbot/tests/test_util.py
@@ -5,6 +5,7 @@
 """
 import os
 import pkg_resources
+import unittest
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -73,3 +74,24 @@ def load_pyopenssl_private_key(*names):
     loader = _guess_loader(
         names[-1], OpenSSL.crypto.FILETYPE_PEM, OpenSSL.crypto.FILETYPE_ASN1)
     return OpenSSL.crypto.load_privatekey(loader, load_vector(*names))
+
+
+def skipUnless(condition, reason):
+    """Skip tests unless a condition holds.
+
+    This implements the basic functionality of unittest.skipUnless
+    which is only available on Python 2.7+.
+
+    :param bool condition: If ``False``, the test will be skipped
+    :param str reason: the reason for skipping the test
+
+    :rtype: callable
+    :returns: decorator that hides tests unless condition is ``True``
+
+    """
+    if hasattr(unittest, "skipUnless"):
+        return unittest.skipUnless(condition, reason)
+    elif condition:
+        return lambda cls: cls
+    else:
+        return lambda cls: None

--- a/certbot/tests/test_util.py
+++ b/certbot/tests/test_util.py
@@ -76,7 +76,7 @@ def load_pyopenssl_private_key(*names):
     return OpenSSL.crypto.load_privatekey(loader, load_vector(*names))
 
 
-def skipUnless(condition, reason):
+def skip_unless(condition, reason):  # pragma: no cover
     """Skip tests unless a condition holds.
 
     This implements the basic functionality of unittest.skipUnless


### PR DESCRIPTION
With the addition of using another port in the release script, it allows us to successfully build packages that pass our unit tests. Yay!