### PR TITLE
Py3 enable boulder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,13 +78,33 @@ matrix:
       env: TOXENV=apacheconftest
       sudo: required
     - python: "3.3"
-      env: TOXENV=py33
+      env: TOXENV=py33 BOULDER_INTEGRATION=1
+      sudo: required
+      after_failure:
+        - sudo cat /var/log/mysql/error.log
+        - ps aux | grep mysql
+      services: docker
     - python: "3.4"
-      env: TOXENV=py34
+      env: TOXENV=py34 BOULDER_INTEGRATION=1
+      sudo: required
+      after_failure:
+        - sudo cat /var/log/mysql/error.log
+        - ps aux | grep mysql
+      services: docker
     - python: "3.5"
-      env: TOXENV=py35
+      env: TOXENV=py35 BOULDER_INTEGRATION=1
+      sudo: required
+      after_failure:
+        - sudo cat /var/log/mysql/error.log
+        - ps aux | grep mysql
+      services: docker
     - python: "3.6"
-      env: TOXENV=py36
+      env: TOXENV=py36 BOULDER_INTEGRATION=1
+      sudo: required
+      after_failure:
+        - sudo cat /var/log/mysql/error.log
+        - ps aux | grep mysql
+      services: docker
     - python: "2.7"
       env: TOXENV=nginxroundtrip
 

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -629,7 +629,8 @@ class NginxConfigurator(common.Plugin):
             proc = subprocess.Popen(
                 [self.conf('ctl'), "-c", self.nginx_conf, "-V"],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                universal_newlines=True)
             text = proc.communicate()[1]  # nginx prints output to stderr
         except (OSError, ValueError) as error:
             logger.debug(error, exc_info=True)

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -82,7 +82,7 @@ CheckHooks() {
 
 # We start a server listening on the port for the
 # unrequested challenge to prevent regressions in #3601.
-python -m SimpleHTTPServer $http_01_port &
+python ./tests/run_http_server.py $http_01_port &
 python_server_pid=$!
 
 common --domains le1.wtf --preferred-challenges tls-sni-01 auth \
@@ -90,7 +90,7 @@ common --domains le1.wtf --preferred-challenges tls-sni-01 auth \
        --post-hook 'echo wtf.post >> "$HOOK_TEST"'\
        --renew-hook 'echo renew >> "$HOOK_TEST"'
 kill $python_server_pid
-python -m SimpleHTTPServer $tls_sni_01_port &
+python ./tests/run_http_server.py $tls_sni_01_port &
 python_server_pid=$!
 common --domains le2.wtf --preferred-challenges http-01 run \
        --pre-hook 'echo wtf.pre >> "$HOOK_TEST"' \

--- a/tests/manual-http-auth.sh
+++ b/tests/manual-http-auth.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 uri_path=".well-known/acme-challenge/$CERTBOT_TOKEN"
 
+# This script should be run from the top level. e.g. ./tests/manual-http-auth.sh
+source_dir="$(pwd)"
 cd $(mktemp -d)
 mkdir -p $(dirname $uri_path)
 echo $CERTBOT_VALIDATION > $uri_path
-python -m SimpleHTTPServer $http_01_port >/dev/null 2>&1 &
+python "$source_dir/tests/run_http_server.py" $http_01_port >/dev/null 2>&1 &
 server_pid=$!
 while ! curl "http://localhost:$http_01_port/$uri_path" >/dev/null 2>&1; do
     sleep 1s

--- a/tests/run_http_server.py
+++ b/tests/run_http_server.py
@@ -1,0 +1,11 @@
+import runpy
+import sys
+
+# Run Python's built-in HTTP server
+# Usage: python ./tests/run_http_server.py port_num
+# NOTE: This script should be compatible with 2.6, 2.7, 3.3+
+
+# sys.argv (port number) is passed as-is to the HTTP server module
+runpy.run_module(
+    'http.server' if sys.version_info[0] == 3 else 'SimpleHTTPServer',
+    run_name='__main__')


### PR DESCRIPTION
This pull request enables boulder integration tests for all Python 3 versions on Travis CI as well as fix bugs identified by integration tests.

Ref: #3179 
Ref: #4264. Commit 7a71779 ("certbot: Use bytes objects for all server-returned data") fixes an issue with a very similar backtrace as #4264. I believe they're the same bug.