### PR TITLE
Make default renewal file permissions more strict

### DIFF
--- a/certbot/util.py
+++ b/certbot/util.py
@@ -181,7 +181,7 @@ def unique_file(path, chmod=0o777, mode="w"):
         count=0, chmod=chmod, mode=mode)
 
 
-def unique_lineage_name(path, filename, chmod=0o777, mode="w"):
+def unique_lineage_name(path, filename, chmod=0o644, mode="w"):
     """Safely finds a unique file using lineage convention.
 
     :param str path: directory path


### PR DESCRIPTION
We have no reason to write files with too permissive privileges, introducing a bit more strict default.

Fixes #3847