### PR TITLE
Output success message for revoke command

### DIFF
--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -244,7 +244,7 @@ def success_revocation(cert_path):
 
     """
     z_util(interfaces.IDisplay).notification(
-        "Congratulations! You have successfully revoked the certifacte "
+        "Congratulations! You have successfully revoked the certificate "
         "that was located at {0}{1}{1}".format(
             cert_path,
             os.linesep),

--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -237,6 +237,19 @@ def success_renewal(domains):
             os.linesep.join(_gen_ssl_lab_urls(domains))),
         pause=False)
 
+def success_revocation(cert_path):
+    """Display a box confirming a certificate has been revoked.
+
+    :param list cert_path: path to certificate which was revoked.
+
+    """
+    z_util(interfaces.IDisplay).notification(
+        "Congratulations! You have successfully revoked the certifacte "
+        "that was located at {0}{1}{1}".format(
+            cert_path,
+            os.linesep),
+        pause=False)
+
 
 def _gen_ssl_lab_urls(domains):
     """Returns a list of urls.

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -12,6 +12,7 @@ import zope.component
 
 from acme import jose
 from acme import messages
+from acme import errors as acme_errors
 
 import certbot
 
@@ -505,7 +506,7 @@ def revoke(config, unused_plugins):  # TODO: coop with renewal config
     cert = crypto_util.pyopenssl_load_certificate(config.cert_path[1])[0]
     try:
         acme.revoke(jose.ComparableX509(cert))
-    except errors.ClientError as e:
+    except acme_errors.ClientError as e:
         return e.message
 
     display_ops.success_revocation(config.cert_path[0])

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -503,7 +503,12 @@ def revoke(config, unused_plugins):  # TODO: coop with renewal config
         key = acc.key
     acme = client.acme_from_config_key(config, key)
     cert = crypto_util.pyopenssl_load_certificate(config.cert_path[1])[0]
-    acme.revoke(jose.ComparableX509(cert))
+    try:
+        acme.revoke(jose.ComparableX509(cert))
+    except errors.ClientError as e:
+        return e.message
+    finally:
+        display_ops.success_revocation(config.cert_path[0])
 
 
 def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -507,8 +507,8 @@ def revoke(config, unused_plugins):  # TODO: coop with renewal config
         acme.revoke(jose.ComparableX509(cert))
     except errors.ClientError as e:
         return e.message
-    finally:
-        display_ops.success_revocation(config.cert_path[0])
+
+    display_ops.success_revocation(config.cert_path[0])
 
 
 def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -336,6 +336,21 @@ class SuccessRenewalTest(unittest.TestCase):
         for name in names:
             self.assertTrue(name in arg)
 
+class SuccessRevocationTest(unittest.TestCase):
+    # pylint: disable=too-few-public-methods
+    """Test the success revocation message."""
+    @classmethod
+    def _call(cls, path):
+        from certbot.display.ops import success_revocation
+        success_revocation(path)
+
+    @mock.patch("certbot.display.ops.z_util")
+    def test_success_revocation(self, mock_util):
+        mock_util().notification.return_value = None
+        path = "/path/to/cert.pem"
+        self._call(path)
+        mock_util().notification.assert_called_once()
+        self.assertTrue(path in mock_util().notification.call_args[0][0])
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -170,8 +170,7 @@ class RevokeTest(unittest.TestCase):
     def test_revocation_error(self):
         from acme import errors as acme_errors
         self.mock_acme_client.side_effect = acme_errors.ClientError()
-        with self.assertRaises(acme_errors.ClientError):
-            self._call()
+        self.assertRaises(acme_errors.ClientError, self._call)
         self.mock_success_revoke.assert_not_called()
 
 class SetupLogFileHandlerTest(unittest.TestCase):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -123,7 +123,7 @@ class RevokeTest(unittest.TestCase):
     def setUp(self):
         self.tempdir_path = tempfile.mkdtemp()
         shutil.copy(CERT_PATH, self.tempdir_path)
-        self.tmp_cert_path = os.path.abspath(os.path.join(self.tempdir_path, 
+        self.tmp_cert_path = os.path.abspath(os.path.join(self.tempdir_path,
             'cert.pem'))
 
         self.patches = [
@@ -168,9 +168,9 @@ class RevokeTest(unittest.TestCase):
         self.mock_success_revoke.assert_called_once_with(self.tmp_cert_path)
 
     def test_revocation_error(self):
-        from acme import errors
-        self.mock_acme_client.side_effect = errors.ClientError() 
-        with self.assertRaises(errors.ClientError):
+        from acme import errors as acme_errors
+        self.mock_acme_client.side_effect = acme_errors.ClientError()
+        with self.assertRaises(acme_errors.ClientError):
             self._call()
         self.mock_success_revoke.assert_not_called()
 


### PR DESCRIPTION
Fixes #2819.

Added a new `certbot.display.ops.success_revocation` method, and call it from `certbot.main.revoke` if the call to `acme.client.Client.revoke` doesn't raise an error. Added tests for success and failure of the `certbot.main.revoke` command.