### PR TITLE
Update CLI usage docs for --csr

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -901,10 +901,8 @@ def _create_subparsers(helpful):
              'Encrypt server, set this to "".')
     helpful.add("certonly",
                 "--csr", type=read_file,
-                help="Path to a Certificate Signing Request (CSR) in DER"
-                " format; note that the .csr file *must* contain a Subject"
-                " Alternative Name field for each domain you want certified."
-                " Currently --csr only works with the 'certonly' subcommand'")
+                help="Path to a Certificate Signing Request (CSR) in DER or PEM format."
+                " Currently --csr only works with the 'certonly' subcommand.")
     helpful.add("rollback",
                 "--checkpoints", type=int, metavar="N",
                 default=flag_default("rollback_checkpoints"),

--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -229,11 +229,9 @@ certonly:
                         the port Certbot listens on. A conforming ACME server
                         will still attempt to connect on port 80. (default:
                         80)
-  --csr CSR             Path to a Certificate Signing Request (CSR) in DER
-                        format; note that the .csr file *must* contain a
-                        Subject Alternative Name field for each domain you
-                        want certified. Currently --csr only works with the
-                        'certonly' subcommand' (default: None)
+  --csr CSR             Path to a Certificate Signing Request (CSR) in DER or
+                        PEM format. Currently --csr only works with the
+                        'certonly' subcommand. (default: None)
 
 install:
   Options for modifying how a cert is deployed


### PR DESCRIPTION
With #2403 and #3046, `certbot` gained the ability to parse CSRs encoded as PEM and without a SAN extension. Update the CLI usage docs to reflect this change.