### PR TITLE
RFC: Add route53 plugin.

### DIFF
--- a/certbot/plugins/route53.py
+++ b/certbot/plugins/route53.py
@@ -1,0 +1,167 @@
+"""Route53 Authenticator."""
+# Adapted from https://github.com/alex/letsencrypt-aws
+# Copyright (c) Alex Gaynor and individual contributors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of letsencrypt-aws nor the names of its contributors
+#        may be used to endorse or promote products derived from this software
+#        without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import zope.interface
+
+from acme import challenges
+from certbot import interfaces
+from certbot.plugins import common
+
+import boto3
+import time
+import datetime
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class Authenticator(common.Plugin):
+    """Route53 Authenticator
+
+    This authenticator solves a DNS01 challenge by uploading the answer to AWS
+    Route53.
+    """
+
+    description = "Add TXT records to AWS Route53"
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+        session = boto3.Session()
+        self.route53_client = session.client("route53")
+        # A list of (dns name, TXT value) tuples, for cleanup.
+        self.txt_records = []
+
+    @property
+    def supported_challenges(self):
+        """Challenges supported by this plugin."""
+        return [challenges.Challenge.TYPES[challenges.DNS01.typ]]
+
+    def more_info(self):  # pylint: disable=missing-docstring
+        return("Solve a DNS01 challenge using AWS Route53")
+
+    def prepare(self):  # pylint: disable=missing-docstring
+        pass
+
+    def get_chall_pref(self, domain):
+        # pylint: disable=unused-argument,missing-docstring
+        return self.supported_challenges
+
+    def perform(self, achalls):  # pylint: disable=missing-docstring
+        change_ids = [self._create_single(achall) for achall in achalls]
+        for change_id in change_ids:
+            self._wait_for_change(change_id)
+        return [achall.response(achall.account_key) for achall in achalls]
+
+    def cleanup(self, achalls):  # pylint: disable=missing-docstring
+        for name, value in self.txt_records:
+            self._delete_txt_record(name, value)
+        pass
+
+    def _create_single(self, achall):
+        """Create a TXT record, return a change_id"""
+        name, value = (achall.validation_domain_name(achall.domain),
+            achall.validation(achall.account_key))
+        change_id = self._create_txt_record(name, value)
+        self.txt_records.append((name, value))
+        return change_id
+
+    def _find_zone_id_for_domain(self, domain):
+        paginator = self.route53_client.get_paginator("list_hosted_zones")
+        zones = []
+        for page in paginator.paginate():
+            for zone in page["HostedZones"]:
+                if (
+                    domain.endswith(zone["Name"]) or
+                    (domain + ".").endswith(zone["Name"])
+                ) and not zone["Config"]["PrivateZone"]:
+                    zones.append((zone["Name"], zone["Id"]))
+
+        if not zones:
+            raise ValueError(
+                "Unable to find a Route53 hosted zone for {}".format(domain)
+            )
+
+        # Order the zones that are suffixes for our desired to domain by
+        # length, this puts them in an order like:
+        # ["foo.bar.baz.com", "bar.baz.com", "baz.com", "com"]
+        # And then we choose the first one, which will be the most specific.
+        zones.sort(key=lambda z: len(z[0]), reverse=True)
+        return zones[0][1]
+
+    def _change_txt_record(self, action, zone_id, domain, value):
+        response = self.route53_client.change_resource_record_sets(
+            HostedZoneId=zone_id,
+            ChangeBatch={
+                "Changes": [
+                    {
+                        "Action": action,
+                        "ResourceRecordSet": {
+                            "Name": domain,
+                            "Type": "TXT",
+                            "TTL": 0,
+                            "ResourceRecords": [
+                                # For some reason TXT records need to be
+                                # manually quoted.
+                                {"Value": '"{}"'.format(value)}
+                            ],
+                        }
+                    }
+                ]
+            }
+        )
+        return response["ChangeInfo"]["Id"]
+
+    def _create_txt_record(self, host, value):
+        zone_id = self._find_zone_id_for_domain(host)
+        change_id = self._change_txt_record(
+            "UPSERT",
+            zone_id,
+            host,
+            value,
+        )
+        return change_id
+
+    def _delete_txt_record(self, host, value):
+        zone_id = self._find_zone_id_for_domain(host)
+        change_id = self._change_txt_record(
+            "DELETE",
+            zone_id,
+            host,
+            value,
+        )
+        return change_id
+
+    def _wait_for_change(self, change_id):
+        deadline = datetime.datetime.now() + datetime.timedelta(minutes=1)
+        while datetime.datetime.now() < deadline:
+            response = self.route53_client.get_change(Id=change_id)
+            if response["ChangeInfo"]["Status"] == "INSYNC":
+                return
+            time.sleep(5)
+        raise Exception(
+            "Timed out waiting for Route53 change. Current status: %s" %
+            response["ChangeInfo"]["Status"])

--- a/certbot/plugins/route53.py
+++ b/certbot/plugins/route53.py
@@ -155,7 +155,7 @@ class Authenticator(common.Plugin):
         return change_id
 
     def _wait_for_change(self, change_id):
-        deadline = datetime.datetime.now() + datetime.timedelta(minutes=1)
+        deadline = datetime.datetime.now() + datetime.timedelta(minutes=10)
         while datetime.datetime.now() < deadline:
             response = self.route53_client.get_change(Id=change_id)
             if response["ChangeInfo"]["Status"] == "INSYNC":

--- a/certbot/plugins/route53.py
+++ b/certbot/plugins/route53.py
@@ -79,7 +79,6 @@ class Authenticator(common.Plugin):
     def cleanup(self, achalls):  # pylint: disable=missing-docstring
         for name, value in self.txt_records:
             self._delete_txt_record(name, value)
-        pass
 
     def _create_single(self, achall):
         """Create a TXT record, return a change_id"""

--- a/certbot/plugins/route53.py
+++ b/certbot/plugins/route53.py
@@ -39,7 +39,7 @@ import time
 import datetime
 
 INSTRUCTIONS = (
-    "To use, create an IAM user with the AmazonRoute53FullAccess permission, then store "
+    "To use, create an IAM user and attach the AmazonRoute53FullAccess policy, then store "
     "the access key ID and secret key in ~/.aws/credentials or in "
     "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, as described at "
     "https://boto3.readthedocs.io/en/latest/guide/configuration.html")

--- a/certbot/plugins/route53.py
+++ b/certbot/plugins/route53.py
@@ -38,6 +38,12 @@ from botocore.exceptions import NoCredentialsError
 import time
 import datetime
 
+INSTRUCTIONS = (
+    "To use, create an IAM user with the AmazonRoute53FullAccess permission, then store "
+    "the access key ID and secret key in ~/.aws/credentials or in "
+    "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, as described at "
+    "https://boto3.readthedocs.io/en/latest/guide/configuration.html")
+
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(common.Plugin):
@@ -47,7 +53,10 @@ class Authenticator(common.Plugin):
     Route53.
     """
 
-    description = "Add TXT records to AWS Route53"
+    description = ("Authenticate domain names using the DNS challenge type, "
+        "by automatically updating TXT records using AWS Route53. Works only "
+        "if you use AWS Route53 to host DNS for your domains. " +
+        INSTRUCTIONS)
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)
@@ -78,7 +87,7 @@ class Authenticator(common.Plugin):
                 self._wait_for_change(change_id)
             return [achall.response(achall.account_key) for achall in achalls]
         except NoCredentialsError:
-            raise Exception("no crds")
+            raise Exception("No AWS Route53 credentials found. " + INSTRUCTIONS)
 
     def cleanup(self, achalls):  # pylint: disable=missing-docstring
         for name, value in self.txt_records:

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ version = meta['version']
 # https://github.com/pypa/pip/issues/988 for more info.
 install_requires = [
     'acme=={0}'.format(version),
+    'boto3',
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
     # saying so here causes a runtime error against our temporary fork of 0.9.3
     # in which we added 2.6 support (see #2243), so we relax the requirement.

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
             'null = certbot.plugins.null:Installer',
             'standalone = certbot.plugins.standalone:Authenticator',
             'webroot = certbot.plugins.webroot:Authenticator',
+            'route53 = certbot.plugins.route53:Authenticator',
         ],
     },
 )


### PR DESCRIPTION
This allows automatically solving DNS challenges using AWS's Route53 API.

This isn't the final form, looking for some comments. In particular, this pulls in an extra dependency (boto3), so isn't suitable to ship with the main certbot distribution. I *think* it probably makes sense to put it at the top level as its own Python package, so you could run `pip install certbot-route53 ; certbot-auto -a route53`. However, I'm not entirely sure how to do that and could use some advice.

Also curious to hear what people think about maintaining this in the core Certbot repo vs its own repo as a truly independent plugin.