### PR TITLE
Suppress "Registering without email" 

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -117,7 +117,7 @@ def register(config, account_storage, tos_cb=None):
                    "--register-unsafely-without-email was not present.")
             logger.warning(msg)
             raise errors.Error(msg)
-        if not config.dry_run:
+        if not config.dry_run and not config.quiet:
             logger.warning("Registering without email!")
 
     # Each new registration shall use a fresh new key

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -101,6 +101,7 @@ class RegisterTest(unittest.TestCase):
                     self.config.email = None
                     self.config.register_unsafely_without_email = True
                     self.config.dry_run = False
+                    self.config.quiet = False
                     self._call()
                     mock_logger.warning.assert_called_once_with(mock.ANY)
                     self.assertTrue(mock_handle.called)


### PR DESCRIPTION
Suppress "Registering without email" message when both --quiet and --register-unsafely-without-email flags are passed.  This addresses https://github.com/certbot/certbot/issues/4408