### PR TITLE
Improve packaging guide.

### DIFF
--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -16,21 +16,19 @@ The following scripts are used in the process:
 
 - https://github.com/letsencrypt/letsencrypt/blob/master/tools/release.sh
 
-We currently version with the following scheme:
+We use git tags to identify releases, using `Semantic Versioning`_. For
+example: `v0.11.1`.
 
-- ``0.1.0``
-- ``0.2.0dev`` for developement in ``master``
-- ``0.2.0`` (only temporarily in ``master``)
-- ...
+.. _`Semantic Versioning`: http://semver.org/
 
 Notes for package maintainers
 =============================
 
-0. Please use our releases, not ``master``!
+0. Please use our tagged releases, not ``master``!
 
 1. Do not package ``certbot-compatibility-test`` or ``letshelp-certbot`` - it's only used internally.
 
-2. If you'd like to include automated renewal in your package ``certbot renew -q`` should be added to crontab or systemd timer.
+2. If you'd like to include automated renewal in your package ``certbot renew -q`` should be added to crontab or systemd timer. Add a random per-system offset to avoid having a large number of clients hit Let's Encrypt's servers simultaneously.
 
 3. ``jws`` is an internal script for ``acme`` module and it doesn't have to be packaged - it's mostly for debugging: you can use it as ``echo foo | jws sign | jws verify``.
 
@@ -44,34 +42,33 @@ Arch
 ----
 
 From our official releases:
+
 - https://www.archlinux.org/packages/community/any/python2-acme
 - https://www.archlinux.org/packages/community/any/certbot
 - https://www.archlinux.org/packages/community/any/certbot-apache
 - https://www.archlinux.org/packages/community/any/certbot-nginx
-- https://www.archlinux.org/packages/community/any/letshelp-certbot
 
 From ``master``: https://aur.archlinux.org/packages/certbot-git
 
 Debian (and its derivatives, including Ubuntu)
 ------
 
-https://packages.debian.org/sid/certbot
-https://packages.debian.org/sid/python-certbot
-https://packages.debian.org/sid/python-certbot-apache
+- https://packages.debian.org/sid/certbot
+- https://packages.debian.org/sid/python-certbot
+- https://packages.debian.org/sid/python-certbot-apache
 
 Fedora
 ------
 
 In Fedora 23+.
 
-- https://admin.fedoraproject.org/pkgdb/package/letsencrypt/
 - https://admin.fedoraproject.org/pkgdb/package/certbot/
 - https://admin.fedoraproject.org/pkgdb/package/python-acme/
 
 FreeBSD
 -------
 
-https://svnweb.freebsd.org/ports/head/security/py-certbot/
+- https://svnweb.freebsd.org/ports/head/security/py-certbot/
 
 GNU Guix
 --------

--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -28,7 +28,7 @@ Notes for package maintainers
 
 1. Do not package ``certbot-compatibility-test`` or ``letshelp-certbot`` - it's only used internally.
 
-2. If you'd like to include automated renewal in your package ``certbot renew -q`` should be added to crontab or systemd timer. Add a random per-system offset to avoid having a large number of clients hit Let's Encrypt's servers simultaneously.
+2. If you'd like to include automated renewal in your package ``certbot renew -q`` should be added to crontab or systemd timer. Additionally you should include a random per-machine time offset to avoid having a large number of your clients hit Let's Encrypt's servers simultaneously.
 
 3. ``jws`` is an internal script for ``acme`` module and it doesn't have to be packaged - it's mostly for debugging: you can use it as ``echo foo | jws sign | jws verify``.
 


### PR DESCRIPTION
Correct tagging format.
Add request for random offsets for renewal.
Make all bulleted lists consistent.
Remove obsolete `letsencrypt` package for Fedora.
Remove discouraged letshelp-certbot package.