### PR TITLE
Improved info for FreeBSD

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -427,7 +427,7 @@ For squeeze you will need to:
 FreeBSD
 -------
 
-Packages can be installed FreeBSD using ``pkg``, 
+Packages can be installed on FreeBSD using ``pkg``, 
 or any other port-management tool (``portupgrade``, ``portmanager``, etc.) 
 from the pre-built package or can be built and installed from ports. 
 Either way will ensure proper installation of all the dependencies required 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -427,11 +427,11 @@ For squeeze you will need to:
 FreeBSD
 -------
 
-The package can be installed FreeBSD using ``pkg`` (e.g. ``pkg install py27-certbot``), 
+Packages can be installed FreeBSD using ``pkg``, 
 or any other port-management tool (``portupgrade``, ``portmanager``, etc.) 
-from the pre-compiled package or can be built and installed from ports. 
+from the pre-built package or can be built and installed from ports. 
 Either way will ensure proper installation of all the dependencies required 
-to run ``certbot``.
+for the package.
 
 FreeBSD by default uses ``tcsh``. In order to activate virtualenv (see
 above), you will need a compatible shell, e.g. ``pkg install bash &&

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -427,8 +427,12 @@ For squeeze you will need to:
 FreeBSD
 -------
 
-Package installation for FreeBSD uses ``pkg``, not ports.
+The package can be installed FreeBSD using ``pkg`` (e.g. ``pkg install py27-certbot``), 
+or any other port-management tool (``portupgrade``, ``portmanager``, etc.) 
+from the pre-compiled package or can be built and installed from ports. 
+Either way will ensure proper installation of all the dependencies required 
+to run ``certbot``.
 
 FreeBSD by default uses ``tcsh``. In order to activate virtualenv (see
-below), you will need a compatible shell, e.g. ``pkg install bash &&
+above), you will need a compatible shell, e.g. ``pkg install bash &&
 bash``.


### PR DESCRIPTION
1. Replace the outdated reference to "vritualenv", "see below" -> "see above".
2. Replace the awkward sentence (partially incorrect) about installing on FreeBSD. 
It can be installed via different ways: "pkg" is not exclusive. I am not aware of any reason why it can **not** be installed from ports. Some people prefer build and install everything from ports. (The previous version of the description implies that ports cannot be used.)