### PR TITLE
interface: IConfig is missing fields used in client.py

### DIFF
--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -235,6 +235,22 @@ class IConfig(zope.interface.Interface):
         "This only affects the port Certbot listens on. "
         "A conforming ACME server will still attempt to connect on port 80.")
 
+    pref_challs = zope.interface.Attribute(
+        "Sorted user specified preferred challenges"
+        "type strings with the most preferred challenge listed first")
+
+    allow_subset_of_names = zope.interface.Attribute(
+        "When performing domain validation, do not consider it a failure "
+        "if authorizations can not be obtained for a strict subset of "
+        "the requested domains. This may be useful for allowing renewals for "
+        "multiple domains to succeed even if some domains no longer point "
+        "at this system. This is a boolean")
+
+    strict_permissions = zope.interface.Attribute(
+        "Require that all configuration files are owned by the current "
+        "user; only needed if your config is somewhere unsafe like /tmp/."
+        "This is a boolean")
+
 
 class IInstaller(IPlugin):
     """Generic Certbot Installer Interface.


### PR DESCRIPTION
Certbot version: 0.12.0

A user using certbot as an API, must implement `pref_challs` in config, failure to do so will result in an error like:
```
  File "site-packages/certbot-0.12.0-py3.4.egg/certbot/client.py", line 207, in __init__
    auth, self.acme, self.account, self.config.pref_challs)
AttributeError: 'CustomConfig' object has no attribute 'pref_challs'
```

or:
```
  File "site-packages/certbot-0.12.0-py3.4.egg/certbot/client.py", line 265, in obtain_certificate
    self.config.allow_subset_of_names)
AttributeError: 'CustomConfig' object has no attribute 'allow_subset_of_names'
```

or:
```
  File "site-packages/certbot-0.12.0-py3.4.egg/certbot/crypto_util.py", line 55, in init_save_key
    config.strict_permissions)
AttributeError: 'CertbotConfig' object has no attribute 'strict_permissions'

```