### PR TITLE
Serialize coverage tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ matrix:
       after_failure:
         - sudo cat /var/log/mysql/error.log
         - ps aux | grep mysql
+      services: docker
     - sudo: required
       env: TOXENV=apache_compat
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,7 @@ env:
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=cover BOULDER_INTEGRATION=1
-      sudo: required
-      after_failure:
-        - sudo cat /var/log/mysql/error.log
-        - ps aux | grep mysql
-      services: docker
+      env: TOXENV=cover
     - python: "2.7"
       env: TOXENV=lint
     - python: "2.7"
@@ -46,6 +41,12 @@ matrix:
         - sudo cat /var/log/mysql/error.log
         - ps aux | grep mysql
       services: docker
+    - python: "2.7"
+      env: TOXENV=py27_install BOULDER_INTEGRATION=1
+      sudo: required
+      after_failure:
+        - sudo cat /var/log/mysql/error.log
+        - ps aux | grep mysql
     - sudo: required
       env: TOXENV=apache_compat
       services: docker

--- a/tox.cover.sh
+++ b/tox.cover.sh
@@ -36,9 +36,8 @@ cover () {
   # specific package, positional argument scopes tests only to
   # specific package directory; --cover-tests makes sure every tests
   # is run (c.f. #403)
-  nosetests -c /dev/null --with-cover --cover-tests --cover-package \
-            "$1" --cover-min-percentage="$min" "$1" --processes=-1 \
-            --process-timeout=100
+  nosetests -c /dev/null --with-cover --cover-tests --cover-package  \
+            "$1" --cover-min-percentage="$min" "$1"
 }
 
 rm -f .coverage  # --cover-erase is off, make sure stats are correct

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,11 @@ commands =
     pip install -e .[dev]
     nosetests -v certbot --processes=-1 --process-timeout=100
 
+[testenv:py27_install]
+basepython = python2.7
+commands =
+    pip install -e acme[dns,dev] -e .[dev] -e certbot-apache -e certbot-nginx -e letshelp-certbot
+
 [testenv:cover]
 basepython = python2.7
 commands =


### PR DESCRIPTION
I noticed today that coverage is now skipping files. For example, looking at the coverage run from #3916, `certbot/notify.py` and `certbot/plugins/script.py` aren't reporting coverage at all. While looking into this I saw this quote from https://nose.readthedocs.io/en/latest/doc_tests/test_multiprocess/multiprocess.html:

> Plugin interaction warning

> The multiprocess plugin does not work well with other plugins that expect to wrap or gain control of the test-running process. Examples from nose’s builtin plugins include **coverage** and profiling: a test run using both multiprocess and either of those is likely to fail in some confusing and spectacular way.

While I like the speed increase, I don't think it's worth our tests being buggy when there are documented problems here. This only disables running our coverage tests in parallel. Our normal unit tests and lint are unaffected by this PR.