### PR TITLE
Add missing comma to documentation for 'renew' subcommand

### DIFF
--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -1,4 +1,4 @@
-usage: 
+usage:
   certbot [SUBCOMMAND] [options] [-d domain] [-d domain] ...
 
 Certbot can obtain and install HTTPS/TLS/SSL certificates.  By default,
@@ -178,7 +178,7 @@ renew:
   The 'renew' subcommand will attempt to renew all certificates (or more
   precisely, certificate lineages) you have previously obtained if they are
   close to expiry, and print a summary of the results. By default, 'renew'
-  will reuse the options used to create obtain or most recently successfully
+  will reuse the options used to create, obtain or most recently successfully
   renew each certificate lineage. You can try it with `--dry-run` first. For
   more fine-grained control, you can renew individual lineages with the
   `certonly` subcommand. Hooks are available to run commands before and


### PR DESCRIPTION
`By default, 'renew' will reuse the options used to create obtain or most recently successfully renew each certificate lineage.`

should be,

`By default, 'renew' will reuse the options used to create, obtain or most recently successfully renew each certificate lineage.`