### PR TITLE
Security enhancement cleanup

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -388,15 +388,10 @@ class Client(object):
             # sites may have been enabled / final cleanup
             self.installer.restart()
 
-    def enhance_config(self, domains, config, chain_path):
+    def enhance_config(self, domains, chain_path):
         """Enhance the configuration.
 
         :param list domains: list of domains to configure
-
-        :ivar config: Namespace typically produced by
-            :meth:`argparse.ArgumentParser.parse_args`.
-            it must have the redirect, hsts and uir attributes.
-        :type namespace: :class:`argparse.Namespace`
 
         :param chain_path: chain file path
         :type chain_path: `str` or `None`
@@ -411,16 +406,12 @@ class Client(object):
                            "configuration to enhance.")
             raise errors.Error("No installer available")
 
-        if config is None:
-            logger.warning("No config is specified.")
-            raise errors.Error("No config available")
-
         supported = self.installer.supported_enhancements()
 
-        redirect = config.redirect if "redirect" in supported else False
-        hsts = config.hsts if "ensure-http-header" in supported else False
-        uir = config.uir if "ensure-http-header" in supported else False
-        staple = config.staple if "staple-ocsp" in supported else False
+        hsts = self.config.hsts if "ensure-http-header" in supported else False
+        redirect = self.config.redirect if "redirect" in supported else False
+        staple = self.config.staple if "staple-ocsp" in supported else False
+        uir = self.config.uir if "ensure-http-header" in supported else False
 
         if redirect is None:
             redirect = enhancements.ask("redirect")

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -417,7 +417,7 @@ class Client(object):
                     enhanced = True
             elif config_value:
                 logger.warning(
-                    "Option %s is not supported by the selected installer."
+                    "Option %s is not supported by the selected installer. "
                     "Skipping enhancement.", config_name)
 
         msg = ("We were unable to restart web server")

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -196,11 +196,6 @@ class Client(object):
         else:
             self.auth_handler = None
 
-        # Warn if the client is using unsupported config options with an
-        # installer
-        if self.installer is not None:
-            self._verify_all_config_options_supported(config)
-
     def obtain_certificate_from_csr(self, domains, csr,
         typ=OpenSSL.crypto.FILETYPE_ASN1, authzr=None):
         """Obtain certificate.
@@ -392,7 +387,6 @@ class Client(object):
         """Enhance the configuration.
 
         :param list domains: list of domains to configure
-
         :param chain_path: chain file path
         :type chain_path: `str` or `None`
 
@@ -400,36 +394,34 @@ class Client(object):
             client.
 
         """
-
         if self.installer is None:
             logger.warning("No installer is specified, there isn't any "
                            "configuration to enhance.")
             raise errors.Error("No installer available")
 
+        enhanced = False
+        enhancement_info = (
+            ("hsts", "ensure-http-header", "Strict-Transport-Security"),
+            ("redirect", "redirect", None),
+            ("staple", "staple-ocsp", chain_path),
+            ("uir", "ensure-http-header", "Upgrade-Insecure-Requests"),)
         supported = self.installer.supported_enhancements()
 
-        hsts = self.config.hsts if "ensure-http-header" in supported else False
-        redirect = self.config.redirect if "redirect" in supported else False
-        staple = self.config.staple if "staple-ocsp" in supported else False
-        uir = self.config.uir if "ensure-http-header" in supported else False
-
-        if redirect is None:
-            redirect = enhancements.ask("redirect")
-
-        if redirect:
-            self.apply_enhancement(domains, "redirect")
-
-        if hsts:
-            self.apply_enhancement(domains, "ensure-http-header",
-                    "Strict-Transport-Security")
-        if uir:
-            self.apply_enhancement(domains, "ensure-http-header",
-                    "Upgrade-Insecure-Requests")
-        if staple:
-            self.apply_enhancement(domains, "staple-ocsp", chain_path)
+        for config_name, enhancement_name, option in enhancement_info:
+            config_value = getattr(self.config, config_name)
+            if enhancement_name in supported:
+                if config_name == "redirect" and config_value is None:
+                    config_value = enhancements.ask(enhancement_name)
+                if config_value:
+                    self.apply_enhancement(domains, enhancement_name, option)
+                    enhanced = True
+            elif config_value:
+                logger.warning(
+                    "Option %s is not supported by the selected installer."
+                    "Skipping enhancement.", config_name)
 
         msg = ("We were unable to restart web server")
-        if redirect or hsts or uir or staple:
+        if enhanced:
             with error_handler.ErrorHandler(self._rollback_and_restart, msg):
                 self.installer.restart()
 
@@ -498,32 +490,6 @@ class Client(object):
                 reporter.HIGH_PRIORITY)
             raise
         reporter.add_message(success_msg, reporter.HIGH_PRIORITY)
-
-    def _verify_all_config_options_supported(self, config):
-        """Verifies that all config options are supported in current installer.
-
-         :ivar config: Namespace typically produced by
-            :meth:`argparse.ArgumentParser.parse_args`.
-         :type namespace: :class:`argparse.Namespace`
-        """
-        # Mapping between config options and string describing config option
-        # support in installer supported_enhancements.
-        option_support = {
-            "redirect": "redirect",
-            "hsts": "ensure-http-header",
-            "uir": "ensure-http-header",
-            "staple": "staple-ocsp"
-        }
-
-        supported = self.installer.supported_enhancements()
-
-        for config_name, support_string in option_support.items():
-            config_value = getattr(config, config_name, None)
-            if config_value and support_string not in supported:
-                msg = ("Option %s is not allowed with the current installer. "
-                       "Please disable the option and try again." %
-                       config_name)
-                logger.warning(msg)
 
 
 def validate_key_csr(privkey, csr=None):

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -435,7 +435,7 @@ def install(config, plugins):
     le_client.deploy_certificate(
         domains, config.key_path, config.cert_path, config.chain_path,
         config.fullchain_path)
-    le_client.enhance_config(domains, config, config.chain_path)
+    le_client.enhance_config(domains, config.chain_path)
 
 
 def plugins_cmd(config, plugins):  # TODO: Use IDisplay rather than print
@@ -532,7 +532,7 @@ def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
         domains, lineage.privkey, lineage.cert,
         lineage.chain, lineage.fullchain)
 
-    le_client.enhance_config(domains, config, lineage.chain)
+    le_client.enhance_config(domains, lineage.chain)
 
     if action in ("newcert", "reinstall",):
         display_ops.success_installation(domains)

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -386,7 +386,7 @@ class EnhanceConfigTest(ClientTestCommon):
         self.client.installer.save.side_effect = errors.PluginError
         self._test_enhance_error()
         self.client.installer.recovery_routine.assert_called_once_with()
-        self.client.installer.save.assert_called_once_with()
+        self.client.installer.save.assert_called_once_with(mock.ANY)
 
     def test_enhance_config_restart_failure(self):
         self.client.installer = mock.MagicMock()

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -334,12 +334,12 @@ class EnhanceConfigTest(ClientTestCommon):
         self.config.uir = False
         self.domain = "example.org"
 
-    def test_enhance_config_no_installer(self):
+    def test_no_installer(self):
         self.assertRaises(
             errors.Error, self.client.enhance_config, [self.domain], None)
 
     @mock.patch("certbot.client.enhancements")
-    def test_enhance_config_unsupported(self, mock_enhancements):
+    def test_unsupported(self, mock_enhancements):
         self.client.installer = mock.MagicMock()
         self.client.installer.supported_enhancements.return_value = []
 
@@ -351,66 +351,66 @@ class EnhanceConfigTest(ClientTestCommon):
         self.client.installer.enhance.assert_not_called()
         mock_enhancements.ask.assert_not_called()
 
-    def test_enhance_config_no_ask_hsts(self):
+    def test_no_ask_hsts(self):
         self.config.hsts = True
         self._test_with_all_supported()
         self.client.installer.enhance.assert_called_with(
             self.domain, "ensure-http-header", "Strict-Transport-Security")
 
-    def test_enhance_config_no_ask_redirect(self):
+    def test_no_ask_redirect(self):
         self.config.redirect = True
         self._test_with_all_supported()
         self.client.installer.enhance.assert_called_with(
             self.domain, "redirect", None)
 
-    def test_enhance_config_no_ask_staple(self):
+    def test_no_ask_staple(self):
         self.config.staple = True
         self._test_with_all_supported()
         self.client.installer.enhance.assert_called_with(
             self.domain, "staple-ocsp", None)
 
-    def test_enhance_config_no_ask_uir(self):
+    def test_no_ask_uir(self):
         self.config.uir = True
         self._test_with_all_supported()
         self.client.installer.enhance.assert_called_with(
             self.domain, "ensure-http-header", "Upgrade-Insecure-Requests")
 
-    def test_enhance_config_enhance_failure(self):
+    def test_enhance_failure(self):
         self.client.installer = mock.MagicMock()
         self.client.installer.enhance.side_effect = errors.PluginError
-        self._test_enhance_error()
+        self._test_error()
         self.client.installer.recovery_routine.assert_called_once_with()
 
-    def test_enhance_config_save_failure(self):
+    def test_save_failure(self):
         self.client.installer = mock.MagicMock()
         self.client.installer.save.side_effect = errors.PluginError
-        self._test_enhance_error()
+        self._test_error()
         self.client.installer.recovery_routine.assert_called_once_with()
         self.client.installer.save.assert_called_once_with(mock.ANY)
 
-    def test_enhance_config_restart_failure(self):
+    def test_restart_failure(self):
         self.client.installer = mock.MagicMock()
         self.client.installer.restart.side_effect = [errors.PluginError, None]
-        self._test_enhance_error_with_rollback()
+        self._test_error_with_rollback()
 
-    def test_enhance_config_restart_failure2(self):
+    def test_restart_failure2(self):
         installer = mock.MagicMock()
         installer.restart.side_effect = errors.PluginError
         installer.rollback_checkpoints.side_effect = errors.ReverterError
         self.client.installer = installer
-        self._test_enhance_error_with_rollback()
+        self._test_error_with_rollback()
 
     @mock.patch("certbot.client.enhancements.ask")
-    def test_enhance_ask(self, mock_ask):
+    def test_ask(self, mock_ask):
         self.config.redirect = None
         mock_ask.return_value = True
         self._test_with_all_supported()
 
-    def _test_enhance_error_with_rollback(self):
-        self._test_enhance_error()
+    def _test_error_with_rollback(self):
+        self._test_error()
         self.assertTrue(self.client.installer.restart.called)
 
-    def _test_enhance_error(self):
+    def _test_error(self):
         self.config.redirect = True
         with mock.patch("certbot.client.zope.component.getUtility") as mock_gu:
             self.assertRaises(


### PR DESCRIPTION
This is largely a refactor PR. The only production behavior this should change is instead of warning about an unsupported enhancement early in Certbot's execution, we warn about it when performing the enhancement. I think this is to be preferred because it makes the user more likely to see the warning (enhancements are one of the last things Certbot does) and it keeps the enhancement functionality localized to one function. The reason it wasn't done this way when it was implemented is my review comments were ambiguous.

This PR also increases test coverage (although coveralls may disagree because of all of the deleted lines).