### PR TITLE
Don't re-add redirects if one exists

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -29,6 +29,21 @@ from certbot_nginx import parser
 
 logger = logging.getLogger(__name__)
 
+REDIRECT_BLOCK = [[
+    ['\n    ', 'if', ' ', '($scheme != "https") '],
+    [['\n        ', 'return', ' ', '301 https://$host$request_uri'],
+     '\n    ']
+], ['\n']]
+
+TEST_REDIRECT_BLOCK = [
+    [
+        ['if', '($scheme != "https")'],
+        [
+            ['return', '301 https://$host$request_uri']
+        ]
+    ],
+    ['#', ' managed by Certbot']
+]
 
 @zope.interface.implementer(interfaces.IAuthenticator, interfaces.IInstaller)
 @zope.interface.provider(interfaces.IPluginFactory)
@@ -482,6 +497,26 @@ class NginxConfigurator(common.Plugin):
             logger.warning("Failed %s for %s", enhancement, domain)
             raise
 
+    def _has_certbot_redirect(self, vhost):
+        return vhost.contains_list(TEST_REDIRECT_BLOCK)
+
+    def _add_redirect_block(self, vhost, active=True):
+        """Add redirect directive to vhost
+        """
+        if active:
+            redirect_block = REDIRECT_BLOCK
+        else:
+            redirect_block = [
+                ['\n    ', '#', ' Redirect non-https traffic to https'],
+                ['\n    ', '#', ' if ($scheme != "https") {'],
+                ['\n    ', '#', "     return 301 https://$host$request_uri;"],
+                ['\n    ', '#', " } # managed by Certbot"],
+                ['\n']
+            ]
+
+        self.parser.add_server_directives(
+            vhost, redirect_block, replace=False)
+
     def _enable_redirect(self, domain, unused_options):
         """Redirect all equivalent HTTP traffic to ssl_vhost.
 
@@ -504,17 +539,19 @@ class NginxConfigurator(common.Plugin):
             logger.info("No matching insecure server blocks listening on port %s found.",
                 self.DEFAULT_LISTEN_PORT)
         else:
-            # Redirect plaintextish host to https
-            redirect_block = [[
-                ['\n    ', 'if', ' ', '($scheme != "https") '],
-                [['\n        ', 'return', ' ', '301 https://$host$request_uri'],
-                 '\n    ']
-            ], ['\n']]
-
-            self.parser.add_server_directives(
-                vhost, redirect_block, replace=False)
-            logger.info("Redirecting all traffic on port %s to ssl in %s",
-                self.DEFAULT_LISTEN_PORT, vhost.filep)
+            if self._has_certbot_redirect(vhost):
+                logger.info("Traffic on port %s already redirecting to ssl in %s",
+                    self.DEFAULT_LISTEN_PORT, vhost.filep)
+            elif vhost.has_redirect():
+                self._add_redirect_block(vhost, active=False)
+                logger.info("The appropriate server block is already redirecting "
+                            "traffic. To enable redirect anyway, uncomment the "
+                            "redirect lines in %s.", vhost.filep)
+            else:
+                # Redirect plaintextish host to https
+                self._add_redirect_block(vhost, active=True)
+                logger.info("Redirecting all traffic on port %s to ssl in %s",
+                    self.DEFAULT_LISTEN_PORT, vhost.filep)
 
     def _enable_ocsp_stapling(self, domain, chain_path):
         """Include OCSP response in TLS handshake

--- a/certbot-nginx/certbot_nginx/obj.py
+++ b/certbot-nginx/certbot_nginx/obj.py
@@ -161,23 +161,17 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
         return False
 
     def contains_list(self, test):
-        """Determine if raw server block contains test list
+        """Determine if raw server block contains test list at top level
         """
-        return _has_block(self.raw, test)
+        return _raw_server_contains_directives(self.raw, test)
 
-def _has_block(haystack, needle):
+def _raw_server_contains_directives(haystack, needle):
     """Determine if needle appears in haystack
     """
     if len(haystack) == 0 or isinstance(haystack, str):
         return False
-    if haystack == needle:
-        return True
     for i in xrange(0, len(haystack) - len(needle)):
         if haystack[i:i + len(needle)] == needle:
-            return True
-    for sub in haystack:
-        found = _has_block(sub, needle)
-        if found:
             return True
     return False
 

--- a/certbot-nginx/certbot_nginx/obj.py
+++ b/certbot-nginx/certbot_nginx/obj.py
@@ -171,15 +171,11 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
 def _find_directive(directives, directive_name):
     """Find a directive of type directive_name in directives
     """
-    if len(directive_name) == 0 or not directives or \
-        isinstance(directives, str) or len(directives) == 0:
+    if not directives or isinstance(directives, str) or len(directives) == 0:
         return None
-    else:
-        if directives[0] == directive_name:
-            return directives
-        else:
-            for line in directives:
-                found = _find_directive(line, directive_name)
-                if found is not None:
-                    return found
-            return None
+
+    if directives[0] == directive_name:
+        return directives
+
+    matches = (_find_directive(line, directive_name) for line in directives)
+    return next((m for m in matches if m is not None), None)

--- a/certbot-nginx/certbot_nginx/obj.py
+++ b/certbot-nginx/certbot_nginx/obj.py
@@ -163,18 +163,10 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
     def contains_list(self, test):
         """Determine if raw server block contains test list at top level
         """
-        return _raw_server_contains_directives(self.raw, test)
-
-def _raw_server_contains_directives(haystack, needle):
-    """Determine if needle appears in haystack
-    """
-    if len(haystack) == 0 or isinstance(haystack, str):
+        for i in xrange(0, len(self.raw) - len(test)):
+            if self.raw[i:i + len(test)] == test:
+                return True
         return False
-    for i in xrange(0, len(haystack) - len(needle)):
-        if haystack[i:i + len(needle)] == needle:
-            return True
-    return False
-
 
 def _find_directive(directives, directive_name):
     """Find a directive of type directive_name in directives

--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -496,7 +496,6 @@ def parse_server(server):
 
     return parsed_server
 
-
 def _add_directives(block, directives, replace):
     """Adds or replaces directives in a config block.
 

--- a/certbot-nginx/certbot_nginx/tests/obj_test.py
+++ b/certbot-nginx/certbot_nginx/tests/obj_test.py
@@ -87,10 +87,43 @@ class VirtualHostTest(unittest.TestCase):
     def setUp(self):
         from certbot_nginx.obj import VirtualHost
         from certbot_nginx.obj import Addr
+        raw1 = [
+            ['listen', '69.50.225.155:9000'],
+            [['if', '($scheme != "https") '],
+                [['return', '301 https://$host$request_uri']]
+            ],
+            ['#', ' managed by Certbot']
+        ]
         self.vhost1 = VirtualHost(
             "filep",
             set([Addr.fromstring("localhost")]), False, False,
-            set(['localhost']), [], [])
+            set(['localhost']), raw1, [])
+        raw2 = [
+            ['listen', '69.50.225.155:9000'],
+            [['if', '($scheme != "https") '],
+                [['return', '301 https://$host$request_uri']]
+            ]
+        ]
+        self.vhost2 = VirtualHost(
+            "filep",
+            set([Addr.fromstring("localhost")]), False, False,
+            set(['localhost']), raw2, [])
+        raw3 = [
+            ['listen', '69.50.225.155:9000'],
+            ['rewrite', '^(.*)$ $scheme://www.domain.com$1 permanent;']
+        ]
+        self.vhost3 = VirtualHost(
+            "filep",
+            set([Addr.fromstring("localhost")]), False, False,
+            set(['localhost']), raw3, [])
+        raw4 = [
+            ['listen', '69.50.225.155:9000'],
+            ['server_name', 'return.com']
+        ]
+        self.vhost4 = VirtualHost(
+            "filp",
+            set([Addr.fromstring("localhost")]), False, False,
+            set(['localhost']), raw4, [])
 
     def test_eq(self):
         from certbot_nginx.obj import Addr
@@ -110,6 +143,47 @@ class VirtualHostTest(unittest.TestCase):
                                  'enabled: False'])
         self.assertEqual(stringified, str(self.vhost1))
 
+    def test_has_redirect(self):
+        self.assertTrue(self.vhost1.has_redirect())
+        self.assertTrue(self.vhost2.has_redirect())
+        self.assertTrue(self.vhost3.has_redirect())
+        self.assertFalse(self.vhost4.has_redirect())
+
+    def test_contains_list(self):
+        from certbot_nginx.obj import VirtualHost
+        from certbot_nginx.obj import Addr
+        from certbot_nginx.configurator import TEST_REDIRECT_BLOCK
+        test_needle = TEST_REDIRECT_BLOCK
+        test_haystack = [['listen', '80'], ['root', '/var/www/html'],
+            ['index', 'index.html index.htm index.nginx-debian.html'],
+            ['server_name', 'two.functorkitten.xyz'], ['listen', '443 ssl'],
+            ['#', ' managed by Certbot'],
+            ['ssl_certificate', '/etc/letsencrypt/live/two.functorkitten.xyz/fullchain.pem'],
+            ['#', ' managed by Certbot'],
+            ['ssl_certificate_key', '/etc/letsencrypt/live/two.functorkitten.xyz/privkey.pem'],
+            ['#', ' managed by Certbot'],
+            [['if', '($scheme != "https")'], [['return', '301 https://$host$request_uri']]],
+            ['#', ' managed by Certbot'], []]
+        vhost_haystack = VirtualHost(
+            "filp",
+            set([Addr.fromstring("localhost")]), False, False,
+            set(['localhost']), test_haystack, [])
+        test_bad_haystack = [['listen', '80'], ['root', '/var/www/html'],
+            ['index', 'index.html index.htm index.nginx-debian.html'],
+            ['server_name', 'two.functorkitten.xyz'], ['listen', '443 ssl'],
+            ['#', ' managed by Certbot'],
+            ['ssl_certificate', '/etc/letsencrypt/live/two.functorkitten.xyz/fullchain.pem'],
+            ['#', ' managed by Certbot'],
+            ['ssl_certificate_key', '/etc/letsencrypt/live/two.functorkitten.xyz/privkey.pem'],
+            ['#', ' managed by Certbot'],
+            [['if', '($scheme != "https")'], [['return', '302 https://$host$request_uri']]],
+            ['#', ' managed by Certbot'], []]
+        vhost_bad_haystack = VirtualHost(
+            "filp",
+            set([Addr.fromstring("localhost")]), False, False,
+            set(['localhost']), test_bad_haystack, [])
+        self.assertTrue(vhost_haystack.contains_list(test_needle))
+        self.assertFalse(vhost_bad_haystack.contains_list(test_needle))
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
If we've already added a redirect block, don't add it again. If we didn't add it but there's one in there anyway, add a commented version of the block we add. Fixes #3743 and #3252.