### PR TITLE
Add option to specify revocation reason (#3242)

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -477,17 +477,21 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
                 "Recursion limit reached. Didn't get {0}".format(uri))
         return chain
 
-    def revoke(self, cert):
+    def revoke(self, cert, rsn):
         """Revoke certificate.
 
         :param .ComparableX509 cert: `OpenSSL.crypto.X509` wrapped in
             `.ComparableX509`
 
+        :param int rsn: Reason code for certificate revocation.
+
         :raises .ClientError: If revocation is unsuccessful.
 
         """
         response = self.net.post(self.directory[messages.Revocation],
-                                 messages.Revocation(certificate=cert),
+                                 messages.Revocation(
+                                     certificate=cert,
+                                     reason=rsn),
                                  content_type=None)
         if response.status_code != http_client.OK:
             raise errors.ClientError(

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -81,6 +81,9 @@ class ClientTest(unittest.TestCase):
             uri='https://www.letsencrypt-demo.org/acme/cert/1',
             cert_chain_uri='https://www.letsencrypt-demo.org/ca')
 
+        # Reason code for revocation
+        self.rsn = 1
+
     def test_init_downloads_directory(self):
         uri = 'http://www.letsencrypt-demo.org/directory'
         from acme.client import Client
@@ -427,13 +430,22 @@ class ClientTest(unittest.TestCase):
         self.assertRaises(errors.Error, self.client.fetch_chain, self.certr)
 
     def test_revoke(self):
-        self.client.revoke(self.certr.body)
+        self.client.revoke(self.certr.body, self.rsn)
         self.net.post.assert_called_once_with(
             self.directory[messages.Revocation], mock.ANY, content_type=None)
 
+    def test_revocation_payload(self):
+        obj = messages.Revocation(certificate=self.certr.body, reason=self.rsn)
+        self.assertTrue('reason' in obj.to_partial_json().keys())
+        self.assertEquals(self.rsn, obj.to_partial_json()['reason'])
+
     def test_revoke_bad_status_raises_error(self):
         self.response.status_code = http_client.METHOD_NOT_ALLOWED
-        self.assertRaises(errors.ClientError, self.client.revoke, self.certr)
+        self.assertRaises(
+            errors.ClientError,
+            self.client.revoke,
+            self.certr,
+            self.rsn)
 
 
 class ClientNetworkTest(unittest.TestCase):

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -469,3 +469,4 @@ class Revocation(jose.JSONObjectWithFields):
     resource = fields.Resource(resource_type)
     certificate = jose.Field(
         'certificate', decoder=jose.decode_cert, encoder=jose.encode_cert)
+    reason = jose.Field('reason')

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -35,6 +35,17 @@ CLI_DEFAULTS = dict(
 )
 STAGING_URI = "https://acme-staging.api.letsencrypt.org/directory"
 
+# The set of reasons for revoking a certificate is defined in RFC 5280 in
+# section 5.3.1. The reasons that users are allowed to submit are restricted to
+# those accepted by the ACME server implementation. They are listed in
+# `letsencrypt.boulder.revocation.reasons.go`.
+REVOCATION_REASONS = {
+    "unspecified": 0,
+    "keycompromise": 1,
+    "affiliationchanged": 3,
+    "superseded": 4,
+    "cessationofoperation": 5}
+
 """Defaults for CLI flags and `.IConfig` attributes."""
 
 QUIET_LOGGING_LEVEL = logging.WARNING

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -550,8 +550,10 @@ def revoke(config, unused_plugins):  # TODO: coop with renewal config
         key = acc.key
     acme = client.acme_from_config_key(config, key)
     cert = crypto_util.pyopenssl_load_certificate(config.cert_path[1])[0]
+    logger.debug("Reason code for revocation: %s", config.reason)
+
     try:
-        acme.revoke(jose.ComparableX509(cert))
+        acme.revoke(jose.ComparableX509(cert), config.reason)
     except acme_errors.ClientError as e:
         return e.message
 

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -121,6 +121,7 @@ class ParseTest(unittest.TestCase):
         out = self._help_output(['--help', 'revoke'])
         self.assertTrue("--cert-path" in out)
         self.assertTrue("--key-path" in out)
+        self.assertTrue("--reason" in out)
 
         out = self._help_output(['-h', 'config_changes'])
         self.assertTrue("--cert-path" not in out)
@@ -261,6 +262,14 @@ class ParseTest(unittest.TestCase):
         config_dir_option = 'config_dir'
         self.assertFalse(cli.option_was_set(
             config_dir_option, cli.flag_default(config_dir_option)))
+
+    def test_encode_revocation_reason(self):
+        for reason, code in constants.REVOCATION_REASONS.items():
+            namespace = self.parse(['--reason', reason])
+            self.assertEqual(namespace.reason, code)
+        for reason, code in constants.REVOCATION_REASONS.items():
+            namespace = self.parse(['--reason', reason.upper()])
+            self.assertEqual(namespace.reason, code)
 
     def test_force_interactive(self):
         self.assertRaises(

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -162,7 +162,14 @@ common revoke --cert-path "$root/conf/live/le1.wtf/cert.pem"
 # revoke by cert key
 common revoke --cert-path "$root/conf/live/le2.wtf/cert.pem" \
        --key-path "$root/conf/live/le2.wtf/privkey.pem"
-
+# Get new certs to test revoke with a reason, by account and by cert key
+common --domains le1.wtf
+common revoke --cert-path "$root/conf/live/le1.wtf/cert.pem" \
+    --reason cessationOfOperation
+common --domains le2.wtf
+common revoke --cert-path "$root/conf/live/le2.wtf/cert.pem" \
+    --key-path "$root/conf/live/le2.wtf/privkey.pem" \
+    --reason keyCompromise
 if type nginx;
 then
     . ./certbot-nginx/tests/boulder-integration.sh


### PR DESCRIPTION
Addresses issue #3242. 
This includes two new tests in the integration test script to check that
boulder gets the correct code. The encoding is specified in RFC5280
5.3.1. The codes that boulder will accept are a subset of that,
specified in `boulder.revocation.reasons.go`. 

Supersedes #3903 to clean up the commit history (wrong email address on 
earlier commits). That branch had incorporated merges from master on 
several occasions, so I was uncertain of the effect of `git filter-branch ...` and
thought it better to apply the diff to a fresh branch from master.