### PR TITLE
Remove use of sha1.

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -445,7 +445,7 @@ class TLSSNI01Response(KeyAuthorizationChallengeResponse):
         """
         # pylint: disable=protected-access
         sans = crypto_util._pyopenssl_cert_or_req_san(cert)
-        logger.debug('Certificate %s. SANs: %s', cert.digest('sha1'), sans)
+        logger.debug('Certificate %s. SANs: %s', cert.digest('sha256'), sans)
         return self.z_domain.decode() in sans
 
     def simple_verify(self, chall, domain, account_public_key,

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -336,8 +336,8 @@ class CertLoaderTest(unittest.TestCase):
         from certbot.crypto_util import pyopenssl_load_certificate
 
         cert, file_type = pyopenssl_load_certificate(CERT)
-        self.assertEqual(cert.digest('sha1'),
-                         OpenSSL.crypto.load_certificate(file_type, CERT).digest('sha1'))
+        self.assertEqual(cert.digest('sha256'),
+                         OpenSSL.crypto.load_certificate(file_type, CERT).digest('sha256'))
 
     def test_load_invalid_cert(self):
         from certbot.crypto_util import pyopenssl_load_certificate


### PR DESCRIPTION
These are not security critical uses of sha1 but they should still be removed.