### PR TITLE
Testfarm test new leauto

### DIFF
--- a/tests/letstest/scripts/test_letsencrypt_auto_certonly_standalone.sh
+++ b/tests/letstest/scripts/test_letsencrypt_auto_certonly_standalone.sh
@@ -7,7 +7,7 @@
 #public_ip=$(curl -s http://169.254.169.254/2014-11-05/meta-data/public-ipv4)
 #private_ip=$(curl -s http://169.254.169.254/2014-11-05/meta-data/local-ipv4)
 
-cd letsencrypt
+cd letsencrypt/letsencrypt-auto-source
 ./letsencrypt-auto --os-packages-only --debug --version
 ./letsencrypt-auto certonly --no-self-upgrade -v --standalone --debug \
                    --text --agree-dev-preview --agree-tos \

--- a/tests/letstest/scripts/test_letsencrypt_auto_venv_only.sh
+++ b/tests/letstest/scripts/test_letsencrypt_auto_venv_only.sh
@@ -4,4 +4,4 @@
 
 cd letsencrypt
 # help installs virtualenv and does nothing else
-./letsencrypt-auto -v --debug --help all
+./letsencrypt-auto-source/letsencrypt-auto -v --debug --help all


### PR DESCRIPTION
Test farm tests should test the version of `letsencrypt-auto` that's in the git tree, not the one from the previous release.