### PR TITLE
Docker changes for easier testing

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -58,8 +58,7 @@ RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
     -e /opt/certbot/src/certbot-nginx \
     -e /opt/certbot/src/letshelp-certbot \
     -e /opt/certbot/src/certbot-compatibility-test \
-    -e /opt/certbot/src[dev,docs] \
-    ipdb && \
+    -e /opt/certbot/src[dev,docs] && \
     /opt/certbot/venv/bin/pip install -U setuptools
 
 # install in editable mode (-e) to save space: it's not possible to

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -58,7 +58,9 @@ RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
     -e /opt/certbot/src/certbot-nginx \
     -e /opt/certbot/src/letshelp-certbot \
     -e /opt/certbot/src/certbot-compatibility-test \
-    -e /opt/certbot/src[dev,docs]
+    -e /opt/certbot/src[dev,docs] \
+    ipdb && \
+    /opt/certbot/venv/bin/pip install -U setuptools
 
 # install in editable mode (-e) to save space: it's not possible to
 # "rm -rf /opt/certbot/src" (it's stays in the underlaying image);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,18 @@
-production:
-  build: .
-  ports:
-    - "443:443"
+version: '2'
+services:
+  production:
+    build: .
+    ports:
+      - "443:443"
 
 # For development, mount git root to /opt/certbot/src in order to
 # make the dev workflow more vagrant-like.
-development:
-  build: .
-  ports:
-    - "443:443"
-  volumes:
-    - .:/opt/certbot/src
-    - /opt/certbot/venv
+  development:
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    ports:
+      - "443:443"
+    volumes:
+      - .:/opt/certbot/src
+      - /opt/certbot/venv

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ dev_extras = [
     # Pin astroid==1.3.5, pylint==1.4.2 as a workaround for #289
     'astroid==1.3.5',
     'coverage',
+    'ipdb',
     'nose',
     'pylint==1.4.2',  # upstream #248
     'tox',


### PR DESCRIPTION
These changes allow developers to run tests directly from the host machine using Docker, and to enable ipdb inside the container.

docker-compose.yml is upgraded to version 2 format. This means that you need docker-engine version >= 1.10.0 instead of previous requirement of version >= 1.9.1. The reason for this is to be able to use custom Dockerfile (Dockerfile-dev in this case) in build context.

ipdb has been added to dev dependencies to be able to be able to debug the code without installing it on every docker run. This is also what we recommend for debugging in the developer documentation, so there really is no reason not to install it with the dev dependencies.

setuptools is being upgraded to a newer version to be able to run coverage tests. This was using the older version of setuptools for some reason, and without the upgrade, coverage tests would fail horribly. Upgrading remedies the situation.

Few examples: 

Run unit tests for certbot-apache
`docker-compose run --rm --service-ports development bash -c 'cd src;nosetests -v certbot-apache'`

Run coverage tests
`docker-compose run --rm --service-ports development bash -c 'cd src;./tox.cover.sh'`

Run linter
`docker-compose run --rm --service-ports development bash -c 'cd src;tox -e lint'`

I would like to have a confirmation from @jsha that this PR isn't affecting any tests / development environments for boulder