### PR TITLE
fix bug when certbot is ran without any arguments (#4151)

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -439,7 +439,7 @@ class HelpfulArgumentParser(object):
         self.detect_defaults = detect_defaults
         self.args = args
 
-        if self.args[0] == 'help':
+        if self.args and self.args[0] == 'help':
             self.args[0] = '--help'
 
         self.determine_verb()

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -60,6 +60,11 @@ class ParseTest(unittest.TestCase):
                 self.assertRaises(SystemExit, self.parse, args, output)
         return output.getvalue()
 
+    def test_no_args(self):
+        namespace = self.parse([])
+        for d in ('config_dir', 'logs_dir', 'work_dir'):
+            self.assertEqual(getattr(namespace, d), cli.flag_default(d))
+
     def test_install_abspath(self):
         cert = 'cert'
         key = 'key'


### PR DESCRIPTION
(cherry picked from commit b5d4e0bf6a50872462b99f4f02b3688d1179b2f6)