### PR TITLE
Add --lineage command line option for nicer SAN management.

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -689,6 +689,14 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         help="Run using interactive dialog menus")
     helpful.add(
         [None, "run", "certonly"],
+        "--lineage", metavar="LINEAGE", dest="lineage", default=None,
+        help="File name of a config file under CONFIG_DIR/renewal/ whose associated certificate "
+             "lineage should be renewed by the 'certonly' or 'run' subcommands.  If not specified, "
+             "the relevant certificate lineage will be automatically determined based on the "
+             "specified domain names and the presence or absence of the --expand or --duplicate "
+             "flags.")
+    helpful.add(
+        [None, "run", "certonly"],
         "-d", "--domains", "--domain", dest="domains",
         metavar="DOMAIN", action=_DomainsAction, default=[],
         help="Domain names to apply. For multiple domains you can use "

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -76,6 +76,8 @@ def _auth_from_domains(le_client, config, domains, lineage=None):
     # If lineage is specified, use that one instead of looking around for
     # a matching one.
     if lineage is None:
+        lineage = _cli_lineage(config)
+    if lineage is None:
         # This will find a relevant matching lineage that exists
         action, lineage = _treat_as_renewal(config, domains)
     else:
@@ -274,6 +276,35 @@ def _find_domains(config, installer):
                            "will help in domain names autodiscovery")
 
     return domains
+
+
+def _cli_lineage(config):
+    """Obtain the lineage that was specified using --lineage on the command line
+
+    :returns: A storage.RenewableCert, or None if --lineage was not specified
+    :rtype: storage.RenewableCert or None
+
+    :raises .Error: If the specified lineage does not exist or is broken
+
+    """
+
+    if not config.lineage:
+        return None
+
+    cli_config = configuration.RenewerConfiguration(config)
+    configs_dir = cli_config.renewal_configs_dir
+    # Verify the directory is there
+    util.make_or_verify_dir(configs_dir, mode=0o755, uid=os.geteuid())
+
+    renewal_file = os.path.join(configs_dir, config.lineage)
+    try:
+        lineage = storage.RenewableCert(renewal_file, cli_config)
+    except (errors.CertStorageError, IOError):
+        logger.debug("Traceback:\n%s", traceback.format_exc())
+        raise errors.Error("Renewal conf file " + renewal_file + " does not "
+                           "exist or is broken.")
+
+    return lineage
 
 
 def _report_new_cert(config, cert_path, fullchain_path):


### PR DESCRIPTION
cc @shoen, @PaulSD, @yaegashi 

This PR is from some work by @PaulSD mention in #2071  as an alternative way managing SANs on a cert (instead of --expand & --shrink). I have not tested this to see if it works yet.

From the commit:

This allows the user to explicitly select a certificate lineage for
renewal, which may be necessary when removing a domain from a
multi-domain certificate.