### PR TITLE
Make --quiet reduce the logging level

### DIFF
--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -37,6 +37,9 @@ STAGING_URI = "https://acme-staging.api.letsencrypt.org/directory"
 
 """Defaults for CLI flags and `.IConfig` attributes."""
 
+QUIET_LOGGING_LEVEL = logging.WARNING
+"""Logging level to use in quiet mode."""
+
 RENEWER_DEFAULTS = dict(
     renewer_enabled="yes",
     renew_before_expiry="30 days",

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -625,17 +625,22 @@ def _cli_log_handler(config, level, fmt):
     return handler
 
 
-def setup_logging(config, cli_handler_factory, logfile):
-    """Setup logging."""
-    file_fmt = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
+def setup_logging(config):
+    """Sets up logging to logfiles and the terminal.
+
+    :param certbot.interface.IConfig config: Configuration object
+
+    """
     cli_fmt = "%(message)s"
+    file_fmt = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
+    logfile = "letsencrypt.log"
     if config.quiet:
         level = constants.QUIET_LOGGING_LEVEL
     else:
         level = -config.verbose_count * 10
     file_handler, log_file_path = setup_log_file_handler(
         config, logfile=logfile, fmt=file_fmt)
-    cli_handler = cli_handler_factory(config, level, cli_fmt)
+    cli_handler = _cli_log_handler(config, level, cli_fmt)
 
     # TODO: use fileConfig?
 
@@ -741,7 +746,7 @@ def main(cli_args=sys.argv[1:]):
                             os.geteuid(), config.strict_permissions)
     # Setup logging ASAP, otherwise "No handlers could be found for
     # logger ..." TODO: this should be done before plugins discovery
-    setup_logging(config, _cli_log_handler, logfile='letsencrypt.log')
+    setup_logging(config)
     cli.possible_deprecation_warning(config)
 
     logger.debug("certbot version: %s", certbot.__version__)

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -629,7 +629,10 @@ def setup_logging(config, cli_handler_factory, logfile):
     """Setup logging."""
     file_fmt = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
     cli_fmt = "%(message)s"
-    level = -config.verbose_count * 10
+    if config.quiet:
+        level = constants.QUIET_LOGGING_LEVEL
+    else:
+        level = -config.verbose_count * 10
     file_handler, log_file_path = setup_log_file_handler(
         config, logfile=logfile, fmt=file_fmt)
     cli_handler = cli_handler_factory(config, level, cli_fmt)


### PR DESCRIPTION
Fixes #3592. Additionally, now if both `--quiet` and `--verbose` are specified on the command line, `--verbose` is ignored for the purposes of setting up logging to the terminal.