### PR TITLE
Remove get_all_certs_keys() from Apache and Nginx

### DIFF
--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -1494,38 +1494,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         return redirects
 
-    def get_all_certs_keys(self):
-        """Find all existing keys, certs from configuration.
-
-        Retrieve all certs and keys set in VirtualHosts on the Apache server
-
-        :returns: list of tuples with form [(cert, key, path)]
-            cert - str path to certificate file
-            key - str path to associated key file
-            path - File path to configuration file.
-        :rtype: list
-
-        """
-        c_k = set()
-
-        for vhost in self.vhosts:
-            if vhost.ssl:
-                cert_path = self.parser.find_dir(
-                    "SSLCertificateFile", None,
-                    start=vhost.path, exclude=False)
-                key_path = self.parser.find_dir(
-                    "SSLCertificateKeyFile", None,
-                    start=vhost.path, exclude=False)
-
-                if cert_path and key_path:
-                    cert = os.path.abspath(self.parser.get_arg(cert_path[-1]))
-                    key = os.path.abspath(self.parser.get_arg(key_path[-1]))
-                    c_k.add((cert, key, get_file_path(cert_path[-1])))
-                else:
-                    logger.warning(
-                        "Invalid VirtualHost configuration - %s", vhost.filep)
-        return c_k
-
     def is_site_enabled(self, avail_fp):
         """Checks to see if the given site is enabled.
 

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -775,21 +775,6 @@ class MultipleVhostsTest(util.ApacheTest):
         self.assertRaises(errors.MisconfigurationError,
                           self.config.config_test)
 
-    def test_get_all_certs_keys(self):
-        c_k = self.config.get_all_certs_keys()
-        self.assertEqual(len(c_k), 3)
-        cert, key, path = next(iter(c_k))
-        self.assertTrue("cert" in cert)
-        self.assertTrue("key" in key)
-        self.assertTrue("default-ssl" in path or "ocsp-ssl" in path)
-
-    def test_get_all_certs_keys_malformed_conf(self):
-        self.config.parser.find_dir = mock.Mock(
-            side_effect=[["path"], [], ["path"], [], ["path"], []])
-        c_k = self.config.get_all_certs_keys()
-
-        self.assertFalse(c_k)
-
     def test_more_info(self):
         self.assertTrue(self.config.more_info())
 

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -474,18 +474,6 @@ class NginxConfigurator(common.Plugin):
         self.parser.add_server_directives(
             vhost, ssl_block, replace=False)
 
-    def get_all_certs_keys(self):
-        """Find all existing keys, certs from configuration.
-
-        :returns: list of tuples with form [(cert, key, path)]
-            cert - str path to certificate file
-            key - str path to associated key file
-            path - File path to configuration file.
-        :rtype: set
-
-        """
-        return self.parser.get_all_certs_keys()
-
     ##################################
     # enhancement methods (IInstaller)
     ##################################

--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -298,33 +298,6 @@ class NginxParser(object):
         except errors.MisconfigurationError as err:
             raise errors.MisconfigurationError("Problem in %s: %s" % (filename, err.message))
 
-    def get_all_certs_keys(self):
-        """Gets all certs and keys in the nginx config.
-
-        :returns: list of tuples with form [(cert, key, path)]
-            cert - str path to certificate file
-            key - str path to associated key file
-            path - File path to configuration file.
-        :rtype: set
-
-        """
-        c_k = set()
-        vhosts = self.get_vhosts()
-        for vhost in vhosts:
-            tup = [None, None, vhost.filep]
-            if vhost.ssl:
-                for directive in vhost.raw:
-                    # A directive can be an empty list to preserve whitespace
-                    if not directive:
-                        continue
-                    if directive[0] == 'ssl_certificate':
-                        tup[0] = directive[1]
-                    elif directive[0] == 'ssl_certificate_key':
-                        tup[1] = directive[1]
-            if tup[0] is not None and tup[1] is not None:
-                c_k.add(tuple(tup))
-        return c_k
-
 
 def _do_for_subarray(entry, condition, func, path=None):
     """Executes a function for a subarray of a nested array if it matches

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -238,41 +238,6 @@ class NginxConfiguratorTest(util.NginxTest):
                            ],
                          parsed_migration_conf[0])
 
-    def test_get_all_certs_keys(self):
-        nginx_conf = self.config.parser.abs_path('nginx.conf')
-        example_conf = self.config.parser.abs_path('sites-enabled/example.com')
-        migration_conf = self.config.parser.abs_path('sites-enabled/migration.com')
-        sslon_conf = self.config.parser.abs_path('sites-enabled/sslon.com')
-
-        # Get the default SSL vhost
-        self.config.deploy_cert(
-            "www.example.com",
-            "example/cert.pem",
-            "example/key.pem",
-            "example/chain.pem",
-            "example/fullchain.pem")
-        self.config.deploy_cert(
-            "another.alias",
-            "/etc/nginx/cert.pem",
-            "/etc/nginx/key.pem",
-            "/etc/nginx/chain.pem",
-            "/etc/nginx/fullchain.pem")
-        self.config.deploy_cert(
-            "migration.com",
-            "migration/cert.pem",
-            "migration/key.pem",
-            "migration/chain.pem",
-            "migration/fullchain.pem")
-        self.config.save()
-
-        self.config.parser.load()
-        self.assertEqual(set([
-            ('example/fullchain.pem', 'example/key.pem', example_conf),
-            ('/etc/nginx/fullchain.pem', '/etc/nginx/key.pem', nginx_conf),
-            ('migration/fullchain.pem', 'migration/key.pem', migration_conf),
-            ('snakeoil.cert', 'snakeoil.key', sslon_conf),
-        ]), self.config.get_all_certs_keys())
-
     @mock.patch("certbot_nginx.configurator.tls_sni_01.NginxTlsSni01.perform")
     @mock.patch("certbot_nginx.configurator.NginxConfigurator.restart")
     @mock.patch("certbot_nginx.configurator.NginxConfigurator.revert_challenge_config")

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -291,26 +291,6 @@ class NginxParserTest(util.NginxTest):
             COMMENT_BLOCK,
             ["\n", "e", " ", "f"]])
 
-    def test_get_all_certs_keys(self):
-        nparser = parser.NginxParser(self.config_path, self.ssl_options)
-        filep = nparser.abs_path('sites-enabled/example.com')
-        mock_vhost = obj.VirtualHost(filep,
-                                     None, None, None,
-                                     set(['.example.com', 'example.*']),
-                                     None, [0])
-        nparser.add_server_directives(mock_vhost,
-                                      [['ssl_certificate', 'foo.pem'],
-                                       ['ssl_certificate_key', 'bar.key'],
-                                       ['listen', '443 ssl']],
-                                      replace=False)
-        c_k = nparser.get_all_certs_keys()
-        migration_file = nparser.abs_path('sites-enabled/migration.com')
-        sslon_file = nparser.abs_path('sites-enabled/sslon.com')
-        self.assertEqual(set([('foo.pem', 'bar.key', filep),
-                              ('cert.pem', 'cert.key', migration_file),
-                              ('snakeoil.cert', 'snakeoil.key', sslon_file)
-                             ]), c_k)
-
     def test_parse_server_ssl(self):
         server = parser.parse_server([
             ['listen', '443']


### PR DESCRIPTION
- Remove `get_all_certs_keys()` implementation in 
  - `certbot-apache/certbot_apache/configurator.py`
- Remove corresponding tests for `get_all_certs_keys()` in 
  - `certbot-apache/certbot_apache/tests/configurator_test.py`

- Remove `get_all_certs_keys()` implementation in
  - `certbot-nginx/certbot_nginx/configurator.py`
  - `certbot-nginx/certbot_nginx/parser.py`
- Remove corresponding tests for `get_all_certs_keys()` in
  - `certbot-nginx/certbot_nginx/tests/configurator_test.py`
  - `certbot-nginx/certbot_nginx/tests/parser_test.py`

Resolves #3762