### PR TITLE
Fix requirements.txt surgery in response to shipping certbot-nginx

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -176,7 +176,7 @@ if ! wc -l /tmp/hashes.$$ | grep -qE "^\s*12 " ; then
 fi
 
 # perform hideous surgery on requirements.txt...
-head -n -9 letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt > /tmp/req.$$
+head -n -12 letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt > /tmp/req.$$
 cat /tmp/hashes.$$ >> /tmp/req.$$
 cp /tmp/req.$$ letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
 


### PR DESCRIPTION
Fixes #3431.

While a trivial change, this needs to be merged before we do another release, otherwise, `certbot-auto` will depend on both `certbot-nginx` 0.9.0 and x.y.z for our next release which will obviously cause problems. Wanted to get this out of the way before we forget in case we end up doing a point release.