### PR TITLE
Fix modification-check.sh

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -560,7 +560,7 @@ BootstrapMageiaCommon() {
       exit 1
   fi
 
-  if ! $SUDO urpmi --force \
+  if ! $SUDO urpmi --force $QUIET_FLAG \
       git \
       gcc \
       python-augeas \

--- a/tests/modification-check.sh
+++ b/tests/modification-check.sh
@@ -61,7 +61,7 @@ else
 build.py."
 fi
 
-rm -rf temp_dir
+rm -rf $temp_dir
 
 if $FLAG ; then
 	exit 1

--- a/tests/modification-check.sh
+++ b/tests/modification-check.sh
@@ -61,8 +61,8 @@ else
 build.py."
 fi
 
+rm -rf temp_dir
+
 if $FLAG ; then
 	exit 1
 fi
-
-rm -rf temp_dir

--- a/tests/modification-check.sh
+++ b/tests/modification-check.sh
@@ -46,6 +46,7 @@ cd ${SCRIPT_PATH}/../
 cp letsencrypt-auto-source/letsencrypt-auto ${temp_dir}/original-lea
 python letsencrypt-auto-source/build.py
 cp letsencrypt-auto-source/letsencrypt-auto ${temp_dir}/build-lea
+cp ${temp_dir}/original-lea letsencrypt-auto-source/letsencrypt-auto
 
 cd $temp_dir
 


### PR DESCRIPTION
The version of `modification-check.sh` in `master` modifies `letsencrypt-auto-source/letsencrypt-auto` by running `build.py`. Since Travis reruns our tests up to three times if they fail, if `build.py` needs to be run, `modification-check.sh` will fail the first time and succeed afterwards.

This fixes this problem so changes are properly attributed and prevents confusion for newer contributors when `letsencrypt-auto-source/letsencrypt-auto` suddenly has changes they didn't make.