### PR TITLE
Add logic to detect a domain with only one label [revision requested]

### DIFF
--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -299,9 +299,8 @@ class ChooseNamesTest(unittest.TestCase):
     def test_get_valid_domains(self):
         from certbot.display.ops import get_valid_domains
         all_valid = ["example.com", "second.example.com",
-                     "also.example.com", "under_score.example.com",
-                     "justtld"]
-        all_invalid = ["öóòps.net", "*.wildcard.com", "uniçodé.com"]
+                     "also.example.com", "under_score.example.com"]
+        all_invalid = ["öóòps.net", "*.wildcard.com", "uniçodé.com", "justtld"]
         two_valid = ["example.com", "úniçøde.com", "also.example.com"]
         self.assertEqual(get_valid_domains(all_valid), all_valid)
         self.assertEqual(get_valid_domains(all_invalid), [])
@@ -327,11 +326,10 @@ class ChooseNamesTest(unittest.TestCase):
         mock_util().input.return_value = (display_util.OK,
                                           ("example.com,"
                                            "under_score.example.com,"
-                                           "justtld,"
                                            "valid.example.com"))
         self.assertEqual(_choose_names_manually(),
                          ["example.com", "under_score.example.com",
-                          "justtld", "valid.example.com"])
+                          "valid.example.com"])
         # Three iterations
         mock_util().input.return_value = (display_util.OK,
                                           "uniçodé.com")

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -366,6 +366,9 @@ class EnforceDomainSanityTest(unittest.TestCase):
         from certbot.util import enforce_domain_sanity
         return enforce_domain_sanity(domain)
 
+    def test_valid_domain(self):
+        self._call('example.net')
+
     def test_nonascii_str(self):
         self.assertRaises(errors.ConfigurationError, self._call,
                           u"eichh\u00f6rnchen.example.com".encode("utf-8"))
@@ -373,6 +376,18 @@ class EnforceDomainSanityTest(unittest.TestCase):
     def test_nonascii_unicode(self):
         self.assertRaises(errors.ConfigurationError, self._call,
                           u"eichh\u00f6rnchen.example.com")
+
+    def test_localhost(self):
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          u"localhost")
+
+    def test_two_dots(self):
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          u"..")
+
+    def test_three_dots(self):
+        self.assertRaises(errors.ConfigurationError, self._call,
+                          u"...")
 
     def test_too_long(self):
         long_domain = u"a"*256

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -482,6 +482,8 @@ def enforce_domain_sanity(domain):
     if len(domain) > 255:
         raise errors.ConfigurationError("{0} it is too long.".format(msg))
     labels = domain.split('.')
+    if len(labels) < 2:
+        raise errors.ConfigurationError("{0} it does not have enough labels.".format(msg))
     for l in labels:
         if not l:
             raise errors.ConfigurationError("{0} it contains an empty label.".format(msg))


### PR DESCRIPTION
Domains like ``justtld`` and ``localhost`` are now rejected by ``enforce_domain_sanity``

Also added more tests to ``util_test.py`` and updated tests in ``ops_test.py``

Resolves #4015