### PR TITLE
Add a global lock file to Certbot

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1162,6 +1162,8 @@ def _paths_parser(helpful):
         help="Logs directory.")
     add("paths", "--server", default=flag_default("server"),
         help=config_help("server"))
+    add("paths", "--lock-path", default=flag_default("lock_path"),
+        help=config_help('lock_path'))
 
 
 def _plugins_parsing(helpful, plugins):

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -32,6 +32,7 @@ CLI_DEFAULTS = dict(
     auth_cert_path="./cert.pem",
     auth_chain_path="./chain.pem",
     strict_permissions=False,
+    lock_path="/tmp/.certbot.lock",
 )
 STAGING_URI = "https://acme-staging.api.letsencrypt.org/directory"
 
@@ -109,6 +110,3 @@ FORCE_INTERACTIVE_FLAG = "--force-interactive"
 
 EFF_SUBSCRIBE_URI = "https://supporters.eff.org/subscribe/certbot"
 """EFF URI used to submit the e-mail address of users who opt-in."""
-
-LOCK_FILE = "/tmp/.certbot.lock"
-"""Global lockfile to stop multiple Certbot instances from running at once."""

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -109,3 +109,6 @@ FORCE_INTERACTIVE_FLAG = "--force-interactive"
 
 EFF_SUBSCRIBE_URI = "https://supporters.eff.org/subscribe/certbot"
 """EFF URI used to submit the e-mail address of users who opt-in."""
+
+LOCK_FILE = "/tmp/.certbot.lock"
+"""Global lockfile to stop multiple Certbot instances from running at once."""

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -222,6 +222,9 @@ class IConfig(zope.interface.Interface):
     key_dir = zope.interface.Attribute("Keys storage.")
     temp_checkpoint_dir = zope.interface.Attribute(
         "Temporary checkpoint directory.")
+    lock_path = zope.interface.Attribute(
+        "Path to the lock file used to prevent multiple instances of "
+        "Certbot from modifying your server's configuration at once.")
 
     no_verify_ssl = zope.interface.Attribute(
         "Disable verification of the ACME server's certificate.")

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -452,7 +452,8 @@ class MainTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         os.mkdir(self.logs_dir)
         self.standard_args = ['--config-dir', self.config_dir,
                               '--work-dir', self.work_dir,
-                              '--logs-dir', self.logs_dir, '--text']
+                              '--logs-dir', self.logs_dir, '--text',
+                              '--lock-path', os.path.join(self.tmp_dir, 'certbot.lock')]
 
     def tearDown(self):
         # Reset globals in cli

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1311,8 +1311,10 @@ class TestHandleException(unittest.TestCase):
 class TestAcquireFileLock(unittest.TestCase):
     """Test main.acquire_file_lock."""
 
-    def test_bad_path(self):
+    @mock.patch('certbot.main.logger')
+    def test_bad_path(self, mock_logger):
         lock = main.acquire_file_lock(os.getcwd())
+        self.assertTrue(mock_logger.warning.called)
         self.assertFalse(lock.acquired)
 
 

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1308,5 +1308,13 @@ class TestHandleException(unittest.TestCase):
             traceback.format_exception_only(KeyboardInterrupt, interrupt)))
 
 
+class TestAcquireFileLock(unittest.TestCase):
+    """Test main.acquire_file_lock."""
+
+    def test_bad_path(self):
+        lock = main.acquire_file_lock(os.getcwd())
+        self.assertFalse(lock.acquired)
+
+
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -727,6 +727,9 @@ cryptography==1.5.3 \
 enum34==1.1.2 \
     --hash=sha256:2475d7fcddf5951e92ff546972758802de5260bf409319a9f1934e6bbc8b1dc7 \
     --hash=sha256:35907defb0f992b75ab7788f65fedc1cf20ffa22688e0e6f6f12afc06b3ea501
+fasteners==0.14.1 \
+    --hash=sha256:564a115ff9698767df401efca29620cbb1a1c2146b7095ebd304b79cc5807a7c \
+    --hash=sha256:427c76773fe036ddfa41e57d89086ea03111bbac57c55fc55f3006d027107e18
 funcsigs==0.4 \
     --hash=sha256:ff5ad9e2f8d9e5d1e8bbfbcf47722ab527cf0d51caeeed9da6d0f40799383fde \
     --hash=sha256:d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033
@@ -739,6 +742,9 @@ ipaddress==1.0.16 \
 linecache2==1.0.0 \
     --hash=sha256:e78be9c0a0dfcbac712fe04fbf92b96cddae80b1b842f24248214c8496f006ef \
     --hash=sha256:4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c
+monotonic==1.3 \
+    --hash=sha256:a8c7690953546c6bc8a4f05d347718db50de1225b29f4b9f346c0c6f19bdc286 \
+    --hash=sha256:2b469e2d7dd403f7f7f79227fe5ad551ee1e76f8bb300ae935209884b93c7c1b
 ordereddict==1.1 \
     --hash=sha256:1c35b4ac206cef2d24816c89f89cf289dd3d38cf7c449bb3fab7bf6d43f01b1f
 parsedatetime==2.1 \

--- a/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
+++ b/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
@@ -65,6 +65,9 @@ cryptography==1.5.3 \
 enum34==1.1.2 \
     --hash=sha256:2475d7fcddf5951e92ff546972758802de5260bf409319a9f1934e6bbc8b1dc7 \
     --hash=sha256:35907defb0f992b75ab7788f65fedc1cf20ffa22688e0e6f6f12afc06b3ea501
+fasteners==0.14.1 \
+    --hash=sha256:564a115ff9698767df401efca29620cbb1a1c2146b7095ebd304b79cc5807a7c \
+    --hash=sha256:427c76773fe036ddfa41e57d89086ea03111bbac57c55fc55f3006d027107e18
 funcsigs==0.4 \
     --hash=sha256:ff5ad9e2f8d9e5d1e8bbfbcf47722ab527cf0d51caeeed9da6d0f40799383fde \
     --hash=sha256:d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033
@@ -77,6 +80,9 @@ ipaddress==1.0.16 \
 linecache2==1.0.0 \
     --hash=sha256:e78be9c0a0dfcbac712fe04fbf92b96cddae80b1b842f24248214c8496f006ef \
     --hash=sha256:4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c
+monotonic==1.3 \
+    --hash=sha256:a8c7690953546c6bc8a4f05d347718db50de1225b29f4b9f346c0c6f19bdc286 \
+    --hash=sha256:2b469e2d7dd403f7f7f79227fe5ad551ee1e76f8bb300ae935209884b93c7c1b
 ordereddict==1.1 \
     --hash=sha256:1c35b4ac206cef2d24816c89f89cf289dd3d38cf7c449bb3fab7bf6d43f01b1f
 parsedatetime==2.1 \

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     'ConfigArgParse>=0.9.3',
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
+    'fasteners',
     'mock',
     'parsedatetime>=1.3',  # Calendar.parseDT
     'PyOpenSSL',


### PR DESCRIPTION
Fixes #933.

This PR implements a global lock file to prevent multiple versions of Certbot from running at once. It uses functionality implemented by the OS to put an advisory lock on a file that is tied to your process. If another process tries to grab an advisory lock on the same file, it will fail. The lock file is automatically released when your process exits. I don't have a machine to test it on, but this process should work on both Windows and any UNIX system.

#### Design

Initially I planned to put a lock file in some subset of `config_dir`, `work_dir`, and `logs_dir`. Technically, this isn't enough though. These directories can all be configured to use other paths and we also modify other files like your webserver's configuration. Rather than use lock files for all directories (and hope 3rd party plugins do the same) or leave holes for potential problems, I decided to make a global lock file at it's own path.

I chose `/tmp` because it's usually writeable by all users and is available on all UNIX systems. I made the path configurable so if someone really wants they can change it. I also made the inability to access the lock file a soft fail that just warns the user of the problem. If another process holds the lock, we crash, however, if we can't even access the file, we keep going with a warning. This prevents breaking automatic renewal in systems that have unconventional permissions on `/tmp`.

#### Why fasteners?

I picked `fasteners` because it is the most popular, non-deprecated, Python 2 and 3 compatible, Windows and UNIX compatible lock file module that is packaged on all relevant OSs. It uses `fcntl()`/`lockf()` on UNIX rather than `flock()` which works on systems like [Solaris](https://wiki.enterpriselab.ch/el/public:sysadmin:letsencrypt:install-solaris-11) and works on NFS mounts. It has one dependency on `monotonic`, but both `fasteners` and `monotonic` are relatively small.

One downside of this library (and almost every other library I looked at) is it never deletes the lockfile. It turns out doing this properly is tricky. I found a Python 2 and UNIX only library that does this and we could make work for our purposes, but we'd have to vendor it and deal with the bugs. I'd rather not go down this route just for aesthetics, but if you're curious, there is a branch on this repo containing this code called `lock`.