### PR TITLE
Fix Docker IP detection with different ifconfig output formats

### DIFF
--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -12,5 +12,7 @@ fi
 
 cd ${BOULDERPATH}
 FAKE_DNS=$(ifconfig docker0 | grep "inet addr:" | cut -d: -f2 | awk '{ print $1}')
+[ -z "$FAKE_DNS" ] && FAKE_DNS=$(ifconfig docker0 | grep "inet " | xargs | cut -d ' ' -f 2)
+[ -z "$FAKE_DNS" ] && echo Unable to find the IP for docker0 && exit 1
 sed -i "s/FAKE_DNS: .*/FAKE_DNS: ${FAKE_DNS}/" docker-compose.yml
 docker-compose up -d


### PR DESCRIPTION
When trying out integration tests (#4374), I find that on Arch Linux IP detection doesn't work, leading to failures of integration tests. The cause is that new ```ifconfig``` uses a different layout. For example:
```
$ ifconfig docker0 
docker0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.17.0.1  netmask 255.255.0.0  broadcast 0.0.0.0
        inet6 fe80::42:80ff:fe80:f92  prefixlen 64  scopeid 0x20<link>
        ether 02:42:80:80:0f:92  txqueuelen 0  (Ethernet)
        RX packets 351742  bytes 19691534 (18.7 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 354247  bytes 63201066 (60.2 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
The upstream change can be found in https://sourceforge.net/p/net-tools/code/ci/eb04ef31571f6c707eacaba6846feeebfab518e6/

In this pull request I fix it up as well as report errors earlier so that debugging can be easier for others.