### PR TITLE
Remove old references to pep8 in our code

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,4 +1,0 @@
-[pep8]
-# E265 block comment should start with '# '
-# E501 line too long (X > 79 characters)
-ignore = E265,E501

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -32,7 +32,7 @@ RUN /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto --os-packages-only
 # the above is not likely to change, so by putting it further up the
 # Dockerfile we make sure we cache as much as possible
 
-COPY setup.py README.rst CHANGES.rst MANIFEST.in linter_plugin.py tox.cover.sh tox.ini pep8.travis.sh .pep8 .pylintrc /opt/certbot/src/
+COPY setup.py README.rst CHANGES.rst MANIFEST.in linter_plugin.py tox.cover.sh tox.ini .pylintrc /opt/certbot/src/
 
 # all above files are necessary for setup.py, however, package source
 # code directory has to be copied separately to a subdirectory...

--- a/acme/.pep8
+++ b/acme/.pep8
@@ -1,4 +1,0 @@
-[pep8]
-# E265 block comment should start with '# '
-# E501 line too long (X > 79 characters)
-ignore = E265,E501

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -40,7 +40,6 @@ dns_extras = [
 
 dev_extras = [
     'nose',
-    'pep8',
     'tox',
 ]
 

--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -14,7 +14,7 @@ RUN /opt/certbot/src/certbot-auto -n --os-packages-only
 # the above is not likely to change, so by putting it further up the
 # Dockerfile we make sure we cache as much as possible
 
-COPY setup.py README.rst CHANGES.rst MANIFEST.in linter_plugin.py tox.cover.sh tox.ini pep8.travis.sh .pep8 .pylintrc /opt/certbot/src/
+COPY setup.py README.rst CHANGES.rst MANIFEST.in linter_plugin.py tox.cover.sh tox.ini .pylintrc /opt/certbot/src/
 
 # all above files are necessary for setup.py, however, package source
 # code directory has to be copied separately to a subdirectory...

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -312,17 +312,15 @@ Steps:
 2. Make sure your environment is set up properly and that you're in your
    virtualenv. You can do this by running ``./tools/venv.sh``.
    (this is a **very important** step)
-3. Run ``./pep8.travis.sh`` to do a cursory check of your code style.
-   Fix any errors.
-4. Run ``tox -e lint`` to check for pylint errors. Fix any errors.
-5. Run ``tox --skip-missing-interpreters`` to run the entire test suite
+3. Run ``tox -e lint`` to check for pylint errors. Fix any errors.
+4. Run ``tox --skip-missing-interpreters`` to run the entire test suite
    including coverage. The ``--skip-missing-interpreters`` argument ignores
    missing versions of Python needed for running the tests. Fix any errors.
-6. If your code touches communication with an ACME server/Boulder, you
+5. If your code touches communication with an ACME server/Boulder, you
    should run the integration tests, see `integration`_. See `Known Issues`_
    for some common failures that have nothing to do with your code.
-7. Submit the PR.
-8. Did your tests pass on Travis? If they didn't, fix any errors.
+6. Submit the PR.
+7. Did your tests pass on Travis? If they didn't, fix any errors.
 
 
 Updating certbot-auto and letsencrypt-auto

--- a/pep8.travis.sh
+++ b/pep8.travis.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -e  # Fail fast
-
-pep8 --config=acme/.pep8 acme

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ dev_extras = [
     'astroid==1.3.5',
     'coverage',
     'nose',
-    'pep8',
     'psutil>=2.2.1',  # for tests, optional
     'pylint==1.4.2',  # upstream #248
     'tox',


### PR DESCRIPTION
With #3843, we no longer use `pep8` in our tests. Let's remove lingering references to it.

(If anyone like me actually liked `pep8`, don't worry. I'm going to propose we switch to [flake8](https://flake8.readthedocs.io/en/2.0/) instead of `pylint` here soon.)