### PR TITLE
Make mod-check more flexible

### DIFF
--- a/tests/modification-check.sh
+++ b/tests/modification-check.sh
@@ -3,10 +3,8 @@
 temp_dir=`mktemp -d`
 trap "rm -rf $temp_dir" EXIT
 
-# Script should be run from Certbot's root directory
-
-SCRIPT_PATH=`dirname $0`
-SCRIPT_PATH=`readlink -f $SCRIPT_PATH`
+# cd to repo root
+cd $(dirname $(dirname $(readlink -f $0)))
 FLAG=false
 
 if ! cmp -s certbot-auto letsencrypt-auto; then

--- a/tests/modification-check.sh
+++ b/tests/modification-check.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 temp_dir=`mktemp -d`
+trap "rm -rf $temp_dir" EXIT
 
 # Script should be run from Certbot's root directory
 
@@ -8,38 +9,32 @@ SCRIPT_PATH=`dirname $0`
 SCRIPT_PATH=`readlink -f $SCRIPT_PATH`
 FLAG=false
 
-# Compare root letsencrypt-auto and certbot-auto with published versions
-
-cp letsencrypt-auto ${temp_dir}/letsencrypt-to-be-checked
-cp certbot-auto ${temp_dir}/certbot-to-be-checked
-
-cp letsencrypt-auto-source/pieces/fetch.py ${temp_dir}/fetch.py
-cd ${temp_dir}
-
-LATEST_VERSION=`python fetch.py --latest-version`
-python fetch.py --le-auto-script v${LATEST_VERSION}
-
-cmp -s letsencrypt-auto letsencrypt-to-be-checked
-
-if [ $? != 0 ]; then
-	echo "Root letsencrypt-auto has changed."
-	FLAG=true
+if ! cmp -s certbot-auto letsencrypt-auto; then
+    echo "Root certbot-auto and letsencrypt-auto differ."
+    FLAG=true
 else
-	echo "Root letsencrypt-auto is unchanged."
+    cp certbot-auto "$temp_dir/local-auto"
+    cp letsencrypt-auto-source/pieces/fetch.py "$temp_dir/fetch.py"
+    cd $temp_dir
+
+    # Compare file against current version in the target branch
+    BRANCH=${TRAVIS_BRANCH:-master}
+    URL="https://raw.githubusercontent.com/certbot/certbot/$BRANCH/certbot-auto"
+    curl -sS $URL > certbot-auto
+    if cmp -s certbot-auto local-auto; then
+        echo "Root *-auto were unchanged."
+    else
+        # Compare file against the latest released version
+        python fetch.py --le-auto-script "v$(python fetch.py --latest-version)"
+        if cmp -s letsencrypt-auto local-auto; then
+            echo "Root *-auto were updated to the latest version."
+        else
+            echo "Root *-auto have unexpected changes."
+            FLAG=true
+        fi
+    fi
+    cd ~-
 fi
-
-cmp -s letsencrypt-auto certbot-to-be-checked
-
-if [ $? != 0 ]; then
-	echo "Root certbot-auto has changed."
-	FLAG=true
-else
-	echo "Root certbot-auto is unchanged."
-fi
-
-# Cleanup
-rm ${temp_dir}/*
-cd ${SCRIPT_PATH}/../
 
 # Compare letsencrypt-auto-source/letsencrypt-auto with output of build.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -151,7 +151,9 @@ commands =
     docker run --rm -t -i lea
 whitelist_externals =
     docker
-passenv = DOCKER_*
+passenv =
+    DOCKER_*
+    TRAVIS_BRANCH
 
 [testenv:le_auto_wheezy]
 # At the moment, this tests under Python 2.7 only, as only that version is


### PR DESCRIPTION
After the last release, Travis tests on all PRs failed for a week until #4162 was merged. This PR fixes #4166 making our tests more flexible to prevent this problem in the future.

@ohemorange, would you feel comfortable reviewing this? I'd like to get this in by Wednesday to prevent everyone's PRs from breaking again.

EDIT: I forgot to mention I tested this against the `0.10.x` branch as you can see [here](https://travis-ci.org/certbot/certbot/jobs/205909523).