### PR TITLE
Fix string test bug

### DIFF
--- a/certbot-auto
+++ b/certbot-auto
@@ -131,7 +131,7 @@ su_sudo() {
 
 SUDO_ENV=""
 export CERTBOT_AUTO="$0"
-if [ -n "${LE_AUTO_SUDO+x}" ]; then
+if [ -n "$LE_AUTO_SUDO" ]; then
   case "$LE_AUTO_SUDO" in
     su_sudo|su)
       SUDO=su_sudo


### PR DESCRIPTION
${variable+x} is always going to evaluate to 'x', which will always be a
non-zero length string. I do not believe this was the intention of this
test.