### PR TITLE
plugin: Cloudflare DNS Authenticator

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1218,6 +1218,8 @@ def _plugins_parsing(helpful, plugins):
                 help='Provide laborious manual instructions for obtaining a cert')
     helpful.add(["plugins", "certonly"], "--webroot", action="store_true",
                 help='Obtain certs by placing files in a webroot directory.')
+    helpful.add(["plugins", "certonly"], "--dns-cloudflare", action="store_true",
+                help='Obtain certs using a DNS TXT record (if you are using Cloudflare for DNS).')
 
     # things should not be reorder past/pre this comment:
     # plugins_group should be displayed in --help before plugin

--- a/certbot/plugins/dns_cloudflare.py
+++ b/certbot/plugins/dns_cloudflare.py
@@ -1,0 +1,344 @@
+"""DNS Authenticator for Cloudflare."""
+import logging
+
+import zope.interface
+
+from time import sleep
+
+from acme import challenges
+
+from certbot import errors
+from certbot import interfaces
+
+from certbot.display import util as display_util
+
+from certbot.plugins import common
+
+import CloudFlare
+
+logger = logging.getLogger(__name__)
+
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class Authenticator(common.Plugin):
+    """DNS  Authenticator for Cloudflare
+
+    This Authenticator uses the Cloudflare API to fulfill a dns-01 challenge.
+    """
+
+    description = 'Obtain certs using a DNS TXT record (if you are using Cloudflare for DNS).'
+
+    _attempt_cleanup = False
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+
+        self.email = None
+        self.api_key = None
+
+    @classmethod
+    def add_parser_arguments(cls, add):
+        add('propagation-seconds',
+            default=10,
+            type=int,
+            help='The number of seconds to wait for DNS to propagate before asking the ACME server '
+                 'to verify the DNS record.')
+        add('email',
+            help='Email address associated with Cloudflare account.')
+        add('api-key',
+            help='API key for Cloudflare account. ' +
+                 '(Which can be obtained from https://www.cloudflare.com/a/account/my-account)')
+
+    def prepare(self): # pylint: disable=missing-docstring
+        pass
+
+    def more_info(self): # pylint: disable=missing-docstring,no-self-use
+        return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
+               'the Cloudflare API.'
+
+    def get_chall_pref(self, unused_domain): # pylint: disable=missing-docstring,no-self-use
+        return [challenges.DNS01]
+
+    def perform(self, achalls): # pylint: disable=missing-docstring
+        self._setup_credentials()
+
+        self._attempt_cleanup = True
+
+        responses = []
+        for achall in achalls:
+            self._perform_achall(achall)
+            responses.append(achall.response(achall.account_key))
+
+        # DNS updates take time to propagate and checking to see if the update has occurred is not
+        # reliable (the machine this code is running on might be able to see an update before
+        # the ACME server). So: we sleep for a short amount of time we believe to be long enough.
+        sleep(self.conf('propagation-seconds'))
+
+        return responses
+
+    def _perform_achall(self, achall):
+        """
+        Performs a dns-01 challenge by creating a DNS TXT record.
+
+        :param `~certbot.achallenges.AnnotatedChallenge` achall: the challenge to perform
+        :raises errors.PluginError: If the challenge cannot be performed
+        """
+
+        domain = achall.domain
+        record_name = achall.validation_domain_name(domain)
+        record_content = achall.validation(achall.account_key)
+        ttl = 120
+
+        self._get_cloudflare_client().add_txt_record(domain, record_name, record_content, ttl)
+
+    def cleanup(self, achalls):  # pylint: disable=missing-docstring
+        if self._attempt_cleanup:
+            for achall in achalls:
+                self._cleanup_achall(achall)
+
+    def _cleanup_achall(self, achall):
+        """
+        Deletes the DNS TXT record which would have been created by `_perform_achall`.
+
+        Fails gracefully if no such record exists.
+
+        :param `~certbot.achallenge s.AnnotatedChallenge` achall: the challenge to clean up after
+        """
+
+        domain = achall.domain
+        record_name = achall.validation_domain_name(domain)
+        record_content = achall.validation(achall.account_key)
+
+        self._get_cloudflare_client().del_txt_record(domain, record_name, record_content)
+
+    def _setup_credentials(self):
+        """
+        Establish credentials, prompting if necessary.
+        """
+
+        # XXX: We could make these optional and let CloudFlare.CloudFlare attempt to read them from
+        #      .cloudflare.cfg or ~/.cloudflare.cfg or ~/.cloudflare/cloudflare.cfg
+        #
+        #      Marking them as required seems to provide for a better user experience.
+
+        configured_email = self.conf('email')
+        if configured_email:
+            self.email = configured_email
+        else:
+            self.email = self._prompt_for_data('email address')
+
+        if self.email:
+            setattr(self.config, self.dest('email'), self.email)
+        else:
+            raise errors.PluginError('Cloudflare account email address required to proceed.')
+
+        configured_api_key = self.conf('api-key')
+        if configured_api_key:
+            self.api_key = configured_api_key
+        else:
+            self.api_key = self._prompt_for_data('API key')
+
+        if self.api_key:
+            setattr(self.config, self.dest('api-key'), self.api_key)
+        else:
+            raise errors.PluginError('Cloudflare account API key required to proceed.')
+
+    @staticmethod
+    def _prompt_for_data(label):
+        """
+        Prompt the user for a piece of information.
+
+        :param string label: The user-friendly label for this piece of information.
+        :returns: The user's response (guaranteed non-empty).
+        :rtype: string
+        """
+
+        display = zope.component.getUtility(interfaces.IDisplay)
+
+        while True:
+            code, response = display.input(
+                'Input Cloudflare account {0}'.format(label),
+                force_interactive=True)
+            if code == display_util.HELP:
+                # Displaying help is not currently implemented
+                return None
+            elif code == display_util.CANCEL:
+                return None
+            else:  # code == display_util.OK
+                if not response:
+                    display.notification('Please enter an {0}.'.format(label), pause=False)
+                else:
+                    return response
+
+    def _get_cloudflare_client(self):
+        """
+        Helper method to construct a `_CloudflareClient`.
+
+        Uses configured credentials.
+
+        :return: a new
+        :rtype: `_CloudflareClient`
+        """
+
+        return _CloudflareClient(self.email, self.api_key)
+
+
+class _CloudflareClient(object):
+    """
+    Encapsulates all communication with the Cloudflare API.
+    """
+
+    def __init__(self, email, api_key):
+        self.cf = CloudFlare.CloudFlare(email, api_key)
+
+    def add_txt_record(self, domain, record_name, record_content, record_ttl):
+        """
+        Add a TXT record using the supplied information.
+
+        :param string domain: The domain to use to look up the Cloudflare zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :param int record_ttl: The record TTL (number of seconds that the record may be cached).
+        :raises: errors.PluginError if an error occurs communicating with the Cloudflare API
+        """
+
+        zone_id = self._find_zone_id(domain)
+
+        data = {'type': 'TXT',
+                'name': record_name,
+                'content': record_content,
+                'ttl': record_ttl}
+
+        try:
+            logger.debug('Attempting to add record to zone %s: %s', zone_id, data)
+            self.cf.zones.dns_records.post(zone_id, data=data)  # zones | pylint: disable=no-member
+        except CloudFlare.exceptions.CloudFlareAPIError as e:
+            logger.error('Encountered CloudFlareAPIError adding TXT record: %d %s', e, e)
+            raise errors.PluginError('Error communicating with the Cloudflare API: {0}'.format(e))
+
+        record_id = self._find_txt_record_id(zone_id, record_name, record_content)
+        logger.debug('Successfully added TXT record with record_id: %s', record_id)
+
+    def del_txt_record(self, domain, record_name, record_content):
+        """
+        Delete a TXT record using the supplied information.
+
+        Note that both the record's name and content are used to ensure that similar records
+        created concurrently (e.g., due to concurrent invocations of this plugin) are not deleted.
+
+        Failures are logged, but not raised.
+
+        :param string domain: The domain to use to look up the Cloudflare zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        """
+
+        try:
+            zone_id = self._find_zone_id(domain)
+        except errors.PluginError as e:
+            logger.debug('Encountered error finding zone_id during deletion: %s', e)
+            return
+
+        if zone_id:
+            record_id = self._find_txt_record_id(zone_id, record_name, record_content)
+            if record_id:
+                try:
+                    # zones | pylint: disable=no-member
+                    self.cf.zones.dns_records.delete(zone_id, record_id)
+                    logger.debug('Successfully deleted TXT record.')
+                except CloudFlare.exceptions.CloudFlareAPIError as e:
+                    logger.warn('Encountered CloudFlareAPIError deleting TXT record: %s', e)
+            else:
+                logger.debug('TXT record not found; no cleanup needed.')
+        else:
+            logger.debug('Zone not found; no cleanup needed.')
+
+    def _find_zone_id(self, domain):
+        """
+        Find the zone_id for a given domain.
+
+        :param string domain: The domain for which to find the zone_id.
+        :returns: The zone_id, if found.
+        :rtype: string
+        :raises: errors.PluginError if no zone_id is found.
+        """
+
+        zone_name_guesses = self._zone_name_guesses(domain)
+
+        for zone_name in zone_name_guesses:
+            params = {'name': zone_name,
+                      'per_page': 1}
+
+            try:
+                zones = self.cf.zones.get(params=params)  # zones | pylint: disable=no-member
+            except CloudFlare.exceptions.CloudFlareAPIError as e:
+                code = int(e)
+                hint = None
+
+                if code == 6003:
+                    hint = 'Did you copy your entire API key?'
+                elif code == 9103:
+                    hint = 'Did you enter the correct email address?'
+
+                raise errors.PluginError('Error determining zone_id: {0} {1}. Please confirm that '
+                                         'you have supplied valid Cloudflare API credentials.{2}'
+                                         .format(code, e, ' ({0})'.format(hint) if hint else ''))
+
+            if len(zones) > 0:
+                zone_id = zones[0]['id']
+                logger.debug('Found zone_id of %s for %s using name %s', zone_id, domain, zone_name)
+                return zone_id
+
+        raise errors.PluginError('Unable to determine zone_id for {0} using zone names: {1}. '
+                                 'Please confirm that the domain name has been entered correctly '
+                                 'and is already associated with the supplied Cloudflare account.'
+                                 .format(domain, zone_name_guesses))
+
+    def _find_txt_record_id(self, zone_id, record_name, record_content):
+        """
+        Find the record_id for a TXT record with the given name and content.
+
+        :param string zone_id: The zone_id which contains the record.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :returns: The record_id, if found.
+        :rtype: string
+        """
+
+        params = {'type': 'TXT',
+                  'name': record_name,
+                  'content': record_content,
+                  'per_page': 1}
+        try:
+            # zones | pylint: disable=no-member
+            records = self.cf.zones.dns_records.get(zone_id, params=params)
+        except CloudFlare.exceptions.CloudFlareAPIError as e:
+            logger.debug('Encountered CloudFlareAPIError getting TXT record_id: %s', e)
+            records = []
+
+        if len(records) > 0:
+            # Cleanup is returning the system to the state we found it. If, for some reason,
+            # there are multiple matching records, we only delete one because we only added one.
+            return records[0]['id']
+        else:
+            logger.debug('Unable to find TXT record.')
+
+    @staticmethod
+    def _zone_name_guesses(domain):
+        """Return a list of progressively less-specific domain names.
+
+        One of these will probably be the Cloudflare zone name.
+
+        :Example:
+
+        >>> _zone_name_guesses('foo.bar.baz.example.com')
+        ['foo.bar.baz.example.com', 'bar.baz.example.com', 'baz.example.com', 'example.com', 'com']
+
+        :param string domain: The domain for which to return guesses.
+        :returns: The a list of less specific domain names.
+        :rtype: list
+        """
+
+        fragments = domain.split('.')
+        return ['.'.join(fragments[i:]) for i in range(0, len(fragments))]

--- a/certbot/plugins/dns_cloudflare_test.py
+++ b/certbot/plugins/dns_cloudflare_test.py
@@ -1,0 +1,300 @@
+"""Tests for certbot.plugins.dns_cloudflare."""
+
+import mock
+import six
+import unittest
+
+from acme import challenges
+from acme import jose
+
+from certbot import achallenges
+from certbot import errors
+
+from certbot.display import util as display_util
+
+from certbot.tests import acme_util
+from certbot.tests import util as test_util
+
+import CloudFlare
+
+API_ERROR = CloudFlare.exceptions.CloudFlareAPIError(1000, '', '')
+API_KEY = 'an-api-key'
+DOMAIN = 'example.com'
+EMAIL = 'example@example.com'
+KEY = jose.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
+
+class AuthenticatorTest(unittest.TestCase):
+
+    achall = achallenges.KeyAuthorizationAnnotatedChallenge(
+        challb=acme_util.DNS01, domain=DOMAIN, account_key=KEY)
+
+    def setUp(self):
+        from certbot.plugins.dns_cloudflare import Authenticator
+        self.config = mock.MagicMock(cloudflare_email=EMAIL,
+                                     cloudflare_api_key=API_KEY,
+                                     cloudflare_propagation_seconds=0)  # don't wait during tests
+
+        self.auth = Authenticator(self.config, "cloudflare")
+
+        self.cfc = mock.MagicMock()
+        # _get_cloudflare_client | pylint: disable=protected-access
+        self.auth._get_cloudflare_client = mock.MagicMock(return_value=self.cfc)
+
+    def test_more_info(self):
+        self.assertTrue(isinstance(self.auth.more_info(), six.string_types))
+
+    def test_get_chall_pref(self):
+        self.assertEqual(self.auth.get_chall_pref(None), [challenges.DNS01])
+
+    def test_perform(self):
+        self.auth.perform([self.achall])
+
+        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY, mock.ANY)]
+        self.assertEqual(expected, self.cfc.mock_calls)
+
+    def test_cleanup(self):
+        # _attempt_cleanup | pylint: disable=protected-access
+        self.auth._attempt_cleanup = True
+        self.auth.cleanup([self.achall])
+
+        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.cfc.mock_calls)
+
+
+class AuthenticatorInputTest(unittest.TestCase):
+    supplied_email = 'fake@example.com'
+    supplied_api_key = 'fake-api-key'
+
+    # Not using setUp because the flow is dependent on the test case
+    def _setUp(self, email=None, api_key=None):
+        from certbot.plugins.dns_cloudflare import Authenticator
+        config = mock.MagicMock()
+        config.cloudflare_propagation_seconds = 0  # don't wait during tests
+        if email:
+            config.cloudflare_email = email
+        else:
+            config.cloudflare_email = None
+
+        if api_key:
+            config.cloudflare_api_key = api_key
+        else:
+            config.cloudflare_api_key = None
+
+        auth = Authenticator(config, "cloudflare")
+        return auth
+
+    @test_util.patch_get_utility()
+    def test_user_input_email(self, mock_get_utility):
+        auth = self._setUp(api_key=API_KEY)
+
+        mock_display = mock_get_utility()
+        mock_display.input.return_value = (display_util.OK, self.supplied_email,)
+
+        auth.perform([])
+
+        self.assertEqual(auth.email, self.supplied_email)
+
+        self.assertEqual(auth.conf('email'), self.supplied_email)
+        self.assertEqual(auth.conf('api-key'), API_KEY)
+
+    @test_util.patch_get_utility()
+    def test_user_input_api_key(self, mock_get_utility):
+        auth = self._setUp(email=EMAIL)
+
+        mock_display = mock_get_utility()
+        mock_display.input.return_value = (display_util.OK, self.supplied_api_key,)
+
+        auth.perform([])
+
+        self.assertEqual(auth.api_key, self.supplied_api_key)
+
+        self.assertEqual(auth.conf('email'), EMAIL)
+        self.assertEqual(auth.conf('api-key'), self.supplied_api_key)
+
+    @test_util.patch_get_utility()
+    def test_user_input_both(self, mock_get_utility):
+        auth = self._setUp()
+
+        mock_display = mock_get_utility()
+        mock_display.input.side_effect = [(display_util.OK, self.supplied_email,),
+                                          (display_util.OK, self.supplied_api_key,)]
+
+        auth.perform([])
+
+        self.assertEqual(auth.email, self.supplied_email)
+        self.assertEqual(auth.api_key, self.supplied_api_key)
+
+        self.assertEqual(auth.conf('email'), self.supplied_email)
+        self.assertEqual(auth.conf('api-key'), self.supplied_api_key)
+
+    @test_util.patch_get_utility()
+    def test_user_input_retrying(self, mock_get_utility):
+        auth = self._setUp(api_key=API_KEY)
+
+        mock_display = mock_get_utility()
+        mock_display.input.side_effect = [(display_util.OK, "",),
+                                          (display_util.OK, self.supplied_email,)]
+
+        auth.perform([])
+
+        self.assertEqual(auth.email, self.supplied_email)
+
+    @test_util.patch_get_utility()
+    def test_user_input_email_cancel(self, mock_get_utility):
+        auth = self._setUp(api_key=API_KEY)
+
+        mock_display = mock_get_utility()
+        mock_display.input.side_effect = [(display_util.CANCEL, "C",),]
+
+        self.assertRaises(errors.PluginError, auth.perform, [])
+
+    @test_util.patch_get_utility()
+    def test_user_input_api_key_cancel(self, mock_get_utility):
+        auth = self._setUp(email=EMAIL)
+
+        mock_display = mock_get_utility()
+        mock_display.input.side_effect = [(display_util.CANCEL, "C",),]
+
+        self.assertRaises(errors.PluginError, auth.perform, [])
+
+
+class CloudflareClientTest(unittest.TestCase):
+    record_name = "foo"
+    record_content = "bar"
+    record_ttl = 42
+    zone_id = 1
+    record_id = 2
+
+    def setUp(self):
+        from certbot.plugins.dns_cloudflare import _CloudflareClient
+
+        self.cloudflare_client = _CloudflareClient(EMAIL, API_KEY)
+
+        self.cf = mock.MagicMock()
+        self.cloudflare_client.cf = self.cf
+
+    def test_add_txt_record(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+
+        self.cloudflare_client.add_txt_record(DOMAIN, self.record_name, self.record_content,
+                                              self.record_ttl)
+
+        self.cf.zones.dns_records.post.assert_called_with(self.zone_id, data=mock.ANY)
+
+        post_data = self.cf.zones.dns_records.post.call_args[1]['data']
+
+        self.assertEqual('TXT', post_data['type'])
+        self.assertEqual(self.record_name, post_data['name'])
+        self.assertEqual(self.record_content, post_data['content'])
+        self.assertEqual(self.record_ttl, post_data['ttl'])
+
+    def test_add_txt_record_error(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+
+        self.cf.zones.dns_records.post.side_effect = API_ERROR
+
+        self.assertRaises(
+            errors.PluginError,
+            self.cloudflare_client.add_txt_record,
+            DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    def test_add_txt_record_error_during_zone_lookup(self):
+        self.cf.zones.get.side_effect = API_ERROR
+
+        self.assertRaises(
+            errors.PluginError,
+            self.cloudflare_client.add_txt_record,
+            DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    def test_add_txt_record_zone_not_found(self):
+        self.cf.zones.get.return_value = []
+
+        self.assertRaises(
+            errors.PluginError,
+            self.cloudflare_client.add_txt_record,
+            DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    def test_del_txt_record(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+        self.cf.zones.dns_records.get.return_value = [{'id': self.record_id}]
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        expected = [mock.call.zones.get(params=mock.ANY),
+                    mock.call.zones.dns_records.get(self.zone_id, params=mock.ANY),
+                    mock.call.zones.dns_records.delete(self.zone_id, self.record_id)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+        get_data = self.cf.zones.dns_records.get.call_args[1]['params']
+
+        self.assertEqual('TXT', get_data['type'])
+        self.assertEqual(self.record_name, get_data['name'])
+        self.assertEqual(self.record_content, get_data['content'])
+
+    def test_del_txt_record_error_during_zone_lookup(self):
+        self.cf.zones.get.side_effect = API_ERROR
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_during_delete(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+        self.cf.zones.dns_records.get.return_value = [{'id': self.record_id}]
+        self.cf.zones.dns_records.delete.side_effect = API_ERROR
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+        expected = [mock.call.zones.get(params=mock.ANY),
+                    mock.call.zones.dns_records.get(self.zone_id, params=mock.ANY),
+                    mock.call.zones.dns_records.delete(self.zone_id, self.record_id)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+    def test_del_txt_record_error_during_get(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+        self.cf.zones.dns_records.get.side_effect = API_ERROR
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+        expected = [mock.call.zones.get(params=mock.ANY),
+                    mock.call.zones.dns_records.get(self.zone_id, params=mock.ANY)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+    def test_del_txt_record_no_record(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+        self.cf.zones.dns_records.get.return_value = []
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+        expected = [mock.call.zones.get(params=mock.ANY),
+                    mock.call.zones.dns_records.get(self.zone_id, params=mock.ANY)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+    def test_del_txt_record_no_zone(self):
+        self.cf.zones.get.return_value = [{'id': None}]
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+        expected = [mock.call.zones.get(params=mock.ANY)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+    def test_zone_name_guesses(self):
+        self.assertTrue(
+            'example.com' in
+            # _zone_name_guesses | pylint: disable=protected-access
+            self.cloudflare_client._zone_name_guesses("example.com")
+        )
+
+        self.assertTrue(
+            'example.com' in
+            # _zone_name_guesses | pylint: disable=protected-access
+            self.cloudflare_client._zone_name_guesses("foo.bar.baz.example.com")
+        )
+
+        self.assertTrue(
+            'example.co.uk' in
+            # _zone_name_guesses | pylint: disable=protected-access
+            self.cloudflare_client._zone_name_guesses("foo.bar.baz.example.co.uk")
+        )
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -133,7 +133,7 @@ def choose_plugin(prepared, question):
         else:
             return None
 
-noninstaller_plugins = ["webroot", "manual", "standalone"]
+noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare"]
 
 def record_chosen_plugins(config, plugins, auth, inst):
     "Update the config entries to reflect the plugins we actually selected."
@@ -237,6 +237,8 @@ def cli_plugin_requests(config):
         req_auth = set_configurator(req_auth, "webroot")
     if config.manual:
         req_auth = set_configurator(req_auth, "manual")
+    if config.dns_cloudflare:
+        req_auth = set_configurator(req_auth, "dns-cloudflare")
     logger.debug("Requested authenticator %s and installer %s", req_auth, req_inst)
     return req_auth, req_inst
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ version = meta['version']
 install_requires = [
     'acme=={0}'.format(version),
     'argparse',
+    'cloudflare>=1.5.1',
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
     # saying so here causes a runtime error against our temporary fork of 0.9.3
     # in which we added 2.6 support (see #2243), so we relax the requirement.
@@ -124,6 +125,7 @@ setup(
             'null = certbot.plugins.null:Installer',
             'standalone = certbot.plugins.standalone:Authenticator',
             'webroot = certbot.plugins.webroot:Authenticator',
+            'dns-cloudflare = certbot.plugins.dns_cloudflare:Authenticator',
         ],
     },
 )


### PR DESCRIPTION
Implement an Authenticator which can fulfill a dns-01 challenge using the
Cloudflare API. Applicable only for domains using Cloudflare for DNS.

Testing Done:
 * tox -e py27
 * tox -e lint
 * Manual testing:
    * Used `certbot certonly --dns-cloudflare -d`, specifying an API key
      and email as command line arguments. Verified that a certificate
      was successfully obtained without user interaction.
    * Used `certbot certonly --dns-cloudflare -d`, without specifying an
      API key and email as command line arguments. Verified that the user
      was prompted and that a certificate was successfully obtained.
    * Used `certbot certonly -d`. Verified that the user was prompted for
      API key and email address after selecting cloudflare interactively
      and that a certificate was successfully obtained.
    * Used `certbot renew --force-renewal`. Verified that certificates
      were renewed without user interaction.
 * ./tox.cover.sh certbot
    * certbot/plugins/dns_cloudflare.py: 98% (Uncovered: 161, 180)
    * certbot/plugins/dns_cloudflare_test.py: 100%