### PR TITLE
Fix direct usages of the root logger

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -425,7 +425,7 @@ class TLSSNI01Response(KeyAuthorizationChallengeResponse):
         # TODO: domain is not necessary if host is provided
         if "host" not in kwargs:
             host = socket.gethostbyname(domain)
-            logging.debug('%s resolved to %s', domain, host)
+            logger.debug('%s resolved to %s', domain, host)
             kwargs["host"] = host
 
         kwargs.setdefault("port", self.PORT)
@@ -445,7 +445,7 @@ class TLSSNI01Response(KeyAuthorizationChallengeResponse):
         """
         # pylint: disable=protected-access
         sans = crypto_util._pyopenssl_cert_or_req_san(cert)
-        logging.debug('Certificate %s. SANs: %s', cert.digest('sha1'), sans)
+        logger.debug('Certificate %s. SANs: %s', cert.digest('sha1'), sans)
         return self.z_domain.decode() in sans
 
     def simple_verify(self, chall, domain, account_public_key,

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -600,10 +600,10 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
 
         """
         if method == "POST":
-            logging.debug('Sending POST request to %s:\n%s',
+            logger.debug('Sending POST request to %s:\n%s',
                           url, kwargs['data'])
         else:
-            logging.debug('Sending %s request to %s.', method, url)
+            logger.debug('Sending %s request to %s.', method, url)
         kwargs['verify'] = self.verify_ssl
         kwargs.setdefault('headers', {})
         kwargs['headers'].setdefault('User-Agent', self.user_agent)
@@ -650,7 +650,7 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
 
     def _get_nonce(self, url):
         if not self._nonces:
-            logging.debug('Requesting fresh nonce')
+            logger.debug('Requesting fresh nonce')
             self._add_nonce(self.head(url))
         return self._nonces.pop()
 

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -543,7 +543,7 @@ class ClientNetworkTest(unittest.TestCase):
             content=b"hi")
         # pylint: disable=protected-access
         self.net._send_request('HEAD', 'http://example.com/', 'foo', bar='baz')
-        mock_logger.debug.assert_called_once_with(
+        mock_logger.debug.assert_called_with(
             'Received response:\nHTTP %d\n%s\n\n%s', 200,
             'Content-Type: application/pkix-cert', b'aGk=')
 

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -630,7 +630,7 @@ class NginxConfigurator(common.Plugin):
                 stderr=subprocess.PIPE)
             text = proc.communicate()[1]  # nginx prints output to stderr
         except (OSError, ValueError) as error:
-            logging.debug(error, exc_info=True)
+            logger.debug(error, exc_info=True)
             raise errors.PluginError(
                 "Unable to run %s -V" % self.conf('ctl'))
 

--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -16,7 +16,7 @@ class RevocationChecker(object):
         self.broken = False
 
         if not util.exe_exists("openssl"):
-            logging.info("openssl not installed, can't check revocation")
+            logger.info("openssl not installed, can't check revocation")
             self.broken = True
             return
 
@@ -61,7 +61,7 @@ class RevocationChecker(object):
         logger.debug("Querying OCSP for %s", cert_path)
         logger.debug(" ".join(cmd))
         try:
-            output, err = util.run_script(cmd, log=logging.debug)
+            output, err = util.run_script(cmd, log=logger.debug)
         except errors.SubprocessError:
             logger.info("OCSP check failed for %s (are we offline?)", cert_path)
             return False
@@ -80,7 +80,7 @@ class RevocationChecker(object):
         try:
             url, _err = util.run_script(
                 ["openssl", "x509", "-in", cert_path, "-noout", "-ocsp_uri"],
-                log=logging.debug)
+                log=logger.debug)
         except errors.SubprocessError:
             logger.info("Cannot extract OCSP URI from %s", cert_path)
             return None, None

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -28,7 +28,7 @@ class OCSPTest(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @mock.patch('certbot.ocsp.logging.info')
+    @mock.patch('certbot.ocsp.logger.info')
     @mock.patch('certbot.ocsp.Popen')
     @mock.patch('certbot.util.exe_exists')
     def test_init(self, mock_exists, mock_popen, mock_log):


### PR DESCRIPTION
A couple of places use `logging.info` and `logging.debug` instead of `logger.info` and `logger.debug`, making it impossible to silence these messages.