### PR TITLE
Json certificate output (#3909)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ show_missing = True
 [run]
 
 omit = certbot/tests/util.py
+    certbot/tests/cert_manager_test.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
 [report]
 # show lines missing coverage in output
 show_missing = True
+
+[run]
+
+omit = certbot/tests/util.py

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -80,8 +80,21 @@ def certificates(config):
             logger.debug("Traceback was:\n%s", traceback.format_exc())
             parse_failures.append(renewal_file)
 
+    if config.json is True:
+        style = "json"
+    #elif config.grep is True:
+    #    style = "grep"
+    else:
+        style = "human_readable"
+
+    formatter = {
+        "human_readable": HumanReadableCertOutputFormatter,
+        "json": JSONCertificateOutputFormatter,
+        #"grep": GrepCertificateOutputFormatter
+    }
+
     # Describe all the certs
-    _describe_certs(config, parsed_certs, parse_failures)
+    _describe_certs(formatter[style](parsed_certs, parse_failures))
 
 def delete(config):
     """Delete Certbot files associated with a certificate lineage."""

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -81,20 +81,21 @@ def certificates(config):
             parse_failures.append(renewal_file)
 
     if config.json is True:
-        style = "json"
+        style = "json"  # pylint: disable=unused-variable
     #elif config.grep is True:
     #    style = "grep"
     else:
-        style = "human_readable"
+        style = "human_readable"  # pylint: disable=unused-variable
 
-    formatter = {
+    formatter = {  # pylint: disable=unused-variable
         "human_readable": HumanReadableCertOutputFormatter,
         "json": JSONCertificateOutputFormatter,
         #"grep": GrepCertificateOutputFormatter
     }
 
     # Describe all the certs
-    _describe_certs(formatter[style](config, parsed_certs, parse_failures))
+    #_describe_certs(formatter[style](config, parsed_certs, parse_failures))
+    _describe_certs(config, parsed_certs, parse_failures)
 
 def delete(config):
     """Delete Certbot files associated with a certificate lineage."""
@@ -348,13 +349,13 @@ def _report_human_readable(config, parsed_certs):
                             cert.privkey))
     return "\n".join(certinfo)
 
-def _describe_certs(formatter):
+def _new_describe_certs(formatter):
     """Print information about the certs we know about"""
     out = formatter.report()
     disp = zope.component.getUtility(interfaces.IDisplay)
     disp.notification(out, pause=False, wrap=False)
 
-def _old_describe_certs(config, parsed_certs, parse_failures):
+def _describe_certs(config, parsed_certs, parse_failures):
     """Print information about the certs we know about"""
     out = []
 

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -163,7 +163,7 @@ class BaseCertificateOutputFormatter(object):
                 notify(self.report_failures())
         return out
 
-    def report_successes(self):
+    def report_successes(self, preface):
         """Stub method to be implemented by subclasses."""
         pass
 
@@ -215,9 +215,9 @@ class HumanReadableCertOutputFormatter(BaseCertificateOutputFormatter):
         certinfo = []
         checker = ocsp.RevocationChecker()
         for cert in self.parsed_certs:
-            if self.config.certname and cert.lineagename != config.certname:
+            if self.config.certname and cert.lineagename != self.config.certname:
                 continue
-            if self.config.domains and not set(config.domains).issubset(cert.names()):
+            if self.config.domains and not set(self.config.domains).issubset(cert.names()):
                 continue
             valid_string = self._cert_validity(cert, checker)
             certinfo.append("  Certificate Name: {0}\n"

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -141,6 +141,23 @@ def find_duplicative_certs(config, domains):
 # Private Helpers
 ###################
 
+
+class JSONCertificateOutputFormatter(object):
+    """Extract certificate information and format it for JSON. """
+
+    def report(self):
+        """Produce a JSON report of certificate information. """
+        pass
+
+    def report_successes(self):
+        """Format a JSON report of certificate information. """
+        pass
+
+    def report_failures(self):
+        """Format a JSON report of problem conf files. """
+        pass
+
+
 def _get_certname(config, verb):
     """Get certname from flag, interactively, or error out.
     """

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -354,9 +354,6 @@ def _describe_certs(config, parsed_certs, parse_failures):
     if config.json is True:
         Formatter = JSONCertificateOutputFormatter
     else:
-        # TODO Use legacy function for now, later transition to use
-        # formatter for all cases.
-        #_describe_certs(config, parsed_certs, parse_failures)
         Formatter = HumanReadableCertOutputFormatter
 
     formatter = Formatter(config, parsed_certs, parse_failures)

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -283,6 +283,7 @@ class JSONCertificateOutputFormatter(BaseCertificateOutputFormatter):
     def report_missing(self):
         return {"No certs found": "Please check config dir"}
 
+
 def _get_certname(config, verb):
     """Get certname from flag, interactively, or error out.
     """
@@ -300,6 +301,53 @@ def _get_certname(config, verb):
             raise errors.Error("User ended interaction.")
         certname = choices[index]
     return certname
+
+#def _report_lines(msgs):
+#    """Format a results report for a category of single-line renewal outcomes"""
+#    return "  " + "\n  ".join(str(msg) for msg in msgs)
+
+def _report_human_readable(config, parsed_certs):
+    """Format a results report for a parsed cert"""
+    certinfo = []
+    checker = ocsp.RevocationChecker()
+    for cert in parsed_certs:
+        if config.certname and cert.lineagename != config.certname:
+            continue
+        if config.domains and not set(config.domains).issubset(cert.names()):
+            continue
+        now = pytz.UTC.fromutc(datetime.datetime.utcnow())
+
+        reasons = []
+        if cert.is_test_cert:
+            reasons.append('TEST_CERT')
+        if cert.target_expiry <= now:
+            reasons.append('EXPIRED')
+        if checker.ocsp_revoked(cert.cert, cert.chain):
+            reasons.append('REVOKED')
+
+        if reasons:
+            status = "INVALID: " + ", ".join(reasons)
+        else:
+            diff = cert.target_expiry - now
+            if diff.days == 1:
+                status = "VALID: 1 day"
+            elif diff.days < 1:
+                status = "VALID: {0} hour(s)".format(diff.seconds // 3600)
+            else:
+                status = "VALID: {0} days".format(diff.days)
+
+        valid_string = "{0} ({1})".format(cert.target_expiry, status)
+        certinfo.append("  Certificate Name: {0}\n"
+                        "    Domains: {1}\n"
+                        "    Expiry Date: {2}\n"
+                        "    Certificate Path: {3}\n"
+                        "    Private Key Path: {4}".format(
+                            cert.lineagename,
+                            " ".join(cert.names()),
+                            valid_string,
+                            cert.fullchain,
+                            cert.privkey))
+    return "\n".join(certinfo)
 
 def _describe_certs(config, parsed_certs, parse_failures):
     """Print information about the certs we know about"""

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -235,8 +235,8 @@ class HumanReadableCertOutputFormatter(BaseCertificateOutputFormatter):
 
     def report_failures(self):
         """Format a results report for a category of single-line renewal outcomes"""
-        failures = "\n".join(str(path) for path in self.parse_failures)
         preface = "\nThe following renewal configuration files were invalid: \n"
+        failures = "\n".join(str(path) for path in self.parse_failures)
         return  preface + failures
 
     def report_missing(self):
@@ -277,8 +277,7 @@ class JSONCertificateOutputFormatter(BaseCertificateOutputFormatter):
         """Format a JSON report of problem conf files. """
         report = []
         for path in self.parse_failures:
-            report.append({
-                "invalid_conf_file": path})
+            report.append(path)
         return {"failures": report}
 
     def report_missing(self):

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -203,6 +203,44 @@ class BaseCertificateOutputFormatter(object):
         return valid_string
 
 
+class HumanReadableCertOutputFormatter(BaseCertificateOutputFormatter):
+    """Extract certificate information and format it to be human readable. """
+
+    def report(self):  # pylint: disable=arguments-differ
+        """Produce a human readable report of certificate information. """
+        out = []
+        notify = out.append
+        return "\n".join(super(HumanReadableCertOutputFormatter, self).report(
+            notify, out))
+
+    def report_successes(self):
+        """Format a human readable report of certificate information. """
+        certinfo = []
+        for cert in self.parsed_certs:
+            valid_string = self._cert_validity(cert)
+            certinfo.append("  Certificate Name: {0}\n"
+                            "    Domains: {1}\n"
+                            "    Expiry Date: {2}\n"
+                            "    Certificate Path: {3}\n"
+                            "    Private Key Path: {4}".format(
+                                cert.lineagename,
+                                " ".join(cert.names()),
+                                valid_string,
+                                cert.fullchain,
+                                cert.privkey))
+            successes = "\n".join(certinfo)
+        return "Found the following certs: \n" + successes
+
+    def report_failures(self):
+        """Format a results report for a category of single-line renewal outcomes"""
+        failures = "\n".join(str(path) for path in self.parse_failures)
+        preface = "\nThe following renewal configuration files were invalid: \n"
+        return  preface + failures
+
+    def report_missing(self):
+        return "No certs found."
+
+
 class JSONCertificateOutputFormatter(BaseCertificateOutputFormatter):
     """Extract certificate information and format it for JSON. """
 

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -80,7 +80,7 @@ def certificates(config):
             logger.debug("Traceback was:\n%s", traceback.format_exc())
             parse_failures.append(renewal_file)
 
-    _new_describe_certs(config, parsed_certs, parse_failures)
+    _describe_certs(config, parsed_certs, parse_failures)
 
 
 def delete(config):
@@ -335,7 +335,7 @@ def _report_human_readable(config, parsed_certs):
                             cert.privkey))
     return "\n".join(certinfo)
 
-def _new_describe_certs(config, parsed_certs, parse_failures):
+def _describe_certs(config, parsed_certs, parse_failures):
     """Print information about the certs we know about"""
     if config.json is True:
         Formatter = JSONCertificateOutputFormatter
@@ -350,7 +350,7 @@ def _new_describe_certs(config, parsed_certs, parse_failures):
     disp = zope.component.getUtility(interfaces.IDisplay)
     disp.notification(out, pause=False, wrap=False)
 
-def _describe_certs(config, parsed_certs, parse_failures):
+def _old_describe_certs(config, parsed_certs, parse_failures):
     """Print information about the certs we know about"""
     out = []
 

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -156,7 +156,9 @@ class BaseCertificateOutputFormatter(object):
             notify(self.report_missing())
         else:
             if self.parsed_certs:
-                notify(self.report_successes())
+                match = "matching " if self.config.certname or self.config.domains else ""
+                preface = "Found the following {0}certs:\n".format(match)
+                notify(self.report_successes(preface))
             if self.parse_failures:
                 notify(self.report_failures())
         return out
@@ -201,7 +203,7 @@ class HumanReadableCertOutputFormatter(BaseCertificateOutputFormatter):
         return "\n".join(super(HumanReadableCertOutputFormatter, self).report(
             notify, out))
 
-    def report_successes(self):
+    def report_successes(self, preface):
         """Format a human readable report of certificate information. """
         certinfo = []
         for cert in self.parsed_certs:
@@ -217,8 +219,6 @@ class HumanReadableCertOutputFormatter(BaseCertificateOutputFormatter):
                                 cert.fullchain,
                                 cert.privkey))
             successes = "\n".join(certinfo)
-        match = "matching " if self.config.certname or self.config.domains else ""
-        preface = "Found the following {0}certs:\n".format(match)
         return preface + successes
 
     def report_failures(self):
@@ -243,7 +243,7 @@ class JSONCertificateOutputFormatter(BaseCertificateOutputFormatter):
             notify, out),
             indent=4)
 
-    def report_successes(self):
+    def report_successes(self, preface):
         """Format a JSON report of certificate information. """
         certs = []
         for cert in self.parsed_certs:
@@ -254,8 +254,6 @@ class JSONCertificateOutputFormatter(BaseCertificateOutputFormatter):
                 "expiry_date": valid_string,
                 "certificate_path": cert.fullchain,
                 "private_key_path": cert.privkey})
-        match = "matching " if self.config.certname or self.config.domains else ""
-        preface = "Found the following {0}certs".format(match)
         return {"found": [preface, certs]}
 
     def report_failures(self):

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -271,7 +271,7 @@ class JSONCertificateOutputFormatter(BaseCertificateOutputFormatter):
                 "expiry_date": valid_string,
                 "certificate_path": cert.fullchain,
                 "private_key_path": cert.privkey})
-        return {"found": [preface, certs]}
+        return {"found": certs}
 
     def report_failures(self):
         """Format a JSON report of problem conf files. """

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -80,15 +80,7 @@ def certificates(config):
             logger.debug("Traceback was:\n%s", traceback.format_exc())
             parse_failures.append(renewal_file)
 
-    if config.json is True:
-        formatter = JSONCertificateOutputFormatter
-    else:
-        # TODO Use legacy function for now, later transition to use
-        # formatter for all cases.
-        #_describe_certs(config, parsed_certs, parse_failures)
-        formatter = HumanReadableCertOutputFormatter
-
-    _new_describe_certs(formatter(config, parsed_certs, parse_failures))
+    _new_describe_certs(config, parsed_certs, parse_failures)
 
 
 def delete(config):
@@ -343,8 +335,17 @@ def _report_human_readable(config, parsed_certs):
                             cert.privkey))
     return "\n".join(certinfo)
 
-def _new_describe_certs(formatter):
+def _new_describe_certs(config, parsed_certs, parse_failures):
     """Print information about the certs we know about"""
+    if config.json is True:
+        Formatter = JSONCertificateOutputFormatter
+    else:
+        # TODO Use legacy function for now, later transition to use
+        # formatter for all cases.
+        #_describe_certs(config, parsed_certs, parse_failures)
+        Formatter = HumanReadableCertOutputFormatter
+
+    formatter = Formatter(config, parsed_certs, parse_failures)
     out = formatter.report()
     disp = zope.component.getUtility(interfaces.IDisplay)
     disp.notification(out, pause=False, wrap=False)

--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -81,21 +81,15 @@ def certificates(config):
             parse_failures.append(renewal_file)
 
     if config.json is True:
-        style = "json"  # pylint: disable=unused-variable
-    #elif config.grep is True:
-    #    style = "grep"
+        formatter = JSONCertificateOutputFormatter
     else:
-        style = "human_readable"  # pylint: disable=unused-variable
+        # TODO Use legacy function for now, later transition to use
+        # formatter for all cases.
+        #_describe_certs(config, parsed_certs, parse_failures)
+        formatter = HumanReadableCertOutputFormatter
 
-    formatter = {  # pylint: disable=unused-variable
-        "human_readable": HumanReadableCertOutputFormatter,
-        "json": JSONCertificateOutputFormatter,
-        #"grep": GrepCertificateOutputFormatter
-    }
+    _new_describe_certs(formatter(config, parsed_certs, parse_failures))
 
-    # Describe all the certs
-    #_describe_certs(formatter[style](config, parsed_certs, parse_failures))
-    _describe_certs(config, parsed_certs, parse_failures)
 
 def delete(config):
     """Delete Certbot files associated with a certificate lineage."""

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1080,6 +1080,8 @@ def _create_subparsers(helpful):
              "plugin. If you wish to hide your server OS version from the Let's "
              'Encrypt server, set this to "". '
              '(default: {0})'.format(sample_user_agent()))
+    helpful.add("certificates",
+                "--json", action="store_true", default=False, help="Use json format.")
     helpful.add("certonly",
                 "--csr", type=read_file,
                 help="Path to a Certificate Signing Request (CSR) in DER or PEM format."

--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -556,6 +556,19 @@ class NoninteractiveDisplay(object):
         return self.input(message, default, cli_flag)
 
 
+@zope.interface.implementer(interfaces.IDisplay)
+class MachineReadableDisplay(NoninteractiveDisplay):
+    """An iDisplay implementation that produces machine readable output. """
+
+    def __init__(self, outfile):
+        super(MachineReadableDisplay, self).__init__(outfile)
+
+    def notification(self, message, **unused_kwargs):
+        """Displays output for consumption by another program.
+        :param str message: Message to display to stdout
+        """
+        self.outfile.write(message + "\n")
+
 def separate_list_input(input_):
     """Separate a comma or space separated list.
 

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -822,7 +822,6 @@ def make_or_verify_needed_dirs(config):
     make_or_verify_core_dir(config.logs_dir, 0o700,
                             os.geteuid(), config.strict_permissions)
 
-
 def set_displayer(config):
     """Set the displayer"""
     if config.quiet:
@@ -833,6 +832,10 @@ def set_displayer(config):
     else:
         displayer = display_util.FileDisplay(sys.stdout,
                                              config.force_interactive)
+
+    if config.json:
+        displayer = display_util.MachineReadableDisplay(sys.stdout)
+
     zope.component.provideUtility(displayer)
 
 def _post_logging_setup(config, plugins, cli_args):

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -184,7 +184,6 @@ class CertificatesTest(BaseCertManagerTest):
     @mock.patch('certbot.cert_manager.ocsp.RevocationChecker.ocsp_revoked')
     def test_report_human_readable(self, mock_revoked):
         mock_revoked.return_value = None
-        import datetime, pytz
         expiry = pytz.UTC.fromutc(datetime.datetime.utcnow())
 
         cert = mock.MagicMock(lineagename="nameone")

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -366,8 +366,7 @@ class FormattersTest(CertificatesTest):
             mock_config,
             parsed_certs,
             None)
-        mock_preface = 'Found certs' 
-        out = formatter.report_successes(mock_preface)
+        out = formatter.report_successes('Found certs')
 
         try:
             out = json.dumps(out)

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -366,8 +366,8 @@ class FormattersTest(CertificatesTest):
             mock_config,
             parsed_certs,
             None)
-
-        out = formatter.report_successes()
+        mock_preface = 'Found certs' 
+        out = formatter.report_successes(mock_preface)
 
         try:
             out = json.dumps(out)

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -6,16 +6,6 @@ import shutil
 import tempfile
 import unittest
 
-# Workaround to skip unittests in Python2.6
-# From http://stackoverflow.com/questions/20395524/
-# how-to-skip-a-unittest-case-in-python-2-6#34558606
-try:
-    from unittest import skip
-except ImportError:
-    def skip(f):  # pylint: disable=unused-argument
-        """Removes tests decorated with @skip in Python2.6"""
-        return lambda self: None
-
 import configobj
 import mock
 
@@ -162,7 +152,7 @@ class CertificatesTest(BaseCertManagerTest):
     @mock.patch('certbot.cert_manager.logger')
     @test_util.patch_get_utility()
     @mock.patch("certbot.storage.RenewableCert")
-    @mock.patch('certbot.cert_manager._report_human_readable')
+    @mock.patch('certbot.cert_manager.HumanReadableCertOutputFormatter.report')
     def test_certificates_parse_success(self, mock_report, mock_renewable_cert,
         mock_utility, mock_logger):
         mock_report.return_value = ""
@@ -260,7 +250,6 @@ class CertificatesTest(BaseCertManagerTest):
 class FormattersTest(CertificatesTest):
     """Tests for certbot.cert_manager.*CertOutputFormatter classes"""
 
-    @skip("Formatter not currently connected")
     @mock.patch('certbot.cert_manager.logger')
     @mock.patch('zope.component.getUtility')
     @mock.patch("certbot.storage.RenewableCert")
@@ -274,7 +263,6 @@ class FormattersTest(CertificatesTest):
         self.assertTrue(mock_utility.called)
         self.assertTrue(mock_renewable_cert.called)
 
-    @skip("Formatter not currently connected")
     @mock.patch('certbot.cert_manager.ocsp.RevocationChecker.ocsp_revoked')
     def test_report_human_readable_formatter(self, mock_revoked):
         mock_revoked.return_value = None
@@ -341,7 +329,6 @@ class FormattersTest(CertificatesTest):
         out = get_report()
         self.assertEqual(len(re.findall("INVALID:", out)), 0)
 
-    @skip("Formatter not currently connected")
     def test_report_json(self):
         from certbot import cert_manager
         import json
@@ -364,7 +351,6 @@ class FormattersTest(CertificatesTest):
         except ValueError as e:
             self.fail(e)
 
-    @skip("Formatter not currently connected")
     def test_json_formatter(self):
         from certbot import cert_manager
         import json

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -336,6 +336,23 @@ class NoninteractiveDisplayTest(unittest.TestCase):
             self.assertFalse(inspect.getargspec(method).keywords is None)
 
 
+class MachineReadableDisplayTest(unittest.TestCase):
+    """Test output from MachineReadableDisplay. """
+
+    def setUp(self):
+        self.message = "Something"
+        self.mock_stdout = mock.MagicMock()
+        self.displayer = display_util.MachineReadableDisplay(self.mock_stdout)
+
+    def _call(self, message):
+        self.displayer.notification(message)
+
+    def test_output(self):
+        self._call(self.message)
+        string = self.mock_stdout.write.call_args[0][0]
+        self.assertEquals(string, self.message + "\n")
+
+
 class SeparateListInputTest(unittest.TestCase):
     """Test Module functions."""
     def setUp(self):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -594,6 +594,11 @@ class MainTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self._call_no_clientmock(['certificates'])
         self.assertEqual(1, mock_cert_manager.call_count)
 
+    @mock.patch('certbot.cert_manager.certificates')
+    def test_certificates_json(self, mock_cert_manager):
+        self._call_no_clientmock(['certificates', '--json'])
+        self.assertEqual(1, mock_cert_manager.call_count)
+
     @mock.patch('certbot.cert_manager.delete')
     def test_delete(self, mock_cert_manager):
         self._call_no_clientmock(['delete'])

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -24,6 +24,19 @@ from certbot import storage
 from certbot.display import util as display_util
 
 
+class MockCert(object):
+    """A mock class that can be json serialized. """
+    def __init__(self, lineagename, domains, expiry, fullchain, privkey):
+        self.cert = ""
+        self.chain = ""
+        self.lineagename = lineagename
+        self.names = lambda: domains
+        self.target_expiry = expiry
+        self.fullchain = fullchain
+        self.privkey = privkey
+        self.is_test_cert = True
+
+
 def vector_path(*names):
     """Path to a test vector."""
     return pkg_resources.resource_filename(


### PR DESCRIPTION
This PR isn't for merging, it is for code review only. I plan to submit another PR with JSON and Grep certificates output which will clone from this branch. There is some redundant code in `cert_manager.py:_old_describe_certs` and `_report_human_readable` which are left there so another set of eyes can look over and make sure I haven't missed anything in the refactoring. I will delete the redundant code on the new branch.

A [helpful script](https://gist.github.com/dashaxiong/be08f8ac0e8d1e584b3a9d3ac1abcfe2) which when run against a local boulder instance, will show the output of the certificates subcommand.

This PR also excludes two test files from being counted in test coverage. Not sure of best practice, but on the face of it, checking coverage of test files seems like it could lead to a nasty recursion in testing practice. i.e. it seems to assume writing tests for tests ... for tests ... and so on. I wouldn't have brought it up, but `tox -e cover` complained that those two test files weren't up to the coverage standard.