### PR TITLE
Lock file part 2

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -947,12 +947,10 @@ def acquire_lock_file(lock_path):
         return None
 
     try:
-        portalocker.lock(f, portalocker.LOCK_EX | portalocker.LOCK_NB)
+        return portalocker.lock(f, portalocker.LOCK_EX | portalocker.LOCK_NB)
     except portalocker.LockException:
         logger.debug("Encountered exception acquiring lock", exc_info=True)
         raise errors.Error("Another instance of Certbot is already running.")
-
-    return f
 
 
 def main(cli_args=sys.argv[1:]):

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -878,8 +878,7 @@ def acquire_lock_file(lock_path):
     The file is opened in append mode and created with 0666 permissions
     if it doesn't already exist. If lock_path cannot be accessed
     securely, a warning is logged and the lock is not acquired. The lock
-    is automatically released when the file is closed. This lock cannot
-    be used for synchronization between threads.
+    is automatically released when the file is closed.
 
     :param str lock_path: path to the file to be locked
 

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -901,10 +901,12 @@ def acquire_lock_file(lock_path):
         return None
 
     try:
-        return portalocker.lock(f, portalocker.LOCK_EX | portalocker.LOCK_NB)
+        portalocker.lock(f, portalocker.LOCK_EX | portalocker.LOCK_NB)
     except portalocker.LockException:
         logger.debug("Encountered exception acquiring lock", exc_info=True)
         raise errors.Error("Another instance of Certbot is already running.")
+
+    return f
 
 
 def main(cli_args=sys.argv[1:]):

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -207,11 +207,9 @@ class SafePermissiveOpenTest(unittest.TestCase):
         from certbot.util import check_permissions
         return check_permissions(self.path, mode, os.geteuid())
 
-    @mock.patch("certbot.util.logger")
-    def test_failure(self, mock_logger):
+    def test_failure(self):
         os.symlink(self.path + "2", self.path)
         self.assertRaises(OSError, self._call, 0o777)
-        self.assertTrue(mock_logger.debug.called)
 
     def test_success(self):
         mode = 0o600

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -225,23 +225,6 @@ class SafePermissiveOpenTest(unittest.TestCase):
         self.assertTrue(self._check_permissions(mode))
         f.close()
 
-    @mock.patch("certbot.util.logger")
-    @mock.patch("certbot.util.os", spec=os)
-    def test_failure_with_mock_nofollow(self, mock_os, mock_logger):
-        mock_os.O_NOFOLLOW = mock.MagicMock()
-        mock_os.open.side_effect = OSError
-        self.assertRaises(OSError, self._call, 0o777)
-        self.assertTrue(mock_logger.debug.called)
-
-    @mock.patch("certbot.util.logger")
-    @mock.patch("certbot.util.os", spec=os)
-    def test_failure_with_mock_no_nofollow(self, mock_os, mock_logger):
-        if hasattr(mock_os, "O_NOFOLLOW"):
-            del mock_os.O_NOFOLLOW
-        mock_os.open.side_effect = OSError
-        self.assertRaises(OSError, self._call, 0o777)
-        self.assertTrue(mock_logger.debug.called)
-
 
 try:
     file_type = file

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -193,7 +193,6 @@ def safe_permissive_open(path, chmod, mode="w"):
         return safe_open(path, mode, chmod=chmod)
     except OSError as err:
         if err.errno == errno.EEXIST:
-            logger.debug("%s already exists", path, exc_info=True)
             return controlled_open(path, os.O_RDWR, mode)
         raise
     finally:

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -146,12 +146,29 @@ def safe_open(path, mode="w", chmod=None, buffering=None):
         defaults if ``None``.
 
     """
+    flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+    return controlled_open(path, flags, mode, chmod, buffering)
+
+
+def controlled_open(path, flags, mode="r", chmod=None, buffering=None):
+    """Open a file with lower level control.
+
+    :param str path: Path to a file.
+    :param int flags: Same as `flags` for `os.open`
+    :param str mode: Same os `mode` for `open`.
+    :param int chmod: Same as `mode` for `os.open`, uses Python defaults
+        if ``None``.
+    :param int buffering: Same as `bufsize` for `os.fdopen`, uses Python
+        defaults if ``None``.
+
+    :returns: the opened file
+    :rtype: `file`
+
+    """
     # pylint: disable=star-args
     open_args = () if chmod is None else (chmod,)
     fdopen_args = () if buffering is None else (buffering,)
-    return os.fdopen(
-        os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, *open_args),
-        mode, *fdopen_args)
+    return os.fdopen(os.open(path, flags, *open_args), mode, *fdopen_args)
 
 
 def _unique_file(path, filename_pat, count, chmod, mode):

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -135,21 +135,6 @@ def check_permissions(filepath, mode, uid=0):
     return stat.S_IMODE(file_stat.st_mode) == mode and file_stat.st_uid == uid
 
 
-def safe_open(path, mode="w", chmod=None, buffering=None):
-    """Safely open a file.
-
-    :param str path: Path to a file.
-    :param str mode: Same os `mode` for `open`.
-    :param int chmod: Same as `mode` for `os.open`, uses Python defaults
-        if ``None``.
-    :param int buffering: Same as `bufsize` for `os.fdopen`, uses Python
-        defaults if ``None``.
-
-    """
-    flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
-    return controlled_open(path, flags, mode, chmod, buffering)
-
-
 def controlled_open(path, flags, mode="r", chmod=None, buffering=None):
     """Open a file with lower level control.
 
@@ -169,6 +154,21 @@ def controlled_open(path, flags, mode="r", chmod=None, buffering=None):
     open_args = () if chmod is None else (chmod,)
     fdopen_args = () if buffering is None else (buffering,)
     return os.fdopen(os.open(path, flags, *open_args), mode, *fdopen_args)
+
+
+def safe_open(path, mode="w", chmod=None, buffering=None):
+    """Safely open a file.
+
+    :param str path: Path to a file.
+    :param str mode: Same os `mode` for `open`.
+    :param int chmod: Same as `mode` for `os.open`, uses Python defaults
+        if ``None``.
+    :param int buffering: Same as `bufsize` for `os.fdopen`, uses Python
+        defaults if ``None``.
+
+    """
+    flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+    return controlled_open(path, flags, mode, chmod, buffering)
 
 
 def _unique_file(path, filename_pat, count, chmod, mode):

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -5,7 +5,6 @@ import collections
 # For more info, see: https://github.com/PyCQA/pylint/issues/73
 import distutils.version  # pylint: disable=import-error,no-name-in-module
 import errno
-import functools
 import logging
 import os
 import platform
@@ -172,34 +171,6 @@ def safe_open(path, mode="w", chmod=None, buffering=None):
     return controlled_open(path, flags, mode, chmod, buffering)
 
 
-def _safe_permissive_open(path, chmod, mode):
-    """Try to safely open a file with the specified permissions.
-
-    This will fail if there is a symlink at path or O_NOFOLLOW is not
-    supported by the OS and there is an existing file at path.
-
-    :param str path: Path to a file.
-    :param int chmod: Same as `mode` for `os.open`, uses Python defaults
-        if ``None``.
-    :param str mode: Same os `mode` for `open`.
-
-    :returns: the opened file
-    :rtype: `file`
-
-    """
-    if hasattr(os, "O_NOFOLLOW"):
-        flags = os.O_CREAT | os.O_NOFOLLOW | os.O_RDWR
-        open_func = functools.partial(controlled_open, flags=flags)
-    else:
-        open_func = safe_open
-
-    old_umask = os.umask(0o000)
-    try:
-        return open_func(path, mode=mode, chmod=chmod)
-    finally:
-        os.umask(old_umask)
-
-
 def safe_permissive_open(path, chmod, mode="w"):
     """Safely open a file with the specified permissions.
 
@@ -217,12 +188,16 @@ def safe_permissive_open(path, chmod, mode="w"):
     :rtype: `file`
 
     """
+    old_umask = os.umask(0o000)
     try:
-        return _safe_permissive_open(path, chmod, mode)
-    except OSError:
-        logger.debug(
-            "Encountered exception creating/opening %s", path, exc_info=True)
-    return controlled_open(path, os.O_RDWR, mode)
+        return safe_open(path, mode, chmod=chmod)
+    except OSError as err:
+        if err.errno == errno.EEXIST:
+            logger.debug("%s already exists", path, exc_info=True)
+            return controlled_open(path, os.O_RDWR, mode)
+        raise
+    finally:
+        os.umask(old_umask)
 
 
 def _unique_file(path, filename_pat, count, chmod, mode):

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -727,9 +727,6 @@ cryptography==1.5.3 \
 enum34==1.1.2 \
     --hash=sha256:2475d7fcddf5951e92ff546972758802de5260bf409319a9f1934e6bbc8b1dc7 \
     --hash=sha256:35907defb0f992b75ab7788f65fedc1cf20ffa22688e0e6f6f12afc06b3ea501
-fasteners==0.14.1 \
-    --hash=sha256:564a115ff9698767df401efca29620cbb1a1c2146b7095ebd304b79cc5807a7c \
-    --hash=sha256:427c76773fe036ddfa41e57d89086ea03111bbac57c55fc55f3006d027107e18
 funcsigs==0.4 \
     --hash=sha256:ff5ad9e2f8d9e5d1e8bbfbcf47722ab527cf0d51caeeed9da6d0f40799383fde \
     --hash=sha256:d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033
@@ -742,9 +739,6 @@ ipaddress==1.0.16 \
 linecache2==1.0.0 \
     --hash=sha256:e78be9c0a0dfcbac712fe04fbf92b96cddae80b1b842f24248214c8496f006ef \
     --hash=sha256:4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c
-monotonic==1.3 \
-    --hash=sha256:a8c7690953546c6bc8a4f05d347718db50de1225b29f4b9f346c0c6f19bdc286 \
-    --hash=sha256:2b469e2d7dd403f7f7f79227fe5ad551ee1e76f8bb300ae935209884b93c7c1b
 ordereddict==1.1 \
     --hash=sha256:1c35b4ac206cef2d24816c89f89cf289dd3d38cf7c449bb3fab7bf6d43f01b1f
 parsedatetime==2.1 \

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -747,6 +747,9 @@ parsedatetime==2.1 \
 pbr==1.8.1 \
     --hash=sha256:46c8db75ae75a056bd1cc07fa21734fe2e603d11a07833ecc1eeb74c35c72e0c \
     --hash=sha256:e2127626a91e6c885db89668976db31020f0af2da728924b56480fc7ccf09649
+portalocker==1.1.0 \
+    --hash=sha256:3773cb40ccb690900920ac529c554bb49e69e2b396a7ffe20dd3f29c8bbbb497 \
+    --hash=sha256:b955d6197c7cd3206500d3237a2dd6cc899ceebb13460cc97e658cbab70df11b
 pyasn1==0.1.9 \
     --hash=sha256:61f9d99e3cef65feb1bfe3a2eef7a93eb93819d345bf54bcd42f4e63d5204dae \
     --hash=sha256:1802a6dd32045e472a419db1441aecab469d33e0d2749e192abdec52101724af \

--- a/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
+++ b/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
@@ -65,9 +65,6 @@ cryptography==1.5.3 \
 enum34==1.1.2 \
     --hash=sha256:2475d7fcddf5951e92ff546972758802de5260bf409319a9f1934e6bbc8b1dc7 \
     --hash=sha256:35907defb0f992b75ab7788f65fedc1cf20ffa22688e0e6f6f12afc06b3ea501
-fasteners==0.14.1 \
-    --hash=sha256:564a115ff9698767df401efca29620cbb1a1c2146b7095ebd304b79cc5807a7c \
-    --hash=sha256:427c76773fe036ddfa41e57d89086ea03111bbac57c55fc55f3006d027107e18
 funcsigs==0.4 \
     --hash=sha256:ff5ad9e2f8d9e5d1e8bbfbcf47722ab527cf0d51caeeed9da6d0f40799383fde \
     --hash=sha256:d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033
@@ -80,9 +77,6 @@ ipaddress==1.0.16 \
 linecache2==1.0.0 \
     --hash=sha256:e78be9c0a0dfcbac712fe04fbf92b96cddae80b1b842f24248214c8496f006ef \
     --hash=sha256:4b26ff4e7110db76eeb6f5a7b64a82623839d595c2038eeda662f2a2db78e97c
-monotonic==1.3 \
-    --hash=sha256:a8c7690953546c6bc8a4f05d347718db50de1225b29f4b9f346c0c6f19bdc286 \
-    --hash=sha256:2b469e2d7dd403f7f7f79227fe5ad551ee1e76f8bb300ae935209884b93c7c1b
 ordereddict==1.1 \
     --hash=sha256:1c35b4ac206cef2d24816c89f89cf289dd3d38cf7c449bb3fab7bf6d43f01b1f
 parsedatetime==2.1 \

--- a/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
+++ b/letsencrypt-auto-source/pieces/letsencrypt-auto-requirements.txt
@@ -85,6 +85,9 @@ parsedatetime==2.1 \
 pbr==1.8.1 \
     --hash=sha256:46c8db75ae75a056bd1cc07fa21734fe2e603d11a07833ecc1eeb74c35c72e0c \
     --hash=sha256:e2127626a91e6c885db89668976db31020f0af2da728924b56480fc7ccf09649
+portalocker==1.1.0 \
+    --hash=sha256:3773cb40ccb690900920ac529c554bb49e69e2b396a7ffe20dd3f29c8bbbb497 \
+    --hash=sha256:b955d6197c7cd3206500d3237a2dd6cc899ceebb13460cc97e658cbab70df11b
 pyasn1==0.1.9 \
     --hash=sha256:61f9d99e3cef65feb1bfe3a2eef7a93eb93819d345bf54bcd42f4e63d5204dae \
     --hash=sha256:1802a6dd32045e472a419db1441aecab469d33e0d2749e192abdec52101724af \

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ install_requires = [
     'fasteners',
     'mock',
     'parsedatetime>=1.3',  # Calendar.parseDT
+    'portalocker',
     'PyOpenSSL',
     'pyrfc3339',
     'pytz',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ install_requires = [
     'ConfigArgParse>=0.9.3',
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
-    'fasteners',
     'mock',
     'parsedatetime>=1.3',  # Calendar.parseDT
     'portalocker',


### PR DESCRIPTION
Fixes #933 (again).

Much of the design is the same as what I described in #4369. The differences are:

#### Make the lock file world writeable

This allows the lock to be shared regardless of the permissions used to run Certbot. The way this works is if the path provided with `--lock-path` doesn't exist and the target is not a broken symlink, the file is created with 0666 permissions. If it does exist, its permissions are unchanged. If the target is a broken symlink, we'll refuse to create the file, display a warning, and continue without grabbing the lock. We could potentially create the file with more restricted permissions in this case, but I think this behavior is better than allowing an arbitrary user to create arbitrary files.

#### Switch to portalocker

This is mainly due the change above. `portalocker` allows you to handle creating the file yourself and pass it in to `portalocker` to lock it which now works better for us. `portalocker` is packaged everywhere relevant except EPEL and FreeBSD. I believe this can be easily changed on both places to package Certbot.

Also, `portalocker` uses `flock()` on UNIX and I explained a few reasons why `lockf()` works better for us in #4369, but:

1. Python emulates `flock()` on systems where it's not available ([source](https://docs.python.org/2/library/fcntl.html#fcntl.floc) and [source source](https://github.com/python/cpython/blob/6f0eb93183519024cb360162bdd81b9faec97ba6/Modules/fcntlmodule.c#L282)).
2. The `flock()` system call has worked properly over NFS (and by properly I mean the lock isn't limited to the local file system) on Linux since 2005 ([source](http://man7.org/linux/man-pages/man2/flock.2.html)).

~~1. I'm unaware of any UNIX system where `fcntl.flock()` doesn't work in Python. On some systems, this is emulated by a call to `fcntl.fcntl()` ([source](https://docs.python.org/2/library/fcntl.html#fcntl.flock)), but I couldn't find any reports of it not working at all. BSD and Linux have supported the real `flock()` system call since 1983 and no later than 1996 respectively ([source](http://man7.org/linux/man-pages/man2/flock.2.html)). I found reports of it working in Python on Solaris in 2002. The `flock()` system call has worked properly over NFS (and by properly I mean the lock isn't limited to the local file system) on Linux since 2005 ([source](http://man7.org/linux/man-pages/man2/flock.2.html)). While it's possible there's a super old or obscure UNIX system where `flock()` won't work for us, I couldn't find one and not for lack of trying. We will not have a problem here on any modern or popular system.
2. If there is a problem on an obscure system, I've talked to the `portalocker` maintainer and he's willing to add a fallback using `lockf` or `fcntl`. The blocker to doing this now is we have no idea how the error manifests (e.g. `IOError`, `flock()` not defined, etc.).~~