### PR TITLE
Fix link to Docker's user guide

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -119,7 +119,7 @@ For more information about the layout
 of the ``/etc/letsencrypt`` directory, see :ref:`where-certs`.
 
 .. _Docker: https://docker.com
-.. _`install Docker`: https://docs.docker.com/engine/userguide/intro/
+.. _`install Docker`: https://docs.docker.com/engine/installation/
 
 
 Operating System Packages

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -119,7 +119,7 @@ For more information about the layout
 of the ``/etc/letsencrypt`` directory, see :ref:`where-certs`.
 
 .. _Docker: https://docker.com
-.. _`install Docker`: https://docs.docker.com/userguide/
+.. _`install Docker`: https://docs.docker.com/engine/userguide/intro/
 
 
 Operating System Packages


### PR DESCRIPTION
Fixes certbot/website#162.

In my browser, https://docs.docker.com/userguide/ redirects to https://docs.docker.com/engine/userguide/intro/, however, in Python (and presumably Ruby), the URL returns a 404.

```
$ ipython
Python 2.7.12 (default, Jul  1 2016, 15:12:24) 
Type "copyright", "credits" or "license" for more information.

IPython 2.4.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import requests

In [2]: requests.get("https://docs.docker.com/userguide/")
Out[2]: <Response [404]>
```

This PR does nothing but make our tests happy.