### PR TITLE
Save public-ip-logging-ok when set interactively

### DIFF
--- a/certbot/plugins/manual.py
+++ b/certbot/plugins/manual.py
@@ -124,7 +124,8 @@ s.serve_forever()" """
                    'Are you OK with your IP being logged?')
             display = zope.component.getUtility(interfaces.IDisplay)
             if display.yesno(msg, cli_flag=cli_flag, force_interactive=True):
-                setattr(self.config, self.dest('public-ip-logging-ok'), True)
+                dest = self.dest('public-ip-logging-ok')
+                setattr(self.config.namespace, dest, True)
             else:
                 raise errors.PluginError('Must agree to IP logging to proceed')
 

--- a/certbot/plugins/manual_test.py
+++ b/certbot/plugins/manual_test.py
@@ -24,6 +24,7 @@ class AuthenticatorTest(unittest.TestCase):
             http01_port=0, manual_auth_hook=None, manual_cleanup_hook=None,
             manual_public_ip_logging_ok=False, noninteractive_mode=False,
             validate_hooks=False)
+        self.config.namespace.manual_public_ip_logging_ok = False
 
         from certbot.plugins.manual import Authenticator
         self.auth = Authenticator(self.config, name='manual')
@@ -53,7 +54,7 @@ class AuthenticatorTest(unittest.TestCase):
     def test_ip_logging_ok(self, mock_get_utility):
         mock_get_utility().yesno.return_value = True
         self.auth.perform([])
-        self.assertTrue(self.config.manual_public_ip_logging_ok)
+        self.assertTrue(self.config.namespace.manual_public_ip_logging_ok)
 
     def test_script_perform(self):
         self.config.manual_public_ip_logging_ok = True


### PR DESCRIPTION
If someone is using manual with hooks but answered this question interactively, Certbot is going to prompt when it tries to renew!