### PR TITLE
OCSP checking and other cool "certbot certificates" features

### DIFF
--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -172,12 +172,12 @@ def _report_human_readable(parsed_certs):
     for cert in parsed_certs:
         now = pytz.UTC.fromutc(datetime.datetime.utcnow())
         expiration_text = ""
+        revoked = ocsp.revoked_status(cert.cert, cert.chain)
         if cert.is_test_cert:
             expiration_text = "INVALID: TEST CERT"
         elif cert.target_expiry <= now:
             expiration_text = "INVALID: EXPIRED"
         else:
-            revoked = ocsp.revoked_status(cert.cert, cert.chain)
             if revoked:
                 expiration_text = "INVALID: " + revoked
 

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -169,11 +169,14 @@ def _report_lines(msgs):
 def _report_human_readable(parsed_certs):
     """Format a results report for a parsed cert"""
     certinfo = []
+    checker = ocsp.RevocationChecker()
     for cert in parsed_certs:
         now = pytz.UTC.fromutc(datetime.datetime.utcnow())
         expiration_text = ""
-        revoked = ocsp.revoked_status(cert.cert, cert.chain)
-        if cert.is_test_cert:
+        revoked = checker.check_ocsp(cert.cert, cert.chain)
+        if revoked:
+            expiration_text = "INVALID: " + revoked
+        elif cert.is_test_cert:
             expiration_text = "INVALID: TEST CERT"
         elif cert.target_expiry <= now:
             expiration_text = "INVALID: EXPIRED"

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -171,6 +171,10 @@ def _report_human_readable(config, parsed_certs):
     certinfo = []
     checker = ocsp.RevocationChecker(config)
     for cert in parsed_certs:
+        if config.certname and cert.lineagename != config.certname:
+            continue
+        if config.domains and not set(config.domains).issubset(cert.names()):
+            continue
         now = pytz.UTC.fromutc(datetime.datetime.utcnow())
         status = ""
         if cert.is_test_cert:
@@ -212,7 +216,8 @@ def _describe_certs(config, parsed_certs, parse_failures):
         notify("No certs found.")
     else:
         if parsed_certs:
-            notify("Found the following certs:")
+            match = "matching " if config.certname or config.domains else ""
+            notify("Found the following {0}certs:".format(match))
             notify(_report_human_readable(config, parsed_certs))
         if parse_failures:
             notify("\nThe following renewal configuration files "

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -944,9 +944,9 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         help=config_help("no_verify_ssl"),
         default=flag_default("no_verify_ssl"))
     helpful.add(
-        ["testing", "certificates"], "--check-ocsp", default="if otherwise valid",
+        ["certificates", "testing"], "--check-ocsp", default="always",
         help='Whether to check OCSP for listed certs. Can be set to "never", "always",'
-             'or "if otherwise valid".')
+             ' or "lazy" (ie, only for certs that are otherwise valid).')
     helpful.add(
         ["testing", "standalone", "apache", "nginx"], "--tls-sni-01-port", type=int,
         default=flag_default("tls_sni_01_port"),

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -350,8 +350,10 @@ VERB_HELP = [
         "usage": "\n\n  certbot renew [--cert-name NAME] [options]\n\n"
     }),
     ("certificates", {
-        "short": "List all certificates managed by Certbot",
-        "opts": "List all certificates managed by Certbot"
+        "short": "List certificates managed by Certbot",
+        "opts": "List certificates managed by Certbot",
+        "usage": ("\n\n  certbot certificates [options] ...\n\n"
+                  "Print information about the status of certificates managed by Certbot.")
     }),
     ("delete", {
         "short": "Clean up all files related to a certificate",
@@ -824,14 +826,14 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
              "being run in a terminal. This flag cannot be used with the "
              "renew subcommand.")
     helpful.add(
-        [None, "run", "certonly"],
+        [None, "run", "certonly", "certificates"],
         "-d", "--domains", "--domain", dest="domains",
         metavar="DOMAIN", action=_DomainsAction, default=[],
         help="Domain names to apply. For multiple domains you can use "
              "multiple -d flags or enter a comma separated list of domains "
              "as a parameter. (default: Ask)")
     helpful.add(
-        [None, "run", "certonly", "manage", "rename", "delete"],
+        [None, "run", "certonly", "manage", "rename", "delete", "certificates"],
         "--cert-name", dest="certname",
         metavar="CERTNAME", default=None,
         help="Certificate name to apply. Only one certificate name can be used "

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -529,6 +529,10 @@ class HelpfulArgumentParser(object):
                         constants.FORCE_INTERACTIVE_FLAG))
             parsed_args.noninteractive_mode = True
 
+        parsed_args.check_ocsp = parsed_args.check_ocsp.lower()
+        if parsed_args.check_ocsp not in ("always", "never", "lazy"):
+            raise errors.Error('--check-ocsp must be "always", "never", or "lazy"')
+
         if parsed_args.force_interactive and parsed_args.noninteractive_mode:
             raise errors.Error(
                 "Flag for non-interactive mode and {0} conflict".format(

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -944,6 +944,10 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         help=config_help("no_verify_ssl"),
         default=flag_default("no_verify_ssl"))
     helpful.add(
+        ["testing", "certificates"], "--check-ocsp", default="if otherwise valid",
+        help='Whether to check OCSP for listed certs. Can be set to "never", "always",'
+             'or "if otherwise valid".')
+    helpful.add(
         ["testing", "standalone", "apache", "nginx"], "--tls-sni-01-port", type=int,
         default=flag_default("tls_sni_01_port"),
         help=config_help("tls_sni_01_port"))

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -529,10 +529,6 @@ class HelpfulArgumentParser(object):
                         constants.FORCE_INTERACTIVE_FLAG))
             parsed_args.noninteractive_mode = True
 
-        parsed_args.check_ocsp = parsed_args.check_ocsp.lower()
-        if parsed_args.check_ocsp not in ("always", "never", "lazy"):
-            raise errors.Error('--check-ocsp must be "always", "never", or "lazy"')
-
         if parsed_args.force_interactive and parsed_args.noninteractive_mode:
             raise errors.Error(
                 "Flag for non-interactive mode and {0} conflict".format(
@@ -949,10 +945,6 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         "testing", "--no-verify-ssl", action="store_true",
         help=config_help("no_verify_ssl"),
         default=flag_default("no_verify_ssl"))
-    helpful.add(
-        ["certificates", "testing"], "--check-ocsp", default="always",
-        help='Whether to check OCSP for listed certs. Can be set to "never", "always",'
-             ' or "lazy" (ie, only for certs that are otherwise valid).')
     helpful.add(
         ["testing", "standalone", "apache", "nginx"], "--tls-sni-01-port", type=int,
         default=flag_default("tls_sni_01_port"),

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -40,9 +40,10 @@ def revoked_status(cert_path, chain_path):
             "-issuer", chain_path,
             "-cert", cert_path,
             "-url", url,
-            "-CAfile", chain_path])
+            "-CAfile", chain_path,
+            "-verify_other", chain_path])
     except errors.SubprocessError:
-        return "(OCSP Failure)"
+        return "OCSP Failure"
 
     return _translate_ocsp_query(cert_path, output)
 

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -27,7 +27,7 @@ class RevocationChecker(object):
 
        # New versions of openssl want -header var=val, old ones want -header var val
         test_host_format = Popen(["openssl", "ocsp", "-header", "var", "val"],
-                                 stdout=PIPE, stderr=PIPE)
+                                 stdout=PIPE, stderr=PIPE, universal_newlines=True)
         _out, err = test_host_format.communicate()
         if "Missing =" in err:
             self.host_args = lambda host: ["Host=" + host]

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -24,50 +24,69 @@ def revoked_status(cert_path, chain_path):
 
     """
 
-    url, _ = util.run_script(
-        ["openssl", "x509", "-in", cert_path, "-noout", "-ocsp_uri"])
+    if revoked_status.broken:
+        return False
+
+    if not util.exe_exists("openssl"):
+        logging.info("openssl not installed, can't check revocation")
+        revoked_status.broken = True
+        return False
+
+    try:
+        url, err = util.run_script(
+            ["openssl", "x509", "-in", cert_path, "-noout", "-ocsp_uri"],
+            log=logging.debug)
+    except errors.SubprocessError:
+        logger.info("Cannot extract OCSP URI from %s", cert_path)
+        return False
 
     url = url.rstrip()
     host = url.partition("://")[2].rstrip("/")
     if not host:
-        raise errors.Error(
-            "Unable to get OCSP host from cert, url - %s", url)
+        logger.info("Cannot process OCSP host from URL (%s) in cert at %s", url, cert_path)
+        return False
 
     # New versions of openssl want -header var=val, old ones want -header var val
     test_host_format = Popen(["openssl", "ocsp", "-header", "var", "val"],
                              stdout=PIPE, stderr=PIPE)
     _out, err = test_host_format.communicate()
     if "Missing =" in err:
-        host_arg = ["Host=" + host]
+        host_args = ["Host=" + host]
     else:
-        host_arg = ["Host", host]
+        host_args = ["Host", host]
 
     # jdkasten thanks "Bulletproof SSL and TLS - Ivan Ristic" for documenting this!
     try:
-        output, _ = util.run_script(
-            ["openssl", "ocsp",
-            "-no_nonce",
-            "-header"] + host_arg + [
-            "-issuer", chain_path,
-            "-cert", cert_path,
-            "-url", url,
-            "-CAfile", chain_path,
-            "-verify_other", chain_path])
+        cmd = ["openssl", "ocsp",
+               "-no_nonce",
+               "-issuer", chain_path,
+               "-cert", cert_path,
+               "-url", url,
+               "-CAfile", chain_path,
+               "-verify_other", chain_path,
+               "-header"] + host_args
+        output, err = util.run_script(cmd, log=logging.debug)
     except errors.SubprocessError:
-        return "OCSP Failure"
+        logger.info("OCSP querying seems to be broken, assuming nothing is revoked...")
+        logger.debug("Command was:\n%s\nError was:\n%s", " ".join(cmd), err)
+        revoked_status.broken = True
+        return False
 
-    return _translate_ocsp_query(cert_path, output)
+    return _translate_ocsp_query(cert_path, output, err)
+revoked_status.broken = False
 
 
-def _translate_ocsp_query(cert_path, ocsp_output):
+def _translate_ocsp_query(cert_path, ocsp_output, ocsp_errors):
     """Returns a label string out of the query."""
     if not "Response verify OK":
-        return "Revocation Unknown"
+        logger.info("Revocation status for %s is unknown", cert_path)
+        logger.debug("Uncertain ouput:\n%s\nstderr:\n%s", ocsp_output, ocsp_errors)
+        return ""
     if cert_path + ": good" in ocsp_output:
         return ""
     elif cert_path + ": revoked" in ocsp_output:
         return REV_LABEL
     else:
-        raise errors.Error(
-            "Unable to properly parse OCSP output: %s", ocsp_output)
+        logger.warn("Unable to properly parse OCSP output: %s", ocsp_output)
+        return ""
 

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -7,8 +7,7 @@ from certbot import util
 logger = logging.getLogger(__name__)
 
 
-REV_LABEL = "**Revoked**"
-EXP_LABEL = "**Expired**"
+REV_LABEL = "REVOKED"
 
 INSTALL_LABEL = "(Installed)"
 
@@ -36,7 +35,7 @@ def revoked_status(cert_path, chain_path):
     try:
         output, _ = util.run_script(
             ["openssl", "ocsp",
-            "-no_nonce", "-header", "Host", host,
+            "-no_nonce", "-header", "Host="+host,
             "-issuer", chain_path,
             "-cert", cert_path,
             "-url", url,

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -86,7 +86,7 @@ class RevocationChecker(object):
                "-header"] + self.host_args(host)
         try:
             output, err = util.run_script(cmd, log=logging.debug)
-        except errors.SubprocessError, e:
+        except errors.SubprocessError as e:
             logger.info("OCSP check failed for %s (are we offline?)", cert_path)
             logger.debug("Command was:\n%s\nError was:\n%s", " ".join(cmd), e)
             return False

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -23,6 +23,7 @@ class RevocationChecker(object):
         if not util.exe_exists("openssl"):
             logging.info("openssl not installed, can't check revocation")
             self.broken = True
+            return
 
        # New versions of openssl want -header var=val, old ones want -header var val
         test_host_format = Popen(["openssl", "ocsp", "-header", "var", "val"],

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -45,9 +45,9 @@ class RevocationChecker(object):
 
         :returns: a new status including revocation, if the cert is revoked."""
 
-        if self.config.check_ocsp.lower() == "never":
+        if self.config.check_ocsp == "never":
             return status_in
-        elif self.config.check_ocsp.lower() == "lazy" and status_in:
+        elif self.config.check_ocsp == "lazy" and status_in:
             return status_in
 
         revoked = self.check_ocsp(cert_path, chain_path)
@@ -106,9 +106,9 @@ class RevocationChecker(object):
             url, err = util.run_script(
                 ["openssl", "x509", "-in", cert_path, "-noout", "-ocsp_uri"],
                 log=logging.debug)
-        except errors.SubprocessError:
+        except errors.SubprocessError as e:
             logger.info("Cannot extract OCSP URI from %s", cert_path)
-            logger.debug("Error was:\n%s", err)
+            logger.debug("Error was:\n%s", e)
             return None, None
 
         url = url.rstrip()
@@ -122,7 +122,7 @@ class RevocationChecker(object):
 
 def _translate_ocsp_query(cert_path, ocsp_output, ocsp_errors):
     """Returns a label string out of the query."""
-    if not "Response verify OK":
+    if not "Response verify OK" in ocsp_errors:
         logger.info("Revocation status for %s is unknown", cert_path)
         logger.debug("Uncertain ouput:\n%s\nstderr:\n%s", ocsp_output, ocsp_errors)
         return ""

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -86,10 +86,8 @@ class RevocationChecker(object):
         try:
             output, err = util.run_script(cmd, log=logging.debug)
         except errors.SubprocessError, e:
-            logger.info("We're offline, or OCSP querying is broken. "
-                        "Assuming nothing is revoked...")
+            logger.info("We're offline, or OCSP querying is broken. ")
             logger.debug("Command was:\n%s\nError was:\n%s", " ".join(cmd), e)
-            self.broken = True
             return False
 
         return _translate_ocsp_query(cert_path, output, err)

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -86,7 +86,7 @@ class RevocationChecker(object):
         try:
             output, err = util.run_script(cmd, log=logging.debug)
         except errors.SubprocessError, e:
-            logger.info("We're offline, or OCSP querying is broken. ")
+            logger.info("OCSP check failed for %s (are we offline?)", cert_path)
             logger.debug("Command was:\n%s\nError was:\n%s", " ".join(cmd), e)
             return False
 

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -1,14 +1,17 @@
+"""Tools for checking certificate revocation."""
 import logging
 
-from letsencrypt import errors
-from letsencrypt import le_util
-
+from certbot import errors
+from certbot import util
 
 logger = logging.getLogger(__name__)
 
 
 REV_LABEL = "**Revoked**"
 EXP_LABEL = "**Expired**"
+
+INSTALL_LABEL = "(Installed)"
+
 
 def revoked_status(cert_path, chain_path):
     """Get revoked status for a particular cert version.
@@ -19,7 +22,7 @@ def revoked_status(cert_path, chain_path):
     :param str chain_path: Path to chain certificate
 
     """
-    url, _ = le_util.run_script(
+    url, _ = util.run_script(
         ["openssl", "x509", "-in", cert_path, "-noout", "-ocsp_uri"])
 
     url = url.rstrip()
@@ -31,7 +34,7 @@ def revoked_status(cert_path, chain_path):
     # This was a PITA...
     # Thanks to "Bulletproof SSL and TLS - Ivan Ristic" for helping me out
     try:
-        output, _ = le_util.run_script(
+        output, _ = util.run_script(
             ["openssl", "ocsp",
             "-no_nonce", "-header", "Host", host,
             "-issuer", chain_path,
@@ -55,5 +58,4 @@ def _translate_ocsp_query(cert_path, ocsp_output):
     else:
         raise errors.Error(
             "Unable to properly parse OCSP output: %s", ocsp_output)
-
 

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -1,0 +1,59 @@
+import logging
+
+from letsencrypt import errors
+from letsencrypt import le_util
+
+
+logger = logging.getLogger(__name__)
+
+
+REV_LABEL = "**Revoked**"
+EXP_LABEL = "**Expired**"
+
+def revoked_status(cert_path, chain_path):
+    """Get revoked status for a particular cert version.
+
+    .. todo:: Make this a non-blocking call
+
+    :param str cert_path: Path to certificate
+    :param str chain_path: Path to chain certificate
+
+    """
+    url, _ = le_util.run_script(
+        ["openssl", "x509", "-in", cert_path, "-noout", "-ocsp_uri"])
+
+    url = url.rstrip()
+    host = url.partition("://")[2].rstrip("/")
+    if not host:
+        raise errors.Error(
+            "Unable to get OCSP host from cert, url - %s", url)
+
+    # This was a PITA...
+    # Thanks to "Bulletproof SSL and TLS - Ivan Ristic" for helping me out
+    try:
+        output, _ = le_util.run_script(
+            ["openssl", "ocsp",
+            "-no_nonce", "-header", "Host", host,
+            "-issuer", chain_path,
+            "-cert", cert_path,
+            "-url", url,
+            "-CAfile", chain_path])
+    except errors.SubprocessError:
+        return "(OCSP Failure)"
+
+    return _translate_ocsp_query(cert_path, output)
+
+
+def _translate_ocsp_query(cert_path, ocsp_output):
+    """Returns a label string out of the query."""
+    if not "Response verify OK":
+        return "Revocation Unknown"
+    if cert_path + ": good" in ocsp_output:
+        return ""
+    elif cert_path + ": revoked" in ocsp_output:
+        return REV_LABEL
+    else:
+        raise errors.Error(
+            "Unable to properly parse OCSP output: %s", ocsp_output)
+
+

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -179,7 +179,9 @@ class CertificatesTest(BaseCertManagerTest):
         self.assertTrue(mock_utility.called)
         shutil.rmtree(tempdir)
 
-    def test_report_human_readable(self):
+    @mock.patch('certbot.cert_manager.ocsp.RevocationChecker.ocsp_status')
+    def test_report_human_readable(self, mock_ocsp):
+        mock_ocsp.side_effect = lambda _cert, _chain, status: status
         from certbot import cert_manager
         import datetime, pytz
         expiry = pytz.UTC.fromutc(datetime.datetime.utcnow())
@@ -190,7 +192,7 @@ class CertificatesTest(BaseCertManagerTest):
         cert.is_test_cert = False
         parsed_certs = [cert]
 
-        mock_config = mock.MagicMock()
+        mock_config = mock.MagicMock(certname=None, lineagename=None)
         # pylint: disable=protected-access
         out = cert_manager._report_human_readable(mock_config, parsed_certs)
         self.assertTrue("INVALID: EXPIRED" in out)
@@ -216,7 +218,7 @@ class CertificatesTest(BaseCertManagerTest):
 
         cert.is_test_cert = True
         out = cert_manager._report_human_readable(mock_config, parsed_certs)
-        self.assertTrue('INVALID: TEST CERT' in out)
+        self.assertTrue('INVALID: TEST_CERT' in out)
 
 
 class SearchLineagesTest(BaseCertManagerTest):

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -189,31 +189,33 @@ class CertificatesTest(BaseCertManagerTest):
         cert.names.return_value = ["nameone", "nametwo"]
         cert.is_test_cert = False
         parsed_certs = [cert]
+
+        mock_config = mock.MagicMock()
         # pylint: disable=protected-access
-        out = cert_manager._report_human_readable(parsed_certs)
+        out = cert_manager._report_human_readable(mock_config, parsed_certs)
         self.assertTrue("INVALID: EXPIRED" in out)
 
         cert.target_expiry += datetime.timedelta(hours=2)
         # pylint: disable=protected-access
-        out = cert_manager._report_human_readable(parsed_certs)
+        out = cert_manager._report_human_readable(mock_config, parsed_certs)
         self.assertTrue('1 hour(s)' in out)
         self.assertTrue('VALID' in out and not 'INVALID' in out)
 
         cert.target_expiry += datetime.timedelta(days=1)
         # pylint: disable=protected-access
-        out = cert_manager._report_human_readable(parsed_certs)
+        out = cert_manager._report_human_readable(mock_config, parsed_certs)
         self.assertTrue('1 day' in out)
         self.assertFalse('under' in out)
         self.assertTrue('VALID' in out and not 'INVALID' in out)
 
         cert.target_expiry += datetime.timedelta(days=2)
         # pylint: disable=protected-access
-        out = cert_manager._report_human_readable(parsed_certs)
+        out = cert_manager._report_human_readable(mock_config, parsed_certs)
         self.assertTrue('3 days' in out)
         self.assertTrue('VALID' in out and not 'INVALID' in out)
 
         cert.is_test_cert = True
-        out = cert_manager._report_human_readable(parsed_certs)
+        out = cert_manager._report_human_readable(mock_config, parsed_certs)
         self.assertTrue('INVALID: TEST CERT' in out)
 
 

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -179,9 +179,9 @@ class CertificatesTest(BaseCertManagerTest):
         self.assertTrue(mock_utility.called)
         shutil.rmtree(tempdir)
 
-    @mock.patch('certbot.cert_manager.ocsp.RevocationChecker.ocsp_status')
+    @mock.patch('certbot.cert_manager.ocsp.RevocationChecker.ocsp_revoked')
     def test_report_human_readable(self, mock_ocsp):
-        mock_ocsp.side_effect = lambda _cert, _chain, status: status
+        mock_ocsp.side_effect = lambda _cert, _chain: None
         from certbot import cert_manager
         import datetime, pytz
         expiry = pytz.UTC.fromutc(datetime.datetime.utcnow())

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -1,5 +1,5 @@
 """Tests for certbot.cert_manager."""
-# pylint disable=protected-access
+# pylint: disable=protected-access
 import os
 import re
 import shutil
@@ -192,6 +192,8 @@ class CertificatesTest(BaseCertManagerTest):
         cert.names.return_value = ["nameone", "nametwo"]
         cert.is_test_cert = False
         parsed_certs = [cert]
+
+        # pylint: disable=protected-access
         get_report = lambda: cert_manager._report_human_readable(mock_config, parsed_certs)
 
         mock_config = mock.MagicMock(certname=None, lineagename=None)

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -181,8 +181,8 @@ class CertificatesTest(BaseCertManagerTest):
         shutil.rmtree(tempdir)
 
     @mock.patch('certbot.cert_manager.ocsp.RevocationChecker.ocsp_revoked')
-    def test_report_human_readable(self, mock_ocsp):
-        mock_ocsp.return_value = None
+    def test_report_human_readable(self, mock_revoked):
+        mock_revoked.return_value = None
         from certbot import cert_manager
         import datetime, pytz
         expiry = pytz.UTC.fromutc(datetime.datetime.utcnow())
@@ -221,8 +221,9 @@ class CertificatesTest(BaseCertManagerTest):
         self.assertTrue('VALID' in out and not 'INVALID' in out)
 
         cert.is_test_cert = True
+        mock_revoked.return_value = True
         out = get_report()
-        self.assertTrue('INVALID: TEST_CERT' in out)
+        self.assertTrue('INVALID: TEST_CERT, REVOKED' in out)
 
         cert = mock.MagicMock(lineagename="indescribable")
         cert.target_expiry = expiry

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -268,6 +268,10 @@ class ParseTest(unittest.TestCase):
         self.assertRaises(
             errors.Error, self.parse, "-n --force-interactive".split())
 
+    def test_check_ocsp(self):
+        self.assertRaises(errors.Error, self.parse, "certificates --check-ocsp bogus".split())
+        self.parse("certificates --check-ocsp lazy".split())
+
 
 class DefaultTest(unittest.TestCase):
     """Tests for certbot.cli._Default."""

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -270,7 +270,7 @@ class ParseTest(unittest.TestCase):
 
     def test_check_ocsp(self):
         self.assertRaises(errors.Error, self.parse, "certificates --check-ocsp bogus".split())
-        self.parse("certificates --check-ocsp lazy".split())
+        self.parse("certificates --check-ocsp LaZy".split())
 
 
 class DefaultTest(unittest.TestCase):

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -268,10 +268,6 @@ class ParseTest(unittest.TestCase):
         self.assertRaises(
             errors.Error, self.parse, "-n --force-interactive".split())
 
-    def test_check_ocsp(self):
-        self.assertRaises(errors.Error, self.parse, "certificates --check-ocsp bogus".split())
-        self.parse("certificates --check-ocsp LaZy".split())
-
 
 class DefaultTest(unittest.TestCase):
     """Tests for certbot.cli._Default."""

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -1,0 +1,137 @@
+
+"""Tests for hooks.py"""
+# pylint: disable=protected-access
+
+import os
+import unittest
+
+import mock
+
+from certbot import errors
+from certbot import hooks
+
+out = """Missing = in header key=value
+ocsp: Use -help for summary.
+"""
+
+class OCSPTest(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    def setUp(self):
+        from certbot import ocsp
+        self.config = mock.MagicMock()
+        self.checker = ocsp.RevocationChecker(self.config)
+
+    def tearDown(self):
+        pass
+
+    @mock.patch('certbot.ocsp.logging.info')
+    @mock.patch('certbot.ocsp.Popen')
+    @mock.patch('certbot.util.exe_exists')
+    def test_init(self, mock_exists, mock_popen, mock_log):
+        mock_communicate = mock.MagicMock()
+        mock_communicate.communicate.return_value = (None, out)
+        mock_popen.return_value = mock_communicate
+        mock_exists.return_value = True
+
+        from certbot import ocsp
+        checker = ocsp.RevocationChecker(self.config)
+        self.assertEqual(mock_popen.call_count, 1)
+        self.assertEqual(checker.host_args("x"), ["Host=x"])
+
+        mock_communicate.communicate.return_value = (None, out.partition("\n")[2])
+        checker = ocsp.RevocationChecker(self.config)
+        self.assertEqual(checker.host_args("x"), ["Host", "x"])
+        self.assertEqual(checker.broken, False)
+
+        mock_exists.return_value = False
+        mock_popen.call_count = 0
+        checker = ocsp.RevocationChecker(self.config)
+        self.assertEqual(mock_popen.call_count, 0)
+        self.assertEqual(mock_log.call_count, 1)
+        self.assertEqual(checker.broken, True)
+
+    def test_ocsp_status(self):
+        from certbot import ocsp
+        checker = self.checker
+        checker.check_ocsp = mock.MagicMock()
+        checker.check_ocsp.return_value = "octopus found in certificate"
+
+        checker.config.check_ocsp = "never"
+        self.assertEqual(checker.ocsp_status("a", "a", "xyz"), "xyz")
+        self.assertEqual(checker.ocsp_status("a", "a", ""), "")
+        self.assertEqual(checker.check_ocsp.call_count, 0)
+
+        checker.config.check_ocsp = "lazy"
+        self.assertEqual(checker.ocsp_status("a", "a", "xyz"), "xyz")
+        self.assertEqual(checker.check_ocsp.call_count, 0)
+        self.assertEqual(checker.ocsp_status("a", "a", ""), "INVALID: REVOKED")
+
+        checker.config.check_ocsp = "always"
+        self.assertEqual(checker.ocsp_status("a", "a", "xyz"), "xyz,REVOKED")
+        checker.check_ocsp.return_value = ""
+        self.assertEqual(checker.ocsp_status("a", "a", "xyz"), "xyz")
+        
+            
+    @mock.patch('certbot.ocsp.logger.debug')
+    @mock.patch('certbot.ocsp.logger.info')
+    @mock.patch('certbot.util.run_script')
+    def test_determine_ocsp_server(self, mock_run, mock_info, mock_debug):
+        uri = "http://ocsp.stg-int-x1.letsencrypt.org/"
+        host = "ocsp.stg-int-x1.letsencrypt.org"
+        mock_run.return_value = uri, ""
+        self.assertEquals(self.checker.determine_ocsp_server("beep"), (uri, host))
+        mock_run.return_value = "ftp:/" + host + "/", ""
+        self.assertEquals(self.checker.determine_ocsp_server("beep"), (None, None))
+        self.assertEquals(mock_info.call_count, 1)
+
+        c = "confusion"
+        mock_run.side_effect = errors.SubprocessError(c)
+        self.assertEquals(self.checker.determine_ocsp_server("beep"), (None, None))
+        self.assertTrue(c in mock_debug.call_args[0][1])
+
+    @mock.patch('certbot.ocsp.logger')
+    @mock.patch('certbot.util.run_script')
+    def test_translate_ocsp(self, mock_run, mock_log):
+        # pylint: disable=protected-access 
+        mock_run.return_value = openssl_confused
+        from certbot import ocsp
+        self.assertEquals(ocsp._translate_ocsp_query(*openssl_happy), "")
+        self.assertEquals(ocsp._translate_ocsp_query(*openssl_confused), "")
+        self.assertEquals(mock_log.debug.call_count, 1)
+        self.assertEquals(mock_log.warn.call_count, 0)
+        self.assertEquals(ocsp._translate_ocsp_query(*openssl_broken), "")
+        self.assertEquals(mock_log.warn.call_count, 1)
+        self.assertEquals(ocsp._translate_ocsp_query(*openssl_revoked), "REVOKED")
+
+
+openssl_confused = ("", """
+/etc/letsencrypt/live/example.org/cert.pem: good
+	This Update: Dec 17 00:00:00 2016 GMT
+	Next Update: Dec 24 00:00:00 2016 GMT
+""",
+"""
+Response Verify Failure
+139903674214048:error:27069065:OCSP routines:OCSP_basic_verify:certificate verify error:ocsp_vfy.c:138:Verify error:unable to get local issuer certificate
+""")
+
+openssl_happy = ("blah.pem", """
+blah.pem: good
+	This Update: Dec 20 18:00:00 2016 GMT
+	Next Update: Dec 27 18:00:00 2016 GMT
+""",
+"Response verify OK")
+
+openssl_revoked = ("blah.pem", """
+blah.pem: revoked
+	This Update: Dec 20 01:00:00 2016 GMT
+	Next Update: Dec 27 01:00:00 2016 GMT
+	Revocation Time: Dec 20 01:46:34 2016 GMT
+""",
+"""Response verify OK""")
+
+openssl_broken = ("", "tentacles", "Response verify OK")
+
+if __name__ == '__main__':
+    unittest.main()  # pragma: no cover

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -59,17 +59,17 @@ class OCSPTest(unittest.TestCase):
     def test_ocsp_revoked(self, mock_run, mock_determine):
         self.checker.broken = True
         mock_determine.return_value = ("", "")
-        self.assertEqual(self.checker.ocsp_revoked("x", "y"), None)
+        self.assertEqual(self.checker.ocsp_revoked("x", "y"), False)
 
         self.checker.broken = False
         mock_run.return_value = tuple(openssl_happy[1:])
-        self.assertEqual(self.checker.ocsp_revoked("x", "y"), None)
+        self.assertEqual(self.checker.ocsp_revoked("x", "y"), False)
         self.assertEqual(mock_run.call_count, 0)
 
         mock_determine.return_value = ("http://x.co", "x.co")
         self.assertEqual(self.checker.ocsp_revoked("blah.pem", "chain.pem"), False)
         mock_run.side_effect = errors.SubprocessError("Unable to load certificate launcher")
-        self.assertEqual(self.checker.ocsp_revoked("x", "y"), None)
+        self.assertEqual(self.checker.ocsp_revoked("x", "y"), False)
         self.assertEqual(mock_run.call_count, 2)
 
 
@@ -97,10 +97,10 @@ class OCSPTest(unittest.TestCase):
         mock_run.return_value = openssl_confused
         from certbot import ocsp
         self.assertEqual(ocsp._translate_ocsp_query(*openssl_happy), False)
-        self.assertEqual(ocsp._translate_ocsp_query(*openssl_confused), None)
+        self.assertEqual(ocsp._translate_ocsp_query(*openssl_confused), False)
         self.assertEqual(mock_log.debug.call_count, 1)
         self.assertEqual(mock_log.warn.call_count, 0)
-        self.assertEqual(ocsp._translate_ocsp_query(*openssl_broken), None)
+        self.assertEqual(ocsp._translate_ocsp_query(*openssl_broken), False)
         self.assertEqual(mock_log.warn.call_count, 1)
         self.assertEqual(ocsp._translate_ocsp_query(*openssl_revoked), True)
 

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -1,5 +1,4 @@
-
-"""Tests for hooks.py"""
+"""Tests for ocsp.py"""
 # pylint: disable=protected-access
 
 import unittest

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -69,6 +69,9 @@ class OCSPTest(unittest.TestCase):
 
         mock_determine.return_value = ("http://x.co", "x.co")
         self.assertEqual(self.checker.ocsp_revoked("blah.pem", "chain.pem"), False)
+        mock_run.side_effect = errors.SubprocessError("Unable to load certificate launcher")
+        self.assertEqual(self.checker.ocsp_revoked("x", "y"), None)
+        self.assertEqual(mock_run.call_count, 2)
 
 
     @mock.patch('certbot.ocsp.logger.debug')

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -86,7 +86,7 @@ class OCSPTest(unittest.TestCase):
         c = "confusion"
         mock_run.side_effect = errors.SubprocessError(c)
         self.assertEqual(self.checker.determine_ocsp_server("beep"), (None, None))
-        self.assertTrue(c in mock_debug.call_args[0][1])
+        self.assertTrue(c in repr(mock_debug.call_args[0][1]))
 
     @mock.patch('certbot.ocsp.logger')
     @mock.patch('certbot.util.run_script')

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -38,10 +38,11 @@ ANSI_SGR_RED = "\033[31m"
 ANSI_SGR_RESET = "\033[0m"
 
 
-def run_script(params):
+def run_script(params, log=logger.error):
     """Run the script with the given params.
 
     :param list params: List of parameters to pass to Popen
+    :param logging.Logger log: Logger to use for errors
 
     """
     try:
@@ -51,7 +52,7 @@ def run_script(params):
 
     except (OSError, ValueError):
         msg = "Unable to run the command: %s" % " ".join(params)
-        logger.error(msg)
+        log(msg)
         raise errors.SubprocessError(msg)
 
     stdout, stderr = proc.communicate()
@@ -60,7 +61,7 @@ def run_script(params):
         msg = "Error while running %s.\n%s\n%s" % (
             " ".join(params), stdout, stderr)
         # Enter recovery routine...
-        logger.error(msg)
+        log(msg)
         raise errors.SubprocessError(msg)
 
     return stdout, stderr

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -48,7 +48,8 @@ def run_script(params, log=logger.error):
     try:
         proc = subprocess.Popen(params,
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True)
 
     except (OSError, ValueError):
         msg = "Unable to run the command: %s" % " ".join(params)


### PR DESCRIPTION
* Brings in some OCSP code from @jdkasten's ancient `certificate_manager` branch, allowing `certbot certificates` to list revocation statuses. Fixes: #3908 
* Allows the user to filter `certbot certificates` output with `-d` or `--cert-name`. Fixes #3907 