### PR TITLE
Make JWKRSA() generate an RSA private key.

### DIFF
--- a/acme/acme/jose/jwk.py
+++ b/acme/acme/jose/jwk.py
@@ -174,9 +174,10 @@ class JWKOct(JWK):
 class JWKRSA(JWK):
     """RSA JWK.
 
-    :ivar key: `cryptography.hazmat.primitives.rsa.RSAPrivateKey`
+    :ivar key: Optional `cryptography.hazmat.primitives.rsa.RSAPrivateKey`
         or `cryptography.hazmat.primitives.rsa.RSAPublicKey` wrapped
-        in `.ComparableRSAKey`
+        in `.ComparableRSAKey`. If not present, will generate an RSAPrivateKey
+        with suitable defaults.
 
     """
     typ = 'RSA'
@@ -185,8 +186,9 @@ class JWKRSA(JWK):
     required = ('e', JWK.type_field_name, 'n')
 
     def __init__(self, *args, **kwargs):
-        if 'key' in kwargs and not isinstance(
-                kwargs['key'], util.ComparableRSAKey):
+        if 'key' not in kwargs:
+            kwargs['key'] = rsa.generate_private_key(65537, 2048, default_backend())
+        if not isinstance(kwargs['key'], util.ComparableRSAKey):
             kwargs['key'] = util.ComparableRSAKey(kwargs['key'])
         super(JWKRSA, self).__init__(*args, **kwargs)
 

--- a/acme/acme/jose/jwk_test.py
+++ b/acme/acme/jose/jwk_test.py
@@ -3,7 +3,7 @@ import binascii
 import unittest
 
 from acme import test_util
-from cryptography.hazmat.backends.openssl import rsa
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from acme.jose import errors
 from acme.jose import json_util
@@ -119,7 +119,7 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
         from acme.jose.jwk import JWKRSA
         jwk = JWKRSA()
         # pylint: disable=protected-access
-        self.assertTrue(isinstance(jwk.key._wrapped, rsa._RSAPrivateKey))
+        self.assertTrue(isinstance(jwk.key._wrapped, rsa.RSAPrivateKey))
 
     def test_encode_param_zero(self):
         from acme.jose.jwk import JWKRSA

--- a/acme/acme/jose/jwk_test.py
+++ b/acme/acme/jose/jwk_test.py
@@ -3,6 +3,7 @@ import binascii
 import unittest
 
 from acme import test_util
+from cryptography.hazmat.backends.openssl import rsa
 
 from acme.jose import errors
 from acme.jose import json_util
@@ -113,6 +114,11 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
         self.assertTrue(isinstance(
             self.jwk256_not_comparable.key, util.ComparableRSAKey))
         self.assertEqual(self.jwk256, self.jwk256_not_comparable)
+
+    def test_init_default_generate(self):
+        from acme.jose.jwk import JWKRSA
+        jwk = JWKRSA()
+        self.assertTrue(isinstance(jwk.key._wrapped, rsa._RSAPrivateKey))
 
     def test_encode_param_zero(self):
         from acme.jose.jwk import JWKRSA

--- a/acme/acme/jose/jwk_test.py
+++ b/acme/acme/jose/jwk_test.py
@@ -118,6 +118,7 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
     def test_init_default_generate(self):
         from acme.jose.jwk import JWKRSA
         jwk = JWKRSA()
+        # pylint: disable=protected-access
         self.assertTrue(isinstance(jwk.key._wrapped, rsa._RSAPrivateKey))
 
     def test_encode_param_zero(self):


### PR DESCRIPTION
Currently, to use JWKRSA, you need to import
cryptography.hazmat.backends.openssl.rsa and generate your own key. Ideally acme
clients shouldn't have to touch hazmat. This provides a way for them to avoid
that.

Also, fix a typo: 'asymmetric'