### PR TITLE
Add standalone option for running a TLS server when validating HTTP-01 challenges

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -319,7 +319,7 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
         uri = chall.uri(domain)
         logger.debug("Verifying %s at %s...", chall.typ, uri)
         try:
-            http_response = requests.get(uri)
+            http_response = requests.get(uri, verify=False)
         except requests.exceptions.RequestException as error:
             logger.error("Unable to reach %s: %s", uri, error)
             return False

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -216,7 +216,7 @@ class HTTP01ResponseTest(unittest.TestCase):
         mock_get.return_value = mock.MagicMock(text=validation)
         self.assertTrue(self.response.simple_verify(
             self.chall, "local", KEY.public_key()))
-        mock_get.assert_called_once_with(self.chall.uri("local"))
+        mock_get.assert_called_once_with(self.chall.uri("local"), verify=False)
 
     @mock.patch("acme.challenges.requests.get")
     def test_simple_verify_bad_validation(self, mock_get):
@@ -232,7 +232,7 @@ class HTTP01ResponseTest(unittest.TestCase):
                   HTTP01Response.WHITESPACE_CUTSET))
         self.assertTrue(self.response.simple_verify(
             self.chall, "local", KEY.public_key()))
-        mock_get.assert_called_once_with(self.chall.uri("local"))
+        mock_get.assert_called_once_with(self.chall.uri("local"), verify=False)
 
     @mock.patch("acme.challenges.requests.get")
     def test_simple_verify_connection_error(self, mock_get):

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -236,7 +236,9 @@ def gen_ss_cert(key, domains, not_before=None,
 
 
 def key_gen(key_size=2048):
-    return OpenSSL.crypto.PKey().generate_key(OpenSSL.crypto.TYPE_RSA, key_size)
+    key = OpenSSL.crypto.PKey()
+    key.generate_key(OpenSSL.crypto.TYPE_RSA, key_size)
+    return key
 
 
 def dump_key(key):

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -90,7 +90,7 @@ class HTTP01TLSServer(socketserver.TCPServer, ACMEServerMixin):
                                         HTTP01RequestHandler.partial_init(
                                             simple_http_resources=resources))
 
-        self.cert_path, self.cert_descriptor = (
+        self.cert_descriptor, self.cert_path = (
             crypto_util.create_bogus_certificate())
 
         self.socket = ssl.wrap_socket(  # create the tls socket

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -94,7 +94,8 @@ class HTTP01TLSServer(socketserver.TCPServer, ACMEServerMixin):
             self.socket, certfile=self.certificate_file, server_side=True)
 
     def __del__(self):
-        if os.path.exists(self.certificate_file):
+        if hasattr(self, "certificate_file") and \
+                os.path.exists(self.certificate_file):
             os.remove(self.certificate_file)
 
 

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -94,7 +94,7 @@ class HTTP01TLSServer(socketserver.TCPServer, ACMEServerMixin):
             crypto_util.create_bogus_certificate())
 
         self.socket = ssl.wrap_socket(  # create the tls socket
-            self.socket, certfile=self.certificate_file, server_side=True)
+            self.socket, certfile=self.cert_path, server_side=True)
 
     def __del__(self):
         if self.cert_descriptor is not None:

--- a/acme/acme/standalone_test.py
+++ b/acme/acme/standalone_test.py
@@ -6,6 +6,7 @@ import tempfile
 import time
 import unittest
 
+from six.moves import BaseHTTPServer  # pylint: disable=import-error
 from six.moves import http_client  # pylint: disable=import-error
 from six.moves import socketserver  # pylint: disable=import-error
 
@@ -104,6 +105,58 @@ class HTTP01ServerTest(unittest.TestCase):
 
     def test_http01_not_found(self):
         self.assertFalse(self._test_http01(add=False))
+
+
+#  pylint: disable=no-init
+class RedirectHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+    """Creates a simple http -> https redirect for testing"""
+    port = None
+
+    def do_GET(self):  # pylint: disable=invalid-name,missing-docstring
+        # pylint: disable=no-member
+        self.send_response(301)
+        self.send_header(
+            'Location', 'https://localhost:{0}{1}'.format(self.port, self.path))
+        self.end_headers()
+
+    def log_message(self, fmt, *args):  # pylint: disable=missing-docstring
+        pass
+
+
+class HTTP01TLSServerTest(HTTP01ServerTest):
+    """Tests for acme.standalone.HTTP01Server."""
+
+    def setUp(self):
+        # disable insecure requests warning, obviously they are not secure!
+        from requests.packages.urllib3.exceptions import InsecureRequestWarning
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+        self.account_key = jose.JWK.load(
+            test_util.load_vector('rsa1024_key.pem'))
+        self.resources = set()
+
+        # pylint: disable=no-member
+        self.redirect_server = socketserver.TCPServer(('', 0), RedirectHandler)
+        self.port = self.redirect_server.socket.getsockname()[1]
+        self.redirect_thread = threading.Thread(
+            target=self.redirect_server.serve_forever)
+        self.redirect_thread.start()
+
+        from acme.standalone import HTTP01TLSServer
+        self.server = HTTP01TLSServer(('', 0), self.resources)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.start()
+
+        # make sure the redirect server directs to the port where the TLS
+        # server is running
+        RedirectHandler.port = self.server.socket.getsockname()[1]
+
+    def tearDown(self):
+        self.redirect_server.shutdown()  # pylint: disable=no-member
+        self.redirect_thread.join()
+
+        self.server.shutdown()  # pylint: disable=no-member
+        self.thread.join()
 
 
 class TestSimpleTLSSNI01Server(unittest.TestCase):

--- a/acme/acme/standalone_test.py
+++ b/acme/acme/standalone_test.py
@@ -158,6 +158,11 @@ class HTTP01TLSServerTest(HTTP01ServerTest):
         self.server.shutdown()  # pylint: disable=no-member
         self.thread.join()
 
+    def test__del__(self):
+        certificate_file = self.server.certificate_file
+        self.server.__del__()
+        self.assertFalse(os.path.exists(certificate_file))
+
 
 class TestSimpleTLSSNI01Server(unittest.TestCase):
     """Tests for acme.standalone.simple_tls_sni_01_server."""

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -784,6 +784,10 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         dest="http01_port",
         default=flag_default("http01_port"), help=config_help("http01_port"))
     helpful.add(
+        ["certonly", "renew"], "--http-01-use-tls", action="store_true",
+        dest="http01_use_tls", default=flag_default("http01_use_tls"),
+        help=config_help("http01_use_tls"))
+    helpful.add(
         "testing", "--break-my-certs", action="store_true",
         help="Be willing to replace or renew valid certs with invalid "
              "(testing/staging) certs")

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -27,6 +27,7 @@ CLI_DEFAULTS = dict(
     logs_dir="/var/log/letsencrypt",
     no_verify_ssl=False,
     http01_port=challenges.HTTP01Response.PORT,
+    http01_use_tls=False,
     tls_sni_01_port=challenges.TLSSNI01Response.PORT,
 
     auth_cert_path="./cert.pem",

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -238,6 +238,12 @@ class IConfig(zope.interface.Interface):
         "This only affects the port Certbot listens on. "
         "A conforming ACME server will still attempt to connect on port 80.")
 
+    http01_use_tls = zope.interface.Attribute(
+        "Runs the standalone server with a self signed certificate. "
+        "Useful for when you need to validate an http-01 challenge with "
+        "an https endpoint or if you have an upstream proxy redirecting "
+        "all http traffic to https.")
+
 
 class IInstaller(IPlugin):
     """Generic Certbot Installer Interface.

--- a/certbot/plugins/standalone.py
+++ b/certbot/plugins/standalone.py
@@ -38,10 +38,11 @@ class ServerManager(object):
     """
     _Instance = collections.namedtuple("_Instance", "server thread")
 
-    def __init__(self, certs, http_01_resources):
+    def __init__(self, certs, http_01_resources, config):
         self._instances = {}
         self.certs = certs
         self.http_01_resources = http_01_resources
+        self.config = config
 
     def run(self, port, challenge_type):
         """Run ACME server on specified ``port``.
@@ -66,8 +67,12 @@ class ServerManager(object):
             if challenge_type is challenges.TLSSNI01:
                 server = acme_standalone.TLSSNI01Server(address, self.certs)
             else:  # challenges.HTTP01
-                server = acme_standalone.HTTP01Server(
-                    address, self.http_01_resources)
+                if not self.config.http01_use_tls:
+                    server = acme_standalone.HTTP01Server(
+                        address, self.http_01_resources)
+                else:  # HTTP01 with TLS
+                    server = acme_standalone.HTTP01TLSServer(
+                        address, self.http_01_resources)
         except socket.error as error:
             raise errors.StandaloneBindError(error, port)
 
@@ -179,7 +184,8 @@ class Authenticator(common.Plugin):
         self.certs = {}
         self.http_01_resources = set()
 
-        self.servers = ServerManager(self.certs, self.http_01_resources)
+        self.servers = ServerManager(
+            self.certs, self.http_01_resources, self.config)
 
     @classmethod
     def add_parser_arguments(cls, add):

--- a/certbot/plugins/standalone_test.py
+++ b/certbot/plugins/standalone_test.py
@@ -27,7 +27,8 @@ class ServerManagerTest(unittest.TestCase):
         self.certs = {}
         self.http_01_resources = {}
         self.mgr = ServerManager(self.certs, self.http_01_resources,
-                                 NamespaceConfig(mock.MagicMock()))
+                                 NamespaceConfig(mock.MagicMock(
+                                     http01_use_tls=False)))
 
     def test_init(self):
         self.assertTrue(self.mgr.certs is self.certs)
@@ -46,6 +47,16 @@ class ServerManagerTest(unittest.TestCase):
 
     def test_run_stop_http_01(self):
         self._test_run_stop(challenges.HTTP01)
+
+    def test_run_stop_http_01_use_tls(self):
+        from certbot.plugins.standalone import ServerManager
+        from certbot.configuration import NamespaceConfig
+        old_mgr = self.mgr
+        self.mgr = ServerManager(self.certs, self.http_01_resources,
+                                 NamespaceConfig(mock.MagicMock(
+                                     http01_use_tls=True)))
+        self._test_run_stop(challenges.HTTP01)
+        self.mgr = old_mgr
 
     def test_run_idempotent(self):
         server = self.mgr.run(port=0, challenge_type=challenges.HTTP01)

--- a/certbot/plugins/standalone_test.py
+++ b/certbot/plugins/standalone_test.py
@@ -23,9 +23,11 @@ class ServerManagerTest(unittest.TestCase):
 
     def setUp(self):
         from certbot.plugins.standalone import ServerManager
+        from certbot.configuration import NamespaceConfig
         self.certs = {}
         self.http_01_resources = {}
-        self.mgr = ServerManager(self.certs, self.http_01_resources)
+        self.mgr = ServerManager(self.certs, self.http_01_resources,
+                                 NamespaceConfig(mock.MagicMock()))
 
     def test_init(self):
         self.assertTrue(self.mgr.certs is self.certs)


### PR DESCRIPTION
This PR, add an option to the CLI to run the standalone HTTP-01 server using TLS with a self signed certificate. The name of the option is `--http-01-use-tls`. 

Note for reviewers, I had to add a `Content-Length` header to all requests served by the `HTTP01ResponseHandler`. Without this header, http requests are malformed and TLS connections will not be terminated properly. 

Fixes #3645 