### PR TITLE
Pin python-augeas version to avoid error with 1.0.0

### DIFF
--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'acme=={0}'.format(version),
     'certbot=={0}'.format(version),
     'mock',
-    'python-augeas',
+    'python-augeas<=0.5.0',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',


### PR DESCRIPTION
When running ./tools/venv.sh with 1.0.0 (now the latest version), I encountered:
    build/temp.linux-x86_64-2.7/augeas.c:434:35: fatal error: augeas.h: No such file or directory