### PR TITLE
Fixes nginxparser to allow multiline quoted strings

### DIFF
--- a/certbot-nginx/certbot_nginx/nginxparser.py
+++ b/certbot-nginx/certbot_nginx/nginxparser.py
@@ -29,8 +29,8 @@ class RawNginxParser(object):
     # any chars in single or double quotes
     # All of these COULD be upgraded to something like
     # https://stackoverflow.com/a/16130746
-    dquoted = QuotedString('"', multiline=True)
-    squoted = QuotedString("'", multiline=True)
+    dquoted = QuotedString('"', multiline=True, unquoteResults=False)
+    squoted = QuotedString("'", multiline=True, unquoteResults=False)
     nonspecial = Regex(r"[^\{\};,]")
     varsub = Regex(r"(\$\{\w+\})")
     # nonspecial nibbles one character at a time, but the other objects take

--- a/certbot-nginx/certbot_nginx/nginxparser.py
+++ b/certbot-nginx/certbot_nginx/nginxparser.py
@@ -6,7 +6,7 @@ import string
 
 from pyparsing import (
     Literal, White, Word, alphanums, CharsNotIn, Combine, Forward, Group,
-    Optional, OneOrMore, Regex, ZeroOrMore)
+    Optional, OneOrMore, QuotedString, Regex, ZeroOrMore)
 from pyparsing import stringEnd
 from pyparsing import restOfLine
 
@@ -29,8 +29,8 @@ class RawNginxParser(object):
     # any chars in single or double quotes
     # All of these COULD be upgraded to something like
     # https://stackoverflow.com/a/16130746
-    dquoted = Regex(r'(\".*\")')
-    squoted = Regex(r"(\'.*\')")
+    dquoted = QuotedString('"', multiline=True)
+    squoted = QuotedString("'", multiline=True)
     nonspecial = Regex(r"[^\{\};,]")
     varsub = Regex(r"(\$\{\w+\})")
     # nonspecial nibbles one character at a time, but the other objects take

--- a/certbot-nginx/certbot_nginx/tests/nginxparser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/nginxparser_test.py
@@ -109,6 +109,21 @@ class TestRawNginxParser(unittest.TestCase):
                  ['blah', '"hello;world"'],
                  ['try_files', '$uri @rewrites']]]]]])
 
+    def test_parse_from_file3(self):
+        with open(util.get_data_filename('multiline_quotes.conf')) as handle:
+            parsed = util.filter_comments(load(handle))
+        self.assertEqual(
+            parsed,
+            [[['http'],
+                [[['server'],
+                    [['listen', '*:443'],
+                    [['location', '/'],
+                        [['body_filter_by_lua',
+                          'ngx.ctx.buffered = (ngx.ctx.buffered or "") .. string.sub(ngx.arg[1], 1, 1000)\n'
+                          '                            if ngx.arg[2] then\n'
+                          '                              ngx.var.resp_body = ngx.ctx.buffered\n'
+                          '                            end']]]]]]]])
+
     def test_abort_on_parse_failure(self):
         with open(util.get_data_filename('broken.conf')) as handle:
             self.assertRaises(ParseException, load, handle)

--- a/certbot-nginx/certbot_nginx/tests/nginxparser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/nginxparser_test.py
@@ -119,10 +119,13 @@ class TestRawNginxParser(unittest.TestCase):
                     [['listen', '*:443'],
                     [['location', '/'],
                         [['body_filter_by_lua',
-                          'ngx.ctx.buffered = (ngx.ctx.buffered or "") .. string.sub(ngx.arg[1], 1, 1000)\n'
-                          '                            if ngx.arg[2] then\n'
-                          '                              ngx.var.resp_body = ngx.ctx.buffered\n'
-                          '                            end']]]]]]]])
+                          '\'ngx.ctx.buffered = (ngx.ctx.buffered or "")'
+                          ' .. string.sub(ngx.arg[1], 1, 1000)\n'
+                          '                            '
+                          'if ngx.arg[2] then\n'
+                          '                              '
+                          'ngx.var.resp_body = ngx.ctx.buffered\n'
+                          '                            end\'']]]]]]]])
 
     def test_abort_on_parse_failure(self):
         with open(util.get_data_filename('broken.conf')) as handle:

--- a/certbot-nginx/certbot_nginx/tests/testdata/etc_nginx/multiline_quotes.conf
+++ b/certbot-nginx/certbot_nginx/tests/testdata/etc_nginx/multiline_quotes.conf
@@ -1,0 +1,16 @@
+# Test nginx configuration file with multiline quoted strings.
+# Good example of usage for multilined quoted values is when
+# using Openresty's Lua directives and you wish to keep the
+# inline Lua code readable.
+http {
+  server {
+      listen *:443; # because there should be no other port open.
+
+      location / {
+        body_filter_by_lua 'ngx.ctx.buffered = (ngx.ctx.buffered or "") .. string.sub(ngx.arg[1], 1, 1000)
+                            if ngx.arg[2] then
+                              ngx.var.resp_body = ngx.ctx.buffered
+                            end';
+      }
+  }
+}


### PR DESCRIPTION
In the [current nginxparser module](https://github.com/certbot/certbot/blob/master/certbot-nginx/certbot_nginx/nginxparser.py#L32-L33), single and double quoted strings are parsed with:

```python
dquoted = Regex(r'(\".*\")')
squoted = Regex(r"(\'.*\')")
```

However, the parser will miss quoted strings that span several lines (e.g. when using Openresty directives and having inline Lua code, that code can span multiple lines for clarity.)  If the module parses quoted strings with Pyparsing's `QuotedString`, then parsing is able to handle more unwieldy (and sometimes auto-generated) nginx configuration files. This PR proposes a 2 line change to the nginxparser module:

```python
dquoted = QuotedString('"', multiline=True, unquoteResults=False)
squoted = QuotedString("'", multiline=True, unquoteResults=False)
```

I preemptively ran these changes through [TravisCI and everything passes](https://travis-ci.org/kernelpanek/certbot). I hope this is helpful!