### PR TITLE
During certbot-auto upgrade: update venv if it exists

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -618,9 +618,12 @@ if [ "$1" = "--le-auto-phase2" ]; then
     INSTALLED_VERSION="none"
   fi
   if [ "$LE_AUTO_VERSION" != "$INSTALLED_VERSION" ]; then
-    echo "Creating virtual environment..."
     DeterminePythonVersion
-    rm -rf "$VENV_PATH"
+    if [ -d "$VENV_PATH" ]; then
+        echo "Updating virtual environment..."
+    else
+        echo "Creating virtual environment..."
+    fi
     if [ "$VERBOSE" = 1 ]; then
       virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
     else

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -269,9 +269,12 @@ if [ "$1" = "--le-auto-phase2" ]; then
     INSTALLED_VERSION="none"
   fi
   if [ "$LE_AUTO_VERSION" != "$INSTALLED_VERSION" ]; then
-    echo "Creating virtual environment..."
     DeterminePythonVersion
-    rm -rf "$VENV_PATH"
+    if [ -d "$VENV_PATH" ]; then
+        echo "Updating virtual environment..."
+    else
+        echo "Creating virtual environment..."
+    fi
     if [ "$VERBOSE" = 1 ]; then
       virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
     else

--- a/letsencrypt-auto-source/tests/auto_test.py
+++ b/letsencrypt-auto-source/tests/auto_test.py
@@ -296,7 +296,7 @@ class AutoTests(TestCase):
                 set_le_script_version(venv_dir, '0.0.1')
                 out, err = run_letsencrypt_auto()
                 self.assertFalse('Upgrading certbot-auto ' in out)
-                self.assertTrue('Creating virtual environment...' in out)
+                self.assertTrue('Updating virtual environment...' in out)
 
     def test_openssl_failure(self):
         """Make sure we stop if the openssl signature check fails."""


### PR DESCRIPTION
When `certbot-auto` detects it should upgrade, it used to just delete the whole venv folder, and re-create it.
This caused issues with manually installed plugins that just disappeared.

With this change, instead of deleting the whole venv folder, we just delete a few files/folders from it, to force them to get re-installed, and keep the rest as-is.

Fixes #4037