### PR TITLE
Fix tools/venv.sh

### DIFF
--- a/tools/_venv_common.sh
+++ b/tools/_venv_common.sh
@@ -12,13 +12,13 @@ rm -rf *.egg-info
 # `/home/jakub/dev/letsencrypt/letsencrypt/venv/bin/python2` and
 # `venv/bin/python2` are the same file
 mv $VENV_NAME "$VENV_NAME.$(date +%s).bak" || true
-virtualenv --no-site-packages $VENV_NAME $VENV_ARGS
+virtualenv --no-site-packages --setuptools $VENV_NAME $VENV_ARGS
 . ./$VENV_NAME/bin/activate
 
 # Separately install setuptools and pip to make sure following
 # invocations use latest
-pip install -U setuptools
 pip install -U pip
+pip install -U setuptools
 pip install "$@"
 
 set +x


### PR DESCRIPTION
This fixes `tools/venv.sh` when it's run on a system with an old version of `virtualenv`. We need to upgrade `pip` first because setuptools dropped support for being installed with older versions of `pip` (see their [changelog](https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v3400)). Additionally, `--setuptools` is now needed because newer versions of `pip` don't automatically update `distribute`, which is used instead of `setuptools` in some old versions of `virtualenv`, when `pip install -U setuptools` is run ([source](https://github.com/pypa/pip/blob/master/CHANGES.txt#L504)).