### PR TITLE
lineage_for_certname should return None if there is no existing renewal file

### DIFF
--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -100,7 +100,10 @@ def lineage_for_certname(cli_config, certname):
     configs_dir = cli_config.renewal_configs_dir
     # Verify the directory is there
     util.make_or_verify_dir(configs_dir, mode=0o755, uid=os.geteuid())
-    renewal_file = storage.renewal_file_for_certname(cli_config, certname)
+    try:
+        renewal_file = storage.renewal_file_for_certname(cli_config, certname)
+    except errors.CertStorageError:
+        return None
     try:
         return storage.RenewableCert(renewal_file, cli_config)
     except (errors.CertStorageError, IOError):

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -290,6 +290,16 @@ class LineageForCertnameTest(BaseCertManagerTest):
             None)
         self.assertTrue(mock_make_or_verify_dir.called)
 
+    @mock.patch('certbot.util.make_or_verify_dir')
+    @mock.patch('certbot.storage.renewal_file_for_certname')
+    def test_no_renewal_file(self, mock_renewal_conf_file,
+        mock_make_or_verify_dir):
+        mock_renewal_conf_file.side_effect = errors.CertStorageError()
+        from certbot import cert_manager
+        self.assertEqual(cert_manager.lineage_for_certname(self.cli_config, "example.com"),
+            None)
+        self.assertTrue(mock_make_or_verify_dir.called)
+
 
 class DomainsForCertnameTest(BaseCertManagerTest):
     """Tests for certbot.cert_manager.domains_for_certname"""

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -xe
 # Simple integration test. Make sure to activate virtualenv beforehand
 # (source venv/bin/activate) and that you are running Boulder test
-# instance (see ./boulder-fetch.sh).
+# instance (see ./boulder-start.sh).
 #
 # Environment variables:
 #   SERVER: Passed as "certbot --server" argument.
@@ -99,6 +99,8 @@ common certonly -a manual -d le.wtf --rsa-key-size 4096 \
 
 common certonly -a manual -d dns.le.wtf --preferred-challenges dns,tls-sni \
     --manual-auth-hook ./tests/manual-dns-auth.sh
+
+common certonly --cert-name newname -d newname.le.wtf
 
 export CSR_PATH="${root}/csr.der" KEY_PATH="${root}/key.pem" \
        OPENSSL_CNF=examples/openssl.cnf

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -xe
 # Simple integration test. Make sure to activate virtualenv beforehand
 # (source venv/bin/activate) and that you are running Boulder test
-# instance (see ./boulder-start.sh).
+# instance (see ./boulder-fetch.sh).
 #
 # Environment variables:
 #   SERVER: Passed as "certbot --server" argument.


### PR DESCRIPTION
Fixes #4233