### PR TITLE
Make letsencrypt-auto indentation consistent

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -215,71 +215,71 @@ BootstrapDebCommon() {
   virtualenv=
   # virtual env is known to apt and is installable
   if apt-cache show virtualenv > /dev/null 2>&1 ; then
-      if ! LC_ALL=C apt-cache --quiet=0 show virtualenv 2>&1 | grep -q 'No packages found'; then
-          virtualenv="virtualenv"
-      fi
+    if ! LC_ALL=C apt-cache --quiet=0 show virtualenv 2>&1 | grep -q 'No packages found'; then
+      virtualenv="virtualenv"
+    fi
   fi
 
   if apt-cache show python-virtualenv > /dev/null 2>&1; then
-      virtualenv="$virtualenv python-virtualenv"
+    virtualenv="$virtualenv python-virtualenv"
   fi
 
   augeas_pkg="libaugeas0 augeas-lenses"
   AUGVERSION=`LC_ALL=C apt-cache show --no-all-versions libaugeas0 | grep ^Version: | cut -d" " -f2`
 
   if [ "$ASSUME_YES" = 1 ]; then
-      YES_FLAG="-y"
+    YES_FLAG="-y"
   fi
 
   AddBackportRepo() {
-      # ARGS:
-      BACKPORT_NAME="$1"
-      BACKPORT_SOURCELINE="$2"
-      echo "To use the Apache Certbot plugin, augeas needs to be installed from $BACKPORT_NAME."
-      if ! grep -v -e ' *#' /etc/apt/sources.list | grep -q "$BACKPORT_NAME" ; then
-          # This can theoretically error if sources.list.d is empty, but in that case we don't care.
-          if ! grep -v -e ' *#' /etc/apt/sources.list.d/* 2>/dev/null | grep -q "$BACKPORT_NAME"; then
-              if [ "$ASSUME_YES" = 1 ]; then
-                  /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
-                  sleep 1s
-                  /bin/echo -ne "\e[0K\rInstalling augeas from $BACKPORT_NAME in 2 seconds..."
-                  sleep 1s
-                  /bin/echo -e "\e[0K\rInstalling augeas from $BACKPORT_NAME in 1 second ..."
-                  sleep 1s
-                  add_backports=1
-              else
-                  read -p "Would you like to enable the $BACKPORT_NAME repository [Y/n]? " response
-                  case $response in
-                      [yY][eE][sS]|[yY]|"")
-                          add_backports=1;;
-                      *)
-                          add_backports=0;;
-                  esac
-              fi
-              if [ "$add_backports" = 1 ]; then
-                  $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
-                  $SUDO apt-get update
-              fi
-          fi
+    # ARGS:
+    BACKPORT_NAME="$1"
+    BACKPORT_SOURCELINE="$2"
+    echo "To use the Apache Certbot plugin, augeas needs to be installed from $BACKPORT_NAME."
+    if ! grep -v -e ' *#' /etc/apt/sources.list | grep -q "$BACKPORT_NAME" ; then
+      # This can theoretically error if sources.list.d is empty, but in that case we don't care.
+      if ! grep -v -e ' *#' /etc/apt/sources.list.d/* 2>/dev/null | grep -q "$BACKPORT_NAME"; then
+        if [ "$ASSUME_YES" = 1 ]; then
+          /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
+          sleep 1s
+          /bin/echo -ne "\e[0K\rInstalling augeas from $BACKPORT_NAME in 2 seconds..."
+          sleep 1s
+          /bin/echo -e "\e[0K\rInstalling augeas from $BACKPORT_NAME in 1 second ..."
+          sleep 1s
+          add_backports=1
+        else
+          read -p "Would you like to enable the $BACKPORT_NAME repository [Y/n]? " response
+          case $response in
+            [yY][eE][sS]|[yY]|"")
+              add_backports=1;;
+            *)
+              add_backports=0;;
+          esac
+        fi
+        if [ "$add_backports" = 1 ]; then
+          $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
+          $SUDO apt-get update
+        fi
       fi
-      if [ "$add_backports" != 0 ]; then
-          $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
-          augeas_pkg=
-      fi
+    fi
+    if [ "$add_backports" != 0 ]; then
+      $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
+      augeas_pkg=
+    fi
   }
 
 
   if dpkg --compare-versions 1.0 gt "$AUGVERSION" ; then
-      if lsb_release -a | grep -q wheezy ; then
-          AddBackportRepo wheezy-backports "deb http://http.debian.net/debian wheezy-backports main"
-      elif lsb_release -a | grep -q precise ; then
-          # XXX add ARM case
-          AddBackportRepo precise-backports "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse"
-      else
-          echo "No libaugeas0 version is available that's new enough to run the"
-          echo "Certbot apache plugin..."
-      fi
-      # XXX add a case for ubuntu PPAs
+    if lsb_release -a | grep -q wheezy ; then
+      AddBackportRepo wheezy-backports "deb http://http.debian.net/debian wheezy-backports main"
+    elif lsb_release -a | grep -q precise ; then
+      # XXX add ARM case
+      AddBackportRepo precise-backports "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse"
+    else
+      echo "No libaugeas0 version is available that's new enough to run the"
+      echo "Certbot apache plugin..."
+    fi
+    # XXX add a case for ubuntu PPAs
   fi
 
   $SUDO apt-get install $YES_FLAG --no-install-recommends \
@@ -292,7 +292,6 @@ BootstrapDebCommon() {
     openssl \
     libffi-dev \
     ca-certificates \
-
 
 
   if ! $EXISTS virtualenv > /dev/null ; then
@@ -331,12 +330,12 @@ BootstrapRpmCommon() {
       exit 1
     fi
     if [ "$ASSUME_YES" = 1 ]; then
-        /bin/echo -n "Enabling the EPEL repository in 3 seconds..."
-        sleep 1s
-        /bin/echo -ne "\e[0K\rEnabling the EPEL repository in 2 seconds..."
-        sleep 1s
-        /bin/echo -e "\e[0K\rEnabling the EPEL repository in 1 seconds..."
-        sleep 1s
+      /bin/echo -n "Enabling the EPEL repository in 3 seconds..."
+      sleep 1s
+      /bin/echo -ne "\e[0K\rEnabling the EPEL repository in 2 seconds..."
+      sleep 1s
+      /bin/echo -e "\e[0K\rEnabling the EPEL repository in 1 seconds..."
+      sleep 1s
     fi
     if ! $SUDO $tool install $yes_flag epel-release; then
       echo "Could not enable EPEL. Aborting bootstrap!"
@@ -505,15 +504,15 @@ BootstrapMac() {
   fi
 
   if ! hash pip 2>/dev/null; then
-      echo "pip not installed"
-      echo "Installing pip..."
-      curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
+    echo "pip not installed"
+    echo "Installing pip..."
+    curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
   fi
 
   if ! hash virtualenv 2>/dev/null; then
-      echo "virtualenv not installed."
-      echo "Installing with pip..."
-      pip install virtualenv
+    echo "virtualenv not installed."
+    echo "Installing with pip..."
+    pip install virtualenv
   fi
 }
 
@@ -523,26 +522,25 @@ BootstrapSmartOS() {
 }
 
 BootstrapMageiaCommon() {
-    if ! $SUDO urpmi --force  \
-           python \
-           libpython-devel \
-           python-virtualenv
+  if ! $SUDO urpmi --force  \
+      python \
+      libpython-devel \
+      python-virtualenv
     then
       echo "Could not install Python dependencies. Aborting bootstrap!"
       exit 1
-    fi
+  fi
 
-    if ! $SUDO urpmi --force \
-           git \
-           gcc \
-           python-augeas \
-           openssl \
-           libopenssl-devel \
-           libffi-devel \
-           rootcerts
+  if ! $SUDO urpmi --force \
+      git \
+      gcc \
+      python-augeas \
+      libopenssl-devel \
+      libffi-devel \
+      rootcerts
     then
-        echo "Could not install additional dependencies. Aborting bootstrap!"
-        exit 1
+      echo "Could not install additional dependencies. Aborting bootstrap!"
+      exit 1
     fi
 }
 

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -25,71 +25,71 @@ BootstrapDebCommon() {
   virtualenv=
   # virtual env is known to apt and is installable
   if apt-cache show virtualenv > /dev/null 2>&1 ; then
-      if ! LC_ALL=C apt-cache --quiet=0 show virtualenv 2>&1 | grep -q 'No packages found'; then
-          virtualenv="virtualenv"
-      fi
+    if ! LC_ALL=C apt-cache --quiet=0 show virtualenv 2>&1 | grep -q 'No packages found'; then
+      virtualenv="virtualenv"
+    fi
   fi
 
   if apt-cache show python-virtualenv > /dev/null 2>&1; then
-      virtualenv="$virtualenv python-virtualenv"
+    virtualenv="$virtualenv python-virtualenv"
   fi
 
   augeas_pkg="libaugeas0 augeas-lenses"
   AUGVERSION=`LC_ALL=C apt-cache show --no-all-versions libaugeas0 | grep ^Version: | cut -d" " -f2`
 
   if [ "$ASSUME_YES" = 1 ]; then
-      YES_FLAG="-y"
+    YES_FLAG="-y"
   fi
 
   AddBackportRepo() {
-      # ARGS:
-      BACKPORT_NAME="$1"
-      BACKPORT_SOURCELINE="$2"
-      echo "To use the Apache Certbot plugin, augeas needs to be installed from $BACKPORT_NAME."
-      if ! grep -v -e ' *#' /etc/apt/sources.list | grep -q "$BACKPORT_NAME" ; then
-          # This can theoretically error if sources.list.d is empty, but in that case we don't care.
-          if ! grep -v -e ' *#' /etc/apt/sources.list.d/* 2>/dev/null | grep -q "$BACKPORT_NAME"; then
-              if [ "$ASSUME_YES" = 1 ]; then
-                  /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
-                  sleep 1s
-                  /bin/echo -ne "\e[0K\rInstalling augeas from $BACKPORT_NAME in 2 seconds..."
-                  sleep 1s
-                  /bin/echo -e "\e[0K\rInstalling augeas from $BACKPORT_NAME in 1 second ..."
-                  sleep 1s
-                  add_backports=1
-              else
-                  read -p "Would you like to enable the $BACKPORT_NAME repository [Y/n]? " response
-                  case $response in
-                      [yY][eE][sS]|[yY]|"")
-                          add_backports=1;;
-                      *)
-                          add_backports=0;;
-                  esac
-              fi
-              if [ "$add_backports" = 1 ]; then
-                  $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
-                  $SUDO apt-get update
-              fi
-          fi
+    # ARGS:
+    BACKPORT_NAME="$1"
+    BACKPORT_SOURCELINE="$2"
+    echo "To use the Apache Certbot plugin, augeas needs to be installed from $BACKPORT_NAME."
+    if ! grep -v -e ' *#' /etc/apt/sources.list | grep -q "$BACKPORT_NAME" ; then
+      # This can theoretically error if sources.list.d is empty, but in that case we don't care.
+      if ! grep -v -e ' *#' /etc/apt/sources.list.d/* 2>/dev/null | grep -q "$BACKPORT_NAME"; then
+        if [ "$ASSUME_YES" = 1 ]; then
+          /bin/echo -n "Installing augeas from $BACKPORT_NAME in 3 seconds..."
+          sleep 1s
+          /bin/echo -ne "\e[0K\rInstalling augeas from $BACKPORT_NAME in 2 seconds..."
+          sleep 1s
+          /bin/echo -e "\e[0K\rInstalling augeas from $BACKPORT_NAME in 1 second ..."
+          sleep 1s
+          add_backports=1
+        else
+          read -p "Would you like to enable the $BACKPORT_NAME repository [Y/n]? " response
+          case $response in
+            [yY][eE][sS]|[yY]|"")
+              add_backports=1;;
+            *)
+              add_backports=0;;
+          esac
+        fi
+        if [ "$add_backports" = 1 ]; then
+          $SUDO sh -c "echo $BACKPORT_SOURCELINE >> /etc/apt/sources.list.d/$BACKPORT_NAME.list"
+          $SUDO apt-get update
+        fi
       fi
-      if [ "$add_backports" != 0 ]; then
-          $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
-          augeas_pkg=
-      fi
+    fi
+    if [ "$add_backports" != 0 ]; then
+      $SUDO apt-get install $YES_FLAG --no-install-recommends -t "$BACKPORT_NAME" $augeas_pkg
+      augeas_pkg=
+    fi
   }
 
 
   if dpkg --compare-versions 1.0 gt "$AUGVERSION" ; then
-      if lsb_release -a | grep -q wheezy ; then
-          AddBackportRepo wheezy-backports "deb http://http.debian.net/debian wheezy-backports main"
-      elif lsb_release -a | grep -q precise ; then
-          # XXX add ARM case
-          AddBackportRepo precise-backports "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse"
-      else
-          echo "No libaugeas0 version is available that's new enough to run the"
-          echo "Certbot apache plugin..."
-      fi
-      # XXX add a case for ubuntu PPAs
+    if lsb_release -a | grep -q wheezy ; then
+      AddBackportRepo wheezy-backports "deb http://http.debian.net/debian wheezy-backports main"
+    elif lsb_release -a | grep -q precise ; then
+      # XXX add ARM case
+      AddBackportRepo precise-backports "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse"
+    else
+      echo "No libaugeas0 version is available that's new enough to run the"
+      echo "Certbot apache plugin..."
+    fi
+    # XXX add a case for ubuntu PPAs
   fi
 
   $SUDO apt-get install $YES_FLAG --no-install-recommends \
@@ -102,7 +102,6 @@ BootstrapDebCommon() {
     openssl \
     libffi-dev \
     ca-certificates \
-
 
 
   if ! $EXISTS virtualenv > /dev/null ; then

--- a/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
@@ -31,14 +31,14 @@ BootstrapMac() {
   fi
 
   if ! hash pip 2>/dev/null; then
-      echo "pip not installed"
-      echo "Installing pip..."
-      curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
+    echo "pip not installed"
+    echo "Installing pip..."
+    curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
   fi
 
   if ! hash virtualenv 2>/dev/null; then
-      echo "virtualenv not installed."
-      echo "Installing with pip..."
-      pip install virtualenv
+    echo "virtualenv not installed."
+    echo "Installing with pip..."
+    pip install virtualenv
   fi
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/mageia_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mageia_common.sh
@@ -1,23 +1,22 @@
 BootstrapMageiaCommon() {
-    if ! $SUDO urpmi --force  \
-           python \
-           libpython-devel \
-           python-virtualenv
+  if ! $SUDO urpmi --force  \
+      python \
+      libpython-devel \
+      python-virtualenv
     then
       echo "Could not install Python dependencies. Aborting bootstrap!"
       exit 1
-    fi
+  fi
 
-    if ! $SUDO urpmi --force \
-           git \
-           gcc \
-           python-augeas \
-           openssl \
-           libopenssl-devel \
-           libffi-devel \
-           rootcerts
+  if ! $SUDO urpmi --force \
+      git \
+      gcc \
+      python-augeas \
+      libopenssl-devel \
+      libffi-devel \
+      rootcerts
     then
-        echo "Could not install additional dependencies. Aborting bootstrap!"
-        exit 1
+      echo "Could not install additional dependencies. Aborting bootstrap!"
+      exit 1
     fi
 }

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -28,12 +28,12 @@ BootstrapRpmCommon() {
       exit 1
     fi
     if [ "$ASSUME_YES" = 1 ]; then
-        /bin/echo -n "Enabling the EPEL repository in 3 seconds..."
-        sleep 1s
-        /bin/echo -ne "\e[0K\rEnabling the EPEL repository in 2 seconds..."
-        sleep 1s
-        /bin/echo -e "\e[0K\rEnabling the EPEL repository in 1 seconds..."
-        sleep 1s
+      /bin/echo -n "Enabling the EPEL repository in 3 seconds..."
+      sleep 1s
+      /bin/echo -ne "\e[0K\rEnabling the EPEL repository in 2 seconds..."
+      sleep 1s
+      /bin/echo -e "\e[0K\rEnabling the EPEL repository in 1 seconds..."
+      sleep 1s
     fi
     if ! $SUDO $tool install $yes_flag epel-release; then
       echo "Could not enable EPEL. Aborting bootstrap!"

--- a/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/rpm_common.sh
@@ -78,7 +78,7 @@ BootstrapRpmCommon() {
   fi
 
   if ! $SUDO $tool install $yes_flag $pkgs; then
-      echo "Could not install OS dependencies. Aborting bootstrap!"
-      exit 1
+    echo "Could not install OS dependencies. Aborting bootstrap!"
+    exit 1
   fi
 }


### PR DESCRIPTION
Since a majority of letsencrypt-auto uses 2 spaces per indentation level, made indentation in letsencrypt-auto and platform-specific shell scripts a consistent 2 spaces.  

Since this PR touches so much of `letsencrypt-auto`, I'll save rebasing my branch off of `certbot/certbot:master` until after I've addressed any feedback.  

See #3902