### PR TITLE
Revert "Remove Link rel=next for authzs and new-certs."

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -71,13 +71,20 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
             self.directory = directory
 
     @classmethod
-    def _regr_from_response(cls, response, uri=None, terms_of_service=None):
+    def _regr_from_response(cls, response, uri=None, new_authzr_uri=None,
+                            terms_of_service=None):
         if 'terms-of-service' in response.links:
             terms_of_service = response.links['terms-of-service']['url']
+        if 'next' in response.links:
+            new_authzr_uri = response.links['next']['url']
+
+        if new_authzr_uri is None:
+            raise errors.ClientError('"next" link missing')
 
         return messages.RegistrationResource(
             body=messages.Registration.from_json(response.json()),
             uri=response.headers.get('Location', uri),
+            new_authzr_uri=new_authzr_uri,
             terms_of_service=terms_of_service)
 
     def register(self, new_reg=None):
@@ -110,7 +117,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
         # (c.f. acme-spec #94)
 
         return self._regr_from_response(
-            response, uri=regr.uri,
+            response, uri=regr.uri, new_authzr_uri=regr.new_authzr_uri,
             terms_of_service=regr.terms_of_service)
 
     def update_registration(self, regr, update=None):
@@ -167,30 +174,43 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
         return self.update_registration(
             regr.update(body=regr.body.update(agreement=regr.terms_of_service)))
 
-    def _authzr_from_response(self, response, identifier, uri=None):
+    def _authzr_from_response(self, response, identifier,
+                              uri=None, new_cert_uri=None):
+        # pylint: disable=no-self-use
+        if new_cert_uri is None:
+            try:
+                new_cert_uri = response.links['next']['url']
+            except KeyError:
+                raise errors.ClientError('"next" link missing')
+
         authzr = messages.AuthorizationResource(
             body=messages.Authorization.from_json(response.json()),
-            uri=response.headers.get('Location', uri))
+            uri=response.headers.get('Location', uri),
+            new_cert_uri=new_cert_uri)
         if authzr.body.identifier != identifier:
             raise errors.UnexpectedUpdate(authzr)
         return authzr
 
-    def request_challenges(self, identifier):
+    def request_challenges(self, identifier, new_authzr_uri=None):
         """Request challenges.
 
         :param .messages.Identifier identifier: Identifier to be challenged.
+        :param str new_authzr_uri: ``new-authorization`` URI. If omitted,
+            will default to value found in ``directory``.
 
         :returns: Authorization Resource.
         :rtype: `.AuthorizationResource`
 
         """
         new_authz = messages.NewAuthorization(identifier=identifier)
-        response = self.net.post(self.directory.new_authz, new_authz)
+        response = self.net.post(self.directory.new_authz
+                                 if new_authzr_uri is None else new_authzr_uri,
+                                 new_authz)
         # TODO: handle errors
         assert response.status_code == http_client.CREATED
         return self._authzr_from_response(response, identifier)
 
-    def request_domain_challenges(self, domain):
+    def request_domain_challenges(self, domain, new_authzr_uri=None):
         """Request challenges for domain names.
 
         This is simply a convenience function that wraps around
@@ -205,7 +225,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
 
         """
         return self.request_challenges(messages.Identifier(
-            typ=messages.IDENTIFIER_FQDN, value=domain))
+            typ=messages.IDENTIFIER_FQDN, value=domain), new_authzr_uri)
 
     def answer_challenge(self, challb, response):
         """Answer challenge.
@@ -280,7 +300,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
         """
         response = self.net.get(authzr.uri)
         updated_authzr = self._authzr_from_response(
-            response, authzr.body.identifier, authzr.uri)
+            response, authzr.body.identifier, authzr.uri, authzr.new_cert_uri)
         # TODO: check and raise UnexpectedUpdate
         return updated_authzr, response
 
@@ -304,7 +324,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
 
         content_type = DER_CONTENT_TYPE  # TODO: add 'cert_type 'argument
         response = self.net.post(
-            self.directory.new_cert,
+            authzrs[0].new_cert_uri,  # TODO: acme-spec #90
             req,
             content_type=content_type,
             headers={'Accept': content_type})

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -40,8 +40,6 @@ class ClientTest(unittest.TestCase):
                 'https://www.letsencrypt-demo.org/acme/revoke-cert',
             messages.NewAuthorization:
                 'https://www.letsencrypt-demo.org/acme/new-authz',
-            messages.CertificateRequest:
-                'https://www.letsencrypt-demo.org/acme/new-cert',
         })
 
         from acme.client import Client
@@ -58,6 +56,7 @@ class ClientTest(unittest.TestCase):
         self.new_reg = messages.NewRegistration(**dict(reg))
         self.regr = messages.RegistrationResource(
             body=reg, uri='https://www.letsencrypt-demo.org/acme/reg/1',
+            new_authzr_uri='https://www.letsencrypt-demo.org/acme/new-reg',
             terms_of_service='https://www.letsencrypt-demo.org/tos')
 
         # Authorization
@@ -73,7 +72,8 @@ class ClientTest(unittest.TestCase):
                 typ=messages.IDENTIFIER_FQDN, value='example.com'),
             challenges=(challb,), combinations=None)
         self.authzr = messages.AuthorizationResource(
-            body=self.authz, uri=authzr_uri)
+            body=self.authz, uri=authzr_uri,
+            new_cert_uri='https://www.letsencrypt-demo.org/acme/new-cert')
 
         # Request issuance
         self.certr = messages.CertificateResource(
@@ -98,11 +98,17 @@ class ClientTest(unittest.TestCase):
         self.response.json.return_value = self.regr.body.to_json()
         self.response.headers['Location'] = self.regr.uri
         self.response.links.update({
+            'next': {'url': self.regr.new_authzr_uri},
             'terms-of-service': {'url': self.regr.terms_of_service},
         })
 
         self.assertEqual(self.regr, self.client.register(self.new_reg))
         # TODO: test POST call arguments
+
+    def test_register_missing_next(self):
+        self.response.status_code = http_client.CREATED
+        self.assertRaises(
+            errors.ClientError, self.client.register, self.new_reg)
 
     def test_update_registration(self):
         # "Instance of 'Field' has no to_json/update member" bug:
@@ -136,6 +142,13 @@ class ClientTest(unittest.TestCase):
         self.response.json.return_value = self.regr.body.to_json()
         self.assertEqual(self.regr, self.client.query_registration(self.regr))
 
+    def test_query_registration_updates_new_authzr_uri(self):
+        self.response.json.return_value = self.regr.body.to_json()
+        self.response.links = {'next': {'url': 'UPDATED'}}
+        self.assertEqual(
+            'UPDATED',
+            self.client.query_registration(self.regr).new_authzr_uri)
+
     def test_agree_to_tos(self):
         self.client.update_registration = mock.Mock()
         self.client.agree_to_tos(self.regr)
@@ -146,6 +159,9 @@ class ClientTest(unittest.TestCase):
         self.response.status_code = http_client.CREATED
         self.response.headers['Location'] = self.authzr.uri
         self.response.json.return_value = self.authz.to_json()
+        self.response.links = {
+            'next': {'url': self.authzr.new_cert_uri},
+        }
 
     def test_request_challenges(self):
         self._prepare_response_for_request_challenges()
@@ -156,9 +172,8 @@ class ClientTest(unittest.TestCase):
 
     def test_request_challenges_custom_uri(self):
         self._prepare_response_for_request_challenges()
-        self.client.request_challenges(self.identifier)
-        self.net.post.assert_called_once_with(
-            'https://www.letsencrypt-demo.org/acme/new-authz', mock.ANY)
+        self.client.request_challenges(self.identifier, 'URI')
+        self.net.post.assert_called_once_with('URI', mock.ANY)
 
     def test_request_challenges_unexpected_update(self):
         self._prepare_response_for_request_challenges()
@@ -166,13 +181,24 @@ class ClientTest(unittest.TestCase):
             identifier=self.identifier.update(value='foo')).to_json()
         self.assertRaises(
             errors.UnexpectedUpdate, self.client.request_challenges,
-            self.identifier)
+            self.identifier, self.authzr.uri)
+
+    def test_request_challenges_missing_next(self):
+        self.response.status_code = http_client.CREATED
+        self.assertRaises(errors.ClientError, self.client.request_challenges,
+                          self.identifier)
 
     def test_request_domain_challenges(self):
         self.client.request_challenges = mock.MagicMock()
         self.assertEqual(
             self.client.request_challenges(self.identifier),
             self.client.request_domain_challenges('example.com'))
+
+    def test_request_domain_challenges_custom_uri(self):
+        self.client.request_challenges = mock.MagicMock()
+        self.assertEqual(
+            self.client.request_challenges(self.identifier, 'URI'),
+            self.client.request_domain_challenges('example.com', 'URI'))
 
     def test_answer_challenge(self):
         self.response.links['up'] = {'url': self.challr.authzr_uri}

--- a/acme/acme/jose/json_util.py
+++ b/acme/acme/jose/json_util.py
@@ -267,7 +267,7 @@ class JSONObjectWithFields(util.ImmutableMap, interfaces.JSONDeSerializable):
 
         if missing:
             raise errors.DeserializationError(
-                'The following fields are required: {0}'.format(
+                'The following field are required: {0}'.format(
                     ','.join(missing)))
 
     @classmethod

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -191,7 +191,7 @@ class Directory(jose.JSONDeSerializable):
         try:
             return self[name.replace('_', '-')]
         except KeyError as error:
-            raise AttributeError(str(error) + ': ' + name)
+            raise AttributeError(str(error))
 
     def __getitem__(self, name):
         try:
@@ -315,10 +315,12 @@ class RegistrationResource(ResourceWithURI):
     """Registration Resource.
 
     :ivar acme.messages.Registration body:
+    :ivar unicode new_authzr_uri: URI found in the 'next' ``Link`` header
     :ivar unicode terms_of_service: URL for the CA TOS.
 
     """
     body = jose.Field('body', decoder=Registration.from_json)
+    new_authzr_uri = jose.Field('new_authzr_uri')
     terms_of_service = jose.Field('terms_of_service', omitempty=True)
 
 
@@ -423,9 +425,11 @@ class AuthorizationResource(ResourceWithURI):
     """Authorization Resource.
 
     :ivar acme.messages.Authorization body:
+    :ivar unicode new_cert_uri: URI found in the 'next' ``Link`` header
 
     """
     body = jose.Field('body', decoder=Authorization.from_json)
+    new_cert_uri = jose.Field('new_cert_uri')
 
 
 @Directory.register

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -225,12 +225,14 @@ class RegistrationResourceTest(unittest.TestCase):
         from acme.messages import RegistrationResource
         self.regr = RegistrationResource(
             body=mock.sentinel.body, uri=mock.sentinel.uri,
+            new_authzr_uri=mock.sentinel.new_authzr_uri,
             terms_of_service=mock.sentinel.terms_of_service)
 
     def test_to_partial_json(self):
         self.assertEqual(self.regr.to_json(), {
             'body': mock.sentinel.body,
             'uri': mock.sentinel.uri,
+            'new_authzr_uri': mock.sentinel.new_authzr_uri,
             'terms_of_service': mock.sentinel.terms_of_service,
         })
 
@@ -344,7 +346,9 @@ class AuthorizationResourceTest(unittest.TestCase):
         from acme.messages import AuthorizationResource
         authzr = AuthorizationResource(
             uri=mock.sentinel.uri,
-            body=mock.sentinel.body)
+            body=mock.sentinel.body,
+            new_cert_uri=mock.sentinel.new_cert_uri,
+        )
         self.assertTrue(isinstance(authzr, jose.JSONDeSerializable))
 
 

--- a/acme/examples/example_client.py
+++ b/acme/examples/example_client.py
@@ -32,7 +32,8 @@ acme.agree_to_tos(regr)
 logging.debug(regr)
 
 authzr = acme.request_challenges(
-    identifier=messages.Identifier(typ=messages.IDENTIFIER_FQDN, value=DOMAIN))
+    identifier=messages.Identifier(typ=messages.IDENTIFIER_FQDN, value=DOMAIN),
+    new_authzr_uri=regr.new_authzr_uri)
 logging.debug(authzr)
 
 authzr, authzr_response = acme.poll(authzr)

--- a/certbot/auth_handler.py
+++ b/certbot/auth_handler.py
@@ -63,7 +63,8 @@ class AuthHandler(object):
 
         """
         for domain in domains:
-            self.authzr[domain] = self.acme.request_domain_challenges(domain)
+            self.authzr[domain] = self.acme.request_domain_challenges(
+                domain, self.account.regr.new_authzr_uri)
 
         self._choose_challenges(domains)
 

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -110,7 +110,7 @@ class AccountFileStorageTest(unittest.TestCase):
         from certbot.account import Account
         self.acc = Account(
             regr=messages.RegistrationResource(
-                uri=None, body=messages.Registration()),
+                uri=None, new_authzr_uri=None, body=messages.Registration()),
             key=KEY)
 
     def tearDown(self):

--- a/certbot/tests/acme_util.py
+++ b/certbot/tests/acme_util.py
@@ -96,5 +96,6 @@ def gen_authzr(authz_status, domain, challs, statuses, combos=True):
     # pylint: disable=star-args
     return messages.AuthorizationResource(
         uri="https://trusted.ca/new-authz-resource",
+        new_cert_uri="https://trusted.ca/new-cert",
         body=messages.Authorization(**authz_kwargs)
     )

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -309,6 +309,7 @@ class PollChallengesTest(unittest.TestCase):
 
         new_authzr = messages.AuthorizationResource(
             uri=authzr.uri,
+            new_cert_uri=authzr.new_cert_uri,
             body=messages.Authorization(
                 identifier=authzr.body.identifier,
                 challenges=new_challbs,
@@ -436,7 +437,7 @@ def gen_auth_resp(chall_list):
             for chall in chall_list]
 
 
-def gen_dom_authzr(domain, challs, combos=True):
+def gen_dom_authzr(domain, unused_new_authzr_uri, challs, combos=True):
     """Generates new authzr for domains."""
     return acme_util.gen_authzr(
         messages.STATUS_PENDING, domain, challs,

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -104,10 +104,10 @@ class ChooseAccountTest(unittest.TestCase):
         self.key = KEY
 
         self.acc1 = account.Account(messages.RegistrationResource(
-            uri=None, body=messages.Registration.from_data(
+            uri=None, new_authzr_uri=None, body=messages.Registration.from_data(
                 email="email1@g.com")), self.key)
         self.acc2 = account.Account(messages.RegistrationResource(
-            uri=None, body=messages.Registration.from_data(
+            uri=None, new_authzr_uri=None, body=messages.Registration.from_data(
                 email="email2@g.com", phone="phone")), self.key)
 
     @classmethod


### PR DESCRIPTION
Reverts certbot/certbot#4194. #4194 broke forward compatibility with Certbot accounts. Previous versions of Certbot expected and required `new_authzr_uri` to be present in `regr.json` and this field was removed in this PR. This breakage may be OK as we've broken forward compatibility in the past (see #2750), but it was unexpected behavior found during the release process. Let's think about whether or not this is what we want to do.