### PR TITLE
Build wheels correctly for Python 2.6

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -13,6 +13,7 @@ install_requires = [
     # rsa_recover_prime_factors (>=0.8)
     'cryptography>=0.8',
     # Connection.set_tlsext_host_name (>=0.13)
+    'mock',
     'PyOpenSSL>=0.13',
     'pyrfc3339',
     'pytz',
@@ -26,15 +27,6 @@ install_requires = [
     'setuptools>=1.0',
     'six',
 ]
-
-# env markers in extras_require cause problems with older pip: #517
-# Keep in sync with conditional_requirements.py.
-if sys.version_info < (2, 7):
-    install_requires.extend([
-        'mock<1.1.0',
-    ])
-else:
-    install_requires.append('mock')
 
 dev_extras = [
     'nose',

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -10,6 +10,7 @@ version = '0.13.0.dev0'
 install_requires = [
     'acme=={0}'.format(version),
     'certbot=={0}'.format(version),
+    'mock',
     'python-augeas',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
@@ -17,11 +18,6 @@ install_requires = [
     'zope.component',
     'zope.interface',
 ]
-
-if sys.version_info < (2, 7):
-    install_requires.append('mock<1.1.0')
-else:
-    install_requires.append('mock')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-compatibility-test/setup.py
+++ b/certbot-compatibility-test/setup.py
@@ -9,15 +9,11 @@ version = '0.13.0.dev0'
 install_requires = [
     'certbot',
     'certbot-apache',
+    'mock',
     'six',
     'requests',
     'zope.interface',
 ]
-
-if sys.version_info < (2, 7):
-    install_requires.append('mock<1.1.0')
-else:
-    install_requires.append('mock')
 
 if sys.version_info < (2, 7, 9):
     # For secure SSL connexion with Python 2.7 (InsecurePlatformWarning)

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -10,6 +10,7 @@ version = '0.13.0.dev0'
 install_requires = [
     'acme=={0}'.format(version),
     'certbot=={0}'.format(version),
+    'mock',
     'PyOpenSSL',
     'pyparsing>=1.5.5',  # Python3 support; perhaps unnecessary?
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
@@ -17,11 +18,6 @@ install_requires = [
     'setuptools>=1.0',
     'zope.interface',
 ]
-
-if sys.version_info < (2, 7):
-    install_requires.append('mock<1.1.0')
-else:
-    install_requires.append('mock')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/letshelp-certbot/setup.py
+++ b/letshelp-certbot/setup.py
@@ -7,12 +7,9 @@ from setuptools import find_packages
 version = '0.7.0.dev0'
 
 install_requires = [
+    'mock',
     'setuptools',  # pkg_resources
 ]
-if sys.version_info < (2, 7):
-    install_requires.append('mock<1.1.0')
-else:
-    install_requires.append('mock')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     'ConfigArgParse>=0.9.3',
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
+    'mock',
     'parsedatetime>=1.3',  # Calendar.parseDT
     'PyOpenSSL',
     'pyrfc3339',
@@ -54,15 +55,6 @@ install_requires = [
     'zope.component',
     'zope.interface',
 ]
-
-# env markers in extras_require cause problems with older pip: #517
-# Keep in sync with conditional_requirements.py.
-if sys.version_info < (2, 7):
-    install_requires.extend([
-        'mock<1.1.0',
-    ])
-else:
-    install_requires.append('mock')
 
 dev_extras = [
     # Pin astroid==1.3.5, pylint==1.4.2 as a workaround for #289


### PR DESCRIPTION
With #2249 merged, this fixes #2176 and #3455. We pinned <1.1.0 during the brief period between `mock 1.1.0` and `mock 1.1.4` where they didn't support Python 2.6 (see their [changelog](https://mock.readthedocs.io/en/latest/changelog.html#id4)).

@erikrose, can you review this?