### PR TITLE
Add flags to configure log rotation

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -791,6 +791,7 @@ def _add_all_groups(helpful):
     helpful.add_group("manage",
         description="Various subcommands and flags are available for managing your certificates:",
         verbs=["certificates", "delete", "renew", "revoke", "update_symlinks"])
+    helpful.add_group("logging", description="Arguments for controlling how logging is handled.")
 
     # VERBS
     for verb, docs in VERB_HELP:

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -430,7 +430,7 @@ class HelpfulArgumentParser(object):
         }
 
         # List of topics for which additional help can be provided
-        HELP_TOPICS = ["all", "security", "paths", "logging", "automation", "testing"]
+        HELP_TOPICS = ["all", "security", "paths", "automation", "testing"]
         HELP_TOPICS += list(self.VERBS) + self.COMMANDS_TOPICS + ["manage"]
 
         plugin_names = list(plugins)
@@ -791,7 +791,6 @@ def _add_all_groups(helpful):
     helpful.add_group("manage",
         description="Various subcommands and flags are available for managing your certificates:",
         verbs=["certificates", "delete", "renew", "revoke", "update_symlinks"])
-    helpful.add_group("logging", description="Arguments for controlling how logging is handled")
 
     # VERBS
     for verb, docs in VERB_HELP:
@@ -825,17 +824,15 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         None, "-t", "--text", dest="text_mode", action="store_true",
         help=argparse.SUPPRESS)
     helpful.add(
-        [None, "logging", "paths"],
-        "--disable-log-rotation", dest="disable_log_rotation",
-        action="store_true", default=False,
-        help="Disable per-run rotation of the log. This results in a single "
-        "log file.")
-    helpful.add(
-        [None, "logging", "paths"],
+        # Note, 1 is subtracted from max_log_count in certbot/main.py
+        #> to correct an off by one error.
+        [None, "paths"],
         "--max-log-count", dest="max_log_count",
         type=int, default=1000,
         help="Specifies the maximum number of certbot log files "
-        "that will be kept.")
+               "that will be kept. 0 disables log rotation. 1 causes "
+               "only the log from the most recent run to be kept. "
+               "2+ enables log rotation at start of certbot execution.")
     helpful.add(
         [None, "automation", "run", "certonly"], "-n", "--non-interactive", "--noninteractive",
         dest="noninteractive_mode", action="store_true",

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -824,6 +824,12 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         None, "-t", "--text", dest="text_mode", action="store_true",
         help=argparse.SUPPRESS)
     helpful.add(
+        [None, "automation", "paths"],
+        "--disable-log-rotation", dest="disable_log_rotation",
+        action="store_true", default=False,
+        help="Disable per-run rotation of the log. This results in a single "
+        "log file.")
+    helpful.add(
         [None, "automation", "run", "certonly"], "-n", "--non-interactive", "--noninteractive",
         dest="noninteractive_mode", action="store_true",
         help="Run without ever asking for user input. This may require "

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -832,7 +832,7 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
     helpful.add(
         [None, "logging", "paths"],
         "--max-log-count", dest="max_log_count",
-        action="store_true", default=1000,
+        type=int, default=1000,
         help="Specifies the maximum number of certbot log files "
         "that will be kept.")
     helpful.add(

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -824,11 +824,17 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         None, "-t", "--text", dest="text_mode", action="store_true",
         help=argparse.SUPPRESS)
     helpful.add(
-        [None, "automation", "paths"],
+        [None, "logging", "paths"],
         "--disable-log-rotation", dest="disable_log_rotation",
         action="store_true", default=False,
         help="Disable per-run rotation of the log. This results in a single "
         "log file.")
+    helpful.add(
+        [None, "logging", "paths"],
+        "--max-log-count", dest="max_log_count",
+        action="store_true", default=1000,
+        help="Specifies the maximum number of certbot log files "
+        "that will be kept.")
     helpful.add(
         [None, "automation", "run", "certonly"], "-n", "--non-interactive", "--noninteractive",
         dest="noninteractive_mode", action="store_true",

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -430,7 +430,7 @@ class HelpfulArgumentParser(object):
         }
 
         # List of topics for which additional help can be provided
-        HELP_TOPICS = ["all", "security", "paths", "automation", "testing"] + list(self.VERBS)
+        HELP_TOPICS = ["all", "security", "paths", "logging", "automation", "testing"] + list(self.VERBS)
         HELP_TOPICS += self.COMMANDS_TOPICS + ["manage"]
 
         plugin_names = list(plugins)
@@ -791,7 +791,7 @@ def _add_all_groups(helpful):
     helpful.add_group("manage",
         description="Various subcommands and flags are available for managing your certificates:",
         verbs=["certificates", "delete", "renew", "revoke", "update_symlinks"])
-    helpful.add_group("logging", description="Arguments for controlling how logging is handled.")
+    helpful.add_group("logging", description="Arguments for controlling how logging is handled")
 
     # VERBS
     for verb, docs in VERB_HELP:

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -430,8 +430,8 @@ class HelpfulArgumentParser(object):
         }
 
         # List of topics for which additional help can be provided
-        HELP_TOPICS = ["all", "security", "paths", "logging", "automation", "testing"] + list(self.VERBS)
-        HELP_TOPICS += self.COMMANDS_TOPICS + ["manage"]
+        HELP_TOPICS = ["all", "security", "paths", "logging", "automation", "testing"]
+        HELP_TOPICS += list(self.VERBS) + self.COMMANDS_TOPICS + ["manage"]
 
         plugin_names = list(plugins)
         self.help_topics = HELP_TOPICS + plugin_names + [None]

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -694,8 +694,12 @@ def setup_log_file_handler(config, logfile, fmt):
     """Setup file debug logging."""
     log_file_path = os.path.join(config.logs_dir, logfile)
     try:
-        handler = logging.handlers.RotatingFileHandler(
-            log_file_path, maxBytes=2 ** 20, backupCount=1000)
+        if config.disable_log_rotation:
+            handler = logging.handlers.RotatingFileHandler(
+                log_file_path, maxBytes=2 ** 20, backupCount=0)
+        else:
+            handler = logging.handlers.RotatingFileHandler(
+                log_file_path, maxBytes=2 ** 20, backupCount=1000)
     except IOError as error:
         raise errors.Error(_PERM_ERR_FMT.format(error))
     # rotate on each invocation, rollover only possible when maxBytes

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -699,7 +699,7 @@ def setup_log_file_handler(config, logfile, fmt):
                 log_file_path, maxBytes=2 ** 20, backupCount=0)
         else:
             handler = logging.handlers.RotatingFileHandler(
-                log_file_path, maxBytes=2 ** 20, backupCount=1000)
+                log_file_path, maxBytes=2 ** 20, backupCount=config.max_log_count)
     except IOError as error:
         raise errors.Error(_PERM_ERR_FMT.format(error))
     # rotate on each invocation, rollover only possible when maxBytes

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -296,6 +296,10 @@ class SetupLogFileHandlerTest(unittest.TestCase):
         mock_handler.side_effect = IOError
         self.assertRaises(errors.Error, self._call,
                           self.config, "test.log", "%s")
+    def test_oserror(self, mock_handler):
+        mock_handler.side_effect = OSEorror
+        self.assertRaises(errors.Eorror, self._call,
+                          self.config, "test.log", "%s")
 
 
 class SetupLoggingTest(unittest.TestCase):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -280,10 +280,8 @@ class SetupLogFileHandlerTest(unittest.TestCase):
 
     def setUp(self):
         self.config = mock.Mock(spec_set=['logs_dir'],
-                                logs_dir=tempfile.mkdtemp())
-        self.config = mock.Mock(spec_set=['disable_log_rotation'],
-                                disable_log_rotation=False)
-        self.config = mock.Mock(spec_set=['max_log_count'],
+                                logs_dir=tempfile.mkdtemp(),
+                                disable_log_rotation=False,
                                 max_log_count=1)
 
     def tearDown(self):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -280,9 +280,8 @@ class SetupLogFileHandlerTest(unittest.TestCase):
 
     def setUp(self):
         self.config = mock.Mock(spec_set=['logs_dir',
-                      'disable_log_rotation', 'max_log_count'],
+                      'max_log_count'],
                                 logs_dir=tempfile.mkdtemp(),
-                                disable_log_rotation=False,
                                 max_log_count=1)
 
     def tearDown(self):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -281,6 +281,10 @@ class SetupLogFileHandlerTest(unittest.TestCase):
     def setUp(self):
         self.config = mock.Mock(spec_set=['logs_dir'],
                                 logs_dir=tempfile.mkdtemp())
+        self.config = mock.Mock(spec_set=['disable_log_rotation'],
+                                disable_log_rotation=False)
+        self.config = mock.Mock(spec_set=['max_log_count'],
+                                max_log_count=1)
 
     def tearDown(self):
         shutil.rmtree(self.config.logs_dir)

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -279,7 +279,8 @@ class SetupLogFileHandlerTest(unittest.TestCase):
     """Tests for certbot.main.setup_log_file_handler."""
 
     def setUp(self):
-        self.config = mock.Mock(spec_set=['logs_dir'],
+        self.config = mock.Mock(spec_set=['logs_dir',
+                      'disable_log_rotation', 'max_log_count'],
                                 logs_dir=tempfile.mkdtemp(),
                                 disable_log_rotation=False,
                                 max_log_count=1)


### PR DESCRIPTION
Provides a quick, and possibly keep-able, fix to certbot logging issues. Primarily: certbot handling log rotation on its own (--disable-log-rotation) & certbot keeping an insane number of logs (--max-log-count). Further details in #3602 
Thank you,