### PR TITLE
Remove some domain name checks.

### DIFF
--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -68,7 +68,7 @@ class NginxConfiguratorTest(util.NginxTest):
         names = self.config.get_all_names()
         self.assertEqual(names, set(
             ["155.225.50.69.nephoscale.net", "www.example.org", "another.alias",
-             "migration.com", "summer.com", "geese.com", "sslon.com"]))
+             ".example.com", "migration.com", "summer.com", "geese.com", "sslon.com"]))
 
     def test_supported_enhancements(self):
         self.assertEqual(['redirect', 'staple-ocsp'],

--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -165,14 +165,7 @@ def _choose_names_manually(prompt_prefix=""):
     if code == display_util.OK:
         invalid_domains = dict()
         retry_message = ""
-        try:
-            domain_list = display_util.separate_list_input(input_)
-        except UnicodeEncodeError:
-            domain_list = []
-            retry_message = (
-                "Internationalized domain names are not presently "
-                "supported.{0}{0}Would you like to re-enter the "
-                "names?{0}").format(os.linesep)
+        domain_list = display_util.separate_list_input(input_)
 
         for i, domain in enumerate(domain_list):
             try:

--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -443,9 +443,6 @@ def separate_list_input(input_):
 
     """
     no_commas = input_.replace(",", " ")
-    # Each string is naturally unicode, this causes problems with M2Crypto SANs
-    # TODO: check if above is still true when M2Crypto is gone ^
-    return [str(string) for string in no_commas.split()]
 
 
 def _parens_around_char(label):

--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -442,7 +442,7 @@ def separate_list_input(input_):
     :rtype: list
 
     """
-    no_commas = input_.replace(",", " ")
+    return input_.replace(",", " ").split()
 
 
 def _parens_around_char(label):

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -352,25 +352,6 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         # that it's _not_ an error (at the initial sanity check stage)
         util.enforce_domain_sanity('this.is.xn--ls8h.tld')
 
-    def test_check_config_sanity_domain(self):
-        # FQDN
-        self.assertRaises(errors.ConfigurationError,
-                          self._call,
-                          ['-d', 'a' * 64])
-        # FQDN 2
-        self.assertRaises(errors.ConfigurationError,
-                          self._call,
-                          ['-d', (('a' * 50) + '.') * 10])
-        # Wildcard
-        self.assertRaises(errors.ConfigurationError,
-                          self._call,
-                          ['-d', '*.wildcard.tld'])
-
-        # Bare IP address (this is actually a different error message now)
-        self.assertRaises(errors.ConfigurationError,
-                          self._call,
-                          ['-d', '204.11.231.35'])
-
     def test_csr_with_besteffort(self):
         self.assertRaises(
             errors.Error, self._call,
@@ -407,10 +388,6 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         namespace = parse(short_args)
         self.assertEqual(namespace.domains, ['example.com'])
 
-        short_args = ['-d', 'trailing.period.com.']
-        namespace = parse(short_args)
-        self.assertEqual(namespace.domains, ['trailing.period.com'])
-
         short_args = ['-d', 'example.com,another.net,third.org,example.com']
         namespace = parse(short_args)
         self.assertEqual(namespace.domains, ['example.com', 'another.net',
@@ -419,10 +396,6 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         long_args = ['--domains', 'example.com']
         namespace = parse(long_args)
         self.assertEqual(namespace.domains, ['example.com'])
-
-        long_args = ['--domains', 'trailing.period.com.']
-        namespace = parse(long_args)
-        self.assertEqual(namespace.domains, ['trailing.period.com'])
 
         long_args = ['--domains', 'example.com,another.net,example.com']
         namespace = parse(long_args)

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -251,46 +251,25 @@ class ChooseNamesTest(unittest.TestCase):
         from certbot.display.ops import get_valid_domains
         all_valid = ["example.com", "second.example.com",
                      "also.example.com", "under_score.example.com",
-                     "justtld"]
-        all_invalid = ["öóòps.net", "*.wildcard.com", "uniçodé.com"]
-        two_valid = ["example.com", "úniçøde.com", "also.example.com"]
+                     "justtld", "öóòps.net", "uniçodé.com"]
+        all_invalid = ["*.wildcard.com"]
         self.assertEqual(get_valid_domains(all_valid), all_valid)
         self.assertEqual(get_valid_domains(all_invalid), [])
-        self.assertEqual(len(get_valid_domains(two_valid)), 2)
 
     @mock.patch("certbot.display.ops.z_util")
     def test_choose_manually(self, mock_util):
         from certbot.display.ops import _choose_names_manually
-        # No retry
-        mock_util().yesno.return_value = False
-        # IDN and no retry
-        mock_util().input.return_value = (display_util.OK,
-                                          "uniçodé.com")
-        self.assertEqual(_choose_names_manually(), [])
-        # IDN exception with previous mocks
-        with mock.patch(
-                "certbot.display.ops.display_util.separate_list_input"
-        ) as mock_sli:
-            unicode_error = UnicodeEncodeError('mock', u'', 0, 1, 'mock')
-            mock_sli.side_effect = unicode_error
-            self.assertEqual(_choose_names_manually(), [])
         # Valid domains
         mock_util().input.return_value = (display_util.OK,
                                           ("example.com,"
                                            "under_score.example.com,"
                                            "justtld,"
-                                           "valid.example.com"))
+                                           "valid.example.com,"
+                                           "uniçodé.com"))
         self.assertEqual(_choose_names_manually(),
                          ["example.com", "under_score.example.com",
-                          "justtld", "valid.example.com"])
-        # Three iterations
-        mock_util().input.return_value = (display_util.OK,
-                                          "uniçodé.com")
-        yn = mock.MagicMock()
-        yn.side_effect = [True, True, False]
-        mock_util().yesno = yn
-        _choose_names_manually()
-        self.assertEqual(mock_util().yesno.call_count, 3)
+                          "justtld", "valid.example.com",
+                          "uniçodé.com"])
 
 
 class SuccessInstallationTest(unittest.TestCase):

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -336,9 +336,6 @@ class EnforceLeValidity(unittest.TestCase):
         from certbot.util import enforce_le_validity
         return enforce_le_validity(domain)
 
-    def test_sanity(self):
-        self.assertRaises(errors.ConfigurationError, self._call, u"..")
-
     def test_invalid_chars(self):
         self.assertRaises(
             errors.ConfigurationError, self._call, u"hello_world.example.com")
@@ -356,22 +353,6 @@ class EnforceLeValidity(unittest.TestCase):
 
     def test_valid_domain(self):
         self.assertEqual(self._call(u"example.com"), u"example.com")
-
-
-class EnforceDomainSanityTest(unittest.TestCase):
-    """Test enforce_domain_sanity."""
-
-    def _call(self, domain):
-        from certbot.util import enforce_domain_sanity
-        return enforce_domain_sanity(domain)
-
-    def test_nonascii_str(self):
-        self.assertRaises(errors.ConfigurationError, self._call,
-                          u"eichh\u00f6rnchen.example.com".encode("utf-8"))
-
-    def test_nonascii_unicode(self):
-        self.assertRaises(errors.ConfigurationError, self._call,
-                          u"eichh\u00f6rnchen.example.com")
 
 
 class OsInfoTest(unittest.TestCase):

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -10,7 +10,6 @@ import os
 import platform
 import re
 import six
-import socket
 import stat
 import subprocess
 import sys
@@ -445,12 +444,7 @@ def enforce_domain_sanity(domain):
         raise errors.ConfigurationError(
             "Wildcard domains are not supported: {0}".format(domain))
 
-    if isinstance(domain, six.binary_type):
-        domain = domain.decode('utf-8')
     domain = domain.lower()
-
-    # Remove trailing dot
-    domain = domain[:-1] if domain.endswith(u'.') else domain
     return domain
 
 def get_strict_version(normalized):

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -447,6 +447,7 @@ def enforce_domain_sanity(domain):
     domain = domain.lower()
     return domain
 
+
 def get_strict_version(normalized):
     """Converts a normalized version to a strict version.
 


### PR DESCRIPTION
These checks are done on the server side, so it's redundant to do them here, and
it causes some issues. In particular the Unicode check causes a crash, which
gets swallowed so that it isn't printed or written to logs.

Fixes #3700.