### PR TITLE
macOS Fix Python installation when using MacPorts

### DIFF
--- a/certbot-auto
+++ b/certbot-auto
@@ -518,7 +518,11 @@ BootstrapMac() {
     # We want to avoid using the system Python because it requires root to use pip.
     # python.org, MacPorts or HomeBrew Python installations should all be OK.
     echo "Installing python..."
-    $pkgcmd python
+    if [ "$pkgman" == "brew" ]; then
+      $pkgcmd python
+    elif [ "$pkgman" == "port" ]; then
+      $pkgcmd python27
+    fi
   fi
 
   # Workaround for _dlopen not finding augeas on macOS

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -518,7 +518,11 @@ BootstrapMac() {
     # We want to avoid using the system Python because it requires root to use pip.
     # python.org, MacPorts or HomeBrew Python installations should all be OK.
     echo "Installing python..."
-    $pkgcmd python
+    if [ "$pkgman" == "brew" ]; then
+      $pkgcmd python
+    elif [ "$pkgman" == "port" ]; then
+      $pkgcmd python27
+    fi
   fi
 
   # Workaround for _dlopen not finding augeas on macOS

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -518,7 +518,11 @@ BootstrapMac() {
     # We want to avoid using the system Python because it requires root to use pip.
     # python.org, MacPorts or HomeBrew Python installations should all be OK.
     echo "Installing python..."
-    $pkgcmd python
+    if [ "$pkgman" == "brew" ]; then
+      $pkgcmd python
+    elif [ "$pkgman" == "port" ]; then
+      $pkgcmd python27
+    fi
   fi
 
   # Workaround for _dlopen not finding augeas on macOS

--- a/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/mac.sh
@@ -20,7 +20,11 @@ BootstrapMac() {
     # We want to avoid using the system Python because it requires root to use pip.
     # python.org, MacPorts or HomeBrew Python installations should all be OK.
     echo "Installing python..."
-    $pkgcmd python
+    if [ "$pkgman" == "brew" ]; then
+      $pkgcmd python
+    elif [ "$pkgman" == "port" ]; then
+      $pkgcmd python27
+    fi
   fi
 
   # Workaround for _dlopen not finding augeas on macOS


### PR DESCRIPTION
This pull requrest fixes #3479 where I desribe that current `BootstrapMac` function in unable to install Python from MacPorts because port name differes from HomeBrew's.

Simple if condition decides if python is to be installed by MacPorts or HomeBrew.

Homebrew case: brew install python
MacPorts case: sudo port install python27