### PR TITLE
Fix update registration when ToS has changed [revision requested]

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -130,8 +130,6 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
         update = regr.body if update is None else update
         updated_regr = self._send_recv_regr(
             regr, body=messages.UpdateRegistration(**dict(update)))
-        if updated_regr != regr:
-            raise errors.UnexpectedUpdate(regr)
         return updated_regr
 
     def query_registration(self, regr):


### PR DESCRIPTION
Currently update-registration will fail on the client if i.e. the terms of service have changed because the client compares the full request and response registration objects.

If we limit the comparison to just the `body` of the registration objects the registration update will succeed.

The following is an anonymized version of a update request I just tried to send:

``` json
  {
    "body": {
      "contact": [
        "mailto:someone@example.com"
      ],
      "agreement": "https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf",
      "key": {
        "e": "xxx",
        "kty": "RSA",
        "n": "yyy"
      }
    },
    "uri": "https://acme-v01.api.letsencrypt.org/acme/reg/zzz",
    "new_authzr_uri": "https://acme-v01.api.letsencrypt.org/acme/new-authz",
    "terms_of_service": "https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
  }
```

The update failed because the return registration update has an updated terms of service value:

``` json
{
    "body": {
      "contact": [
        "mailto:someone@example.com"
      ],
      "agreement": "https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf",
      "key": {
        "e": "xxx",
        "kty": "RSA",
        "n": "yyy"
      }
    },
    "uri": "https://acme-v01.api.letsencrypt.org/acme/reg/zzz",
    "new_authzr_uri": "https://acme-v01.api.letsencrypt.org/acme/new-authz",
    "terms_of_service": "https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf"
  }
```

This commit changed the client to just comparing the body to determine whether the update succeeded.
