### PR TITLE
Remove unused default parameter

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -820,7 +820,7 @@ class NginxConfigurator(common.Plugin):
             self.restart()
 
 
-def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx.conf"):
+def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx/nginx.conf"):
     """Restarts the Nginx Server.
 
     .. todo:: Nginx restart is fatal if the configuration references

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -820,7 +820,7 @@ class NginxConfigurator(common.Plugin):
             self.restart()
 
 
-def nginx_restart(nginx_ctl, nginx_conf="/etc/nginx/nginx.conf"):
+def nginx_restart(nginx_ctl, nginx_conf):
     """Restarts the Nginx Server.
 
     .. todo:: Nginx restart is fatal if the configuration references


### PR DESCRIPTION
Fixes #4326.

```
(venv) certbot@certbot$ git grep -C 3 nginx_restart
certbot-nginx/certbot_nginx/configurator.py-        :raises .errors.MisconfigurationError: If either the reload fails.
certbot-nginx/certbot_nginx/configurator.py-
certbot-nginx/certbot_nginx/configurator.py-        """
certbot-nginx/certbot_nginx/configurator.py:        nginx_restart(self.conf('ctl'), self.nginx_conf)
certbot-nginx/certbot_nginx/configurator.py-
certbot-nginx/certbot_nginx/configurator.py-    def config_test(self):  # pylint: disable=no-self-use
certbot-nginx/certbot_nginx/configurator.py-        """Check the configuration of Nginx for errors.
--
certbot-nginx/certbot_nginx/configurator.py-            self.restart()
certbot-nginx/certbot_nginx/configurator.py-
certbot-nginx/certbot_nginx/configurator.py-
certbot-nginx/certbot_nginx/configurator.py:def nginx_restart(nginx_ctl, nginx_conf):
certbot-nginx/certbot_nginx/configurator.py-    """Restarts the Nginx Server.
certbot-nginx/certbot_nginx/configurator.py-
certbot-nginx/certbot_nginx/configurator.py-    .. todo:: Nginx restart is fatal if the configuration references
--
certbot-nginx/certbot_nginx/tests/configurator_test.py-        self.assertRaises(errors.PluginError, self.config.get_version)
certbot-nginx/certbot_nginx/tests/configurator_test.py-
certbot-nginx/certbot_nginx/tests/configurator_test.py-    @mock.patch("certbot_nginx.configurator.subprocess.Popen")
certbot-nginx/certbot_nginx/tests/configurator_test.py:    def test_nginx_restart(self, mock_popen):
certbot-nginx/certbot_nginx/tests/configurator_test.py-        mocked = mock_popen()
certbot-nginx/certbot_nginx/tests/configurator_test.py-        mocked.communicate.return_value = ('', '')
certbot-nginx/certbot_nginx/tests/configurator_test.py-        mocked.returncode = 0
certbot-nginx/certbot_nginx/tests/configurator_test.py-        self.config.restart()
certbot-nginx/certbot_nginx/tests/configurator_test.py-
certbot-nginx/certbot_nginx/tests/configurator_test.py-    @mock.patch("certbot_nginx.configurator.subprocess.Popen")
certbot-nginx/certbot_nginx/tests/configurator_test.py:    def test_nginx_restart_fail(self, mock_popen):
certbot-nginx/certbot_nginx/tests/configurator_test.py-        mocked = mock_popen()
certbot-nginx/certbot_nginx/tests/configurator_test.py-        mocked.communicate.return_value = ('', '')
certbot-nginx/certbot_nginx/tests/configurator_test.py-        mocked.returncode = 1
```