### PR TITLE
Adding checking name validity to the Apache plugin

### DIFF
--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -472,7 +472,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
                 "\n\nUnfortunately mod_macro is not yet supported".format(
                     "\n  ".join(vhost_macro)), force_interactive=True)
 
-        return all_names
+        return util.get_filtered_names(all_names)
 
     def get_name_from_ip(self, addr):  # pylint: disable=no-self-use
         """Returns a reverse dns name if available.

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -103,8 +103,8 @@ class MultipleVhostsTest(util.ApacheTest):
         mock_getutility.notification = mock.MagicMock(return_value=True)
         names = self.config.get_all_names()
         self.assertEqual(names, set(
-            ["certbot.demo", "ocspvhost.com", "encryption-example.demo",
-                "ip-172-30-0-17", "*.blue.purple.com"]))
+            ["certbot.demo", "ocspvhost.com", "encryption-example.demo"]
+        ))
 
     @certbot_util.patch_get_utility()
     @mock.patch("certbot_apache.configurator.socket.gethostbyaddr")
@@ -123,7 +123,8 @@ class MultipleVhostsTest(util.ApacheTest):
         self.config.vhosts.append(vhost)
 
         names = self.config.get_all_names()
-        self.assertEqual(len(names), 7)
+        # Names get filtered, only 5 are returned
+        self.assertEqual(len(names), 5)
         self.assertTrue("zombo.com" in names)
         self.assertTrue("google.com" in names)
         self.assertTrue("certbot.demo" in names)

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
@@ -8,6 +8,7 @@ import zope.interface
 
 from certbot import configuration
 from certbot import errors as le_errors
+from certbot import util as certbot_util
 from certbot_apache import configurator
 from certbot_apache import constants
 from certbot_compatibility_test import errors
@@ -106,4 +107,7 @@ def _get_names(config):
                         not util.IP_REGEX.match(words[1]) and
                         words[1].find(".") != -1):
                     all_names.add(words[1])
-    return all_names, non_ip_names
+    return (
+        certbot_util.get_filtered_names(all_names),
+        certbot_util.get_filtered_names(non_ip_names)
+    )

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -403,25 +403,7 @@ class NginxConfigurator(common.Plugin):
                     except (socket.error, socket.herror, socket.timeout):
                         continue
 
-        return self._get_filtered_names(all_names)
-
-    def _get_filtered_names(self, all_names):
-        """Removes names that aren't considered valid by Let's Encrypt.
-
-        :param set all_names: all names found in the Nginx configuration
-
-        :returns: all found names that are considered valid by LE
-        :rtype: set
-
-        """
-        filtered_names = set()
-        for name in all_names:
-            try:
-                filtered_names.add(util.enforce_le_validity(name))
-            except errors.ConfigurationError as error:
-                logger.debug('Not suggesting name "%s"', name)
-                logger.debug(error)
-        return filtered_names
+        return util.get_filtered_names(all_names)
 
     def _get_snakeoil_paths(self):
         # TODO: generate only once

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -219,6 +219,25 @@ def safely_remove(path):
             raise
 
 
+def get_filtered_names(all_names):
+    """Removes names that aren't considered valid by Let's Encrypt.
+
+    :param set all_names: all names found in the configuration
+
+    :returns: all found names that are considered valid by LE
+    :rtype: set
+
+    """
+    filtered_names = set()
+    for name in all_names:
+        try:
+            filtered_names.add(enforce_le_validity(name))
+        except errors.ConfigurationError as error:
+            logger.debug('Not suggesting name "%s"', name)
+            logger.debug(error)
+    return filtered_names
+
+
 def get_os_info(filepath="/etc/os-release"):
     """
     Get OS name and version


### PR DESCRIPTION
Closes https://github.com/certbot/certbot/issues/3638

I think it would be cleaner to move the `_get_filtered_names` method to `util.py` or some other file where common functions are available. Please let me know your thoughts on this. If you agree, I'll do that :)
