### PR TITLE
Don't be unnecessarily inefficient when finding a cert by name.

### DIFF
--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -268,11 +268,11 @@ class LineageForCertnameTest(BaseCertManagerTest):
     """Tests for certbot.cert_manager.lineage_for_certname"""
 
     @mock.patch('certbot.util.make_or_verify_dir')
-    @mock.patch('certbot.storage.renewal_conf_files')
+    @mock.patch('certbot.storage.renewal_file_for_certname')
     @mock.patch('certbot.storage.RenewableCert')
-    def test_found_match(self, mock_renewable_cert, mock_renewal_conf_files,
+    def test_found_match(self, mock_renewable_cert, mock_renewal_conf_file,
         mock_make_or_verify_dir):
-        mock_renewal_conf_files.return_value = ["somefile.conf"]
+        mock_renewal_conf_file.return_value = "somefile.conf"
         mock_match = mock.Mock(lineagename="example.com")
         mock_renewable_cert.return_value = mock_match
         from certbot import cert_manager
@@ -281,13 +281,10 @@ class LineageForCertnameTest(BaseCertManagerTest):
         self.assertTrue(mock_make_or_verify_dir.called)
 
     @mock.patch('certbot.util.make_or_verify_dir')
-    @mock.patch('certbot.storage.renewal_conf_files')
-    @mock.patch('certbot.storage.RenewableCert')
-    def test_no_match(self, mock_renewable_cert, mock_renewal_conf_files,
+    @mock.patch('certbot.storage.renewal_file_for_certname')
+    def test_no_match(self, mock_renewal_conf_file,
         mock_make_or_verify_dir):
-        mock_renewal_conf_files.return_value = ["somefile.conf"]
-        mock_match = mock.Mock(lineagename="other.com")
-        mock_renewable_cert.return_value = mock_match
+        mock_renewal_conf_file.return_value = "other.com.conf"
         from certbot import cert_manager
         self.assertEqual(cert_manager.lineage_for_certname(self.cli_config, "example.com"),
             None)
@@ -298,11 +295,11 @@ class DomainsForCertnameTest(BaseCertManagerTest):
     """Tests for certbot.cert_manager.domains_for_certname"""
 
     @mock.patch('certbot.util.make_or_verify_dir')
-    @mock.patch('certbot.storage.renewal_conf_files')
+    @mock.patch('certbot.storage.renewal_file_for_certname')
     @mock.patch('certbot.storage.RenewableCert')
-    def test_found_match(self, mock_renewable_cert, mock_renewal_conf_files,
+    def test_found_match(self, mock_renewable_cert, mock_renewal_conf_file,
         mock_make_or_verify_dir):
-        mock_renewal_conf_files.return_value = ["somefile.conf"]
+        mock_renewal_conf_file.return_value = "somefile.conf"
         mock_match = mock.Mock(lineagename="example.com")
         domains = ["example.com", "example.org"]
         mock_match.names.return_value = domains
@@ -313,15 +310,10 @@ class DomainsForCertnameTest(BaseCertManagerTest):
         self.assertTrue(mock_make_or_verify_dir.called)
 
     @mock.patch('certbot.util.make_or_verify_dir')
-    @mock.patch('certbot.storage.renewal_conf_files')
-    @mock.patch('certbot.storage.RenewableCert')
-    def test_no_match(self, mock_renewable_cert, mock_renewal_conf_files,
+    @mock.patch('certbot.storage.renewal_file_for_certname')
+    def test_no_match(self, mock_renewal_conf_file,
         mock_make_or_verify_dir):
-        mock_renewal_conf_files.return_value = ["somefile.conf"]
-        mock_match = mock.Mock(lineagename="example.com")
-        domains = ["example.com", "example.org"]
-        mock_match.names.return_value = domains
-        mock_renewable_cert.return_value = mock_match
+        mock_renewal_conf_file.return_value = "somefile.conf"
         from certbot import cert_manager
         self.assertEqual(cert_manager.domains_for_certname(self.cli_config, "other.com"),
             None)


### PR DESCRIPTION
Fixes #4106.