### PR TITLE
Add renew_hook to options stored in the renewal config, #3394

### DIFF
--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # the renewal configuration process loses this information.
 STR_CONFIG_ITEMS = ["config_dir", "logs_dir", "work_dir", "user_agent",
                     "server", "account", "authenticator", "installer",
-                    "standalone_supported_challenges"]
+                    "standalone_supported_challenges", "renew_hook"]
 INT_CONFIG_ITEMS = ["rsa_key_size", "tls_sni_01_port", "http01_port"]
 
 


### PR DESCRIPTION
renew_hook are called for each lineage, so it makes sense to store it and run it for each. Discussion on the issue probably still applies for pre/post hooks though. Discussion was in  #3394