### PR TITLE
Fix Apache constants tests

### DIFF
--- a/certbot-apache/certbot_apache/tests/constants_test.py
+++ b/certbot-apache/certbot_apache/tests/constants_test.py
@@ -20,28 +20,24 @@ class ConstantsTest(unittest.TestCase):
         self.assertEqual(constants.os_constant("vhost_root"),
                          "/etc/httpd/conf.d")
 
+    @mock.patch("certbot.util.get_systemd_os_like")
     @mock.patch("certbot.util.get_os_info")
-    def test_get_default_value(self, os_info):
+    def test_get_default_values(self, os_info, os_like):
         os_info.return_value = ('Nonexistent Linux', '', '')
+        os_like.return_value = {}
+        self.assertFalse(constants.os_constant("handle_mods"))
+        self.assertEqual(constants.os_constant("server_root"), "/etc/apache2")
         self.assertEqual(constants.os_constant("vhost_root"),
                          "/etc/apache2/sites-available")
 
+    @mock.patch("certbot.util.get_systemd_os_like")
     @mock.patch("certbot.util.get_os_info")
-    def test_get_default_constants(self, os_info):
+    def test_get_darwin_like_values(self, os_info, os_like):
         os_info.return_value = ('Nonexistent Linux', '', '')
-        with mock.patch("certbot.util.get_systemd_os_like") as os_like:
-            # Get defaults
-            os_like.return_value = False
-            c_hm = constants.os_constant("handle_mods")
-            c_sr = constants.os_constant("server_root")
-            self.assertFalse(c_hm)
-            self.assertEqual(c_sr, "/etc/apache2")
-            # Use darwin as like test target
-            os_like.return_value = ["something", "nonexistent", "darwin"]
-            d_vr = constants.os_constant("vhost_root")
-            d_em = constants.os_constant("enmod")
-            self.assertFalse(d_em)
-            self.assertEqual(d_vr, "/etc/apache2/other")
+        os_like.return_value = ["something", "nonexistent", "darwin"]
+        self.assertFalse(constants.os_constant("enmod"))
+        self.assertEqual(constants.os_constant("vhost_root"),
+                         "/etc/apache2/other")
 
 
 if __name__ == "__main__":

--- a/certbot-apache/certbot_apache/tests/constants_test.py
+++ b/certbot-apache/certbot_apache/tests/constants_test.py
@@ -42,3 +42,7 @@ class ConstantsTest(unittest.TestCase):
             d_em = constants.os_constant("enmod")
             self.assertFalse(d_em)
             self.assertEqual(d_vr, "/etc/apache2/other")
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover


### PR DESCRIPTION
Mock out both methods used to determine the underlying OS in `constants.py`.