### PR TITLE
make config-dir/work-dir/logs-dir output match help

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -39,7 +39,7 @@ from certbot.plugins import selection as plug_sel
 _PERM_ERR_FMT = os.linesep.join((
     "The following error was encountered:", "{0}",
     "If running as non-root, set --config-dir, "
-    "--logs-dir, and --work-dir to writeable paths."))
+    "--work-dir, and --logs-dir to writeable paths."))
 
 USER_CANCELLED = ("User chose to cancel the operation and may "
                   "reinvoke the client.")


### PR DESCRIPTION
```
$ certbot --help all|grep -- -dir
  --config-dir CONFIG_DIR
  --work-dir WORK_DIR   Working directory. (default: /var/lib/letsencrypt)
  --logs-dir LOGS_DIR   Logs directory. (default: /var/log/letsencrypt)
```

with this commit:
```
$ certbot
The following error was encountered:
[Errno 13] Permission denied: '/etc/letsencrypt'
If running as non-root, set --config-dir, --work-dir, and --logs-dir to writeable paths.
```