### PR TITLE
Remove obsolete fields from Registration.

### DIFF
--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -237,10 +237,6 @@ class Registration(ResourceBody):
     :ivar tuple contact: Contact information following ACME spec,
         `tuple` of `unicode`.
     :ivar unicode agreement:
-    :ivar unicode authorizations: URI where
-        `messages.Registration.Authorizations` can be found.
-    :ivar unicode certificates: URI where
-        `messages.Registration.Certificates` can be found.
 
     """
     # on new-reg key server ignores 'key' and populates it based on
@@ -248,25 +244,7 @@ class Registration(ResourceBody):
     key = jose.Field('key', omitempty=True, decoder=jose.JWK.from_json)
     contact = jose.Field('contact', omitempty=True, default=())
     agreement = jose.Field('agreement', omitempty=True)
-    authorizations = jose.Field('authorizations', omitempty=True)
-    certificates = jose.Field('certificates', omitempty=True)
     status = jose.Field('status', omitempty=True)
-
-    class Authorizations(jose.JSONObjectWithFields):
-        """Authorizations granted to Account in the process of registration.
-
-        :ivar tuple authorizations: URIs to Authorization Resources.
-
-        """
-        authorizations = jose.Field('authorizations')
-
-    class Certificates(jose.JSONObjectWithFields):
-        """Certificates granted to Account in the process of registration.
-
-        :ivar tuple certificates: URIs to Certificate Resources.
-
-        """
-        certificates = jose.Field('certificates')
 
     phone_prefix = 'tel:'
     email_prefix = 'mailto:'

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -170,8 +170,7 @@ class RegistrationTest(unittest.TestCase):
 
         from acme.messages import Registration
         self.reg = Registration(key=key, contact=contact, agreement=agreement)
-        self.reg_none = Registration(authorizations='uri/authorizations',
-                                     certificates='uri/certificates')
+        self.reg_none = Registration()
 
         self.jobj_to = {
             'contact': contact,


### PR DESCRIPTION
Authorizations and certificates were in the original spec but have since been
deleted.