### PR TITLE
Remove reference to #certbot on OFTC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Main Website: https://certbot.eff.org
 
 Let's Encrypt Website: https://letsencrypt.org
 
-IRC Channel: #letsencrypt on `Freenode`_ or #certbot on `OFTC`_
+IRC Channel: #letsencrypt on `Freenode`_
 
 Community: https://community.letsencrypt.org
 


### PR DESCRIPTION
The #letsencrypt channel on Freenode is much more active, and is the defacto place for questions about Certbot. Users posting questions on #certbot on OFTC are not getting prompt answers.