### PR TITLE
Replace e.message with str(e) for Python 3 compatibility

### DIFF
--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -192,12 +192,7 @@ def _choose_names_manually(prompt_prefix=""):
             try:
                 domain_list[i] = util.enforce_domain_sanity(domain)
             except errors.ConfigurationError as e:
-                try:  # Python 2
-                    # pylint: disable=no-member
-                    err_msg = e.message.encode('utf-8')
-                except AttributeError:
-                    err_msg = str(e)
-                invalid_domains[domain] = err_msg
+                invalid_domains[domain] = str(e)
 
         if len(invalid_domains):
             retry_message = (

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -582,7 +582,7 @@ def revoke(config, unused_plugins):  # TODO: coop with renewal config
     try:
         acme.revoke(jose.ComparableX509(cert), config.reason)
     except acme_errors.ClientError as e:
-        return e.message
+        return str(e)
 
     display_ops.success_revocation(config.cert_path[0])
 
@@ -594,7 +594,7 @@ def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
     try:
         installer, authenticator = plug_sel.choose_configurator_plugins(config, plugins, "run")
     except errors.PluginSelectionError as e:
-        return e.message
+        return str(e)
 
     # TODO: Handle errors from _init_le_client?
     le_client = _init_le_client(config, authenticator, installer)

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -79,7 +79,7 @@ def _reconstitute(config, full_path):
     except (ValueError, errors.Error) as error:
         logger.warning(
             "An error occurred while parsing %s. The error was %s. "
-            "Skipping the file.", full_path, error.message)
+            "Skipping the file.", full_path, str(error))
         logger.debug("Traceback was:\n%s", traceback.format_exc())
         return None
 


### PR DESCRIPTION
BaseException.message is deprecated since Python 2.6 and removed in Python 3.0. [1] Python Docs suggests ```str(err)``` or ```unicode(err)``` for a given exception ```err```. [2][3]

About the change in ```certbot/display/ops.py```: it was originally written by me in #3375. Maybe there was something wrong with me that I wrote such horrible codes. It turns out that simple ```str(e)``` works fine in this case as well. For example, in a Python 2.7 virtual environment, I enter an invalid domain name manually:

```
$ certbot --config-dir config --work-dir work --logs-dir logs certonly --webroot --register-unsafely-without-email --agree-tos --lock-path lock
Saving debug log to /home/yen/Projects/certbot/logs/letsencrypt.log
Please enter in your domain name(s) (comma and/or space separated)  (Enter 'c'
to cancel):大中天.com

-------------------------------------------------------------------------------
One or more of the entered domain names was not valid:

大中天.com: Non-ASCII domain names not supported. To issue for an
Internationalized Domain Name, use Punycode.

Would you like to re-enter the names?
-------------------------------------------------------------------------------
(Y)es/(N)o: n
Please specify --domains, or --installer that will help in domain names autodiscovery, or --cert-name for an existing certificate name.
```
The result is quite similar in a Python 3.6 virtual environment:
```
$ certbot --config-dir config --work-dir work --logs-dir logs certonly --webroot --register-unsafely-without-email --agree-tos --lock-path lock
Saving debug log to /home/yen/Projects/certbot/logs/letsencrypt.log
Please enter in your domain name(s) (comma and/or space separated)  (Enter 'c'
to cancel):大中天.com

-------------------------------------------------------------------------------
One or more of the entered domain names was not valid:

大中天.com: Non-ASCII domain names not supported. To issue for an Internationalized
Domain Name, use Punycode.

Would you like to re-enter the names?
-------------------------------------------------------------------------------
(Y)es/(N)o: n
Please specify --domains, or --installer that will help in domain names autodiscovery, or --cert-name for an existing certificate name.
```

Ref: #3179

[1] https://www.python.org/dev/peps/pep-0352/
[2] https://docs.python.org/2.7/library/exceptions.html#exceptions.BaseException
[3] https://docs.python.org/3/library/exceptions.html#BaseException
[4] https://github.com/certbot/certbot/pull/3375/files#diff-40ac93e6d65229db0defa872ab745538