### PR TITLE
Add Dependencies to generate Sphinx documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -384,8 +384,9 @@ Note that you will need to have the ``Sphinx``, ``sphinx_rtd_theme``, and
 Install these packages by running:
 
 .. code-block:: shell
-    # pip install -U Sphinx sphinx_rtd_theme
-    # easy_install repoze.sphinx.autointerface
+
+    pip install -U Sphinx sphinx_rtd_theme
+    easy_install repoze.sphinx.autointerface
 
 
 Other methods for running the client

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -379,6 +379,14 @@ commands:
 This should generate documentation in the ``docs/_build/html``
 directory.
 
+Note that you will need to have the ``Sphinx``, ``sphinx_rtd_theme``, and
+``repoze.sphinx.autointerface`` packages installed to build the documentation.
+Install these packages by running:
+
+.. code-block:: shell
+    # pip install -U Sphinx sphinx_rtd_theme
+    # easy_install repoze.sphinx.autointerface
+
 
 Other methods for running the client
 ====================================


### PR DESCRIPTION
Specify that developers should install `Sphinx`, `sphinx_rtd_theme`, and `repoze.sphinx.autointerface` to build the documentation

See #3980 