### PR TITLE
Fix Travis failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,8 @@ setenv =
 
 # cffi<=1.7 is required for oldest tests due to
 # https://bitbucket.org/cffi/cffi/commits/18cdf37d6b2691301a15b0e54f49757ebd4ed0f2?at=default
+# requests<=2.11.1 required for py26-oldest tests due to
+# https://github.com/shazow/urllib3/pull/930
 deps =
     py{26,27}-oldest: cffi<=1.7
     py{26,27}-oldest: cryptography==0.8
@@ -38,6 +40,7 @@ deps =
     py{26,27}-oldest: dnspython>=1.12
     py{26,27}-oldest: psutil==2.1.0
     py{26,27}-oldest: PyOpenSSL==0.13
+    py26-oldest: requests<=2.11.1
 
 [testenv:py33]
 commands =


### PR DESCRIPTION
Older versions of the Python standard library provide very limited support for SSL. Luckily, `urllib3` allows you to use `pyopenssl`, which we already have as a dependency for other reasons, to implement SSL. We use the package `requests` for all of our outgoing communication with the ACME server which itself depends on `urllib3` and in fact vendorizes it in the `requests` package.

In [acme.client](https://github.com/certbot/certbot/blob/master/acme/acme/client.py#L29), we ask the vendorized `urllib3` to use `pyopenssl` for SSL. Unfortunately, `urllib3` recently changed the dependencies necessary to do this, requiring versions greater than what is available in the oldest tests. A version of `urllib3` with this change was included in the version of `requests` released today (see [requests' changelog](https://github.com/kennethreitz/requests/blob/master/HISTORY.rst#2120-2016-11-15) or the [urllib3 PR](https://github.com/shazow/urllib3/pull/930) that made this change for more info).

While unfortunate, I doubt this will be a real problem for us. People installing Certbot through `certbot-auto` get new enough versions of all of our dependencies so that injecting `pyopenssl` into `urllib3` still works. Additionally, this only affects OS packages with really old `cryptography` or `pyopenssl` and a brand new version of `requests` which seems very unlikely. Luckily, if anyone ever finds themselves in this situation, the code in `acme.client` I linked to above raises an exception causing Certbot to crash in the ~12 combinations of package versions I tested, rather than failing silently and allowing Certbot to run with poor SSL support. It would be nice if we could make the `pyopenssl` injection work in these circumstances, but I don't think it's feasible.

This PR just pins the version of `requests` used in the Python 2.6 oldest tests so they pass. This is not necessary in the Python 2.7 tests because the standard library already provides reasonable SSL support. In the unlikely event that a Certbot user sees errors here in the future, we can address the problem then since I don't believe we have a reasonable way to mitigate the problem at this time. Even if you disagree that we should more or less ignore this problem, this PR should be merged to fix Travis while we investigate other solutions.