### PR TITLE
IChallengeProvider interface added - Domain challenge serialization

### DIFF
--- a/certbot/errors.py
+++ b/certbot/errors.py
@@ -81,6 +81,10 @@ class NotSupportedError(PluginError):
     """Certbot Plugin function not supported error."""
 
 
+class NoChallengeError(PluginError):
+    """Certbot Plugin function could not restore challenge."""
+
+
 class StandaloneBindError(Error):
     """Standalone plugin bind error."""
 

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -359,6 +359,46 @@ class IInstaller(IPlugin):
         """
 
 
+class IChallengeProvider(zope.interface.Interface):
+    """Certbot domain challenge provider for domains.
+
+    Object implementing `IAuthenticator` can implement also this interface
+    in order to support domain validation across multiple Certbot invocations.
+
+    By default AuthHandler is asking ACME for domain challenges, in the
+    beginning of the authentication process. This interface enables to
+    develop plugins which provide the challenges by different means,
+    e.g., by deserializing them from previous Certbot invocations.
+
+    """
+
+    def request_domain_challenges(domain, acme=None, account=None):
+        """Returns challenges for particular domain.
+
+        Returns the same object as `acme.acme.client.request_domain_challenges()`
+
+        :param str domain: domain name to load challenges for
+        :param acme.client.Client acme: ACME client API.
+        :param `certbot.account.Account` account: Client's Account
+
+        :returns: Authorization Resource.
+        :rtype: `acme.messages.AuthorizationResource`
+
+        :raises errors.NoChallengeError: if challenge could not be resolved
+            and traditional load has to be used.
+
+        """
+
+    def on_domain_challenge_loaded(domain, challenge):
+        """Called when Certbot loads domain challenges from the ACME server.
+        Enables serialization of the challenges for the next Certbot invocation.
+
+        :param str domain: domain the challenge belongs to
+        :param `acme.AuthorizationResource` challenge: loaded challenge
+        :return: None
+        """
+
+
 class IDisplay(zope.interface.Interface):
     """Generic display."""
     # pylint: disable=too-many-arguments


### PR DESCRIPTION
[Feedback required]
AuthHandler asks ACME directly for domain challenges. With this new interface developers can augment objects implementing `IAuthenticator` so the authenticator plugin is able to restore serialised domain challenges. In this way Certbot can validate domains across multiple Certbot invocations which is suitable e.g., for Ansible (e.g. DNS domain validation with Ansible DNS modules. 2 Certbot invocations are needed. See linked issue for more info).

We are developing external auth plugin for the Certbot which can really use this plugin extension in the Certbot.

If the PR is merged, the idea with our plugin is the following:

 - Execute `./certbot <arguments> --configurator plugin --to-session /tmp/mydomain.json`
   - The first phase of the validation. 
   - Requests challenges from ACME, stores them to `/tmp/mydomain.json` - serialized state
   - Outputs JSON to Stdout so Ansible can parse the output
 - Update DNS in Ansible task
 - Execute `./certbot <arguments> --configurator plugin --from-session /tmp/mydomain.json`
   - The second phase of the validation.
   - Deserializes domain challenges from the json file instead of generating new ones on ACME.
   - Finishes the process.

We tested this domain challenge serialization/deserialization approach and it works smoothly. The only thing is we need a hook in the Certbot to either use ACME or the auth plugin to load challenges.

Update: Another way to implement this with lower change footprint is to have only one method in the `IChallengeProvider`.  If Authenticator implements also `IChallengeProvider` the `AuthHandler` would call the plugin to obtain challenges. The downside is the plugin would need to call ACME plugin as a fallback if it cannot find the domain challenge in the storage.

Thanks for considering!
