### PR TITLE
If we fail to reload, try starting Nginx once without catching output

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -829,10 +829,8 @@ def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx.conf"):
 
     """
     try:
-        proc = subprocess.Popen([nginx_ctl, "-c", nginx_conf, "-s", "reload"],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        stdout, stderr = proc.communicate()
+        proc = subprocess.Popen([nginx_ctl, "-c", nginx_conf, "-s", "reload"])
+        proc.communicate()
 
         if proc.returncode != 0:
             # Maybe Nginx isn't running

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -835,27 +835,15 @@ def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx.conf"):
 
         if proc.returncode != 0:
             # Maybe Nginx isn't running
+            # Write to temporary files instead of piping because of communication issues on Arch
+            # https://github.com/certbot/certbot/issues/4324
             with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
-                nginx_proc = subprocess.Popen([nginx_ctl, "-c", nginx_conf],
-                                              stdout=out,
-                                              stderr=err)
+                nginx_proc = subprocess.Popen([nginx_ctl, "-c", nginx_conf], stdout=out, stderr=err)
                 nginx_proc.communicate()
-                # stdout, stderr = out.read(), err.read()
                 if nginx_proc.returncode != 0:
                     # Enter recovery routine...
                     raise errors.MisconfigurationError(
                         "nginx restart failed:\n%s\n%s" % (out.read(), err.read()))
-            # Minor hack: don't call communicate(), because it hangs on Arch
-            # if nginx_proc.poll() == 0
-            # https://github.com/certbot/certbot/issues/4324
-            # and we can't use wait() here, because that is known to block with piped output
-            # while nginx_proc.poll() is None:
-            #     time.sleep(.1)
-            # if nginx_proc.poll() != 0:
-            #     # Enter recovery routine...
-            #     raise errors.MisconfigurationError(
-            #         "nginx restart failed:\n%s\n%s" % (nginx_proc.stdout.read(),
-            #             nginx_proc.stderr.read()))
 
     except (OSError, ValueError):
         raise errors.MisconfigurationError("nginx restart failed")

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -839,7 +839,6 @@ def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx.conf"):
             nginx_proc = subprocess.Popen([nginx_ctl, "-c", nginx_conf],
                                           stdout=subprocess.PIPE,
                                           stderr=subprocess.PIPE)
-            # Maybe Nginx isn't running
             # Minor hack: don't call communicate(), because it hangs on Arch
             # if nginx_proc.poll() == 0
             # https://github.com/certbot/certbot/issues/4324

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -837,13 +837,15 @@ def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx.conf"):
             # Maybe Nginx isn't running
             # Write to temporary files instead of piping because of communication issues on Arch
             # https://github.com/certbot/certbot/issues/4324
-            with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
-                nginx_proc = subprocess.Popen([nginx_ctl, "-c", nginx_conf], stdout=out, stderr=err)
-                nginx_proc.communicate()
-                if nginx_proc.returncode != 0:
-                    # Enter recovery routine...
-                    raise errors.MisconfigurationError(
-                        "nginx restart failed:\n%s\n%s" % (out.read(), err.read()))
+            with tempfile.TemporaryFile() as out:
+                with tempfile.TemporaryFile() as err:
+                    nginx_proc = subprocess.Popen([nginx_ctl, "-c", nginx_conf],
+                        stdout=out, stderr=err)
+                    nginx_proc.communicate()
+                    if nginx_proc.returncode != 0:
+                        # Enter recovery routine...
+                        raise errors.MisconfigurationError(
+                            "nginx restart failed:\n%s\n%s" % (out.read(), err.read()))
 
     except (OSError, ValueError):
         raise errors.MisconfigurationError("nginx restart failed")

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -842,6 +842,9 @@ def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx.conf"):
             # Minor hack: don't call communicate(), because it hangs on Arch
             # if nginx_proc.poll() == 0
             # https://github.com/certbot/certbot/issues/4324
+            # and we can't use wait() here, because that is known to block with piped output
+            while nginx_proc.poll() is None:
+                time.sleep(.1)
             if nginx_proc.poll() != 0:
                 # Enter recovery routine...
                 raise errors.MisconfigurationError(


### PR DESCRIPTION
Because a successful start with piped output hangs on Arch.

Fixes #4324.