### PR TITLE
Add --debug-challenges flag (#1684)

### DIFF
--- a/certbot/auth_handler.py
+++ b/certbot/auth_handler.py
@@ -66,11 +66,16 @@ class AuthHandler(object):
             self.authzr[domain] = self.acme.request_domain_challenges(domain)
 
         self._choose_challenges(domains)
+        config = zope.component.getUtility(interfaces.IConfig)
+        notify = zope.component.getUtility(interfaces.IDisplay).notification
 
         # While there are still challenges remaining...
         while self.achalls:
             resp = self._solve_challenges()
             logger.info("Waiting for verification...")
+            if config.debug_challenges:
+                notify('Challenges loaded. Press continue to submit to CA. '
+                       'Pass "-v" for more info about challenges.', pause=True)
 
             # Send all Responses - this modifies achalls
             self._respond(resp, best_effort)

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -956,7 +956,7 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         help="Show tracebacks in case of errors, and allow certbot-auto "
              "execution on experimental platforms")
     helpful.add(
-        ["certonly", "renew", "run"], "--debug-challenges", action="store_true",
+        [None, "certonly", "renew", "run"], "--debug-challenges", action="store_true",
         default=flag_default("debug_challenges"),
         help="After setting up challenges, wait for user input before "
              "submitting to CA")

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -956,6 +956,11 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         help="Show tracebacks in case of errors, and allow certbot-auto "
              "execution on experimental platforms")
     helpful.add(
+        ["certonly", "renew", "run"], "--debug-challenges", action="store_true",
+        default=flag_default("debug_challenges"),
+        help="After setting up challenges, wait for user input before "
+             "submitting to CA")
+    helpful.add(
         "testing", "--no-verify-ssl", action="store_true",
         help=config_help("no_verify_ssl"),
         default=flag_default("no_verify_ssl"))

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -32,6 +32,7 @@ CLI_DEFAULTS = dict(
     auth_cert_path="./cert.pem",
     auth_chain_path="./chain.pem",
     strict_permissions=False,
+    debug_challenges=False,
 )
 STAGING_URI = "https://acme-staging.api.letsencrypt.org/directory"
 

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -5,6 +5,7 @@ import unittest
 
 import mock
 import six
+import zope.component
 
 from acme import challenges
 from acme import client as acme_client
@@ -12,6 +13,7 @@ from acme import messages
 
 from certbot import achallenges
 from certbot import errors
+from certbot import interfaces
 from certbot import util
 
 from certbot.tests import acme_util
@@ -64,6 +66,12 @@ class GetAuthorizationsTest(unittest.TestCase):
 
     def setUp(self):
         from certbot.auth_handler import AuthHandler
+
+        self.mock_display = mock.Mock()
+        zope.component.provideUtility(
+            self.mock_display, interfaces.IDisplay)
+        zope.component.provideUtility(
+            mock.Mock(debug_challenges=False), interfaces.IConfig)
 
         self.mock_auth = mock.MagicMock(name="ApacheConfigurator")
 
@@ -156,6 +164,20 @@ class GetAuthorizationsTest(unittest.TestCase):
         self.assertEqual(self.mock_auth.cleanup.call_count, 1)
 
         self.assertEqual(len(authzr), 3)
+
+    @mock.patch("certbot.auth_handler.AuthHandler._poll_challenges")
+    def test_debug_challenges(self, mock_poll):
+        zope.component.provideUtility(
+            mock.Mock(debug_challenges=True), interfaces.IConfig)
+        self.mock_net.request_domain_challenges.side_effect = functools.partial(
+            gen_dom_authzr, challs=acme_util.CHALLENGES)
+
+        mock_poll.side_effect = self._validate_all
+
+        self.handler.get_authorizations(["0"])
+
+        self.assertEqual(self.mock_net.answer_challenge.call_count, 1)
+        self.assertEqual(self.mock_display.notification.call_count, 1)
 
     def test_perform_failure(self):
         self.mock_net.request_domain_challenges.side_effect = functools.partial(


### PR DESCRIPTION
Initial version of https://github.com/certbot/certbot/issues/1684.

Pausing after challenges are setup and suggesting the user use "-v" to debug further.