### PR TITLE
Fix _get_runtime_cfg on Python 3

### DIFF
--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -136,7 +136,8 @@ class ApacheParser(object):
             proc = subprocess.Popen(
                 constants.os_constant("define_cmd"),
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                universal_newlines=True)
             stdout, stderr = proc.communicate()
 
         except (OSError, ValueError):


### PR DESCRIPTION
subprocess outputs are always bytes-like objects. On Python 2 bytes and unicode strings are interchangeable. On Python 3, string literals are unicode objects by default, so programmars have to do the conversion manually.

Here's the error when invoking ```sudo certbot``` under Python 3.6 without this fix.
```
2017-02-25 14:56:44,168:DEBUG:certbot.main:Exiting abnormally:
Traceback (most recent call last):
  File "/home/yen/Projects/tmp/certbot/.tox/py36/bin/certbot", line 11, in <module>
    load_entry_point('certbot', 'console_scripts', 'certbot')()
  File "/home/yen/Projects/tmp/certbot/certbot/main.py", line 896, in main
    return config.func(config, plugins)
  File "/home/yen/Projects/tmp/certbot/certbot/main.py", line 594, in run
    installer, authenticator = plug_sel.choose_configurator_plugins(config, plugins, "run")
  File "/home/yen/Projects/tmp/certbot/certbot/plugins/selection.py", line 185, in choose_configurator_plugins
    authenticator = installer = pick_configurator(config, req_inst, plugins)
  File "/home/yen/Projects/tmp/certbot/certbot/plugins/selection.py", line 25, in pick_configurator
    (interfaces.IAuthenticator, interfaces.IInstaller))
  File "/home/yen/Projects/tmp/certbot/certbot/plugins/selection.py", line 77, in pick_plugin
    verified.prepare()
  File "/home/yen/Projects/tmp/certbot/certbot/plugins/disco.py", line 228, in prepare
    return [plugin_ep.prepare() for plugin_ep in six.itervalues(self._plugins)]
  File "/home/yen/Projects/tmp/certbot/certbot/plugins/disco.py", line 228, in <listcomp>
    return [plugin_ep.prepare() for plugin_ep in six.itervalues(self._plugins)]
  File "/home/yen/Projects/tmp/certbot/certbot/plugins/disco.py", line 114, in prepare
    self._initialized.prepare()
  File "/home/yen/Projects/tmp/certbot/certbot-apache/certbot_apache/configurator.py", line 189, in prepare
    self.version)
  File "/home/yen/Projects/tmp/certbot/certbot-apache/certbot_apache/parser.py", line 43, in __init__
    self.update_runtime_variables()
  File "/home/yen/Projects/tmp/certbot/certbot-apache/certbot_apache/parser.py", line 112, in update_runtime_variables
    matches = re.compile(r"Define: ([^ \n]*)").findall(stdout)
TypeError: cannot use a string pattern on a bytes-like object
```
After this fix and tweaking paths in certbot-apache/certbot_apache/constants.py (I use Arch Linux, which is missing from constants.py), I can fetch certificates and update apache configurations with ```sudo certbot```, yay!