### PR TITLE
Fix --debug

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -688,7 +688,7 @@ def _handle_exception(exc_type, exc_value, trace, config):
                 with open(logfile, "w") as logfd:
                     traceback.print_exception(
                         exc_type, exc_value, trace, file=logfd)
-                assert "--debug" not in sys.argv
+                assert "--debug" not in sys.argv  # config is None if this explodes
             except:  # pylint: disable=bare-except
                 sys.exit("".join(
                     traceback.format_exception(exc_type, exc_value, trace)))

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -676,10 +676,8 @@ def _handle_exception(exc_type, exc_value, trace, config):
     to the user. sys.exit is always called with a nonzero status.
 
     """
-    logger.debug(
-        "Exiting abnormally:%s%s",
-        os.linesep,
-        "".join(traceback.format_exception(exc_type, exc_value, trace)))
+    tb_str = "".join(traceback.format_exception(exc_type, exc_value, trace))
+    logger.debug("Exiting abnormally:%s%s", os.linesep, tb_str)
 
     if issubclass(exc_type, Exception) and (config is None or not config.debug):
         if config is None:
@@ -688,10 +686,10 @@ def _handle_exception(exc_type, exc_value, trace, config):
                 with open(logfile, "w") as logfd:
                     traceback.print_exception(
                         exc_type, exc_value, trace, file=logfd)
-                assert "--debug" not in sys.argv  # config is None if this explodes
             except:  # pylint: disable=bare-except
-                sys.exit("".join(
-                    traceback.format_exception(exc_type, exc_value, trace)))
+                sys.exit(tb_str)
+            if "--debug" in sys.argv:
+                sys.exit(tb_str)
 
         if issubclass(exc_type, errors.Error):
             sys.exit(exc_value)
@@ -716,8 +714,7 @@ def _handle_exception(exc_type, exc_value, trace, config):
                 msg += "logfiles in {0} for more details.".format(config.logs_dir)
             sys.exit(msg)
     else:
-        sys.exit("".join(
-            traceback.format_exception(exc_type, exc_value, trace)))
+        sys.exit(tb_str)
 
 
 def make_or_verify_core_dir(directory, mode, uid, strict):

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -688,6 +688,7 @@ def _handle_exception(exc_type, exc_value, trace, config):
                 with open(logfile, "w") as logfd:
                     traceback.print_exception(
                         exc_type, exc_value, trace, file=logfd)
+                assert "--debug" not in sys.argv
             except:  # pylint: disable=bare-except
                 sys.exit("".join(
                     traceback.format_exception(exc_type, exc_value, trace)))


### PR DESCRIPTION
Currently `--debug` doesn't work to print tracebacks for crashes before there is a `config` object. This PR fixes that.