### PR TITLE
Allow user to select all domains by typing empty string at checklist

### DIFF
--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -179,9 +179,12 @@ class FileDisplay(object):
             self._print_menu(message, tags)
 
             code, ans = self.input("Select the appropriate numbers separated "
-                                   "by commas and/or spaces")
+                                   "by commas and/or spaces, or press enter to "
+                                   "select all domains shown")
 
             if code == OK:
+                if len(ans) == 0:
+                    ans = " ".join([str(x) for x in range(1, len(tags)+1)])
                 indices = separate_list_input(ans)
                 selected_tags = self._scrub_checklist_input(indices, tags)
                 if selected_tags:

--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -179,12 +179,12 @@ class FileDisplay(object):
             self._print_menu(message, tags)
 
             code, ans = self.input("Select the appropriate numbers separated "
-                                   "by commas and/or spaces, or press enter to "
-                                   "select all domains shown")
+                                   "by commas and/or spaces, or leave input "
+                                   "blank to select all options shown")
 
             if code == OK:
-                if len(ans) == 0:
-                    ans = " ".join([str(x) for x in range(1, len(tags)+1)])
+                if len(ans.strip()) == 0:
+                    ans = " ".join(str(x) for x in range(1, len(tags)+1))
                 indices = separate_list_input(ans)
                 selected_tags = self._scrub_checklist_input(indices, tags)
                 if selected_tags:

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -80,6 +80,13 @@ class FileOutputDisplayTest(unittest.TestCase):
             (code, set(tag_list)), (display_util.OK, set(["tag1", "tag2"])))
 
     @mock.patch("certbot.display.util.FileDisplay.input")
+    def test_checklist_empty(self, mock_input):
+        mock_input.return_value = (display_util.OK, "")
+        code, tag_list = self.displayer.checklist("msg", TAGS)
+        self.assertEqual(
+            (code, set(tag_list)), (display_util.OK, set(["tag1", "tag2", "tag3"])))
+
+    @mock.patch("certbot.display.util.FileDisplay.input")
     def test_checklist_miss_valid(self, mock_input):
         mock_input.side_effect = [
             (display_util.OK, "10"),


### PR DESCRIPTION
Addresses #3629, as a follow-up to #3665.