### PR TITLE
Silence Package Manager Output when certbot-auto invoked with --quiet

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -38,8 +38,9 @@ Help for certbot itself cannot be provided until it is installed.
   -n, --non-interactive, --noninteractive   run without asking for user input
   --no-self-upgrade                         do not download updates
   --os-packages-only                        install OS dependencies and exit
-  -q, --quiet                               provide only update/error output; implies --non-interactive
   -v, --verbose                             provide more output
+  -q, --quiet                               provide only update/error output;
+                                            implies --non-interactive
 
 All arguments are accepted and forwarded to the Certbot client when run."
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -207,7 +207,11 @@ BootstrapDebCommon() {
   #
   # - Debian 6.0.10 "squeeze" (x64)
 
-  $SUDO apt-get update || echo apt-get update hit problems but continuing anyway...
+  if [ "$QUIET" == 1 ]; then
+      QUIET_FLAG='-qq'
+  fi
+
+  $SUDO apt-get $QUIET_FLAG update || echo apt-get update hit problems but continuing anyway...
 
   # virtualenv binary can be found in different packages depending on
   # distro version (#346)
@@ -258,12 +262,12 @@ BootstrapDebCommon() {
         fi
         if [ "$add_backports" = 1 ]; then
           $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
-          $SUDO apt-get update
+          $SUDO apt-get $QUIET_FLAG update
         fi
       fi
     fi
     if [ "$add_backports" != 0 ]; then
-      $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
+      $SUDO apt-get install $QUIET_FLAG $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
       augeas_pkg=
     fi
   }
@@ -282,7 +286,7 @@ BootstrapDebCommon() {
     # XXX add a case for ubuntu PPAs
   fi
 
-  $SUDO apt-get install $YES_FLAG --no-install-recommends \
+  $SUDO apt-get install $QUIET_FLAG $YES_FLAG --no-install-recommends \
     python \
     python-dev \
     $virtualenv \
@@ -321,6 +325,9 @@ BootstrapRpmCommon() {
 
   if [ "$ASSUME_YES" = 1 ]; then
     yes_flag="-y"
+  fi
+  if [ "$QUIET" == 1 ]; then
+    $QUIET_FLAG='--quiet'
   fi
 
   if ! $SUDO $tool list *virtualenv >/dev/null 2>&1; then
@@ -380,8 +387,8 @@ BootstrapRpmCommon() {
   fi
 
   if ! $SUDO $tool install $yes_flag $pkgs; then
-      echo "Could not install OS dependencies. Aborting bootstrap!"
-      exit 1
+    echo "Could not install OS dependencies. Aborting bootstrap!"
+    exit 1
   fi
 }
 
@@ -464,7 +471,11 @@ BootstrapGentooCommon() {
 }
 
 BootstrapFreeBsd() {
-  $SUDO pkg install -Ay \
+  if [ "$QUIET" == 1 ]; then
+      QUIET_FLAG="--quiet"
+  fi
+
+  $SUDO pkg install -Ay $QUIET_FLAG \
     python \
     py27-virtualenv \
     augeas \
@@ -522,7 +533,11 @@ BootstrapSmartOS() {
 }
 
 BootstrapMageiaCommon() {
-  if ! $SUDO urpmi --force  \
+  if [ "$QUIET" == 1 ]; then
+      QUIET_FLAG='--quiet'
+  fi
+
+  if ! $SUDO urpmi --force $QUIET_FLAG \
       python \
       libpython-devel \
       python-virtualenv

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -214,7 +214,7 @@ BootstrapDebCommon() {
   # - Debian 6.0.10 "squeeze" (x64)
 
   if [ "$QUIET" == 1 ]; then
-      QUIET_FLAG='-qq'
+    QUIET_FLAG='-qq'
   fi
 
   $SUDO apt-get $QUIET_FLAG update || echo apt-get update hit problems but continuing anyway...
@@ -407,7 +407,7 @@ BootstrapSuseCommon() {
   fi
 
   if [ "$QUIET" == 1 ]; then
-      QUIET_FLAG='-qq'
+    QUIET_FLAG='-qq'
   fi
 
   $SUDO zypper $QUIET_FLAG $zypper_flags in $install_flags \
@@ -449,9 +449,9 @@ BootstrapArchCommon() {
 
   if [ "$missing" ]; then
     if [ "$QUIET" == 1]; then
-        $SUDO pacman -S --needed $missing $noconfirm > /dev/null
+      $SUDO pacman -S --needed $missing $noconfirm > /dev/null
     else
-        $SUDO pacman -S --needed $missing $noconfirm
+      $SUDO pacman -S --needed $missing $noconfirm
     fi
   fi
 }
@@ -486,7 +486,7 @@ BootstrapGentooCommon() {
 
 BootstrapFreeBsd() {
   if [ "$QUIET" == 1 ]; then
-      QUIET_FLAG="--quiet"
+    QUIET_FLAG="--quiet"
   fi
 
   $SUDO pkg install -Ay $QUIET_FLAG \
@@ -548,7 +548,7 @@ BootstrapSmartOS() {
 
 BootstrapMageiaCommon() {
   if [ "$QUIET" == 1 ]; then
-      QUIET_FLAG='--quiet'
+    QUIET_FLAG='--quiet'
   fi
 
   if ! $SUDO urpmi --force $QUIET_FLAG \

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -327,7 +327,7 @@ BootstrapRpmCommon() {
     yes_flag="-y"
   fi
   if [ "$QUIET" == 1 ]; then
-    $QUIET_FLAG='--quiet'
+    QUIET_FLAG='--quiet'
   fi
 
   if ! $SUDO $tool list *virtualenv >/dev/null 2>&1; then
@@ -386,7 +386,7 @@ BootstrapRpmCommon() {
     "
   fi
 
-  if ! $SUDO $tool install $yes_flag $pkgs; then
+  if ! $SUDO $tool install $yes_flag $QUIET_FLAG $pkgs; then
     echo "Could not install OS dependencies. Aborting bootstrap!"
     exit 1
   fi

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -38,7 +38,7 @@ Help for certbot itself cannot be provided until it is installed.
   -n, --non-interactive, --noninteractive   run without asking for user input
   --no-self-upgrade                         do not download updates
   --os-packages-only                        install OS dependencies and exit
-  -q, --quiet                               provide only update/error output
+  -q, --quiet                               provide only update/error output; implies --non-interactive
   -v, --verbose                             provide more output
 
 All arguments are accepted and forwarded to the Certbot client when run."
@@ -82,6 +82,11 @@ if [ $BASENAME = "letsencrypt-auto" ]; then
   # letsencrypt-auto does not respect --help or --yes for backwards compatibility
   ASSUME_YES=1
   HELP=0
+fi
+
+# Set ASSUME_YES to 1 if QUIET (i.e. --quiet implies --non-interactive)
+if [ $QUIET == 1 ]; then
+  ASSUME_YES=1
 fi
 
 # Support for busybox and others where there is no "command",
@@ -344,7 +349,7 @@ BootstrapRpmCommon() {
       /bin/echo -e "\e[0K\rEnabling the EPEL repository in 1 seconds..."
       sleep 1s
     fi
-    if ! $SUDO $tool install $yes_flag epel-release; then
+    if ! $SUDO $tool install $yes_flag $QUIET_FLAG epel-release; then
       echo "Could not enable EPEL. Aborting bootstrap!"
       exit 1
     fi
@@ -400,7 +405,11 @@ BootstrapSuseCommon() {
     install_flags="-l"
   fi
 
-  $SUDO zypper $zypper_flags in $install_flags \
+  if [ "$QUIET" == 1 ]; then
+      QUIET_FLAG='-qq'
+  fi
+
+  $SUDO zypper $QUIET_FLAG $zypper_flags in $install_flags \
     python \
     python-devel \
     python-virtualenv \
@@ -438,7 +447,11 @@ BootstrapArchCommon() {
   fi
 
   if [ "$missing" ]; then
-    $SUDO pacman -S --needed $missing $noconfirm
+    if [ "$QUIET" == 1]; then
+        $SUDO pacman -S --needed $missing $noconfirm > /dev/null
+    else
+        $SUDO pacman -S --needed $missing $noconfirm
+    fi
   fi
 }
 

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -38,8 +38,9 @@ Help for certbot itself cannot be provided until it is installed.
   -n, --non-interactive, --noninteractive   run without asking for user input
   --no-self-upgrade                         do not download updates
   --os-packages-only                        install OS dependencies and exit
-  -q, --quiet                               provide only update/error output; implies --non-interactive
   -v, --verbose                             provide more output
+  -q, --quiet                               provide only update/error output;
+                                            implies --non-interactive
 
 All arguments are accepted and forwarded to the Certbot client when run."
 

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -38,7 +38,7 @@ Help for certbot itself cannot be provided until it is installed.
   -n, --non-interactive, --noninteractive   run without asking for user input
   --no-self-upgrade                         do not download updates
   --os-packages-only                        install OS dependencies and exit
-  -q, --quiet                               provide only update/error output
+  -q, --quiet                               provide only update/error output; implies --non-interactive
   -v, --verbose                             provide more output
 
 All arguments are accepted and forwarded to the Certbot client when run."
@@ -82,6 +82,11 @@ if [ $BASENAME = "letsencrypt-auto" ]; then
   # letsencrypt-auto does not respect --help or --yes for backwards compatibility
   ASSUME_YES=1
   HELP=0
+fi
+
+# Set ASSUME_YES to 1 if QUIET (i.e. --quiet implies --non-interactive)
+if [ $QUIET == 1 ]; then
+  ASSUME_YES=1
 fi
 
 # Support for busybox and others where there is no "command",

--- a/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
@@ -25,6 +25,10 @@ BootstrapArchCommon() {
   fi
 
   if [ "$missing" ]; then
-    $SUDO pacman -S --needed $missing $noconfirm
+    if [ "$QUIET" == 1]; then
+        $SUDO pacman -S --needed $missing $noconfirm > /dev/null
+    else
+        $SUDO pacman -S --needed $missing $noconfirm
+    fi
   fi
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
@@ -26,9 +26,9 @@ BootstrapArchCommon() {
 
   if [ "$missing" ]; then
     if [ "$QUIET" == 1]; then
-        $SUDO pacman -S --needed $missing $noconfirm > /dev/null
+      $SUDO pacman -S --needed $missing $noconfirm > /dev/null
     else
-        $SUDO pacman -S --needed $missing $noconfirm
+      $SUDO pacman -S --needed $missing $noconfirm
     fi
   fi
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -18,7 +18,7 @@ BootstrapDebCommon() {
   # - Debian 6.0.10 "squeeze" (x64)
 
   if [ "$QUIET" == 1 ]; then
-      QUIET_FLAG='-qq'
+    QUIET_FLAG='-qq'
   fi
 
   $SUDO apt-get $QUIET_FLAG update || echo apt-get update hit problems but continuing anyway...

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -17,7 +17,11 @@ BootstrapDebCommon() {
   #
   # - Debian 6.0.10 "squeeze" (x64)
 
-  $SUDO apt-get update || echo apt-get update hit problems but continuing anyway...
+  if [ "$QUIET" == 1 ]; then
+      QUIET_FLAG='-qq'
+  fi
+
+  $SUDO apt-get $QUIET_FLAG update || echo apt-get update hit problems but continuing anyway...
 
   # virtualenv binary can be found in different packages depending on
   # distro version (#346)
@@ -68,12 +72,12 @@ BootstrapDebCommon() {
         fi
         if [ "$add_backports" = 1 ]; then
           $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
-          $SUDO apt-get update
+          $SUDO apt-get $QUIET_FLAG update
         fi
       fi
     fi
     if [ "$add_backports" != 0 ]; then
-      $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
+      $SUDO apt-get install $QUIET_FLAG $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
       augeas_pkg=
     fi
   }
@@ -92,7 +96,7 @@ BootstrapDebCommon() {
     # XXX add a case for ubuntu PPAs
   fi
 
-  $SUDO apt-get install $YES_FLAG --no-install-recommends \
+  $SUDO apt-get install $QUIET_FLAG $YES_FLAG --no-install-recommends \
     python \
     python-dev \
     $virtualenv \

--- a/letsencrypt-auto-source/pieces/bootstrappers/free_bsd.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/free_bsd.sh
@@ -1,6 +1,6 @@
 BootstrapFreeBsd() {
   if [ "$QUIET" == 1 ]; then
-      QUIET_FLAG="--quiet"
+    QUIET_FLAG="--quiet"
   fi
 
   $SUDO pkg install -Ay $QUIET_FLAG \

--- a/letsencrypt-auto-source/pieces/bootstrappers/free_bsd.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/free_bsd.sh
@@ -1,5 +1,9 @@
 BootstrapFreeBsd() {
-  $SUDO pkg install -Ay \
+  if [ "$QUIET" == 1 ]; then
+      QUIET_FLAG="--quiet"
+  fi
+
+  $SUDO pkg install -Ay $QUIET_FLAG \
     python \
     py27-virtualenv \
     augeas \

--- a/letsencrypt-auto-source/pieces/bootstrappers/mageia_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mageia_common.sh
@@ -1,6 +1,6 @@
 BootstrapMageiaCommon() {
   if [ "$QUIET" == 1 ]; then
-      QUIET_FLAG='--quiet'
+    QUIET_FLAG='--quiet'
   fi
 
   if ! $SUDO urpmi --force $QUIET_FLAG \

--- a/letsencrypt-auto-source/pieces/bootstrappers/mageia_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mageia_common.sh
@@ -1,5 +1,9 @@
 BootstrapMageiaCommon() {
-  if ! $SUDO urpmi --force  \
+  if [ "$QUIET" == 1 ]; then
+      QUIET_FLAG='--quiet'
+  fi
+
+  if ! $SUDO urpmi --force $QUIET_FLAG \
       python \
       libpython-devel \
       python-virtualenv

--- a/letsencrypt-auto-source/pieces/bootstrappers/mageia_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mageia_common.sh
@@ -12,7 +12,7 @@ BootstrapMageiaCommon() {
       exit 1
   fi
 
-  if ! $SUDO urpmi --force \
+  if ! $SUDO urpmi --force $QUIET_FLAG \
       git \
       gcc \
       python-augeas \

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -21,7 +21,7 @@ BootstrapRpmCommon() {
     yes_flag="-y"
   fi
   if [ "$QUIET" == 1 ]; then
-    $QUIET_FLAG='--quiet'
+    QUIET_FLAG='--quiet'
   fi
 
   if ! $SUDO $tool list *virtualenv >/dev/null 2>&1; then
@@ -80,7 +80,7 @@ BootstrapRpmCommon() {
     "
   fi
 
-  if ! $SUDO $tool install $yes_flag $pkgs; then
+  if ! $SUDO $tool install $yes_flag $QUIET_FLAG $pkgs; then
     echo "Could not install OS dependencies. Aborting bootstrap!"
     exit 1
   fi

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -20,6 +20,9 @@ BootstrapRpmCommon() {
   if [ "$ASSUME_YES" = 1 ]; then
     yes_flag="-y"
   fi
+  if [ "$QUIET" == 1 ]; then
+    $QUIET_FLAG='--quiet'
+  fi
 
   if ! $SUDO $tool list *virtualenv >/dev/null 2>&1; then
     echo "To use Certbot, packages from the EPEL repository need to be installed."

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -38,7 +38,7 @@ BootstrapRpmCommon() {
       /bin/echo -e "\e[0K\rEnabling the EPEL repository in 1 seconds..."
       sleep 1s
     fi
-    if ! $SUDO $tool install $yes_flag epel-release; then
+    if ! $SUDO $tool install $yes_flag $QUIET_FLAG epel-release; then
       echo "Could not enable EPEL. Aborting bootstrap!"
       exit 1
     fi

--- a/letsencrypt-auto-source/pieces/bootstrappers/suse_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/suse_common.sh
@@ -7,7 +7,7 @@ BootstrapSuseCommon() {
   fi
 
   if [ "$QUIET" == 1 ]; then
-      QUIET_FLAG='-qq'
+    QUIET_FLAG='-qq'
   fi
 
   $SUDO zypper $QUIET_FLAG $zypper_flags in $install_flags \

--- a/letsencrypt-auto-source/pieces/bootstrappers/suse_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/suse_common.sh
@@ -6,7 +6,11 @@ BootstrapSuseCommon() {
     install_flags="-l"
   fi
 
-  $SUDO zypper $zypper_flags in $install_flags \
+  if [ "$QUIET" == 1 ]; then
+      QUIET_FLAG='-qq'
+  fi
+
+  $SUDO zypper $QUIET_FLAG $zypper_flags in $install_flags \
     python \
     python-devel \
     python-virtualenv \


### PR DESCRIPTION
Add the following flags when `certbot-auto --quiet` is invoked:
- Add `-qq` to calls to `apt-get` in Debian
- Add `--quiet` to calls to `yum` or `dnf` in CentOS or Fedora
- Add `--quiet`to calls to `urpmi` in Mageia
- Add `--quiet` to calls to `pkg install` in FreeBSD

Changes were made to `letsencrypt-auto-source/pieces/bootstrappers/*` and were seen reflected in `letsencrypt-auto-source/letsencrypt-auto` after running `letsencrypt-auto-source/build.py`, but did not appear to propagate to `certbot-auto` or `letsencrypt-auto`.  I suppose this relates to #3703; if I can get a better understanding of how auto-updating of these scripts works, I can work on #3703 too.  

Also of note:  running `letsencrypt-auto-source/build.py` propagated changes from 8c1aa3ef to `letsencrypt-auto-source/pieces/letsencrypt-auto`.  I noticed in #3410 that @bmw requested that `build.py` be run but it does not seem like the script was run (or that the changes made by the script were committed).  My fork and branch are based off of the current `HEAD` of `certbot/certbot`, so I'm assuming that this omission was simply overlooked when merging #3410 in.  The changes from running `build.py` were made in a separate commit (e1ca6dc) to facilitate easier issue tracking; I can cherry-pick this commit and open a separate PR for that issue if doing so is preferred.  

---

In terms of design decisions for the code in this PR, it is possible (and likely) that the script execute such that `$QUIET_FLAG` is uninitialized.  This may be problematic if `set -u` is set, as the script will exit with an error.  

On a more esoteric level, uninitialized variables can be an issue for destructive commands; to use a canonical example, if the following function is invoked without an argument, we're probably not going to have a nice day:
```
function remove_bin() {
    # I have no idea why this function would exist in the first place...
    DIRECTORY=$1
    rm -rf $DIRECTORY/bin
}
```

But since he `$QUIET_FLAG` evaluating to an empty string leaves the package manager commands syntactically and functionally valid (and in fact equivalent to the commands currently being run), I opted to follow the convention set forth by `$YES_FLAG` and left `$QUIET_FLAG` uninitialized.  If the script exiting if `set -u` is set is deemed problematic, I'd be more than happy to initialize `$QUIET_FLAG` and `$YES_FLAG` in a separate Issue/PR.  

(Resolves #3515)