### PR TITLE
Run installer.restart() only once during renew

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -643,7 +643,7 @@ def obtain_cert(config, plugins, lineage=None):
             # In case of a renewal, reload server to pick up new certificate.
             # In principle we could have a configuration option to inhibit this
             # from happening.
-            installer.restart()
+
             notify("new certificate deployed with reload of {0} server; fullchain is {1}".format(
                    config.installer, lineage.fullchain), pause=False)
     elif action == "reinstall" and config.verb == "certonly":

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -20,6 +20,7 @@ from certbot import util
 from certbot import hooks
 from certbot import storage
 from certbot.plugins import disco as plugins_disco
+from certbot.plugins import selection as plug_sel
 
 logger = logging.getLogger(__name__)
 
@@ -335,7 +336,7 @@ def _renew_describe_results(config, renew_successes, renew_failures,
     print("\n".join(out))
 
 
-def handle_renewal_request(config):
+def handle_renewal_request(config):  # pylint: disable=too-many-branches,too-many-statements
     """Examine each lineage; renew if due and report results"""
 
     # This is trivially False if config.domains is empty
@@ -399,6 +400,19 @@ def handle_renewal_request(config):
     # Describe all the results
     _renew_describe_results(config, renew_successes, renew_failures,
                             renew_skipped, parse_failures)
+
+    # Restart if we have successes
+    if renew_successes:
+        try:
+            plugins = plugins_disco.PluginsRegistry.find_all()
+            installer, _ = plug_sel.choose_configurator_plugins(
+                config, plugins, "certonly")
+            if installer:
+                installer.restart()
+
+        except errors.PluginSelectionError as e:
+            logger.info("Could not choose appropriate plugin: %s", e)
+            raise
 
     if renew_failures or parse_failures:
         raise errors.Error("{0} renew failure(s), {1} parse failure(s)".format(


### PR DESCRIPTION
Changed renew behavior to only run installer.restart() once
during executing of renew. Even if more then one certificate
is renewed.

Closes #4045