### PR TITLE
Alternate help syntax - issue 3371

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -432,6 +432,10 @@ class HelpfulArgumentParser(object):
 
         self.detect_defaults = detect_defaults
         self.args = args
+
+        if self.args[0] == 'help':
+            self.args[0] = '--help'
+
         self.determine_verb()
         help1 = self.prescan_for_flag("-h", self.help_topics)
         help2 = self.prescan_for_flag("--help", self.help_topics)

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -131,7 +131,7 @@ class ParseTest(unittest.TestCase):
         self.assertTrue("%s" not in out)
         self.assertTrue("{0}" not in out)
 
-        # testing alternate help syntax
+    def test_help_no_dashes(self):
         self._help_output(['help'])  # assert SystemExit is raised here
 
         out = self._help_output(['help', 'all'])

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -131,6 +131,26 @@ class ParseTest(unittest.TestCase):
         self.assertTrue("%s" not in out)
         self.assertTrue("{0}" not in out)
 
+        # testing alternate help syntax
+        self._help_output(['help'])  # assert SystemExit is raised here
+
+        out = self._help_output(['help', 'all'])
+        self.assertTrue("--configurator" in out)
+        self.assertTrue("how a cert is deployed" in out)
+        self.assertTrue("--webroot-path" in out)
+        self.assertTrue("--text" not in out)
+        self.assertTrue("--dialog" not in out)
+        self.assertTrue("%s" not in out)
+        self.assertTrue("{0}" not in out)
+
+        out = self._help_output(['help', 'install'])
+        self.assertTrue("--cert-path" in out)
+        self.assertTrue("--key-path" in out)
+
+        out = self._help_output(['help', 'revoke'])
+        self.assertTrue("--cert-path" in out)
+        self.assertTrue("--key-path" in out)
+
     def test_parse_domains(self):
         short_args = ['-d', 'example.com']
         namespace = self.parse(short_args)


### PR DESCRIPTION
I originally followed the approach detailed in the first comment here: https://github.com/certbot/certbot/issues/3371, but realized there was a much shorter way to implement this. (Can easily switch back to the other approach if need be.)

Also, `certbot help --help help -h standalone` works!