### PR TITLE
Add lockfile

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -29,7 +29,10 @@ install_requires = [
 
 # env markers cause problems with older pip and setuptools
 if sys.version_info < (2, 7):
-    install_requires.append('argparse')
+    install_requires.extend([
+        'argparse',
+        'ordereddict',
+    ])
 
 dev_extras = [
     'nose',

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -200,7 +200,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         # Prevent two Apache plugins from modifying a config at once
         try:
             util.lock_dir_until_exit(self.conf("server-root"))
-        except errors.LockError:
+        except (OSError, errors.LockError):
             logger.debug("Encountered error:", exc_info=True)
             raise errors.PluginError(
                 "Unable to lock %s", self.conf("server-root"))

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -197,6 +197,14 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
         install_ssl_options_conf(self.mod_ssl_conf)
 
+        # Prevent two Apache plugins from modifying a config at once
+        try:
+            util.lock_dir_until_exit(self.conf("server-root"))
+        except errors.LockError:
+            logger.debug("Encountered error:", exc_info=True)
+            raise errors.PluginError(
+                "Unable to lock %s", self.conf("server-root"))
+
     def _check_aug_version(self):
         """ Checks that we have recent enough version of libaugeas.
         If augeas version is recent enough, it will support case insensitive

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -165,7 +165,7 @@ class NginxConfigurator(common.Plugin):
         # Prevent two Nginx plugins from modifying a config at once
         try:
             util.lock_dir_until_exit(self.conf('server-root'))
-        except errors.LockError:
+        except (OSError, errors.LockError):
             logger.debug('Encountered error:', exc_info=True)
             raise errors.PluginError(
                 'Unable to lock %s', self.conf('server-root'))

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -162,6 +162,14 @@ class NginxConfigurator(common.Plugin):
         if self.version is None:
             self.version = self.get_version()
 
+        # Prevent two Nginx plugins from modifying a config at once
+        try:
+            util.lock_dir_until_exit(self.conf('server-root'))
+        except errors.LockError:
+            logger.debug('Encountered error:', exc_info=True)
+            raise errors.PluginError(
+                'Unable to lock %s', self.conf('server-root'))
+
     # Entry point in main.py for installing cert
     def deploy_cert(self, domain, cert_path, key_path,
                     chain_path=None, fullchain_path=None):

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -12,6 +12,7 @@ from acme import messages
 
 from certbot import achallenges
 from certbot import errors
+from certbot.tests import util as certbot_test_util
 
 from certbot_nginx import obj
 from certbot_nginx import parser
@@ -64,6 +65,23 @@ class NginxConfiguratorTest(util.NginxTest):
         self.config.config_test = mock.Mock()
         self.config.prepare()
         self.assertEqual((1, 6, 2), self.config.version)
+
+    def test_prepare_locked(self):
+        server_root = self.config.conf("server-root")
+        self.config.config_test = mock.Mock()
+        os.remove(os.path.join(server_root, ".certbot.lock"))
+        certbot_test_util.lock_and_call(self._test_prepare_locked, server_root)
+
+    @mock.patch("certbot_nginx.configurator.util.exe_exists")
+    def _test_prepare_locked(self, unused_exe_exists):
+        try:
+            self.config.prepare()
+        except errors.PluginError as err:
+            err_msg = str(err)
+            self.assertTrue("lock" in err_msg)
+            self.assertTrue(self.config.conf("server-root") in err_msg)
+        else:  # pragma: no cover
+            self.fail("Exception wasn't raised!")
 
     @mock.patch("certbot_nginx.configurator.socket.gethostbyaddr")
     def test_get_all_names(self, mock_gethostbyaddr):

--- a/certbot/errors.py
+++ b/certbot/errors.py
@@ -33,6 +33,10 @@ class SignalExit(Error):
     """A Unix signal was received while in the ErrorHandler context manager."""
 
 
+class LockError(Error):
+    """File locking error."""
+
+
 # Auth Handler Errors
 class AuthorizationError(Error):
     """Authorization error."""

--- a/certbot/lock.py
+++ b/certbot/lock.py
@@ -56,11 +56,7 @@ class LockFile(object):
         """
         while self._fd is None:
             # Open the file
-            try:
-                fd = os.open(self._path, os.O_CREAT | os.O_WRONLY, 0o600)
-            except OSError:
-                logger.debug("Exception was:", exc_info=True)
-                raise errors.LockError("Unable to open {0}".format(self._path))
+            fd = os.open(self._path, os.O_CREAT | os.O_WRONLY, 0o600)
             try:
                 self._try_lock(fd)
                 if self._lock_success(fd):

--- a/certbot/lock.py
+++ b/certbot/lock.py
@@ -51,7 +51,8 @@ class LockFile(object):
     def acquire(self):
         """Acquire the lock file.
 
-        :raises errors.LockError: if unable to acquire the lock
+        :raises errors.LockError: if lock is already held
+        :raises OSError: if unable to open or stat the lock file
 
         """
         while self._fd is None:

--- a/certbot/lock.py
+++ b/certbot/lock.py
@@ -11,9 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 class LockFile(object):
-    """A UNIX lock file
+    """A UNIX lock file.
 
-    This lock file is based on the lock_file package by Martin Horcicka.
+    This lock file cannot be used to provide synchronization between
+    threads. It is based on the lock_file package by Martin Horcicka.
 
     """
     def __init__(self, path):
@@ -38,7 +39,7 @@ class LockFile(object):
         """
         while self._fd is None:
             # Open the file
-            fd = os.open(self._path, os.O_CREAT | os.O_WRONLY, 0600)
+            fd = os.open(self._path, os.O_CREAT | os.O_WRONLY, 0o600)
             try:
                 self._try_lock(fd)
                 if self._lock_success(fd):
@@ -79,8 +80,8 @@ class LockFile(object):
         """
         try:
             stat1 = os.stat(self._path)
-        except OSError, e:
-            if e.errno == errno.ENOENT:
+        except OSError as err:
+            if err.errno == errno.ENOENT:
                 return False
             raise
 
@@ -90,7 +91,7 @@ class LockFile(object):
         return stat1.st_dev == stat2.st_dev and stat1.st_ino == stat2.st_ino
 
     def __repr__(self):
-        repr_str = '{0}({1}) <'.format(self.__class__.__name__, self._fd)
+        repr_str = '{0}({1}) <'.format(self.__class__.__name__, self._path)
         if self._fd is None:
             repr_str += 'released>'
         else:

--- a/certbot/lock.py
+++ b/certbot/lock.py
@@ -1,0 +1,191 @@
+# $Id: lock_file.py 18 2007-10-24 04:47:12Z horcicka $
+
+'''Lock file manipulation.
+
+Lock file is a traditional means of synchronization among processes. In
+this module it is implemented as an empty regular file exclusively
+locked using fcntl.lockf. When it is to be released it is removed by
+default. However, if all cooperating processes turn off the removal,
+they get a guaranteed order of acquisitions and better scalability.
+
+Example: Checking if at most one instance of the script is running
+
+    import sys
+    from lock_file import LockFile, LockError
+
+    try:
+        lock_f = LockFile('/var/run/app.lock')
+    except LockError:
+        sys.exit('The script is already running')
+
+    try:
+        do_something_useful()
+    finally:
+        lock_f.release()
+
+Example: Waiting for the lock file acquisition
+
+    from lock_file import LockFile
+
+    lock_f = LockFile('/var/run/app.lock', wait = True)
+    try:
+        do_something_useful()
+    finally:
+        lock_f.release()
+
+Example: Waiting for the lock file acquisition (in Python 2.5 and
+higher)
+
+    from __future__ import with_statement
+    from lock_file import LockFile
+
+    with LockFile('/var/run/app.lock', wait = True):
+        do_something_useful()
+'''
+
+__all__ = 'LockError', 'LockFile'
+
+import errno
+import fcntl
+import os
+
+
+class LockError(Exception):
+    '''Lock error.
+
+    Raised when a lock file acquisition is unsuccessful because the lock
+    file is held by another process.
+    '''
+
+    def __init__(self, message):
+        Exception.__init__(self, message)
+
+
+    def __repr__(self):
+        return self.__class__.__name__ + '(' + repr(self.args[0]) + ')'
+
+
+class LockFile(object):
+    '''Lock file.
+
+    This class represents an acquired lock file. After its releasing
+    most methods lose their sense and raise a ValueError.
+    '''
+
+    def __init__(self, path, wait = False, remove = True):
+        '''Initialize and acquire the lock file.
+
+        Creates and locks the specified file. The wait argument can be
+        set to True to wait until the lock file can be acquired. The
+        remove argument can be set to False to keep the file after
+        releasing.
+
+        Raises LockError if the wait argument is False and the lock file
+        is held by another process. Raises OSError or IOError if any
+        other error occurs. In particular, raises IOError with the errno
+        attribute set to errno.EINTR, if waiting for the acquisition is
+        interrupted by a signal.
+        '''
+
+        object.__init__(self)
+        self._path = path
+        self._fd = None
+        self._remove = remove
+
+        # Acquire the lock file
+        while self._fd is None:
+            # Open the file
+            fd = os.open(path, os.O_CREAT | os.O_WRONLY, 0666)
+            try:
+                # Acquire an exclusive lock
+                if wait:
+                    fcntl.lockf(fd, fcntl.LOCK_EX)
+                else:
+                    try:
+                        fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except IOError, e:
+                        if e.errno in (errno.EACCES, errno.EAGAIN):
+                            raise LockError(
+                                'Lock file is held by another process: '
+                                + repr(self._path))
+                        else:
+                            raise
+
+                # Check if the locked file is the required one (it could
+                # have been removed and possibly recreated between the
+                # opening and the lock acquisition)
+                try:
+                    stat1 = os.stat(path)
+                except OSError, e:
+                    if e.errno != errno.ENOENT:
+                        raise
+                else:
+                    stat2 = os.fstat(fd)
+                    if stat1.st_dev == stat2.st_dev \
+                        and stat1.st_ino == stat2.st_ino:
+
+                        self._fd = fd
+
+            finally:
+                # Close the file if it is not the required one
+                if self._fd is None:
+                    os.close(fd)
+
+
+    def __enter__(self):
+        if self._fd is None:
+            raise ValueError('The lock file is released')
+
+        return self
+
+
+    def __repr__(self):
+        repr_str = '<'
+        if self._fd is None:
+            repr_str += 'released'
+        else:
+            repr_str += 'acquired'
+
+        repr_str += ' lock file ' + repr(self._path) + '>'
+        return repr_str
+
+
+    def get_path(self):
+        if self._fd is None:
+            raise ValueError('The lock file is released')
+
+        return self._path
+
+
+    def fileno(self):
+        if self._fd is None:
+            raise ValueError('The lock file is released')
+
+        return self._fd
+
+
+    def release(self):
+        '''Release the lock file.
+
+        Removes (optionally) and closes the lock file.
+
+        Raises ValueError if the lock file is already released. Raises
+        OSError if any other error occurs.
+        '''
+
+        if self._fd is None:
+            raise ValueError('The lock file is already released')
+
+        # Remove and close the file
+        try:
+            if self._remove:
+                os.remove(self._path)
+        finally:
+            try:
+                os.close(self._fd)
+            finally:
+                self._fd = None
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.release()

--- a/certbot/lock.py
+++ b/certbot/lock.py
@@ -5,39 +5,8 @@ import logging
 import os
 
 from certbot import errors
-from certbot import util
-
 
 logger = logging.getLogger(__name__)
-
-
-# Contains the list of locks to cleanup at program exit. If the program
-# exits before the lock is cleaned up, it is automatically released, but
-# the file isn't deleted.
-_LOCKS = []
-
-
-def lock_dir_until_exit(dir_path):
-    """Lock the directory at dir_path until program exit.
-
-    :param str dir_path: path to directory
-
-    :raises errors.LockFile: if the lock is held by another process
-
-    """
-    lock = lock_dir(dir_path)
-    if not _LOCKS:  # this is the first lock to be released at exit
-        util.atexit_register(_release_locks)
-    _LOCKS.append(lock)
-
-
-def _release_locks():
-    for lock in _LOCKS:
-        try:
-            lock.release()
-        except:  # pylint: disable=bare-except
-            msg = 'Encountered exception releasing lock: {0!r}'.format(lock)
-            logger.debug(msg, exc_info=True)
 
 
 def lock_dir(dir_path):

--- a/certbot/lock.py
+++ b/certbot/lock.py
@@ -10,6 +10,23 @@ from certbot import errors
 logger = logging.getLogger(__name__)
 
 
+def lock_dir(dir_path):
+    """Place a lock file on the directory at dir_path.
+
+    The lock file is placed in the root of dir_path with the name
+    .certbot.lock.
+
+    :param str dir_path: path to directory
+
+    :returns: the locked LockFile object
+    :rtype: LockFile
+
+    :raises errors.LockFile: if the lock is held by another process
+
+    """
+    return LockFile(os.path.join(dir_path, '.certbot.lock'))
+
+
 class LockFile(object):
     """A UNIX lock file.
 

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -131,7 +131,7 @@ def setup_log_file_handler(config, logfile, fmt):
     """
     # TODO: logs might contain sensitive data such as contents of the
     # private key! #525
-    util.make_or_verify_core_dir(
+    util.set_up_core_dir(
         config.logs_dir, 0o700, os.geteuid(), config.strict_permissions)
     log_file_path = os.path.join(config.logs_dir, logfile)
     try:

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -696,10 +696,10 @@ def renew(config, unused_plugins):
 
 def make_or_verify_needed_dirs(config):
     """Create or verify existence of config and work directories"""
-    util.make_or_verify_core_dir(config.config_dir, constants.CONFIG_DIRS_MODE,
-                            os.geteuid(), config.strict_permissions)
-    util.make_or_verify_core_dir(config.work_dir, constants.CONFIG_DIRS_MODE,
-                            os.geteuid(), config.strict_permissions)
+    util.set_up_core_dir(config.config_dir, constants.CONFIG_DIRS_MODE,
+                         os.geteuid(), config.strict_permissions)
+    util.set_up_core_dir(config.work_dir, constants.CONFIG_DIRS_MODE,
+                         os.geteuid(), config.strict_permissions)
 
 
 def set_displayer(config):

--- a/certbot/plugins/disco.py
+++ b/certbot/plugins/disco.py
@@ -12,6 +12,12 @@ from certbot import constants
 from certbot import errors
 from certbot import interfaces
 
+try:
+    from collections import OrderedDict
+except ImportError:  # pragma: no cover
+    # OrderedDict was added in Python 2.7
+    from ordereddict import OrderedDict  # pylint: disable=import-error
+
 
 logger = logging.getLogger(__name__)
 
@@ -168,7 +174,9 @@ class PluginsRegistry(collections.Mapping):
     """Plugins registry."""
 
     def __init__(self, plugins):
-        self._plugins = plugins
+        # plugins are sorted so the same order is used between runs.
+        # This prevents deadlock caused by plugins acquiring a lock.
+        self._plugins = OrderedDict(sorted(six.iteritems(plugins)))
 
     @classmethod
     def find_all(cls):

--- a/certbot/plugins/disco.py
+++ b/certbot/plugins/disco.py
@@ -175,7 +175,9 @@ class PluginsRegistry(collections.Mapping):
 
     def __init__(self, plugins):
         # plugins are sorted so the same order is used between runs.
-        # This prevents deadlock caused by plugins acquiring a lock.
+        # This prevents deadlock caused by plugins acquiring a lock
+        # and ensures at least one concurrent Certbot instance will run
+        # successfully.
         self._plugins = OrderedDict(sorted(six.iteritems(plugins)))
 
     @classmethod

--- a/certbot/tests/lock_test.py
+++ b/certbot/tests/lock_test.py
@@ -39,11 +39,6 @@ class LockFileTest(test_util.TempDirTestCase):
             self.assertRaises, errors.LockError, self._call, self.lock_path)
         test_util.lock_and_call(assert_raises, self.lock_path)
 
-    @mock.patch('certbot.lock.os.open')
-    def test_failed_open(self, mock_open):
-        mock_open.side_effect = OSError
-        self.assertRaises(errors.LockError, self._call, self.lock_path)
-
     def test_locked_repr(self):
         lock_file = self._call(self.lock_path)
         locked_repr = repr(lock_file)

--- a/certbot/tests/lock_test.py
+++ b/certbot/tests/lock_test.py
@@ -1,0 +1,116 @@
+"""Tests for certbot.lock."""
+import os
+import multiprocessing
+import unittest
+
+import mock
+
+from certbot import errors
+from certbot.tests import util as test_util
+
+
+class LockFileTest(test_util.TempDirTestCase):
+    """Tests for certbot.lock.LockFile."""
+    @classmethod
+    def _call(cls, *args, **kwargs):
+        from certbot.lock import LockFile
+        return LockFile(*args, **kwargs)
+
+    def setUp(self):
+        super(LockFileTest, self).setUp()
+        self.lock_path = os.path.join(self.tempdir, 'test.lock')
+
+    def test_contention(self):
+        # start child and wait for it to grab the lock
+        cv = multiprocessing.Condition()
+        cv.acquire()
+        child_args = (cv, self.lock_path,)
+        child = multiprocessing.Process(target=hold_lock, args=child_args)
+        child.start()
+        cv.wait()
+
+        # assert we can't grab lock and terminate the child
+        self.assertRaises(
+            errors.LockError, self._call, self.lock_path)
+        cv.notify()
+        cv.release()
+        child.join()
+        self.assertEqual(child.exitcode, 0)
+
+    def test_race(self):
+        should_delete = [True, False]
+        stat = os.stat
+
+        def delete_and_stat(path):
+            """Wrap os.stat and maybe delete the file first."""
+            if path == self.lock_path and should_delete.pop(0):
+                os.remove(path)
+            return stat(path)
+
+        with mock.patch('certbot.lock.os.stat') as mock_stat:
+            mock_stat.side_effect = delete_and_stat
+            self._call(self.lock_path)
+        self.assertFalse(should_delete)
+
+    def test_locked_repr(self):
+        lock_file = self._call(self.lock_path)
+        locked_repr = repr(lock_file)
+        self._test_repr_common(lock_file, locked_repr)
+        self.assertTrue('acquired' in locked_repr)
+
+    def test_released_repr(self):
+        lock_file = self._call(self.lock_path)
+        lock_file.release()
+        released_repr = repr(lock_file)
+        self._test_repr_common(lock_file, released_repr)
+        self.assertTrue('released' in released_repr)
+
+    def _test_repr_common(self, lock_file, lock_repr):
+        self.assertTrue(lock_file.__class__.__name__ in lock_repr)
+        self.assertTrue(self.lock_path in lock_repr)
+
+    def test_removed(self):
+        lock_file = self._call(self.lock_path)
+        lock_file.release()
+        self.assertFalse(os.path.exists(self.lock_path))
+
+    @mock.patch('certbot.lock.fcntl.lockf')
+    def test_unexpected_lockf_err(self, mock_lockf):
+        msg = 'hi there'
+        mock_lockf.side_effect = IOError(msg)
+        try:
+            self._call(self.lock_path)
+        except IOError as err:
+            self.assertTrue(msg in str(err))
+        else:  # pragma: no cover
+            self.fail('IOError not raised')
+
+    @mock.patch('certbot.lock.os.stat')
+    def test_unexpected_stat_err(self, mock_stat):
+        msg = 'hi there'
+        mock_stat.side_effect = OSError(msg)
+        try:
+            self._call(self.lock_path)
+        except OSError as err:
+            self.assertTrue(msg in str(err))
+        else:  # pragma: no cover
+            self.fail('OSError not raised')
+
+
+def hold_lock(cv, lock_path):  # pragma: no cover
+    """Acquire a file lock at lock_path and wait to release it.
+
+    :param multiprocessing.Condition cv: condition for syncronization
+    :param str lock_path: path to the file lock
+
+    """
+    from certbot.lock import LockFile
+    lock_file = LockFile(lock_path)
+    cv.acquire()
+    cv.notify()
+    cv.wait()
+    lock_file.release()
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/tests/lock_test.py
+++ b/certbot/tests/lock_test.py
@@ -2,40 +2,12 @@
 import functools
 import multiprocessing
 import os
-import shutil
 import unittest
 
 import mock
-from six.moves import reload_module  # pylint: disable=import-error
 
 from certbot import errors
 from certbot.tests import util as test_util
-
-
-class LockDirUntilExit(test_util.TempDirTestCase):
-    """Tests for certbot.lock.lock_dir_until_exit."""
-    @classmethod
-    def _call(cls, *args, **kwargs):
-        from certbot.lock import lock_dir_until_exit
-        return lock_dir_until_exit(*args, **kwargs)
-
-    def setUp(self):
-        super(LockDirUntilExit, self).setUp()
-        # reset global state from other tests
-        import certbot.lock
-        reload_module(certbot.lock)
-
-    @mock.patch('certbot.lock.util.atexit_register')
-    def test_it(self, mock_register):
-        subdir = os.path.join(self.tempdir, 'subdir')
-        os.mkdir(subdir)
-        self._call(self.tempdir)
-        self._call(subdir)
-
-        self.assertEqual(mock_register.call_count, 1)
-        registered_func = mock_register.call_args[0][0]
-        shutil.rmtree(subdir)
-        registered_func()  # exception not raised
 
 
 class LockDirTest(test_util.TempDirTestCase):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -792,12 +792,12 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
                 print(lf.read())
 
     def test_renew_verb(self):
-        test_util.make_lineage(self, 'sample-renewal.conf')
+        test_util.make_lineage(self.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "-tvv"]
         self._test_renewal_common(True, [], args=args, should_renew=True)
 
     def test_quiet_renew(self):
-        test_util.make_lineage(self, 'sample-renewal.conf')
+        test_util.make_lineage(self.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run"]
         _, _, stdout = self._test_renewal_common(True, [], args=args, should_renew=True)
         out = stdout.getvalue()
@@ -809,13 +809,13 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
         self.assertEqual("", out)
 
     def test_renew_hook_validation(self):
-        test_util.make_lineage(self, 'sample-renewal.conf')
+        test_util.make_lineage(self.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "--post-hook=no-such-command"]
         self._test_renewal_common(True, [], args=args, should_renew=False,
                                   error_expected=True)
 
     def test_renew_no_hook_validation(self):
-        test_util.make_lineage(self, 'sample-renewal.conf')
+        test_util.make_lineage(self.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run", "--post-hook=no-such-command",
                 "--disable-hook-validation"]
         with mock.patch("certbot.hooks.post_hook"):
@@ -825,7 +825,8 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
     @mock.patch("certbot.cli.set_by_cli")
     def test_ancient_webroot_renewal_conf(self, mock_set_by_cli):
         mock_set_by_cli.return_value = False
-        rc_path = test_util.make_lineage(self, 'sample-renewal-ancient.conf')
+        rc_path = test_util.make_lineage(
+            self.config_dir, 'sample-renewal-ancient.conf')
         args = mock.MagicMock(account=None, config_dir=self.config_dir,
                               logs_dir=self.logs_dir, work_dir=self.work_dir,
                               email=None, webroot_path=None)
@@ -846,7 +847,7 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
         self._test_renewal_common(False, [], args=args, should_renew=False, error_expected=True)
 
     def test_renew_with_certname(self):
-        test_util.make_lineage(self, 'sample-renewal.conf')
+        test_util.make_lineage(self.config_dir, 'sample-renewal.conf')
         self._test_renewal_common(True, [], should_renew=True,
             args=['renew', '--dry-run', '--cert-name', 'sample-renewal'])
 

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -21,7 +21,8 @@ class RenewalTest(util.TempDirTestCase):
     @mock.patch('certbot.cli.set_by_cli')
     def test_ancient_webroot_renewal_conf(self, mock_set_by_cli):
         mock_set_by_cli.return_value = False
-        rc_path = util.make_lineage(self, 'sample-renewal-ancient.conf')
+        rc_path = util.make_lineage(
+            self.config_dir, 'sample-renewal-ancient.conf')
         args = mock.MagicMock(account=None, config_dir=self.config_dir,
                               logs_dir="logs", work_dir="work",
                               email=None, webroot_path=None)

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -14,12 +14,14 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 import mock
 import OpenSSL
+from six.moves import reload_module  # pylint: disable=import-error
 
 from acme import jose
 
 from certbot import constants
 from certbot import interfaces
 from certbot import storage
+from certbot import util
 
 from certbot.display import util as display_util
 
@@ -251,6 +253,9 @@ def lock_and_call(func, lock_path):
     :param str lock_path: path to file or directory to lock
 
     """
+    # Reload module to reset internal _LOCKS dictionary
+    reload_module(util)
+
     # start child and wait for it to grab the lock
     cv = multiprocessing.Condition()
     cv.acquire()

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -109,12 +109,13 @@ def skip_unless(condition, reason):  # pragma: no cover
         return lambda cls: None
 
 
-def make_lineage(self, testfile):
+def make_lineage(config_dir, testfile):
     """Creates a lineage defined by testfile.
 
     This creates the archive, live, and renewal directories if
     necessary and creates a simple lineage.
 
+    :param str config_dir: path to the configuration directory
     :param str testfile: configuration file to base the lineage on
 
     :returns: path to the renewal conf file for the created lineage
@@ -124,11 +125,11 @@ def make_lineage(self, testfile):
     lineage_name = testfile[:-len('.conf')]
 
     conf_dir = os.path.join(
-        self.config_dir, constants.RENEWAL_CONFIGS_DIR)
+        config_dir, constants.RENEWAL_CONFIGS_DIR)
     archive_dir = os.path.join(
-        self.config_dir, constants.ARCHIVE_DIR, lineage_name)
+        config_dir, constants.ARCHIVE_DIR, lineage_name)
     live_dir = os.path.join(
-        self.config_dir, constants.LIVE_DIR, lineage_name)
+        config_dir, constants.LIVE_DIR, lineage_name)
 
     for directory in (archive_dir, conf_dir, live_dir,):
         if not os.path.exists(directory):
@@ -143,11 +144,11 @@ def make_lineage(self, testfile):
         os.symlink(os.path.join(archive_dir, '{0}1.pem'.format(kind)),
                    os.path.join(live_dir, '{0}.pem'.format(kind)))
 
-    conf_path = os.path.join(self.config_dir, conf_dir, testfile)
+    conf_path = os.path.join(config_dir, conf_dir, testfile)
     with open(vector_path(testfile)) as src:
         with open(conf_path, 'w') as dst:
             dst.writelines(
-                line.replace('MAGICDIR', self.config_dir) for line in src)
+                line.replace('MAGICDIR', config_dir) for line in src)
 
     return conf_path
 

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -145,9 +145,10 @@ def set_up_core_dir(directory, mode, uid, strict):
     """
     try:
         make_or_verify_dir(directory, mode, uid, strict)
+        lock_dir_until_exit(directory)
     except OSError as error:
+        logger.debug("Exception was:", exc_info=True)
         raise errors.Error(PERM_ERR_FMT.format(error))
-    lock_dir_until_exit(directory)
 
 
 def make_or_verify_dir(directory, mode=0o755, uid=0, strict=False):

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -20,6 +20,7 @@ import configargparse
 
 from certbot import constants
 from certbot import errors
+from certbot import lock
 
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,10 @@ PERM_ERR_FMT = os.linesep.join((
 
 # Stores importing process ID to be used by atexit_register()
 _INITIAL_PID = os.getpid()
+# Contains the list of locks to cleanup at program exit. If the program
+# exits before the lock is cleaned up, it is automatically released, but
+# the file isn't deleted.
+_LOCKS = []
 
 
 def run_script(params, log=logger.error):
@@ -103,14 +108,38 @@ def exe_exists(exe):
     return False
 
 
-def make_or_verify_core_dir(directory, mode, uid, strict):
-    """Make sure directory exists with proper permissions.
+def lock_dir_until_exit(dir_path):
+    """Lock the directory at dir_path until program exit.
+
+    :param str dir_path: path to directory
+
+    :raises errors.LockFile: if the lock is held by another process
+
+    """
+    dir_lock = lock.lock_dir(dir_path)
+    if not _LOCKS:  # this is the first lock to be released at exit
+        atexit_register(_release_locks)
+    _LOCKS.append(dir_lock)
+
+
+def _release_locks():
+    for dir_lock in _LOCKS:
+        try:
+            dir_lock.release()
+        except:  # pylint: disable=bare-except
+            msg = 'Exception occurred releasing lock: {0!r}'.format(dir_lock)
+            logger.debug(msg, exc_info=True)
+
+
+def set_up_core_dir(directory, mode, uid, strict):
+    """Ensure directory exists with proper permissions and is locked.
 
     :param str directory: Path to a directory.
     :param int mode: Directory mode.
     :param int uid: Directory owner.
     :param bool strict: require directory to be owned by current user
 
+    :raises .errors.LockError: if the directory cannot be locked
     :raises .errors.Error: if the directory cannot be made or verified
 
     """
@@ -118,6 +147,7 @@ def make_or_verify_core_dir(directory, mode, uid, strict):
         make_or_verify_dir(directory, mode, uid, strict)
     except OSError as error:
         raise errors.Error(PERM_ERR_FMT.format(error))
+    lock_dir_until_exit(directory)
 
 
 def make_or_verify_dir(directory, mode=0o755, uid=0, strict=False):

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,10 @@ install_requires = [
 
 # env markers cause problems with older pip and setuptools
 if sys.version_info < (2, 7):
-    install_requires.append('argparse')
+    install_requires.extend([
+        'argparse',
+        'ordereddict',
+    ])
 
 dev_extras = [
     # Pin astroid==1.3.5, pylint==1.4.2 as a workaround for #289

--- a/tests/lock_test.py
+++ b/tests/lock_test.py
@@ -24,6 +24,7 @@ def main():
     for subcommand in ('certonly', 'install', 'renew', 'run',):
         logger.info('Testing subcommand: %s', subcommand)
         test_command(base_cmd + [subcommand], dirs)
+    logger.info('Lock test ran successfully.')
 
 
 def set_up():

--- a/tests/lock_test.py
+++ b/tests/lock_test.py
@@ -1,0 +1,211 @@
+"""Tests to ensure the lock order is preserved."""
+import contextlib
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from certbot import lock
+
+from certbot.tests import util as test_util
+
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    """Run the lock tests."""
+    logging.basicConfig(format='%(message)s', level=logging.INFO)
+    with temporary_dir() as temp_dir:
+        subdirs = create_subdirs(temp_dir)
+        base_cmd = set_up_certbot_cmd(subdirs)
+        for subcommand in ('certonly', 'install', 'run'):
+            cmd = base_cmd + [subcommand]
+            logger.info('Testing command: %s', ' '.join(cmd))
+            test_command(cmd, subdirs)
+    logger.info('Lock test ran successfully.')
+
+
+@contextlib.contextmanager
+def temporary_dir():
+    """Context manager for creating and destroying a temp directory."""
+    temp_dir = tempfile.mkdtemp()
+    logger.debug('Created temporary directory: %s', temp_dir)
+    yield temp_dir
+    shutil.rmtree(temp_dir)
+
+
+def create_subdirs(parent_dir):
+    """Creates four subdirectories for Certbot and the chosen plugin.
+
+    These directories are created under parent_dir.
+
+    :param str parent_dir: path to create directories in
+
+    :returns: paths to four directories created under paren_dir
+    :rtype: `list` of `str`
+
+    """
+    created = []
+    for name in ('foo', 'bar', 'baz', 'qux',):
+        full_path = os.path.join(parent_dir, name)
+        os.mkdir(full_path)
+        created.append(full_path)
+    return created
+
+
+def set_up_certbot_cmd(dirs):
+    """Build the Certbot command to run for testing.
+
+    The directory paths in dirs are used in the order that locks are
+    acquired. If you run the returned command when all locks are held,
+    Certbot should error trying to acquire the first directory in dirs.
+    If you release the lock on that directory, it should then error
+    trying to acquire the lock on the second directory. This continues
+    until all directories in dirs has been used. If dirs contains too
+    many or too few directories, this function raises an error.
+
+    The resulting command is set up so Nginx can be used and a basic
+    Nginx configuration is placed in that directory by this function.
+
+    :param iterable dirs: directories to be used
+
+    :returns: certbot command to execute for testing
+    :rtype: `list` of `str`
+
+    """
+    assert len(dirs) == 4, 'Unexpected number of directories!'
+    logs_dir, config_dir, work_dir, nginx_dir = dirs
+    set_up_nginx_dir(nginx_dir)
+    cmd = 'certbot --cert-path {0} '.format(test_util.vector_path('cert.pem'))
+    cmd += '--key-path {0} '.format(test_util.vector_path('rsa512_key.pem'))
+    cmd += '--logs-dir {0} --config-dir {1} '.format(logs_dir, config_dir)
+    cmd += '--work-dir {} '.format(work_dir)
+    cmd += '--nginx-server-root {} '.format(nginx_dir)
+    cmd += '--debug --nginx --verbose '
+    return cmd.split()
+
+
+def set_up_nginx_dir(root_path):
+    """Create a basic Nginx configuration in nginx_dir.
+
+    :param str root_path: where the Nginx server root should be placed
+
+    """
+    # Get the root of the git repository
+    repo_root = check_call('git rev-parse --show-toplevel'.split()).strip()
+    conf_script = os.path.join(
+        repo_root, 'certbot-nginx', 'tests', 'boulder-integration.conf.sh')
+    os.environ['root'] = root_path
+    with open(os.path.join(root_path, 'nginx.conf'), 'w') as f:
+        f.write(check_call(['/bin/sh', conf_script]))
+    del os.environ['root']
+
+
+def test_command(command, directories):
+    """Assert Certbot acquires locks in a specific order.
+
+    command is run repeatedly testing that Certbot acquires locks on
+    directories in the order they appear in the parameter directories.
+
+    :param list command: Certbot command to execute
+    :param list directories: list of directories Certbot should fail
+        to acquire the lock on in sorted order
+
+    """
+    locks = [lock.lock_dir(directory) for directory in directories]
+    for dir_path, dir_lock in zip(directories, locks):
+        check_error(command, dir_path)
+        dir_lock.release()
+
+
+def check_error(command, dir_path):
+    """Run command and verify it fails to acquire the lock for dir_path.
+
+    :param str command: certbot command to run
+    :param str dir_path: path to directory containing the lock Certbot
+        should fail on
+
+    """
+    ret, out, err = subprocess_call(command)
+    if ret == 0:
+        report_failure("Certbot didn't exit with a nonzero status!", out, err)
+
+    match = re.search("Please see the logfile '(.*)' for more details", err)
+    if match is not None:
+        # Get error output from more verbose logfile
+        with open(match.group(1)) as f:
+            err = f.read()
+
+    pattern = 'A lock on {}.* is held by another process'.format(dir_path)
+    if not re.search(pattern, err):
+        err_msg = 'Directory path {} not error output!'.format(dir_path)
+        report_failure(err_msg, out, err)
+
+
+def check_call(args):
+    """Simple imitation of subprocess.check_call.
+
+    This function is only available in subprocess in Python 2.7+.
+
+    :param list args: program and it's arguments to be run
+
+    :returns: stdout output
+    :rtype: str
+
+    """
+    exit_code, out, err = subprocess_call(args)
+    if exit_code:
+        report_failure('Command exited with a nonzero status!', out, err)
+    return out
+
+
+def report_failure(err_msg, out, err):
+    """Report a subprocess failure and exit.
+
+    :param str err_msg: error message to report
+    :param str out: stdout output
+    :param str err: stderr output
+
+    """
+    logger.fatal(err_msg)
+    log_output(logging.INFO, out, err)
+    sys.exit(err_msg)
+
+
+def subprocess_call(args):
+    """Run a command with subprocess and return the result.
+
+    :param list args: program and it's arguments to be run
+
+    :returns: return code, stdout output, stderr output
+    :rtype: tuple
+
+    """
+    process = subprocess.Popen(args, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE, universal_newlines=True)
+    out, err = process.communicate()
+    logger.debug('Return code was %d', process.returncode)
+    log_output(logging.DEBUG, out, err)
+    return process.returncode, out, err
+
+
+def log_output(level, out, err):
+    """Logs stdout and stderr output at the requested level.
+
+    :param int level: logging level to use
+    :param str out: stdout output
+    :param str err: stderr output
+
+    """
+    if out:
+        logger.log(level, 'Stdout output was:\n%s', out)
+    if err:
+        logger.log(level, 'Stderr output was:\n%s', err)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lock_test.py
+++ b/tests/lock_test.py
@@ -167,9 +167,9 @@ def check_error(command, dir_path):
         with open(match.group(1)) as f:
             err = f.read()
 
-    pattern = 'A lock on {}.* is held by another process'.format(dir_path)
+    pattern = 'A lock on {0}.* is held by another process'.format(dir_path)
     if not re.search(pattern, err):
-        err_msg = 'Directory path {} not in error output!'.format(dir_path)
+        err_msg = 'Directory path {0} not in error output!'.format(dir_path)
         report_failure(err_msg, out, err)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ basepython = python2.7
 # continue, but tox return code will reflect previous error
 commands =
     pip install -q -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-compatibility-test -e letshelp-certbot
-    pylint --reports=n --rcfile=.pylintrc acme/acme certbot certbot-apache/certbot_apache certbot-nginx/certbot_nginx certbot-compatibility-test/certbot_compatibility_test letshelp-certbot/letshelp_certbot
+    pylint --reports=n --rcfile=.pylintrc acme/acme certbot certbot-apache/certbot_apache certbot-nginx/certbot_nginx certbot-compatibility-test/certbot_compatibility_test letshelp-certbot/letshelp_certbot tests/lock_test.py
 
 [testenv:mypy]
 basepython = python3.4

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands =
     nosetests -v certbot_nginx --processes=-1
     pip install -e letshelp-certbot
     nosetests -v letshelp_certbot --processes=-1
+    python tests/lock_test.py
 
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Built on #4554. Fixes #933.

This is a large PR, but over 60% of it is testing.

#### Design decisions

* I came full circle and decided to put a lock in the top level of each directory we use. The biggest problem with a global, world writeable lockfile is arbitrary users can lock the file and prevent your program from running or remove protections entirely.
* Since we're creating the lockfile in our directories which have permissions 755 ([source](https://github.com/certbot/certbot/blob/v0.12.0/certbot/constants.py#L79)), give it 600 permissions.
* Try and delete the lockfile on exit. With the OS level locking mechanisms we're using, the lock is automatically released when the process exits, but lets not leave `.certbot.lock` files everywhere. Users will complain about us littering files all over their system or wonder if Certbot crashed. The `lock_file` module which the `LockFile` class is based on is the only Python lock file module I found that securely deletes the lockfile.
* `lock_file` is no longer maintained and isn't packaged anywhere, so I added it to our tree and cleaned it up. There's a slight benefit here because we've promised Debian we wouldn't be adding any new (non-optional) dependencies to Certbot. `lock_file` doesn't work on Windows, but neither does Certbot right now so we can deal with that problem when/if it comes up.
* Ensure consistent locking order through testing to so if two Certbot instances run concurrently, at least one of them will be successful. We don't block on locks because it increases the chance of deadlock, we'd have to write our own timeout code (if we wanted a timeout), and we may block on a lock we don't need in the case of plugins.