### PR TITLE
Add default timeout to ClientNetwork.

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -627,6 +627,7 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         kwargs['verify'] = self.verify_ssl
         kwargs.setdefault('headers', {})
         kwargs['headers'].setdefault('User-Agent', self.user_agent)
+        kwargs.setdefault('timeout', 45) # timeout after 45 seconds
         response = self.session.request(method, url, *args, **kwargs)
         # If content is DER, log the base64 of it instead of raw bytes, to keep
         # binary data out of the logs.

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -558,7 +558,7 @@ class ClientNetworkTest(unittest.TestCase):
             'HEAD', 'http://example.com/', 'foo', bar='baz'))
         self.net.session.request.assert_called_once_with(
             'HEAD', 'http://example.com/', 'foo',
-            headers=mock.ANY, verify=mock.ANY, bar='baz')
+            headers=mock.ANY, verify=mock.ANY, timeout=mock.ANY, bar='baz')
 
     @mock.patch('acme.client.logger')
     def test_send_request_get_der(self, mock_logger):
@@ -568,7 +568,8 @@ class ClientNetworkTest(unittest.TestCase):
             headers={"Content-Type": "application/pkix-cert"},
             content=b"hi")
         # pylint: disable=protected-access
-        self.net._send_request('HEAD', 'http://example.com/', 'foo', bar='baz')
+        self.net._send_request('HEAD', 'http://example.com/', 'foo',
+          timeout=mock.ANY, bar='baz')
         mock_logger.debug.assert_called_once_with(
             'Received response:\nHTTP %d\n%s\n\n%s', 200,
             'Content-Type: application/pkix-cert', b'aGk=')
@@ -581,7 +582,7 @@ class ClientNetworkTest(unittest.TestCase):
             'POST', 'http://example.com/', 'foo', data='qux', bar='baz'))
         self.net.session.request.assert_called_once_with(
             'POST', 'http://example.com/', 'foo',
-            headers=mock.ANY, verify=mock.ANY, data='qux', bar='baz')
+            headers=mock.ANY, verify=mock.ANY, timeout=mock.ANY, data='qux', bar='baz')
 
     def test_send_request_verify_ssl(self):
         # pylint: disable=protected-access
@@ -594,7 +595,8 @@ class ClientNetworkTest(unittest.TestCase):
                 self.response,
                 self.net._send_request('GET', 'http://example.com/'))
             self.net.session.request.assert_called_once_with(
-                'GET', 'http://example.com/', verify=verify, headers=mock.ANY)
+                'GET', 'http://example.com/', verify=verify,
+                timeout=mock.ANY, headers=mock.ANY)
 
     def test_send_request_user_agent(self):
         self.net.session = mock.MagicMock()
@@ -603,13 +605,23 @@ class ClientNetworkTest(unittest.TestCase):
                                headers={'bar': 'baz'})
         self.net.session.request.assert_called_once_with(
             'GET', 'http://example.com/', verify=mock.ANY,
+            timeout=mock.ANY,
             headers={'User-Agent': 'acme-python-test', 'bar': 'baz'})
 
         self.net._send_request('GET', 'http://example.com/',
                                headers={'User-Agent': 'foo2'})
         self.net.session.request.assert_called_with(
             'GET', 'http://example.com/',
-            verify=mock.ANY, headers={'User-Agent': 'foo2'})
+            verify=mock.ANY, timeout=mock.ANY, headers={'User-Agent': 'foo2'})
+
+    def test_send_request_timeout(self):
+        self.net.session = mock.MagicMock()
+        # pylint: disable=protected-access
+        self.net._send_request('GET', 'http://example.com/',
+                               headers={'bar': 'baz'})
+        self.net.session.request.assert_called_once_with(
+            mock.ANY, mock.ANY, verify=mock.ANY, headers=mock.ANY,
+            timeout=45)
 
     def test_del(self):
         sess = mock.MagicMock()


### PR DESCRIPTION
In https://community.letsencrypt.org/t/letsencrypt-cli-hangs-on-certificate-request/27211,
a community member pointed out that Certbot seems to hang when there are
routing problems.