### PR TITLE
Yo dawg, I heard you liked tests so I created a test script for running unit tests on your test farm

### DIFF
--- a/tests/letstest/scripts/test_tests.sh
+++ b/tests/letstest/scripts/test_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -xe
+
+MODULES="acme certbot certbot_apache certbot_nginx"
+VENV_NAME=venv
+
+# *-auto respects VENV_PATH
+VENV_PATH=$VENV_NAME letsencrypt/certbot-auto --debug --non-interactive --version
+. $VENV_NAME/bin/activate
+
+# change to an empty directory to ensure CWD doesn't affect tests
+cd $(mktemp -d)
+pip install nose
+
+for module in $MODULES ; do
+    echo testing $module
+    nosetests -v $module
+done


### PR DESCRIPTION
I had to use `VENV_PATH` because our tests assume that `certbot` was not installed with `certbot-auto`. We shouldn't be making this assumption, however, we've done this in our tests for over 10 months and I don't think fixing this should block our release. I created #3632 to track that issue.