### PR TITLE
pyopenssl inject workaround

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -27,7 +27,11 @@ logger = logging.getLogger(__name__)
 # for SSL, which does allow these options to be configured.
 # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
 if sys.version_info < (2, 7, 9):  # pragma: no cover
-    requests.packages.urllib3.contrib.pyopenssl.inject_into_urllib3()
+    try:
+        requests.packages.urllib3.contrib.pyopenssl.inject_into_urllib3()
+    except AttributeError:
+        import urllib3.contrib.pyopenssl  # pylint: disable=import-error
+        urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 DER_CONTENT_TYPE = 'application/pkix-cert'
 


### PR DESCRIPTION
This adds workaround for platforms where injecting pyopenssl to urllib3 fails with requests package (Ubuntu Trusty) originally started as #3779.

The whole block is covered by `#pragma: no cover` and I've added `# pylint: disable=import-error` as requested in original PR.

`tox -e lint` is now fine.