### PR TITLE
Remove erroneous advice

### DIFF
--- a/certbot/account.py
+++ b/certbot/account.py
@@ -82,7 +82,7 @@ class Account(object):  # pylint: disable=too-few-public-methods
                 self.meta == other.meta)
 
 
-def report_new_account(acc, config):
+def report_new_account(config):
     """Informs the user about their new ACME account."""
     reporter = zope.component.queryUtility(interfaces.IReporter)
     if reporter is None:

--- a/certbot/account.py
+++ b/certbot/account.py
@@ -96,12 +96,6 @@ def report_new_account(acc, config):
             config.config_dir),
         reporter.MEDIUM_PRIORITY)
 
-    if acc.regr.body.emails:
-        recovery_msg = ("If you lose your account credentials, you can "
-                        "recover through e-mails sent to {0}.".format(
-                            ", ".join(acc.regr.body.emails)))
-        reporter.add_message(recovery_msg, reporter.MEDIUM_PRIORITY)
-
 
 class AccountMemoryStorage(interfaces.AccountStorage):
     """In-memory account strage."""

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -137,7 +137,7 @@ def register(config, account_storage, tos_cb=None):
         regr = acme.agree_to_tos(regr)
 
     acc = account.Account(regr, key)
-    account.report_new_account(acc, config)
+    account.report_new_account(config)
     account_storage.save(acc)
 
     eff.handle_subscription(config)

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -80,8 +80,6 @@ class ReportNewAccountTest(unittest.TestCase):
         self._call()
         call_list = mock_zope().add_message.call_args_list
         self.assertTrue(self.config.config_dir in call_list[0][0][0])
-        self.assertTrue(
-            ", ".join(self.acc.regr.body.emails) in call_list[1][0][0])
 
 
 class AccountMemoryStorageTest(unittest.TestCase):

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -62,13 +62,10 @@ class ReportNewAccountTest(unittest.TestCase):
 
     def setUp(self):
         self.config = mock.MagicMock(config_dir="/etc/letsencrypt")
-        reg = messages.Registration.from_data(email="rhino@jungle.io")
-        self.acc = mock.MagicMock(regr=messages.RegistrationResource(
-            uri=None, new_authzr_uri=None, body=reg))
 
     def _call(self):
         from certbot.account import report_new_account
-        report_new_account(self.acc, self.config)
+        report_new_account(self.config)
 
     @mock.patch("certbot.account.zope.component.queryUtility")
     def test_no_reporter(self, mock_zope):


### PR DESCRIPTION
Per @patf at https://community.letsencrypt.org/t/-/21318/2:

> This is not really true anymore - account recovery via email was planned to be added at some point, but has been removed from the spec since.