### PR TITLE
Fix hooks integration tests

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -47,23 +47,24 @@ common() {
 
 export HOOK_TEST="/tmp/hook$$"
 CheckHooks() {
-    COMMON="wtf2.auth\nwtf2.cleanup\nrenew\nrenew"
     EXPECTED="/tmp/expected$$"
     if [ $(head -n1 $HOOK_TEST) = "wtf.pre" ]; then
         echo "wtf.pre" > "$EXPECTED"
         echo "wtf2.pre" >> "$EXPECTED"
-        echo $COMMON >> "$EXPECTED"
+        echo "renew" >> "$EXPECTED"
+        echo "renew" >> "$EXPECTED"
         echo "wtf.post" >> "$EXPECTED"
         echo "wtf2.post" >> "$EXPECTED"
     else
         echo "wtf2.pre" > "$EXPECTED"
         echo "wtf.pre" >> "$EXPECTED"
-        echo $COMMON >> "$EXPECTED"
+        echo "renew" >> "$EXPECTED"
+        echo "renew" >> "$EXPECTED"
         echo "wtf2.post" >> "$EXPECTED"
         echo "wtf.post" >> "$EXPECTED"
     fi
 
-    if cmp --quiet "$EXPECTED" "$HOOK_TEST" ; then
+    if ! cmp --quiet "$EXPECTED" "$HOOK_TEST" ; then
         echo Hooks did not run as expected\; got
         cat "$HOOK_TEST"
         echo Expected
@@ -91,8 +92,8 @@ common --domains le2.wtf --preferred-challenges http-01 run \
 kill $python_server_pid
 
 common certonly -a manual -d le.wtf --rsa-key-size 4096 \
-    --manual-auth-hook 'echo wtf2.auth >> "$HOOK_TEST" && ./tests/manual-http-auth.sh' \
-    --manual-cleanup-hook 'echo wtf2.cleanup >> "$HOOK_TEST" && ./tests/manual-http-cleanup.sh' \
+    --manual-auth-hook ./tests/manual-http-auth.sh \
+    --manual-cleanup-hook ./tests/manual-http-cleanup.sh \
     --pre-hook 'echo wtf2.pre >> "$HOOK_TEST"' \
     --post-hook 'echo wtf2.post >> "$HOOK_TEST"'
 


### PR DESCRIPTION
With the current logic, we exit with an error if `CheckHooks` ever succeeds. Tests for manual hooks are coming in another PR.