### PR TITLE
Dump Boulder logs on integration test failures.

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -8,7 +8,7 @@
 #
 # Note: this script is called by Boulder integration test suite!
 
-set -ex
+set -eux
 
 . ./tests/integration/_common.sh
 export PATH="$PATH:/usr/sbin"  # /usr/sbin/nginx
@@ -26,14 +26,14 @@ cleanup_and_exit() {
         echo Kill server subprocess, left running by abnormal exit
         kill $SERVER_STILL_RUNNING
     fi
-    echo "------------------ ------------------ ------------------"
-    echo "------------------ begin boulder logs ------------------"
-    echo "------------------ ------------------ ------------------"
     # Dump boulder logs in case they contain useful debugging information.
+    : "------------------ ------------------ ------------------"
+    : "------------------ begin boulder logs ------------------"
+    : "------------------ ------------------ ------------------"
     docker logs boulder_boulder_1
-    echo "------------------ ------------------ ------------------"
-    echo "------------------  end boulder logs  ------------------"
-    echo "------------------ ------------------ ------------------"
+    : "------------------ ------------------ ------------------"
+    : "------------------  end boulder logs  ------------------"
+    : "------------------ ------------------ ------------------"
     exit $EXIT_STATUS
 }
 

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -8,7 +8,7 @@
 #
 # Note: this script is called by Boulder integration test suite!
 
-set -eux
+set -ex
 
 . ./tests/integration/_common.sh
 export PATH="$PATH:/usr/sbin"  # /usr/sbin/nginx

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/bash
 # Simple integration test. Make sure to activate virtualenv beforehand
 # (source venv/bin/activate) and that you are running Boulder test
 # instance (see ./boulder-fetch.sh).
@@ -8,11 +8,10 @@
 #
 # Note: this script is called by Boulder integration test suite!
 
+set -eux
+
 . ./tests/integration/_common.sh
 export PATH="$PATH:/usr/sbin"  # /usr/sbin/nginx
-
-export GOPATH="${GOPATH:-/tmp/go}"
-export PATH="$GOPATH/bin:$PATH"
 
 if [ `uname` = "Darwin" ];then
   readlink="greadlink"
@@ -27,6 +26,14 @@ cleanup_and_exit() {
         echo Kill server subprocess, left running by abnormal exit
         kill $SERVER_STILL_RUNNING
     fi
+    echo "------------------ ------------------ ------------------"
+    echo "------------------ begin boulder logs ------------------"
+    echo "------------------ ------------------ ------------------"
+    # Dump boulder logs in case they contain useful debugging information.
+    docker logs boulder_boulder_1
+    echo "------------------ ------------------ ------------------"
+    echo "------------------  end boulder logs  ------------------"
+    echo "------------------ ------------------ ------------------"
     exit $EXIT_STATUS
 }
 

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 # The -t is required on macOS. It provides a template file path for
 # the kernel to use.
 root=${root:-$(mktemp -d -t leitXXXX)}

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
 
-if [ "xxx$root" = "xxx" ];
-then
-    # The -t is required on macOS. It provides a template file path for
-    # the kernel to use.
-    root="$(mktemp -d -t leitXXXX)"
-    echo "Root integration tests directory: $root"
-fi
+# The -t is required on macOS. It provides a template file path for
+# the kernel to use.
+root=${root:-$(mktemp -d -t leitXXXX)}
+echo "Root integration tests directory: $root"
 store_flags="--config-dir $root/conf --work-dir $root/work"
 store_flags="$store_flags --logs-dir $root/logs"
 tls_sni_01_port=5001


### PR DESCRIPTION
Might help debug https://github.com/certbot/certbot/issues/4363.

Also:
- make "bash" vs "sh" explicit
- move the paranoia flags (`-ex`) from the shebang into the body
- add `-u` (fail on unset variables)
- change _common to work with `-u`
- remove some env vars that were no longer used
- remove shebang from _common.sh because it's meant to be sourced, not run