### PR TITLE
Fix Error Message for invalid FQDNs

### DIFF
--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -375,10 +375,13 @@ class EnforceDomainSanityTest(unittest.TestCase):
                           u"eichh\u00f6rnchen.example.com")
 
     def test_too_long(self):
-        # pylint: disable=line-too-long
-        long_domain = u"LoremipsumdolorsitametconsecteturadipiscingelitInestorcitinciduntidjustoacmolestielaoreetnislNullamidiaculisloremadignissimturpisSuspendissenecdictumnequeFuscetinciduntquisvelitutfringillaPellentesquehabitantmorbitristiquesenectusetnetusetmalesuadafamesac"
+        long_domain = u"a"*256
         self.assertRaises(errors.ConfigurationError, self._call,
                           long_domain)
+
+    def test_not_too_long(self):
+        not_too_long_domain = u"{0}.{1}.{2}.{3}".format("a"*63, "b"*63, "c"*63, "d"*63)
+        self._call(not_too_long_domain)
 
     def test_empty_label(self):
         empty_label_domain = u"fizz..example.com"
@@ -390,11 +393,19 @@ class EnforceDomainSanityTest(unittest.TestCase):
         self.assertRaises(errors.ConfigurationError, self._call,
                           empty_trailing_label_domain)
 
-    def test_long_label(self):
-        # pylint: disable=line-too-long
-        long_label_domain = u"LoremipsumdolorsitametconsecteturadipiscingelitInestorcitincidunt.example.com"
+    def test_long_label_1(self):
+        long_label_domain = u"a"*64
         self.assertRaises(errors.ConfigurationError, self._call,
                           long_label_domain)
+
+    def test_long_label_2(self):
+        long_label_domain = u"{0}.{1}.com".format(u"a"*64, u"b"*63)
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          long_label_domain)
+
+    def test_not_long_label(self):
+        not_too_long_label_domain = u"{0}.{1}.com".format(u"a"*63, u"b"*63)
+        self._call(not_too_long_label_domain)
 
     def test_empty_domain(self):
         empty_domain = u""

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -374,6 +374,33 @@ class EnforceDomainSanityTest(unittest.TestCase):
         self.assertRaises(errors.ConfigurationError, self._call,
                           u"eichh\u00f6rnchen.example.com")
 
+    def test_too_long(self):
+        # pylint: disable=line-too-long
+        long_domain = u"LoremipsumdolorsitametconsecteturadipiscingelitInestorcitinciduntidjustoacmolestielaoreetnislNullamidiaculisloremadignissimturpisSuspendissenecdictumnequeFuscetinciduntquisvelitutfringillaPellentesquehabitantmorbitristiquesenectusetnetusetmalesuadafamesac"
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          long_domain)
+
+    def test_empty_label(self):
+        empty_label_domain = u"fizz..example.com"
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          empty_label_domain)
+
+    def test_empty_trailing_label(self):
+        empty_trailing_label_domain = u"example.com.."
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          empty_trailing_label_domain)
+
+    def test_long_label(self):
+        # pylint: disable=line-too-long
+        long_label_domain = u"LoremipsumdolorsitametconsecteturadipiscingelitInestorcitincidunt.example.com"
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          long_label_domain)
+
+    def test_empty_domain(self):
+        empty_domain = u""
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          empty_domain)
+
     def test_punycode_ok(self):
         # Punycode is now legal, so no longer an error; instead check
         # that it's _not_ an error (at the initial sanity check stage)

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -479,12 +479,14 @@ def enforce_domain_sanity(domain):
     # octets (inclusive). And each label is 1 - 63 octets (inclusive).
     # https://tools.ietf.org/html/rfc2181#section-11
     msg = "Requested domain {0} is not a FQDN because ".format(domain)
-    labels = domain.split('.')
-    for l in labels:
-        if not 0 < len(l) < 64:
-            raise errors.ConfigurationError(msg + "label {0} is too long.".format(l))
     if len(domain) > 255:
         raise errors.ConfigurationError(msg + "it is too long.")
+    labels = domain.split('.')
+    for l in labels:
+        if not l:
+            raise errors.ConfigurationError("{0} it contains an empty label.".format(msg))
+        elif len(l) > 63:
+            raise errors.ConfigurationError("{0} label {1} is too long.".format(msg, l))
 
     return domain
 


### PR DESCRIPTION
This PR adds logic to better handle errors generated by invalid FQDNs.  Prior to this PR, errors were generated for FQDNs that are too long and FQDNs that have an invalid label.  This PR adds logic to generate an error when a label is empty.  

A few tests have also been added to the unit test suite as well.  

See #3347 