### PR TITLE
Add cleanup trap to integration test script

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -20,6 +20,18 @@ else
   readlink="readlink"
 fi
 
+cleanup_and_exit() {
+    EXIT_STATUS=$?
+    if SERVER_STILL_RUNNING=`ps -p $python_server_pid -o pid=`
+    then
+        echo Kill server subprocess, left running by abnormal exit
+        kill $SERVER_STILL_RUNNING
+    fi
+    exit $EXIT_STATUS
+}
+
+trap cleanup_and_exit EXIT
+
 common_no_force_renew() {
     certbot_test_no_force_renew \
         --authenticator standalone \


### PR DESCRIPTION
The integration test script spins up Python webservers. This trap will
ensure that those webservers are shutdown at exit.

Supersedes #3905 