### PR TITLE
Logging setup before argument parsing

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -19,6 +19,7 @@ import certbot
 from certbot import constants
 from certbot import crypto_util
 from certbot import errors
+from certbot import hooks
 from certbot import interfaces
 from certbot import util
 
@@ -555,6 +556,11 @@ class HelpfulArgumentParser(object):
 
         if parsed_args.must_staple:
             parsed_args.staple = True
+
+        if parsed_args.validate_hooks:
+            hooks.validate_hooks(parsed_args)
+
+        possible_deprecation_warning(parsed_args)
 
         return parsed_args
 

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -204,7 +204,7 @@ class MemoryHandler(logging.handlers.MemoryHandler):
         return False
 
 
-def except_hook(exc_type, exc_value, unused_trace, debug, log_path):
+def except_hook(exc_type, exc_value, trace, debug, log_path):
     """Logs fatal exceptions and reports them to the user.
 
     If debug is True, the full exception and traceback is shown to the
@@ -213,18 +213,20 @@ def except_hook(exc_type, exc_value, unused_trace, debug, log_path):
 
     :param type exc_type: type of the raised exception
     :param BaseException exc_value: raised exception
+    :param traceback trace: traceback of where the exception was raised
     :param bool debug: True if the traceback should be shown to the user
     :param str log_path: path to file or directory containing the log
 
     """
+    exc_info = (exc_type, exc_value, trace)
     # constants.QUIET_LOGGING_LEVEL or higher should be used to
     # display message the user, otherwise, a lower level like
     # logger.DEBUG should be used
     if debug or not issubclass(exc_type, Exception):
         assert constants.QUIET_LOGGING_LEVEL <= logging.ERROR
-        logger.exception('Exiting abnormally:')
+        logger.error('Exiting abnormally:', exc_info=exc_info)
     else:
-        logger.debug('Exiting abnormally:', exc_info=True)
+        logger.debug('Exiting abnormally:', exc_info=exc_info)
         if issubclass(exc_type, errors.Error):
             sys.exit(exc_value)
         print('An unexpected error occurred:', file=sys.stderr)

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -66,6 +66,8 @@ def pre_arg_parse_setup():
     root_logger.addHandler(memory_handler)
     root_logger.addHandler(stream_handler)
 
+    # logging.shutdown will flush the memory handler because flush() and
+    # close() are explicitly called
     util.atexit_register(logging.shutdown)
     sys.excepthook = functools.partial(
         except_hook, debug='--debug' in sys.argv, log_path=temp_handler.path)

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -75,7 +75,7 @@ def post_arg_parse_setup(config):
     logs_dir = os.path.dirname(file_path)
 
     root_logger = logging.getLogger()
-    assert len(root_logger.handlers) == 2, "Expected handlers not found!"
+    assert len(root_logger.handlers) == 2, "Unexpected handlers found!"
     # pylint: disable=unbalanced-tuple-unpacking
     if isinstance(root_logger.handlers[0], MemoryHandler):
         memory_handler, stderr_handler = root_logger.handlers

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -98,8 +98,8 @@ def post_arg_parse_setup(config):
     else:
         level = -config.verbose_count * 10
     stderr_handler.setLevel(level)
-    logger.debug("Root logging level set at %d", level)
-    logger.info("Saving debug log to %s", file_path)
+    logger.debug('Root logging level set at %d', level)
+    logger.info('Saving debug log to %s', file_path)
 
     sys.excepthook = functools.partial(
         except_hook, debug=config.debug, log_path=logs_dir)
@@ -147,7 +147,6 @@ class ColoredStreamHandler(logging.StreamHandler):
     :ivar bool red_level: The level at which to output
 
     """
-
     def __init__(self, stream=None):
         if sys.version_info < (2, 7):  # pragma: no cover
             logging.StreamHandler.__init__(self, stream)

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -207,6 +207,39 @@ def except_hook(exc_type, exc_value, trace, config):
         sys.exit(tb_str)
 
 
+def new_except_hook(exc_type, exc_value, unused_trace, debug, log_path):
+    """Logs fatal exceptions and reports them to the user.
+
+    If debug is True, the full exception and traceback is shown to the
+    user, otherwise, it is suppressed. sys.exit is always called with a
+    nonzero status.
+
+    :param type exc_type: type of the raised exception
+    :param BaseException exc_value: raised exception
+    :param bool debug: True if the traceback should be shown to the user
+    :param str log_path: path to file or directory containing the log
+
+    """
+    # constants.QUIET_LOGGING_LEVEL or higher should be used to
+    # display message the user, otherwise, a lower level like
+    # logger.DEBUG should be used
+    if debug or not issubclass(exc_type, Exception):
+        assert constants.QUIET_LOGGING_LEVEL <= logging.ERROR
+        logger.exception('Exiting abnormally:')
+    else:
+        logger.debug('Exiting abnormally:', exc_info=True)
+        if issubclass(exc_type, errors.Error):
+            sys.exit(exc_value)
+        print('An unexpected error occurred:', file=sys.stderr)
+        if messages.is_acme_error(exc_value):
+            # Remove the ACME error prefix from the exception
+            _, _, exc_str = str(exc_value).partition(':: ')
+            print(exc_str, file=sys.stderr)
+        else:
+            traceback.print_exception(exc_type, exc_value, None)
+    exit_with_log_path(log_path)
+
+
 def exit_with_log_path(log_path):
     """Print a message about the log location and exit.
 
@@ -216,10 +249,10 @@ def exit_with_log_path(log_path):
     :param str log_path: path to file or directory containing the log
 
     """
-    msg = "Please see the "
+    msg = 'Please see the '
     if os.path.isdir(log_path):
-        msg += "logfiles in {0} ".format(log_path)
+        msg += 'logfiles in {0} '.format(log_path)
     else:
         msg += "logfile '{0}' ".format(log_path)
-    msg += "for more details."
+    msg += 'for more details.'
     sys.exit(msg)

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -5,8 +5,8 @@ import logging
 import logging.handlers
 import os
 import sys
-import time
 import tempfile
+import time
 import traceback
 
 from acme import messages

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import functools
 import logging
+import logging.handlers
 import os
 import sys
 import time
@@ -99,9 +100,7 @@ class ColoredStreamHandler(logging.StreamHandler):
     """
 
     def __init__(self, stream=None):
-        if sys.version_info < (2, 7):
-            # pragma: no cover
-            # pylint: disable=non-parent-init-called
+        if sys.version_info < (2, 7):  # pragma: no cover
             logging.StreamHandler.__init__(self, stream)
         else:
             super(ColoredStreamHandler, self).__init__(stream)
@@ -125,6 +124,34 @@ class ColoredStreamHandler(logging.StreamHandler):
             return ''.join((util.ANSI_SGR_RED, out, util.ANSI_SGR_RESET))
         else:
             return out
+
+
+class MemoryHandler(logging.handlers.MemoryHandler):
+    """Buffers logging messages in memory until the buffer is flushed.
+
+    This differs from logging.handlers.MemoryHandler in that flushing
+    only happens when it is done explicitly.
+
+    """
+    def __init__(self, target=None):
+        # capacity doesn't matter because should_flush() is overridden
+        capacity = float('inf')
+        if sys.version_info < (2, 7):  # pragma: no cover
+            logging.handlers.MemoryHandler.__init__(
+                self, capacity, target=target)
+        else:
+            super(MemoryHandler, self).__init__(capacity, target=target)
+
+    def shouldFlush(self, record):
+        """Should the buffer be automatically flushed?
+
+        :param logging.LogRecord record: log record to be considered
+
+        :returns: False because the buffer should never be auto-flushed
+        :rtype: bool
+
+        """
+        return False
 
 
 def except_hook(exc_type, exc_value, trace, config):

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -75,14 +75,15 @@ def post_arg_parse_setup(config):
     logs_dir = os.path.dirname(file_path)
 
     root_logger = logging.getLogger()
-    assert len(root_logger.handlers) == 2, "Unexpected handlers found!"
+    assert_msg = "Unexpected logging handlers found!"
+    assert len(root_logger.handlers) == 2, assert_msg
     # pylint: disable=unbalanced-tuple-unpacking
     if isinstance(root_logger.handlers[0], MemoryHandler):
         memory_handler, stderr_handler = root_logger.handlers
     else:
         stderr_handler, memory_handler = root_logger.handlers
-    assert isinstance(memory_handler, MemoryHandler)
-    assert isinstance(stderr_handler, ColoredStreamHandler)
+    assert isinstance(memory_handler, MemoryHandler), assert_msg
+    assert isinstance(stderr_handler, ColoredStreamHandler), assert_msg
 
     root_logger.addHandler(file_handler)
     root_logger.removeHandler(memory_handler)

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -6,11 +6,11 @@ import logging.handlers
 import os
 import sys
 import time
+import tempfile
 import traceback
 
 from acme import messages
 
-from certbot import cli
 from certbot import constants
 from certbot import errors
 from certbot import util
@@ -24,8 +24,39 @@ logger = logging.getLogger(__name__)
 
 
 def pre_arg_parse_setup():
-    """Ensures fatal exceptions are logged and reported to the user."""
-    sys.excepthook = functools.partial(except_hook, config=None)
+    """Setup logging before command line arguments are parsed.
+
+    Terminal logging is setup using
+    certbot.constants.QUIET_LOGGING_LEVEL so Certbot is as quiet as
+    possible. File logging is setup so that logging messages are
+    buffered in memory so they can either be written to a temporary
+    file before Certbot exits or to the normal logfiles once command
+    line arguments are parsed.
+
+    This function also sets logging.shutdown to be called on program
+    exit which automatically flushes logging handlers and sys.excepthook
+    to properly log/display fatal exceptions.
+
+    """
+    temp_fd, temp_path = tempfile.mkstemp()
+    temp_fd = os.fdopen(temp_fd, 'w')
+    temp_handler = logging.StreamHandler(temp_fd)
+    temp_handler.setFormatter(logging.Formatter(FILE_FMT))
+    temp_handler.setLevel(logging.DEBUG)
+    memory_handler = MemoryHandler(temp_handler)
+
+    stream_handler = ColoredStreamHandler()
+    stream_handler.setFormatter(logging.Formatter(CLI_FMT))
+    stream_handler.setLevel(constants.QUIET_LOGGING_LEVEL)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)  # send all records to handlers
+    root_logger.addHandler(memory_handler)
+    root_logger.addHandler(stream_handler)
+
+    util.atexit_register(logging.shutdown)
+    sys.excepthook = functools.partial(
+        except_hook, debug='--debug' in sys.argv, log_path=temp_path)
 
 
 def post_arg_parse_setup(config):
@@ -154,60 +185,7 @@ class MemoryHandler(logging.handlers.MemoryHandler):
         return False
 
 
-def except_hook(exc_type, exc_value, trace, config):
-    """Logs exceptions and reports them to the user.
-
-    Config is used to determine how to display exceptions to the user. In
-    general, if config.debug is True, then the full exception and traceback is
-    shown to the user, otherwise it is suppressed. If config itself is None,
-    then the traceback and exception is attempted to be written to a logfile.
-    If this is successful, the traceback is suppressed, otherwise it is shown
-    to the user. sys.exit is always called with a nonzero status.
-
-    """
-    tb_str = "".join(traceback.format_exception(exc_type, exc_value, trace))
-    logger.debug("Exiting abnormally:%s%s", os.linesep, tb_str)
-
-    if issubclass(exc_type, Exception) and (config is None or not config.debug):
-        if config is None:
-            logfile = "certbot.log"
-            try:
-                with open(logfile, "w") as logfd:
-                    traceback.print_exception(
-                        exc_type, exc_value, trace, file=logfd)
-                assert "--debug" not in sys.argv  # config is None if this explodes
-            except:  # pylint: disable=bare-except
-                sys.exit(tb_str)
-            if "--debug" in sys.argv:
-                sys.exit(tb_str)
-
-        if issubclass(exc_type, errors.Error):
-            sys.exit(exc_value)
-        else:
-            # Here we're passing a client or ACME error out to the client at the shell
-            # Tell the user a bit about what happened, without overwhelming
-            # them with a full traceback
-            err = traceback.format_exception_only(exc_type, exc_value)[0]
-            # Typical error from the ACME module:
-            # acme.messages.Error: urn:ietf:params:acme:error:malformed :: The
-            # request message was malformed :: Error creating new registration
-            # :: Validation of contact mailto:none@longrandomstring.biz failed:
-            # Server failure at resolver
-            if (messages.is_acme_error(err) and ":: " in err and
-                 config.verbose_count <= cli.flag_default("verbose_count")):
-                # prune ACME error code, we have a human description
-                _code, _sep, err = err.partition(":: ")
-            msg = "An unexpected error occurred:\n" + err + "Please see the "
-            if config is None:
-                msg += "logfile '{0}' for more details.".format(logfile)
-            else:
-                msg += "logfiles in {0} for more details.".format(config.logs_dir)
-            sys.exit(msg)
-    else:
-        sys.exit(tb_str)
-
-
-def new_except_hook(exc_type, exc_value, unused_trace, debug, log_path):
+def except_hook(exc_type, exc_value, unused_trace, debug, log_path):
     """Logs fatal exceptions and reports them to the user.
 
     If debug is True, the full exception and traceback is shown to the

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -75,15 +75,14 @@ def post_arg_parse_setup(config):
     logs_dir = os.path.dirname(file_path)
 
     root_logger = logging.getLogger()
-    assert_msg = "Unexpected logging handlers found!"
-    assert len(root_logger.handlers) == 2, assert_msg
-    # pylint: disable=unbalanced-tuple-unpacking
-    if isinstance(root_logger.handlers[0], MemoryHandler):
-        memory_handler, stderr_handler = root_logger.handlers
-    else:
-        stderr_handler, memory_handler = root_logger.handlers
-    assert isinstance(memory_handler, MemoryHandler), assert_msg
-    assert isinstance(stderr_handler, ColoredStreamHandler), assert_msg
+    memory_handler = stderr_handler = None
+    for handler in root_logger.handlers:
+        if isinstance(handler, ColoredStreamHandler):
+            stderr_handler = handler
+        elif isinstance(handler, MemoryHandler):
+            memory_handler = handler
+    msg = 'Previously configured logging handlers have been removed!'
+    assert memory_handler is not None and stderr_handler is not None, msg
 
     root_logger.addHandler(file_handler)
     root_logger.removeHandler(memory_handler)

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -205,3 +205,21 @@ def except_hook(exc_type, exc_value, trace, config):
             sys.exit(msg)
     else:
         sys.exit(tb_str)
+
+
+def exit_with_log_path(log_path):
+    """Print a message about the log location and exit.
+
+    The message is printed to stderr and the program will exit with a
+    nonzero status.
+
+    :param str log_path: path to file or directory containing the log
+
+    """
+    msg = "Please see the "
+    if os.path.isdir(log_path):
+        msg += "logfiles in {0} ".format(log_path)
+    else:
+        msg += "logfile '{0}' ".format(log_path)
+    msg += "for more details."
+    sys.exit(msg)

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -55,7 +55,7 @@ def pre_arg_parse_setup():
 
     util.atexit_register(logging.shutdown)
     sys.excepthook = functools.partial(
-        except_hook, debug='--debug' in sys.argv, log_path=temp_log)
+        except_hook, debug='--debug' in sys.argv, log_path=temp_log.name)
 
 
 def post_arg_parse_setup(config):

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -38,8 +38,7 @@ def pre_arg_parse_setup():
     to properly log/display fatal exceptions.
 
     """
-    temp_log = tempfile.NamedTemporaryFile('w', delete=False)
-    temp_handler = logging.StreamHandler(temp_log)
+    temp_handler = TempHandler()
     temp_handler.setFormatter(logging.Formatter(FILE_FMT))
     temp_handler.setLevel(logging.DEBUG)
     memory_handler = MemoryHandler(temp_handler)
@@ -55,7 +54,7 @@ def pre_arg_parse_setup():
 
     util.atexit_register(logging.shutdown)
     sys.excepthook = functools.partial(
-        except_hook, debug='--debug' in sys.argv, log_path=temp_log.name)
+        except_hook, debug='--debug' in sys.argv, log_path=temp_handler.path)
 
 
 def post_arg_parse_setup(config):
@@ -86,12 +85,10 @@ def post_arg_parse_setup(config):
 
     root_logger.addHandler(file_handler)
     root_logger.removeHandler(memory_handler)
-    temp_file_handler = memory_handler.target
-    temp_file_path = temp_file_handler.stream.name
-    temp_file_handler.stream.close()
-    os.remove(temp_file_path)
+    temp_handler = memory_handler.target
     memory_handler.setTarget(file_handler)
     memory_handler.close()
+    temp_handler.delete_and_close()
 
     if config.quiet:
         level = constants.QUIET_LOGGING_LEVEL
@@ -200,6 +197,49 @@ class MemoryHandler(logging.handlers.MemoryHandler):
 
         """
         return False
+
+
+class TempHandler(logging.StreamHandler):
+    """Safely logs messages to a temporary file.
+
+    The file is created with permissions 600.
+
+    :ivar str path: file system path to the temporary log file
+
+    """
+    def __init__(self):
+        stream = tempfile.NamedTemporaryFile('w', delete=False)
+        if sys.version_info < (2, 7):  # pragma: no cover
+            logging.StreamHandler.__init__(self, stream)
+        else:
+            super(TempHandler, self).__init__(stream)
+        self.path = stream.name
+
+    def delete_and_close(self):
+        """Close the handler and delete the temporary log file."""
+        self._close(delete=True)
+
+    def close(self):
+        """Close the handler and the temporary log file."""
+        self._close(delete=False)
+
+    def _close(self, delete):
+        """Close the handler and the temporary log file.
+
+        :param bool delete: True if the log file should be deleted
+
+        """
+        self.acquire()
+        try:
+            self.stream.close()
+            if delete:
+                os.remove(self.path)
+            if sys.version_info < (2, 7):  # pragma: no cover
+                logging.StreamHandler.close(self)
+            else:
+                super(TempHandler, self).close()
+        finally:
+            self.release()
 
 
 def except_hook(exc_type, exc_value, trace, debug, log_path):

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -714,37 +714,24 @@ def set_displayer(config):
                                              config.force_interactive)
     zope.component.provideUtility(displayer)
 
-def _post_logging_setup(config, plugins, cli_args):
-    """Perform any setup or configuration tasks that require a logger."""
-
-    # This needs logging, but would otherwise be in HelpfulArgumentParser
-    if config.validate_hooks:
-        hooks.validate_hooks(config)
-
-    cli.possible_deprecation_warning(config)
-
-    logger.debug("certbot version: %s", certbot.__version__)
-    # do not log `config`, as it contains sensitive data (e.g. revoke --key)!
-    logger.debug("Arguments: %r", cli_args)
-    logger.debug("Discovered plugins: %r", plugins)
-
 
 def main(cli_args=sys.argv[1:]):
     """Command line argument parsing and main script execution."""
     log.pre_arg_parse_setup()
+
     plugins = plugins_disco.PluginsRegistry.find_all()
+    logger.debug("certbot version: %s", certbot.__version__)
+    # do not log `config`, as it contains sensitive data (e.g. revoke --key)!
+    logger.debug("Arguments: %r", cli_args)
+    logger.debug("Discovered plugins: %r", plugins)
 
     # note: arg parser internally handles --help (and exits afterwards)
     args = cli.prepare_and_parse_args(plugins, cli_args)
     config = configuration.NamespaceConfig(args)
     zope.component.provideUtility(config)
 
-    make_or_verify_needed_dirs(config)
-
     log.post_arg_parse_setup(config)
-
-    _post_logging_setup(config, plugins, cli_args)
-
+    make_or_verify_needed_dirs(config)
     set_displayer(config)
 
     # Reporter

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -231,6 +231,79 @@ class ExceptHookTest(unittest.TestCase):
             traceback.format_exception_only(KeyboardInterrupt, interrupt)))
 
 
+class NewExceptHookTest(unittest.TestCase):
+    """Tests for certbot.log.new_except_hook."""
+    @classmethod
+    def _call(cls, *args, **kwargs):
+        from certbot.log import new_except_hook
+        return new_except_hook(*args, **kwargs)
+
+    def setUp(self):
+        self.error_msg = 'test error message'
+        self.log_path = 'foo.log'
+
+    def test_base_exception(self):
+        mock_logger, output = self._test_common(KeyboardInterrupt, debug=False)
+        self.assertTrue(mock_logger.exception.called)
+        self._assert_logfile_output(output)
+
+    def test_debug(self):
+        mock_logger, output = self._test_common(ValueError, debug=True)
+        self.assertTrue(mock_logger.exception.called)
+        self._assert_logfile_output(output)
+
+    def test_custom_error(self):
+        mock_logger, output = self._test_common(
+            errors.PluginError, debug=False)
+        self._assert_quiet_output(mock_logger, output)
+
+    def test_acme_error(self):
+        # Get an arbitrary error code
+        acme_code = next(six.iterkeys(messages.ERROR_CODES))
+
+        def get_acme_error(msg):
+            """Wraps ACME errors so the constructor takes only a msg."""
+            return messages.Error.with_code(acme_code, detail=msg)
+
+        mock_logger, output = self._test_common(get_acme_error, debug=False)
+        self._assert_quiet_output(mock_logger, output)
+        self.assertFalse(messages.ERROR_PREFIX in output)
+
+    def test_other_error(self):
+        mock_logger, output = self._test_common(ValueError, debug=False)
+        self._assert_quiet_output(mock_logger, output)
+
+    def _test_common(self, error_type, debug):
+        """Returns the mocked logger and stderr output."""
+        mock_err = six.StringIO()
+        try:
+            raise error_type(self.error_msg)
+        except BaseException:
+            exc_info = sys.exc_info()
+            with mock.patch('certbot.log.logger') as mock_logger:
+                with mock.patch('certbot.log.sys.stderr', mock_err):
+                    try:
+                        # pylint: disable=star-args
+                        self._call(
+                            *exc_info, debug=debug, log_path=self.log_path)
+                    except SystemExit as exit_err:
+                        mock_err.write(str(exit_err))
+                    else:  # pragma: no cover
+                        self.fail('SystemExit not raised.')
+
+        output = mock_err.getvalue()
+        return mock_logger, output
+
+    def _assert_logfile_output(self, output):
+        self.assertTrue('Please see the logfile' in output)
+        self.assertTrue(self.log_path in output)
+
+    def _assert_quiet_output(self, mock_logger, output):
+        self.assertFalse(mock_logger.exception.called)
+        self.assertTrue(mock_logger.debug.called)
+        self.assertTrue(self.error_msg in output)
+
+
 class TestExitWithLogPath(test_util.TempDirTestCase):
     """Tests for certbot.log.exit_with_log_path."""
     @classmethod

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -25,14 +25,14 @@ class PreArgParseSetupTest(unittest.TestCase):
         from certbot.log import pre_arg_parse_setup
         return pre_arg_parse_setup(*args, **kwargs)
 
-    def test_it(self):
-        with mock.patch('certbot.log.util.atexit_register') as mock_register:
-            with mock.patch('certbot.log.logging.getLogger') as mock_get:
-                with mock.patch('certbot.log.except_hook') as mock_except_hook:
-                    with mock.patch('certbot.log.sys') as mock_sys:
-                        mock_sys.argv = ['--debug']
-                        mock_sys.version_info = sys.version_info
-                        self._call()
+    @mock.patch('certbot.log.sys')
+    @mock.patch('certbot.log.except_hook')
+    @mock.patch('certbot.log.logging.getLogger')
+    @mock.patch('certbot.log.util.atexit_register')
+    def test_it(self, mock_register, mock_get, mock_except_hook, mock_sys):
+        mock_sys.argv = ['--debug']
+        mock_sys.version_info = sys.version_info
+        self._call()
 
         mock_register.assert_called_once_with(logging.shutdown)
         mock_sys.excepthook(1, 2, 3)

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -139,6 +139,42 @@ class ColoredStreamHandlerTest(unittest.TestCase):
                                               util.ANSI_SGR_RESET))
 
 
+class MemoryHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.DEBUG)
+        self.msg = 'hi there'
+        self.stream = six.StringIO()
+
+        stream_handler = logging.StreamHandler(self.stream)
+        from certbot.log import MemoryHandler
+        self.handler = MemoryHandler(stream_handler)
+        self.logger.addHandler(self.handler)
+
+    def test_flush(self):
+        self._test_log_debug()
+        self.handler.flush()
+        self.assertEqual(self.stream.getvalue(), self.msg + '\n')
+
+    def test_not_flushed(self):
+        # By default, logging.ERROR messages and higher are flushed
+        self.logger.critical(self.msg)
+        self.assertEqual(self.stream.getvalue(), '')
+
+    def test_target_reset(self):
+        self._test_log_debug()
+
+        new_stream = six.StringIO()
+        stream_handler = logging.StreamHandler(new_stream)
+        self.handler.setTarget(stream_handler)
+        self.handler.flush()
+        self.assertEqual(self.stream.getvalue(), '')
+        self.assertEqual(new_stream.getvalue(), self.msg + '\n')
+
+    def _test_log_debug(self):
+        self.logger.debug(self.msg)
+
+
 class ExceptHookTest(unittest.TestCase):
     """Tests for certbot.log.except_hook."""
     @classmethod

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -119,10 +119,6 @@ class PostArgParseSetupTest(test_util.TempDirTestCase):
         self.config.quiet = True
         self.test_common()
 
-    def test_reversed(self):
-        self.root_logger.handlers.reverse()
-        self.test_common()
-
 
 class SetupLogFileHandlerTest(test_util.TempDirTestCase):
     """Tests for certbot.log.setup_log_file_handler."""

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -3,6 +3,7 @@ import logging
 import logging.handlers
 import os
 import sys
+import tempfile
 import time
 import unittest
 
@@ -66,9 +67,22 @@ class PostArgParseSetupTest(test_util.TempDirTestCase):
     def setUp(self):
         super(PostArgParseSetupTest, self).setUp()
         self.config = mock.MagicMock(
-            logs_dir=self.tempdir, quiet=False,
+            debug=False, logs_dir=self.tempdir, quiet=False,
             verbose_count=constants.CLI_DEFAULTS['verbose_count'])
-        self.root_logger = mock.MagicMock()
+        self.devnull = open(os.devnull, 'w')
+
+        self.temp_file = tempfile.NamedTemporaryFile('w', delete=False)
+        temp_handler = logging.StreamHandler(self.temp_file)
+
+        from certbot.log import ColoredStreamHandler, MemoryHandler
+        self.memory_handler = MemoryHandler(temp_handler)
+        self.stream_handler = ColoredStreamHandler(self.devnull)
+        self.root_logger = mock.MagicMock(
+            handlers=[self.memory_handler, self.stream_handler])
+
+    def tearDown(self):
+        self.devnull.close()
+        super(PostArgSetupTest, self).tearDown()
 
     def test_common(self):
         with mock.patch('certbot.log.logging.getLogger') as mock_get_logger:
@@ -78,21 +92,32 @@ class PostArgParseSetupTest(test_util.TempDirTestCase):
                     mock_sys.version_info = sys.version_info
                     self._call(self.config)
 
-        self.assertEqual(self.root_logger.addHandler.call_count, 2)
+        self.root_logger.removeHandler.assert_called_once_with(
+            self.memory_handler)
+        self.assertTrue(self.root_logger.addHandler.called)
         self.assertTrue(os.path.exists(os.path.join(
             self.config.logs_dir, 'letsencrypt.log')))
+        self.assertFalse(os.path.exists(self.temp_file.name))
         mock_sys.excepthook(1, 2, 3)
-        mock_except_hook.assert_called_once_with(1, 2, 3, config=self.config)
+        mock_except_hook.assert_called_once_with(
+            1, 2, 3, debug=self.config.debug, log_path=self.tempdir)
 
-        stderr_handler = self.root_logger.addHandler.call_args_list[0][0][0]
-        level = stderr_handler.level
+        level = self.stream_handler.level
         if self.config.quiet:
             self.assertEqual(level, constants.QUIET_LOGGING_LEVEL)
         else:
             self.assertEqual(level, -self.config.verbose_count * 10)
 
+    def test_debug(self):
+        self.config.debug = True
+        self.test_common()
+
     def test_quiet(self):
         self.config.quiet = True
+        self.test_common()
+
+    def test_reversed(self):
+        self.root_logger.handlers.reverse()
         self.test_common()
 
 

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -54,6 +54,9 @@ class PreArgParseSetupTest(unittest.TestCase):
                 self.assertTrue(isinstance(handler, logging.StreamHandler))
         self.assertTrue(
             isinstance(memory_handler.target, logging.StreamHandler))
+        temp_file = memory_handler.target.stream.name
+        self.assertTrue(
+            util.check_permissions(temp_file, 0o600, os.getuid()))
 
 
 class PostArgParseSetupTest(test_util.TempDirTestCase):

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -85,7 +85,7 @@ class PostArgParseSetupTest(test_util.TempDirTestCase):
 
     def tearDown(self):
         self.devnull.close()
-        super(PostArgSetupTest, self).tearDown()
+        super(PostArgParseSetupTest, self).tearDown()
 
     def test_common(self):
         with mock.patch('certbot.log.logging.getLogger') as mock_get_logger:

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -2,7 +2,7 @@
 # pylint: disable=too-many-lines
 from __future__ import print_function
 
-import itertools
+import logging
 import mock
 import os
 import shutil
@@ -371,6 +371,12 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
                               '--work-dir', self.work_dir,
                               '--logs-dir', self.logs_dir, '--text']
 
+        # The Python logging module uses global state for configuring
+        # the root logger. Let's reset it before calling main.
+        root_logger = logging.getLogger()
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+
     def tearDown(self):
         # Reset globals in cli
         reload_module(cli)
@@ -427,11 +433,16 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
     def test_noninteractive(self):
         args = ['-n', 'certonly']
         self._cli_missing_flag(args, "specify a plugin")
-        args.extend(['--standalone', '-d', 'eg.is'])
+
+    def test_noninteractive2(self):
+        args = ['-n', 'certonly', '--standalone', '-d', 'eg.is']
         self._cli_missing_flag(args, "register before running")
+
+    def test_noninteractive3(self):
+        args = ['-n', 'certonly', '--standalone',
+                '-d', 'eg.is', '--email', 'io@io.is']
         with mock.patch('certbot.main._get_and_save_cert'):
             with mock.patch('certbot.main.client.acme_from_config_key'):
-                args.extend(['--email', 'io@io.is'])
                 self._cli_missing_flag(args, "--agree-tos")
 
     @mock.patch('certbot.main._report_new_cert')
@@ -457,6 +468,20 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
             if "linux" in plat.lower():
                 self.assertTrue(util.get_os_info_ua() in ua)
 
+    @mock.patch('certbot.main._report_new_cert')
+    @mock.patch('certbot.main.client.acme_client.Client')
+    @mock.patch('certbot.main._determine_account')
+    @mock.patch('certbot.main.client.Client.obtain_and_enroll_certificate')
+    @mock.patch('certbot.main._get_and_save_cert')
+    def test_user_agent2(self, gsc, _obt, det, _client, unused_report):
+        # Normally the client is totally mocked out, but here we need more
+        # arguments to automate it...
+        ua = "bandersnatch"
+        args = ["--standalone", "certonly", "-m", "none@none.com",
+                "-d", "example.com", "--agree-tos", "--user-agent", ua]
+        args += self.standard_args
+        det.return_value = mock.MagicMock(), None
+        gsc.return_value = mock.MagicMock()
         with mock.patch('certbot.main.client.acme_client.ClientNetwork') as acme_net:
             ua = "bandersnatch"
             args += ["--user-agent", ua]
@@ -472,7 +497,7 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
 
     @mock.patch('certbot.main._report_new_cert')
     @mock.patch('certbot.util.exe_exists')
-    def test_configurator_selection(self, mock_exe_exists, unused_report):
+    def test_nginx_selection(self, mock_exe_exists, unused_report):
         mock_exe_exists.return_value = True
         real_plugins = disco.PluginsRegistry.find_all()
         args = ['--apache', '--authenticator', 'standalone']
@@ -495,8 +520,9 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
             self.assertTrue("The nginx plugin is not working" in ret)
             self.assertTrue("MisconfigurationError" in ret)
 
-        self._cli_missing_flag(["--standalone"], "With the standalone plugin, you probably")
 
+    @mock.patch('certbot.main._report_new_cert')
+    def test_manual_selection(self, unused_report):
         with mock.patch("certbot.main._init_le_client") as mock_init:
             with mock.patch("certbot.main._get_and_save_cert") as mock_gsc:
                 mock_gsc.return_value = mock.MagicMock()
@@ -504,14 +530,19 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
                 unused_config, auth, unused_installer = mock_init.call_args[0]
                 self.assertTrue(isinstance(auth, manual.Authenticator))
 
+    def test_standalone_selection(self):
         with mock.patch('certbot.main.certonly') as mock_certonly:
             self._call(["auth", "--standalone"])
             self.assertEqual(1, mock_certonly.call_count)
+
+    def test_standalone_selection2(self):
+        self._cli_missing_flag(["--standalone"], "With the standalone plugin, you probably")
 
     def test_rollback(self):
         _, _, _, client = self._call(['rollback'])
         self.assertEqual(1, client.rollback.call_count)
 
+    def test_rollback2(self):
         _, _, _, client = self._call(['rollback', '--checkpoints', '123'])
         client.rollback.assert_called_once_with(
             mock.ANY, 123, mock.ANY, mock.ANY)
@@ -536,11 +567,49 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
         self.assertEqual(1, mock_cert_manager.call_count)
 
     def test_plugins(self):
-        flags = ['--init', '--prepare', '--authenticators', '--installers']
-        for args in itertools.chain(
-                *(itertools.combinations(flags, r)
-                  for r in six.moves.range(len(flags)))):
-            self._call(['plugins'] + list(args))
+        self._call(['plugins'])
+
+    def test_plugins2(self):
+        self._call(['plugins', '--init'])
+
+    def test_plugins3(self):
+        self._call(['plugins', '--prepare'])
+
+    def test_plugins4(self):
+        self._call(['plugins', '--authenticators'])
+
+    def test_plugins5(self):
+        self._call(['plugins', '--installers'])
+
+    def test_plugins6(self):
+        self._call(['plugins', '--init', '--prepare'])
+
+    def test_plugins7(self):
+        self._call(['plugins', '--init', '--authenticators'])
+
+    def test_plugins8(self):
+        self._call(['plugins', '--init', '--installers'])
+
+    def test_plugins9(self):
+        self._call(['plugins', '--prepare', '--authenticators'])
+
+    def test_plugins10(self):
+        self._call(['plugins', '--prepare', '--installers'])
+
+    def test_plugins11(self):
+        self._call(['plugins', '--authenticators', '--installers'])
+
+    def test_plugins12(self):
+        self._call(['plugins', '--init', '--prepare', '--authenticators'])
+
+    def test_plugins13(self):
+        self._call(['plugins', '--init', '--prepare', '--installers'])
+
+    def test_plugins14(self):
+        self._call(['plugins', '--prepare', '--authenticators', '--installers'])
+
+    def test_plugins15(self):
+        self._call(['plugins', '--init', '--prepare', '--authenticators', '--installers'])
 
     @mock.patch('certbot.main.plugins_disco')
     @mock.patch('certbot.main.cli.HelpfulArgumentParser.determine_help_topics')
@@ -777,12 +846,18 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
         self.assertEqual(get_utility().add_message.call_count, 1)
         self.assertTrue('dry run' in get_utility().add_message.call_args[0][0])
 
-        self._test_renewal_common(False, ['--renew-by-default', '-tvv', '--debug'],
-                                  log_out="Auto-renewal forced")
-        self.assertEqual(get_utility().add_message.call_count, 1)
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_renewal_triggers2(self, unused_notafter):
+        _, get_utility, _ = self._test_renewal_common(
+            False, ['--renew-by-default', '-tvv', '--debug'],
+            log_out="Auto-renewal forced")
+        self.assertEqual(get_utility().add_message.call_count, 2)
 
-        self._test_renewal_common(False, ['-tvv', '--debug', '--keep'],
-                                  log_out="not yet due", should_renew=False)
+    @mock.patch('certbot.crypto_util.notAfter')
+    def test_certonly_renewal_triggers3(self, unused_notafter):
+        self._test_renewal_common(
+            False, ['-tvv', '--debug', '--keep'],
+            log_out="not yet due", should_renew=False)
 
     def _dump_log(self):
         print("Logs:")
@@ -803,6 +878,8 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
         out = stdout.getvalue()
         self.assertTrue("renew" in out)
 
+    def test_quiet_renew2(self):
+        test_util.make_lineage(self, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "-q"]
         _, _, stdout = self._test_renewal_common(True, [], args=args, should_renew=True)
         out = stdout.getvalue()
@@ -1050,7 +1127,10 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
             # TODO: It would be more correct to explicitly check that
             #       _determine_account() gets called in the above case,
             #       but coverage statistics should also show that it did.
-            with mock.patch('certbot.main.account') as mocked_account:
+
+    def test_register2(self):
+        with mock.patch('certbot.main.account') as mocked_account:
+            with mock.patch('certbot.main.client'):
                 mocked_storage = mock.MagicMock()
                 mocked_account.AccountFileStorage.return_value = mocked_storage
                 mocked_storage.find_all.return_value = ["an account"]

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -2,7 +2,7 @@
 # pylint: disable=too-many-lines
 from __future__ import print_function
 
-import logging
+import itertools
 import mock
 import os
 import shutil
@@ -371,12 +371,6 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
                               '--work-dir', self.work_dir,
                               '--logs-dir', self.logs_dir, '--text']
 
-        # The Python logging module uses global state for configuring
-        # the root logger. Let's reset it before calling main.
-        root_logger = logging.getLogger()
-        for handler in list(root_logger.handlers):
-            root_logger.removeHandler(handler)
-
     def tearDown(self):
         # Reset globals in cli
         reload_module(cli)
@@ -433,16 +427,11 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
     def test_noninteractive(self):
         args = ['-n', 'certonly']
         self._cli_missing_flag(args, "specify a plugin")
-
-    def test_noninteractive2(self):
-        args = ['-n', 'certonly', '--standalone', '-d', 'eg.is']
+        args.extend(['--standalone', '-d', 'eg.is'])
         self._cli_missing_flag(args, "register before running")
-
-    def test_noninteractive3(self):
-        args = ['-n', 'certonly', '--standalone',
-                '-d', 'eg.is', '--email', 'io@io.is']
         with mock.patch('certbot.main._get_and_save_cert'):
             with mock.patch('certbot.main.client.acme_from_config_key'):
+                args.extend(['--email', 'io@io.is'])
                 self._cli_missing_flag(args, "--agree-tos")
 
     @mock.patch('certbot.main._report_new_cert')
@@ -468,20 +457,6 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
             if "linux" in plat.lower():
                 self.assertTrue(util.get_os_info_ua() in ua)
 
-    @mock.patch('certbot.main._report_new_cert')
-    @mock.patch('certbot.main.client.acme_client.Client')
-    @mock.patch('certbot.main._determine_account')
-    @mock.patch('certbot.main.client.Client.obtain_and_enroll_certificate')
-    @mock.patch('certbot.main._get_and_save_cert')
-    def test_user_agent2(self, gsc, _obt, det, _client, unused_report):
-        # Normally the client is totally mocked out, but here we need more
-        # arguments to automate it...
-        ua = "bandersnatch"
-        args = ["--standalone", "certonly", "-m", "none@none.com",
-                "-d", "example.com", "--agree-tos", "--user-agent", ua]
-        args += self.standard_args
-        det.return_value = mock.MagicMock(), None
-        gsc.return_value = mock.MagicMock()
         with mock.patch('certbot.main.client.acme_client.ClientNetwork') as acme_net:
             ua = "bandersnatch"
             args += ["--user-agent", ua]
@@ -497,7 +472,7 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
 
     @mock.patch('certbot.main._report_new_cert')
     @mock.patch('certbot.util.exe_exists')
-    def test_nginx_selection(self, mock_exe_exists, unused_report):
+    def test_configurator_selection(self, mock_exe_exists, unused_report):
         mock_exe_exists.return_value = True
         real_plugins = disco.PluginsRegistry.find_all()
         args = ['--apache', '--authenticator', 'standalone']
@@ -520,9 +495,8 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
             self.assertTrue("The nginx plugin is not working" in ret)
             self.assertTrue("MisconfigurationError" in ret)
 
+        self._cli_missing_flag(["--standalone"], "With the standalone plugin, you probably")
 
-    @mock.patch('certbot.main._report_new_cert')
-    def test_manual_selection(self, unused_report):
         with mock.patch("certbot.main._init_le_client") as mock_init:
             with mock.patch("certbot.main._get_and_save_cert") as mock_gsc:
                 mock_gsc.return_value = mock.MagicMock()
@@ -530,19 +504,14 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
                 unused_config, auth, unused_installer = mock_init.call_args[0]
                 self.assertTrue(isinstance(auth, manual.Authenticator))
 
-    def test_standalone_selection(self):
         with mock.patch('certbot.main.certonly') as mock_certonly:
             self._call(["auth", "--standalone"])
             self.assertEqual(1, mock_certonly.call_count)
-
-    def test_standalone_selection2(self):
-        self._cli_missing_flag(["--standalone"], "With the standalone plugin, you probably")
 
     def test_rollback(self):
         _, _, _, client = self._call(['rollback'])
         self.assertEqual(1, client.rollback.call_count)
 
-    def test_rollback2(self):
         _, _, _, client = self._call(['rollback', '--checkpoints', '123'])
         client.rollback.assert_called_once_with(
             mock.ANY, 123, mock.ANY, mock.ANY)
@@ -567,49 +536,11 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
         self.assertEqual(1, mock_cert_manager.call_count)
 
     def test_plugins(self):
-        self._call(['plugins'])
-
-    def test_plugins2(self):
-        self._call(['plugins', '--init'])
-
-    def test_plugins3(self):
-        self._call(['plugins', '--prepare'])
-
-    def test_plugins4(self):
-        self._call(['plugins', '--authenticators'])
-
-    def test_plugins5(self):
-        self._call(['plugins', '--installers'])
-
-    def test_plugins6(self):
-        self._call(['plugins', '--init', '--prepare'])
-
-    def test_plugins7(self):
-        self._call(['plugins', '--init', '--authenticators'])
-
-    def test_plugins8(self):
-        self._call(['plugins', '--init', '--installers'])
-
-    def test_plugins9(self):
-        self._call(['plugins', '--prepare', '--authenticators'])
-
-    def test_plugins10(self):
-        self._call(['plugins', '--prepare', '--installers'])
-
-    def test_plugins11(self):
-        self._call(['plugins', '--authenticators', '--installers'])
-
-    def test_plugins12(self):
-        self._call(['plugins', '--init', '--prepare', '--authenticators'])
-
-    def test_plugins13(self):
-        self._call(['plugins', '--init', '--prepare', '--installers'])
-
-    def test_plugins14(self):
-        self._call(['plugins', '--prepare', '--authenticators', '--installers'])
-
-    def test_plugins15(self):
-        self._call(['plugins', '--init', '--prepare', '--authenticators', '--installers'])
+        flags = ['--init', '--prepare', '--authenticators', '--installers']
+        for args in itertools.chain(
+                *(itertools.combinations(flags, r)
+                  for r in six.moves.range(len(flags)))):
+            self._call(['plugins'] + list(args))
 
     @mock.patch('certbot.main.plugins_disco')
     @mock.patch('certbot.main.cli.HelpfulArgumentParser.determine_help_topics')
@@ -846,18 +777,12 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
         self.assertEqual(get_utility().add_message.call_count, 1)
         self.assertTrue('dry run' in get_utility().add_message.call_args[0][0])
 
-    @mock.patch('certbot.crypto_util.notAfter')
-    def test_certonly_renewal_triggers2(self, unused_notafter):
-        _, get_utility, _ = self._test_renewal_common(
-            False, ['--renew-by-default', '-tvv', '--debug'],
-            log_out="Auto-renewal forced")
-        self.assertEqual(get_utility().add_message.call_count, 2)
+        self._test_renewal_common(False, ['--renew-by-default', '-tvv', '--debug'],
+                                  log_out="Auto-renewal forced")
+        self.assertEqual(get_utility().add_message.call_count, 1)
 
-    @mock.patch('certbot.crypto_util.notAfter')
-    def test_certonly_renewal_triggers3(self, unused_notafter):
-        self._test_renewal_common(
-            False, ['-tvv', '--debug', '--keep'],
-            log_out="not yet due", should_renew=False)
+        self._test_renewal_common(False, ['-tvv', '--debug', '--keep'],
+                                  log_out="not yet due", should_renew=False)
 
     def _dump_log(self):
         print("Logs:")
@@ -878,8 +803,6 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
         out = stdout.getvalue()
         self.assertTrue("renew" in out)
 
-    def test_quiet_renew2(self):
-        test_util.make_lineage(self, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "-q"]
         _, _, stdout = self._test_renewal_common(True, [], args=args, should_renew=True)
         out = stdout.getvalue()
@@ -1127,10 +1050,7 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
             # TODO: It would be more correct to explicitly check that
             #       _determine_account() gets called in the above case,
             #       but coverage statistics should also show that it did.
-
-    def test_register2(self):
-        with mock.patch('certbot.main.account') as mocked_account:
-            with mock.patch('certbot.main.client'):
+            with mock.patch('certbot.main.account') as mocked_account:
                 mocked_storage = mock.MagicMock()
                 mocked_account.AccountFileStorage.return_value = mocked_storage
                 mocked_storage.find_all.return_value = ["an account"]


### PR DESCRIPTION
Second part of #4443. Built on #4444. Fixes #3148.

This fixes an old problem with code logging messages before logging has been set up. How this works is explained in the docstring of certbot.log.pre_arg_setup.

I'm planning on rebasing my locking code for 0.13.0 on top of this PR.