### PR TITLE
Add private key encipherment functionality

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -104,7 +104,7 @@ More detailed help:
 
 
 # These argparse parameters should be removed when detecting defaults.
-ARGPARSE_PARAMS_TO_REMOVE = ("const", "nargs", "type",)
+ARGPARSE_PARAMS_TO_REMOVE = ("const", "type",)
 
 
 # These sets are used when to help detect options set by the user.
@@ -556,6 +556,8 @@ class HelpfulArgumentParser(object):
         if parsed_args.must_staple:
             parsed_args.staple = True
 
+        parsed_args.passphrase = None
+
         return parsed_args
 
     def set_test_server(self, parsed_args):
@@ -610,7 +612,6 @@ class HelpfulArgumentParser(object):
             raise errors.ConfigurationError(
                 "Inconsistent domain requests:\nFrom the CSR: {0}\nFrom command line/config: {1}"
                 .format(", ".join(csr_domains), ", ".join(config_domains)))
-
 
     def determine_verb(self):
         """Determines the verb/subcommand provided by the user.
@@ -974,6 +975,10 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
     helpful.add(
         "security", "--rsa-key-size", type=int, metavar="N",
         default=flag_default("rsa_key_size"), help=config_help("rsa_key_size"))
+    helpful.add(
+        "security", "--encrypt-private-key", metavar="CIPHER",
+        dest="cipher", nargs='?', const='sha256', default=None,
+        help="Use a passphrase to encrypt the private key (default: False)")
     helpful.add(
         "security", "--must-staple", action="store_true",
         help=config_help("must_staple"), dest="must_staple", default=False)

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -208,6 +208,9 @@ class IConfig(zope.interface.Interface):
         "Autoconfigures OCSP Stapling for supported setups "
         "(Apache version >= 2.3.3 ).")
 
+    encrypt_private_key = zope.interface.Attribute(
+		"Encrypt private keys. (Default: False)")
+
     config_dir = zope.interface.Attribute("Configuration directory.")
     work_dir = zope.interface.Attribute("Working directory.")
 


### PR DESCRIPTION
Hi,
in reference to issue #4328, I implemented a little change to the code to allow an optional private key encipherment.

This PR adds a new command line switch `--encrypt-private-key [CIPHER]`, which accepts an optional cipher arguments (all those accepted by OpenSSL, i.e. those reported by `openssl rsa --help`, defaults to `aes256` if not specified), and asks for a passphrase, which is then used to encrypt the key using the standard pyOpenSSL routines.
The passphrase is then saved to a variable and made available to be used within the same invocation, for example to sign CSRs without prompting again the user for the same password.

As I am not particularly familiar with certbot's internals, this PR should be tested for a correct integrations with the rest of the package; in particular, I had to remove the `nargs` element from the `ARGPARSE_PARAMS_TO_REMOVE` tuple (from `certbot/cli.py`), as otherwise the `argparse`'s `nargs='?'` argument would not work - and it seems that no other option uses it.
I had also to use a `if not isinstance(cipher, str):` statement instead of `if cipher is None:` as otherwise the code would not pass the `py27` test (but would correctly pass the `py36` one, which I think suggests that the problem lies elsewhere in the package).

I hope you'll find this addition useful :)