### PR TITLE
Change link of haproxy plugin to new version

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -193,7 +193,7 @@ postfix_    N    Y    STARTTLS Everywhere is becoming a Certbot Postfix/Exim plu
 =========== ==== ==== ===============================================================
 
 .. _plesk: https://github.com/plesk/letsencrypt-plesk
-.. _haproxy: https://code.greenhost.net/open/letsencrypt-haproxy
+.. _haproxy: https://github.com/greenhost/certbot-haproxy
 .. _s3front: https://github.com/dlapiduz/letsencrypt-s3front
 .. _gandi: https://github.com/Gandi/letsencrypt-gandi
 .. _icecast: https://github.com/e00E/lets-encrypt-icecast


### PR DESCRIPTION
Greenhost has rewritten their HAProxy plugin and it's hosted on a different location. The original URL also points to this new location: https://code.greenhost.net/open/letsencrypt-haproxy