### PR TITLE
Add note regarding cryptography dependency in contribution docs [revision requested]

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -90,6 +90,12 @@ The following tools are there to help you:
   code. Alternatively, you can use Python's standard library `pdb`,
   but you won't get TAB completion...
 
+.. important::
+   To run Certbot's automated Python tests via ``tox`` you must be able to
+   install ``cryptography`` via ``pip``. See `Cryptography's documentation`_
+   for more information on its requirements for installation.
+
+.. _Cryptography's documentation: https://cryptography.io/en/latest/installation/#installation
 
 .. _integration:
 


### PR DESCRIPTION
Installation of the cryptography pip module requires some admin work, and is
required to run tox tests.

Partial #3683
