### PR TITLE
security: preserve permissions on renewal conf

### DIFF
--- a/certbot/storage.py
+++ b/certbot/storage.py
@@ -4,6 +4,7 @@ import glob
 import logging
 import os
 import re
+import stat
 
 import configobj
 import parsedatetime
@@ -117,9 +118,19 @@ def write_renewal_config(o_filename, n_filename, archive_dir, target, relevant_d
     # TODO: add human-readable comments explaining other available
     #       parameters
     logger.debug("Writing new config %s.", n_filename)
+
+    # Ensure that the file exists
+    open(n_filename, 'a').close()
+
+    # Copy permissions from the old version of the file, if it exists.
+    if os.path.exists(o_filename):
+        current_permissions = stat.S_IMODE(os.lstat(o_filename).st_mode)
+        os.chmod(n_filename, current_permissions)
+
     with open(n_filename, "wb") as f:
         config.write(outfile=f)
     return config
+
 
 def rename_renewal_config(prev_name, new_name, cli_config):
     """Renames cli_config.certname's config to cli_config.new_certname.


### PR DESCRIPTION
Ensure that permissions are preserved when renewal data is written to
conf files. This allows users to limit access to the file, if they wish.

Testing done:
 * `tox -e py27`
 * `tox -e lint`
 * Manual Testing
    * Got a new certificate. Restricted the permissions on the renewal
      conf. Renewed the certificate. Verified that the new renewal conf
      permissions matched.

Resolves #4575.