### PR TITLE
Fixed  output of `certbot-auto --version`(#3637).

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -335,6 +335,7 @@ class HelpfulArgumentParser(object):
         self.help_topics = HELP_TOPICS + plugin_names + [None]
         usage, short_usage = usage_strings(plugins)
         self.parser = configargparse.ArgParser(
+            prog="certbot",
             usage=short_usage,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
             args_for_setting_config_path=["-c", "--config"],

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -143,6 +143,21 @@ class CLITest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         out = self._help_output(['-h'])
         self.assertTrue(cli.usage_strings(plugins)[0] in out)
 
+    def test_version_string_program_name(self):
+        toy_out = six.StringIO()
+        toy_err = six.StringIO()
+        with mock.patch('certbot.main.sys.stdout', new=toy_out):
+            with mock.patch('certbot.main.sys.stderr', new=toy_err):
+                try:
+                    main.main(["--version"])
+                except SystemExit:
+                    pass
+                finally:
+                    output = toy_out.getvalue() or toy_err.getvalue()
+                    self.assertTrue("certbot" in output, "Output is {0}".format(output))
+        toy_out.close()
+        toy_err.close()
+
     def _cli_missing_flag(self, args, message):
         "Ensure that a particular error raises a missing cli flag error containing message"
         exc = None


### PR DESCRIPTION
This pull request closes #3637.

The version string previously output `sys.argv[0]` which was assigned to `prog` by `argparse` by default. Now `prog` is set to "certbot". It's hardcoded in the argparse config section of `certbot/cli.py`. Is there a better way of doing this (such as pulling it in from `setup.py`)?