### PR TITLE
Fix unorderable types error

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -358,14 +358,18 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
 
         # priority queue with datetime.datetime (based on Retry-After) as key,
         # and original Authorization Resource as value
-        waiting = [(datetime.datetime.now(), authzr) for authzr in authzrs]
+        waiting = [
+            (datetime.datetime.now(), index, authzr)
+            for index, authzr in enumerate(authzrs)
+        ]
+        heapq.heapify(waiting)
         # mapping between original Authorization Resource and the most
         # recently updated one
         updated = dict((authzr, authzr) for authzr in authzrs)
 
         while waiting:
             # find the smallest Retry-After, and sleep if necessary
-            when, authzr = heapq.heappop(waiting)
+            when, index, authzr = heapq.heappop(waiting)
             now = datetime.datetime.now()
             if when > now:
                 seconds = (when - now).seconds
@@ -384,7 +388,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
                 if attempts[authzr] < max_attempts:
                     # push back to the priority queue, with updated retry_after
                     heapq.heappush(waiting, (self.retry_after(
-                        response, default=mintime), authzr))
+                        response, default=mintime), index, authzr))
                 else:
                     exhausted.add(authzr)
 


### PR DESCRIPTION
Seen on 0.9.3 and 0.12.0 with python 3.4

I ran into this issue where the `poll_and_request_issuance()` threw an "unorderable type" error because it attempted to compare the AuthenticationResource objects. After inspecting, some elements of the `waiting` heap shows similar datetime.

If I'm not wrong the piece of code that this PR is modifying assumes the datetime of the tuples wouldn't collide. If the datetime collides, the comparator of heapq will move onto the AuthorizationResource value and throws an "unorderable type" error.

This adds an index value to the element tuple to ensure that they are always strictly ordered.