### PR TITLE
Fix non-ASCII domain check.

### DIFF
--- a/certbot/util.py
+++ b/certbot/util.py
@@ -447,7 +447,10 @@ def enforce_domain_sanity(domain):
 
     # Unicode
     try:
-        domain.decode('utf-8').encode('ascii')
+        if isinstance(domain, six.binary_type):
+            domain.encode('ascii')
+        else:
+            domain.decode('utf-8').encode('ascii')
     except UnicodeError:
         raise errors.ConfigurationError("Non-ASCII domain names not supported. "
             "To issue for an Internationalized Domain Name, use Punycode.")

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -449,7 +449,7 @@ def enforce_domain_sanity(domain):
     try:
         if isinstance(domain, six.binary_type):
             domain = domain.decode('utf-8')
-            domain.encode('ascii')
+        domain.encode('ascii')
     except UnicodeError:
         raise errors.ConfigurationError("Non-ASCII domain names not supported. "
             "To issue for an Internationalized Domain Name, use Punycode.")

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -448,9 +448,8 @@ def enforce_domain_sanity(domain):
     # Unicode
     try:
         if isinstance(domain, six.binary_type):
+            domain = domain.decode('utf-8')
             domain.encode('ascii')
-        else:
-            domain.decode('utf-8').encode('ascii')
     except UnicodeError:
         raise errors.ConfigurationError("Non-ASCII domain names not supported. "
             "To issue for an Internationalized Domain Name, use Punycode.")

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -447,16 +447,10 @@ def enforce_domain_sanity(domain):
 
     # Unicode
     try:
-        if isinstance(domain, six.binary_type):
-            domain = domain.decode('utf-8')
-        domain.encode('ascii')
+        domain.decode('utf-8').encode('ascii')
     except UnicodeError:
-        error_fmt = (u"Internationalized domain names "
-                     "are not presently supported: {0}")
-        if isinstance(domain, six.text_type):
-            raise errors.ConfigurationError(error_fmt.format(domain))
-        else:
-            raise errors.ConfigurationError(str(error_fmt).format(domain))
+        raise errors.ConfigurationError("Non-ASCII domain names not supported. "
+            "To issue for an Internationalized Domain Name, use Punycode.")
 
     domain = domain.lower()
 


### PR DESCRIPTION
Previously, the code would convert to utf-8, check for non-ASCII, and then try
to use .format() to interpolate the result into an error message. This would
generate a second error that would cause the whole message to get dropped, and
the program to silently exit. The problem can be succinctly observed like so:

```
$ python
>>> "{0}".format("ウェブ.crud.net")
'\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\x96.crud.net'
>>> "{0}".format(u"ウェブ.crud.net")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)
```

Note for the curious: This problem only seems to happen with .format():

```
>>> "%s" % ("ウェブ.crud.net")
'\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\x96.crud.net'
>>> "%s" % (u"ウェブ.crud.net")
u'\u30a6\u30a7\u30d6.crud.net'
```