### PR TITLE
Improve path_surgery warning

### DIFF
--- a/certbot/plugins/util.py
+++ b/certbot/plugins/util.py
@@ -33,6 +33,6 @@ def path_surgery(cmd):
         return True
     else:
         expanded = " expanded" if any(added) else ""
-        logger.warning("Failed to find %s in%s PATH: %s", cmd,
+        logger.warning("Failed to find executable %s in%s PATH: %s", cmd,
                        expanded, path)
         return False


### PR DESCRIPTION
Stops output like:
```
Failed to find certbot.log in PATH: ...
renew-hook command certbot.log exists, but is not executable.
```