### PR TITLE
Improve Account.repr()

### DIFF
--- a/certbot/account.py
+++ b/certbot/account.py
@@ -75,7 +75,7 @@ class Account(object):  # pylint: disable=too-few-public-methods
 
     def __repr__(self):
         return "<{0}({1}, {2}, {3})>".format(
-            self.__class__.__name__, self.id, self.regr, self.meta)
+            self.__class__.__name__, self.regr, self.id, self.meta)
 
     def __eq__(self, other):
         return (isinstance(other, self.__class__) and

--- a/certbot/account.py
+++ b/certbot/account.py
@@ -74,7 +74,8 @@ class Account(object):  # pylint: disable=too-few-public-methods
             self.meta.creation_dt), self.meta.creation_host, self.id[:4])
 
     def __repr__(self):
-        return "<{0}({1})>".format(self.__class__.__name__, self.id)
+        return "<{0}({1}, {2}, {3})>".format(
+            self.__class__.__name__, self.id, self.regr, self.meta)
 
     def __eq__(self, other):
         return (isinstance(other, self.__class__) and

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -52,10 +52,7 @@ class AccountTest(unittest.TestCase):
             self.acc.slug, "test.certbot.org@2015-07-04T14:04:10Z (bca5)")
 
     def test_repr(self):
-        self.assertEqual(
-            repr(self.acc),
-            "<Account(bca5889f66457d5b62fbba7b25f9ab6f)>")
-
+        self.assertTrue("<Account(bca5889f66457d5b62fbba7b25f9ab6f" in repr(self.acc))
 
 class ReportNewAccountTest(unittest.TestCase):
     """Tests for certbot.account.report_new_account."""

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -31,7 +31,7 @@ class AccountTest(unittest.TestCase):
             creation_dt=datetime.datetime(
                 2015, 7, 4, 14, 4, 10, tzinfo=pytz.UTC))
         self.acc = Account(self.regr, KEY, self.meta)
-        self.regr.__repr__ = mock.MagicMock(return_value = "i_am_a_regr")
+        self.regr.__repr__ = mock.MagicMock(return_value="i_am_a_regr")
 
         with mock.patch("certbot.account.socket") as mock_socket:
             mock_socket.getfqdn.return_value = "test.certbot.org"

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -53,11 +53,8 @@ class AccountTest(unittest.TestCase):
             self.acc.slug, "test.certbot.org@2015-07-04T14:04:10Z (bca5)")
 
     def test_repr(self):
-        self.assertEqual(repr(self.acc),
-          "<Account(i_am_a_regr, bca5889f66457d5b62fbba7b25f9ab6f, " +
-          "Meta(creation_host='test.certbot.org', " +
-          "creation_dt=datetime.datetime(2015, 7, 4, " +
-          "14, 4, 10, tzinfo=<UTC>)))>")
+        self.assertTrue(repr(self.acc).startswith(
+          "<Account(i_am_a_regr, bca5889f66457d5b62fbba7b25f9ab6f, Meta("))
 
 class ReportNewAccountTest(unittest.TestCase):
     """Tests for certbot.account.report_new_account."""

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -31,6 +31,7 @@ class AccountTest(unittest.TestCase):
             creation_dt=datetime.datetime(
                 2015, 7, 4, 14, 4, 10, tzinfo=pytz.UTC))
         self.acc = Account(self.regr, KEY, self.meta)
+        self.regr.__repr__ = mock.MagicMock(return_value = "i_am_a_regr")
 
         with mock.patch("certbot.account.socket") as mock_socket:
             mock_socket.getfqdn.return_value = "test.certbot.org"
@@ -52,7 +53,11 @@ class AccountTest(unittest.TestCase):
             self.acc.slug, "test.certbot.org@2015-07-04T14:04:10Z (bca5)")
 
     def test_repr(self):
-        self.assertTrue("<Account(bca5889f66457d5b62fbba7b25f9ab6f" in repr(self.acc))
+        self.assertEqual(repr(self.acc),
+          "<Account(i_am_a_regr, bca5889f66457d5b62fbba7b25f9ab6f, " +
+          "Meta(creation_host='test.certbot.org', " +
+          "creation_dt=datetime.datetime(2015, 7, 4, " +
+          "14, 4, 10, tzinfo=<UTC>)))>")
 
 class ReportNewAccountTest(unittest.TestCase):
     """Tests for certbot.account.report_new_account."""


### PR DESCRIPTION
The old version had two problems:
 - It printed `<Account(bca5889f66457d5b62fbba7b25f9ab6f)>`, which showed the id, but looked like it was showing a pointer of some sort.
 - It failed to print the meta and regr fields.

This meant that, for instance, when a test failed because two Accounts differed, the test output would not contain sufficient information to see where they differed.