### PR TITLE
tests: deduplicate temporary directory code (#4078)

### DIFF
--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -4,7 +4,6 @@ import json
 import os
 import shutil
 import stat
-import tempfile
 import unittest
 
 import mock
@@ -16,6 +15,8 @@ from acme import messages
 from certbot import errors
 
 from certbot.tests import util
+
+from certbot.tests.util import TempDirTestCase
 
 
 KEY = jose.JWKRSA.load(util.load_vector("rsa512_key_2.pem"))
@@ -98,13 +99,14 @@ class AccountMemoryStorageTest(unittest.TestCase):
         self.assertEqual([account], self.storage.find_all())
 
 
-class AccountFileStorageTest(unittest.TestCase):
+class AccountFileStorageTest(TempDirTestCase):
     """Tests for certbot.account.AccountFileStorage."""
 
     def setUp(self):
-        self.tmp = tempfile.mkdtemp()
+        super(AccountFileStorageTest, self).setUp()
+
         self.config = mock.MagicMock(
-            accounts_dir=os.path.join(self.tmp, "accounts"))
+            accounts_dir=os.path.join(self.tempdir, "accounts"))
         from certbot.account import AccountFileStorage
         self.storage = AccountFileStorage(self.config)
 
@@ -117,9 +119,6 @@ class AccountFileStorageTest(unittest.TestCase):
             key=KEY)
         self.mock_client = mock.MagicMock()
         self.mock_client.directory.new_authz = new_authzr_uri
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp)
 
     def test_init_creates_dir(self):
         self.assertTrue(os.path.isdir(self.config.accounts_dir))

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -18,11 +18,14 @@ from certbot.storage import ALL_FOUR
 from certbot.tests import storage_test
 from certbot.tests import util as test_util
 
-class BaseCertManagerTest(unittest.TestCase):
+from certbot.tests.util import TempDirTestCase
+
+
+class BaseCertManagerTest(TempDirTestCase):
     """Base class for setting up Cert Manager tests.
     """
     def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
+        super(BaseCertManagerTest, self).setUp()
 
         os.makedirs(os.path.join(self.tempdir, "renewal"))
 
@@ -67,9 +70,6 @@ class BaseCertManagerTest(unittest.TestCase):
                                        domain + ".conf")
         config.write()
         return config
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
 
 
 class UpdateLiveSymlinksTest(BaseCertManagerTest):
@@ -436,9 +436,6 @@ class DuplicativeCertsTest(storage_test.BaseRenewableCertTest):
         super(DuplicativeCertsTest, self).setUp()
         self.config.write()
         self._write_out_ex_kinds()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
 
     @mock.patch('certbot.util.make_or_verify_dir')
     def test_find_duplicative_names(self, unused_makedir):

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -15,17 +15,18 @@ from certbot import constants
 from certbot import errors
 from certbot.plugins import disco
 
+from certbot.tests.util import TempDirTestCase
+
 PLUGINS = disco.PluginsRegistry.find_all()
 
 
-class TestReadFile(unittest.TestCase):
+class TestReadFile(TempDirTestCase):
     '''Test cli.read_file'''
 
     _multiprocess_can_split_ = True
 
     def test_read_file(self):
-        tmp_dir = tempfile.mkdtemp()
-        rel_test_path = os.path.relpath(os.path.join(tmp_dir, 'foo'))
+        rel_test_path = os.path.relpath(os.path.join(self.tempdir, 'foo'))
         self.assertRaises(
             argparse.ArgumentTypeError, cli.read_file, rel_test_path)
 

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -1,8 +1,6 @@
 """Tests for certbot.crypto_util."""
 import logging
 import os
-import shutil
-import tempfile
 import unittest
 
 import OpenSSL
@@ -22,18 +20,20 @@ CERT = test_util.load_vector('cert.pem')
 SAN_CERT = test_util.load_vector('cert-san.pem')
 
 
-class InitSaveKeyTest(unittest.TestCase):
+class InitSaveKeyTest(test_util.TempDirTestCase):
     """Tests for certbot.crypto_util.init_save_key."""
     def setUp(self):
+        super(InitSaveKeyTest, self).setUp()
+
         logging.disable(logging.CRITICAL)
         zope.component.provideUtility(
             mock.Mock(strict_permissions=True, dry_run=False),
             interfaces.IConfig)
-        self.key_dir = tempfile.mkdtemp('key_dir')
 
     def tearDown(self):
+        super(InitSaveKeyTest, self).tearDown()
+
         logging.disable(logging.NOTSET)
-        shutil.rmtree(self.key_dir)
 
     @classmethod
     def _call(cls, key_size, key_dir):
@@ -43,10 +43,10 @@ class InitSaveKeyTest(unittest.TestCase):
     @mock.patch('certbot.crypto_util.make_key')
     def test_success(self, mock_make):
         mock_make.return_value = b'key_pem'
-        key = self._call(1024, self.key_dir)
+        key = self._call(1024, self.tempdir)
         self.assertEqual(key.pem, b'key_pem')
         self.assertTrue('key-certbot.pem' in key.file)
-        self.assertTrue(os.path.exists(os.path.join(self.key_dir, key.file)))
+        self.assertTrue(os.path.exists(os.path.join(self.tempdir, key.file)))
 
     @mock.patch('certbot.crypto_util.make_key')
     def test_success_dry_run(self, mock_make):
@@ -54,27 +54,25 @@ class InitSaveKeyTest(unittest.TestCase):
             mock.Mock(strict_permissions=True, dry_run=True),
             interfaces.IConfig)
         mock_make.return_value = b'key_pem'
-        key = self._call(1024, self.key_dir)
+        key = self._call(1024, self.tempdir)
         self.assertEqual(key.pem, b'key_pem')
         self.assertTrue(key.file is None)
 
     @mock.patch('certbot.crypto_util.make_key')
     def test_key_failure(self, mock_make):
         mock_make.side_effect = ValueError
-        self.assertRaises(ValueError, self._call, 431, self.key_dir)
+        self.assertRaises(ValueError, self._call, 431, self.tempdir)
 
 
-class InitSaveCSRTest(unittest.TestCase):
+class InitSaveCSRTest(test_util.TempDirTestCase):
     """Tests for certbot.crypto_util.init_save_csr."""
 
     def setUp(self):
+        super(InitSaveCSRTest, self).setUp()
+
         zope.component.provideUtility(
             mock.Mock(strict_permissions=True, dry_run=False),
             interfaces.IConfig)
-        self.csr_dir = tempfile.mkdtemp('csr_dir')
-
-    def tearDown(self):
-        shutil.rmtree(self.csr_dir)
 
     @mock.patch('certbot.crypto_util.make_csr')
     @mock.patch('certbot.crypto_util.util.make_or_verify_dir')
@@ -84,7 +82,7 @@ class InitSaveCSRTest(unittest.TestCase):
         mock_csr.return_value = (b'csr_pem', b'csr_der')
 
         csr = init_save_csr(
-            mock.Mock(pem='dummy_key'), 'example.com', self.csr_dir,
+            mock.Mock(pem='dummy_key'), 'example.com', self.tempdir,
             'csr-certbot.pem')
 
         self.assertEqual(csr.data, b'csr_der')
@@ -101,7 +99,7 @@ class InitSaveCSRTest(unittest.TestCase):
         mock_csr.return_value = (b'csr_pem', b'csr_der')
 
         csr = init_save_csr(
-            mock.Mock(pem='dummy_key'), 'example.com', self.csr_dir,
+            mock.Mock(pem='dummy_key'), 'example.com', self.tempdir,
             'csr-certbot.pem')
 
         self.assertEqual(csr.data, b'csr_der')

--- a/certbot/tests/display/completer_test.py
+++ b/certbot/tests/display/completer_test.py
@@ -1,31 +1,30 @@
 """Test certbot.display.completer."""
 import os
 import readline
-import shutil
 import string
 import sys
-import tempfile
 import unittest
 
 import mock
 from six.moves import reload_module  # pylint: disable=import-error
 
+from certbot.tests.util import TempDirTestCase
 
-class CompleterTest(unittest.TestCase):
+class CompleterTest(TempDirTestCase):
     """Test certbot.display.completer.Completer."""
 
     def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
+        super(CompleterTest, self).setUp()
 
         # directories must end with os.sep for completer to
         # search inside the directory for possible completions
-        if self.temp_dir[-1] != os.sep:
-            self.temp_dir += os.sep
+        if self.tempdir[-1] != os.sep:
+            self.tempdir += os.sep
 
         self.paths = []
         # create some files and directories in temp_dir
         for c in string.ascii_lowercase:
-            path = os.path.join(self.temp_dir, c)
+            path = os.path.join(self.tempdir, c)
             self.paths.append(path)
             if ord(c) % 2:
                 os.mkdir(path)
@@ -33,21 +32,18 @@ class CompleterTest(unittest.TestCase):
                 with open(path, 'w'):
                     pass
 
-    def tearDown(self):
-        shutil.rmtree(self.temp_dir)
-
     def test_complete(self):
         from certbot.display import completer
         my_completer = completer.Completer()
         num_paths = len(self.paths)
 
         for i in range(num_paths):
-            completion = my_completer.complete(self.temp_dir, i)
+            completion = my_completer.complete(self.tempdir, i)
             self.assertTrue(completion in self.paths)
             self.paths.remove(completion)
 
         self.assertFalse(self.paths)
-        completion = my_completer.complete(self.temp_dir, num_paths)
+        completion = my_completer.complete(self.tempdir, num_paths)
         self.assertEqual(completion, None)
 
     def test_import_error(self):

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -2,7 +2,6 @@
 """Test certbot.display.ops."""
 import os
 import sys
-import tempfile
 import unittest
 
 import mock
@@ -87,18 +86,19 @@ class GetEmailTest(unittest.TestCase):
             self.assertTrue(invalid_txt in mock_input.call_args[0][0])
 
 
-class ChooseAccountTest(unittest.TestCase):
+class ChooseAccountTest(test_util.TempDirTestCase):
     """Tests for certbot.display.ops.choose_account."""
     def setUp(self):
+        super(ChooseAccountTest, self).setUp()
+
         zope.component.provideUtility(display_util.FileDisplay(sys.stdout,
                                                                False))
 
-        self.accounts_dir = tempfile.mkdtemp("accounts")
-        self.account_keys_dir = os.path.join(self.accounts_dir, "keys")
+        self.account_keys_dir = os.path.join(self.tempdir, "keys")
         os.makedirs(self.account_keys_dir, 0o700)
 
         self.config = mock.MagicMock(
-            accounts_dir=self.accounts_dir,
+            accounts_dir=self.tempdir,
             account_keys_dir=self.account_keys_dir,
             server="certbot-demo.org")
         self.key = KEY

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -7,7 +7,6 @@ import mock
 import multiprocessing
 import os
 import shutil
-import tempfile
 import traceback
 import unittest
 import datetime
@@ -220,13 +219,14 @@ class FindDomainsOrCertnameTest(unittest.TestCase):
             (["one.com", "two.com"], "one.com"))
 
 
-class RevokeTest(unittest.TestCase):
+class RevokeTest(test_util.TempDirTestCase):
     """Tests for certbot.main.revoke."""
 
     def setUp(self):
-        self.tempdir_path = tempfile.mkdtemp()
-        shutil.copy(CERT_PATH, self.tempdir_path)
-        self.tmp_cert_path = os.path.abspath(os.path.join(self.tempdir_path,
+        super(RevokeTest, self).setUp()
+
+        shutil.copy(CERT_PATH, self.tempdir)
+        self.tmp_cert_path = os.path.abspath(os.path.join(self.tempdir,
             'cert.pem'))
 
         self.patches = [
@@ -252,7 +252,8 @@ class RevokeTest(unittest.TestCase):
         self.mock_determine_account.return_value = (self.acc, None)
 
     def tearDown(self):
-        shutil.rmtree(self.tempdir_path)
+        super(RevokeTest, self).tearDown()
+
         for patch in self.patches:
             patch.stop()
 
@@ -288,15 +289,14 @@ class RevokeTest(unittest.TestCase):
         self.mock_success_revoke.assert_not_called()
 
 
-class SetupLogFileHandlerTest(unittest.TestCase):
+class SetupLogFileHandlerTest(test_util.TempDirTestCase):
     """Tests for certbot.main.setup_log_file_handler."""
 
     def setUp(self):
-        self.config = mock.Mock(spec_set=['logs_dir'],
-                                logs_dir=tempfile.mkdtemp())
+        super(SetupLogFileHandlerTest, self).setUp()
 
-    def tearDown(self):
-        shutil.rmtree(self.config.logs_dir)
+        self.config = mock.Mock(spec_set=['logs_dir'],
+                                logs_dir=self.tempdir)
 
     def _call(self, *args, **kwargs):
         from certbot.main import setup_log_file_handler
@@ -309,17 +309,16 @@ class SetupLogFileHandlerTest(unittest.TestCase):
                           self.config, "test.log", "%s")
 
 
-class SetupLoggingTest(unittest.TestCase):
+class SetupLoggingTest(test_util.TempDirTestCase):
     """Tests for certbot.main.setup_logging."""
 
     def setUp(self):
+        super(SetupLoggingTest, self).setUp()
+
         self.config = mock.Mock(
-            logs_dir=tempfile.mkdtemp(),
+            logs_dir=self.tempdir,
             noninteractive_mode=False, quiet=False,
             verbose_count=constants.CLI_DEFAULTS['verbose_count'])
-
-    def tearDown(self):
-        shutil.rmtree(self.config.logs_dir)
 
     @classmethod
     def _call(cls, *args, **kwargs):
@@ -346,21 +345,15 @@ class SetupLoggingTest(unittest.TestCase):
             isinstance(cli_handler, colored_logging.StreamHandler))
 
 
-class MakeOrVerifyCoreDirTest(unittest.TestCase):
+class MakeOrVerifyCoreDirTest(test_util.TempDirTestCase):
     """Tests for certbot.main.make_or_verify_core_dir."""
-
-    def setUp(self):
-        self.dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.dir)
 
     def _call(self, *args, **kwargs):
         from certbot.main import make_or_verify_core_dir
         return make_or_verify_core_dir(*args, **kwargs)
 
     def test_success(self):
-        new_dir = os.path.join(self.dir, 'new')
+        new_dir = os.path.join(self.tempdir, 'new')
         self._call(new_dir, 0o700, os.geteuid(), False)
         self.assertTrue(os.path.exists(new_dir))
 
@@ -368,7 +361,7 @@ class MakeOrVerifyCoreDirTest(unittest.TestCase):
     def test_failure(self, mock_make_or_verify):
         mock_make_or_verify.side_effect = OSError
         self.assertRaises(errors.Error, self._call,
-                          self.dir, 0o700, os.geteuid(), False)
+                          self.tempdir, 0o700, os.geteuid(), False)
 
 
 class DetermineAccountTest(unittest.TestCase):
@@ -441,24 +434,26 @@ class DetermineAccountTest(unittest.TestCase):
         self.assertEqual('other email', self.config.email)
 
 
-class MainTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
+class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-methods
     """Tests for different commands."""
 
     def setUp(self):
-        self.tmp_dir = tempfile.mkdtemp()
-        self.config_dir = os.path.join(self.tmp_dir, 'config')
-        self.work_dir = os.path.join(self.tmp_dir, 'work')
-        self.logs_dir = os.path.join(self.tmp_dir, 'logs')
+        super(MainTest, self).setUp()
+
+        self.config_dir = os.path.join(self.tempdir, 'config')
+        self.work_dir = os.path.join(self.tempdir, 'work')
+        self.logs_dir = os.path.join(self.tempdir, 'logs')
         os.mkdir(self.logs_dir)
         self.standard_args = ['--config-dir', self.config_dir,
                               '--work-dir', self.work_dir,
                               '--logs-dir', self.logs_dir, '--text',
-                              '--lock-path', os.path.join(self.tmp_dir, 'certbot.lock')]
+                              '--lock-path', os.path.join(self.tempdir, 'certbot.lock')]
 
     def tearDown(self):
         # Reset globals in cli
         reload_module(cli)
-        shutil.rmtree(self.tmp_dir)
+
+        super(MainTest, self).tearDown()
 
     def _call(self, args, stdout=None):
         "Run the cli with output streams and actual client mocked out"
@@ -1310,15 +1305,13 @@ class TestHandleException(unittest.TestCase):
             traceback.format_exception_only(KeyboardInterrupt, interrupt)))
 
 
-class TestAcquireFileLock(unittest.TestCase):
+class TestAcquireFileLock(test_util.TempDirTestCase):
     """Test main.acquire_file_lock."""
 
     def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-        self.lock_path = os.path.join(self.tempdir, 'certbot.lock')
+        super(TestAcquireFileLock, self).setUp()
 
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
+        self.lock_path = os.path.join(self.tempdir, 'certbot.lock')
 
     @mock.patch('certbot.main.logger')
     def test_bad_path(self, mock_logger):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -2,8 +2,6 @@
 import os
 import mock
 import unittest
-import shutil
-import tempfile
 
 from acme import challenges
 
@@ -14,13 +12,11 @@ from certbot import storage
 from certbot.tests import util
 
 
-class RenewalTest(unittest.TestCase):
+class RenewalTest(util.TempDirTestCase):
     def setUp(self):
-        self.tmp_dir = tempfile.mkdtemp()
-        self.config_dir = os.path.join(self.tmp_dir, 'config')
+        super(RenewalTest, self).setUp()
 
-    def tearDown(self):
-        shutil.rmtree(self.tmp_dir)
+        self.config_dir = os.path.join(self.tempdir, 'config')
 
     @mock.patch('certbot.cli.set_by_cli')
     def test_ancient_webroot_renewal_conf(self, mock_set_by_cli):

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -3,7 +3,6 @@
 import datetime
 import os
 import shutil
-import tempfile
 import unittest
 
 import configobj
@@ -36,7 +35,7 @@ def fill_with_sample_data(rc_object):
             f.write(kind)
 
 
-class BaseRenewableCertTest(unittest.TestCase):
+class BaseRenewableCertTest(util.TempDirTestCase):
     """Base class for setting up Renewable Cert tests.
 
     .. note:: It may be required to write out self.config for
@@ -47,7 +46,8 @@ class BaseRenewableCertTest(unittest.TestCase):
 
     def setUp(self):
         from certbot import storage
-        self.tempdir = tempfile.mkdtemp()
+
+        super(BaseRenewableCertTest, self).setUp()
 
         self.cli_config = configuration.NamespaceConfig(
             namespace=mock.MagicMock(
@@ -90,9 +90,6 @@ class BaseRenewableCertTest(unittest.TestCase):
         with mock.patch("certbot.storage.RenewableCert._check_symlinks") as check:
             check.return_value = True
             self.test_rc = storage.RenewableCert(config.filename, self.cli_config)
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
 
     def _write_out_kind(self, kind, ver, value=None):
         link = getattr(self.test_rc, kind)
@@ -798,6 +795,7 @@ class DeleteFilesTest(BaseRenewableCertTest):
     """Tests for certbot.storage.delete_files"""
     def setUp(self):
         super(DeleteFilesTest, self).setUp()
+
         for kind in ALL_FOUR:
             kind_path = os.path.join(self.tempdir, "live", "example.org",
                                         kind + ".pem")

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -6,6 +6,7 @@
 import os
 import pkg_resources
 import shutil
+import tempfile
 import unittest
 
 from cryptography.hazmat.backends import default_backend
@@ -230,3 +231,13 @@ def _assert_valid_call(*args, **kwargs):
 
     # pylint: disable=star-args
     display_util.assert_valid_call(*assert_args, **assert_kwargs)
+
+
+class TempDirTestCase(unittest.TestCase):
+    """Base test class which sets up and tears down a temporary directory"""
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -2,9 +2,7 @@
 import argparse
 import errno
 import os
-import shutil
 import stat
-import tempfile
 import unittest
 
 import mock
@@ -75,7 +73,7 @@ class ExeExistsTest(unittest.TestCase):
         self.assertFalse(self._call("exe"))
 
 
-class MakeOrVerifyDirTest(unittest.TestCase):
+class MakeOrVerifyDirTest(test_util.TempDirTestCase):
     """Tests for certbot.util.make_or_verify_dir.
 
     Note that it is not possible to test for a wrong directory owner,
@@ -84,21 +82,19 @@ class MakeOrVerifyDirTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.root_path = tempfile.mkdtemp()
-        self.path = os.path.join(self.root_path, "foo")
+        super(MakeOrVerifyDirTest, self).setUp()
+
+        self.path = os.path.join(self.tempdir, "foo")
         os.mkdir(self.path, 0o400)
 
         self.uid = os.getuid()
-
-    def tearDown(self):
-        shutil.rmtree(self.root_path, ignore_errors=True)
 
     def _call(self, directory, mode):
         from certbot.util import make_or_verify_dir
         return make_or_verify_dir(directory, mode, self.uid, strict=True)
 
     def test_creates_dir_when_missing(self):
-        path = os.path.join(self.root_path, "bar")
+        path = os.path.join(self.tempdir, "bar")
         self._call(path, 0o650)
         self.assertTrue(os.path.isdir(path))
         self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o650)
@@ -116,7 +112,7 @@ class MakeOrVerifyDirTest(unittest.TestCase):
             self.assertRaises(OSError, self._call, "bar", 12312312)
 
 
-class CheckPermissionsTest(unittest.TestCase):
+class CheckPermissionsTest(test_util.TempDirTestCase):
     """Tests for certbot.util.check_permissions.
 
     Note that it is not possible to test for a wrong file owner,
@@ -125,34 +121,30 @@ class CheckPermissionsTest(unittest.TestCase):
     """
 
     def setUp(self):
-        _, self.path = tempfile.mkstemp()
-        self.uid = os.getuid()
+        super(CheckPermissionsTest, self).setUp()
 
-    def tearDown(self):
-        os.remove(self.path)
+        self.uid = os.getuid()
 
     def _call(self, mode):
         from certbot.util import check_permissions
-        return check_permissions(self.path, mode, self.uid)
+        return check_permissions(self.tempdir, mode, self.uid)
 
     def test_ok_mode(self):
-        os.chmod(self.path, 0o600)
+        os.chmod(self.tempdir, 0o600)
         self.assertTrue(self._call(0o600))
 
     def test_wrong_mode(self):
-        os.chmod(self.path, 0o400)
+        os.chmod(self.tempdir, 0o400)
         self.assertFalse(self._call(0o600))
 
 
-class UniqueFileTest(unittest.TestCase):
+class UniqueFileTest(test_util.TempDirTestCase):
     """Tests for certbot.util.unique_file."""
 
     def setUp(self):
-        self.root_path = tempfile.mkdtemp()
-        self.default_name = os.path.join(self.root_path, "foo.txt")
+        super(UniqueFileTest, self).setUp()
 
-    def tearDown(self):
-        shutil.rmtree(self.root_path, ignore_errors=True)
+        self.default_name = os.path.join(self.tempdir, "foo.txt")
 
     def _call(self, mode=0o600):
         from certbot.util import unique_file
@@ -177,9 +169,9 @@ class UniqueFileTest(unittest.TestCase):
         self.assertNotEqual(name1, name3)
         self.assertNotEqual(name2, name3)
 
-        self.assertEqual(os.path.dirname(name1), self.root_path)
-        self.assertEqual(os.path.dirname(name2), self.root_path)
-        self.assertEqual(os.path.dirname(name3), self.root_path)
+        self.assertEqual(os.path.dirname(name1), self.tempdir)
+        self.assertEqual(os.path.dirname(name2), self.tempdir)
+        self.assertEqual(os.path.dirname(name3), self.tempdir)
 
         basename1 = os.path.basename(name2)
         self.assertTrue(basename1.endswith("foo.txt"))
@@ -196,23 +188,17 @@ except NameError:
     file_type = io.TextIOWrapper  # type: ignore
 
 
-class UniqueLineageNameTest(unittest.TestCase):
+class UniqueLineageNameTest(test_util.TempDirTestCase):
     """Tests for certbot.util.unique_lineage_name."""
-
-    def setUp(self):
-        self.root_path = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.root_path, ignore_errors=True)
 
     def _call(self, filename, mode=0o777):
         from certbot.util import unique_lineage_name
-        return unique_lineage_name(self.root_path, filename, mode)
+        return unique_lineage_name(self.tempdir, filename, mode)
 
     def test_basic(self):
         f, path = self._call("wow")
         self.assertTrue(isinstance(f, file_type))
-        self.assertEqual(os.path.join(self.root_path, "wow.conf"), path)
+        self.assertEqual(os.path.join(self.tempdir, "wow.conf"), path)
 
     def test_multiple(self):
         for _ in six.moves.range(10):
@@ -237,15 +223,13 @@ class UniqueLineageNameTest(unittest.TestCase):
         self.assertRaises(OSError, self._call, "wow")
 
 
-class SafelyRemoveTest(unittest.TestCase):
+class SafelyRemoveTest(test_util.TempDirTestCase):
     """Tests for certbot.util.safely_remove."""
 
     def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.path = os.path.join(self.tmp, "foo")
+        super(SafelyRemoveTest, self).setUp()
 
-    def tearDown(self):
-        shutil.rmtree(self.tmp)
+        self.path = os.path.join(self.tempdir, "foo")
 
     def _call(self):
         from certbot.util import safely_remove


### PR DESCRIPTION
Introduce a test class to deduplicate temporary directory setup and teardown in
testing code and update existing test code to use this new class.

Note: #4078 mentions two patterns, but I didn't see duplicated code involving `config_dir`, `work_dir`, `logs_dir` paths. (All three are used in `MainTest`, `config_dir` is used in `RenewalTest`, and `logs_dir` is used as the _only_ temp directory in `SetupLogFileHandlerTest` and `SetupLoggingTest`.)