### PR TITLE
Remove get_all_certs_keys() from interfaces.py

### DIFF
--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -300,19 +300,6 @@ class IInstaller(IPlugin):
 
         """
 
-    def get_all_certs_keys():
-        """Retrieve all certs and keys set in configuration.
-
-        :returns: tuples with form `[(cert, key, path)]`, where:
-
-            - `cert` - str path to certificate file
-            - `key` - str path to associated key file
-            - `path` - file path to configuration file
-
-        :rtype: list
-
-        """
-
     def save(title=None, temporary=False):
         """Saves all changes to the configuration files.
 

--- a/certbot/plugins/null.py
+++ b/certbot/plugins/null.py
@@ -40,9 +40,6 @@ class Installer(common.Plugin):
     def supported_enhancements(self):
         return []
 
-    def get_all_certs_keys(self):
-        return []
-
     def save(self, title=None, temporary=False):
         pass  # pragma: no cover
 

--- a/certbot/plugins/null_test.py
+++ b/certbot/plugins/null_test.py
@@ -15,7 +15,6 @@ class InstallerTest(unittest.TestCase):
         self.assertTrue(isinstance(self.installer.more_info(), str))
         self.assertEqual([], self.installer.get_all_names())
         self.assertEqual([], self.installer.supported_enhancements())
-        self.assertEqual([], self.installer.get_all_certs_keys())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Remove method 'get_all_certs_keys()' from interfaces.py
- Also remove 'get_all_certs_keys()' from plugins/null.py and corresponding unit test

`pep8.travis.sh`, `tox -e lint`, and `tox --skip-missing-interpreters` successfully run.  

Fixes #3749