### PR TITLE
Add Arch Linux constants for Apache

### DIFF
--- a/certbot-apache/certbot_apache/constants.py
+++ b/certbot-apache/certbot_apache/constants.py
@@ -110,6 +110,24 @@ CLI_DEFAULTS_SUSE = dict(
     MOD_SSL_CONF_SRC=pkg_resources.resource_filename(
         "certbot_apache", "options-ssl-apache.conf")
 )
+CLI_DEFAULTS_ARCH = dict(
+    server_root="/etc/httpd",
+    vhost_root="/etc/httpd/conf",
+    vhost_files="*.conf",
+    logs_root="/var/log/httpd",
+    version_cmd=['apachectl', '-v'],
+    define_cmd=['apachectl', '-t', '-D', 'DUMP_RUN_CFG'],
+    restart_cmd=['apachectl', 'graceful'],
+    conftest_cmd=['apachectl', 'configtest'],
+    enmod=None,
+    dismod=None,
+    le_vhost_ext="-le-ssl.conf",
+    handle_mods=False,
+    handle_sites=False,
+    challenge_location="/etc/httpd/conf",
+    MOD_SSL_CONF_SRC=pkg_resources.resource_filename(
+        "certbot_apache", "options-ssl-apache.conf")
+)
 CLI_DEFAULTS = {
     "default": CLI_DEFAULTS_DEFAULT,
     "debian": CLI_DEFAULTS_DEBIAN,
@@ -125,6 +143,7 @@ CLI_DEFAULTS = {
     "darwin": CLI_DEFAULTS_DARWIN,
     "opensuse": CLI_DEFAULTS_SUSE,
     "suse": CLI_DEFAULTS_SUSE,
+    "arch": CLI_DEFAULTS_ARCH,
 }
 """CLI defaults."""
 


### PR DESCRIPTION
Fixes #4461.

CLI_DEFAULTS_ARCH is modified from CLI_DEFAULTS_CENTOS. CentOS is another distro that uses apachectl everywhere instead of apache2ctl. I'm not sure whether all fields are correct or not. The only information is that Arch does as little patch as possible when packaging, so it's likely they're valid. Arch's packaging script at https://git.archlinux.org/svntogit/packages.git/tree/trunk?h=packages/apache can help if there are questions. ```build()``` and ```package()``` in ```PKGBUILD``` are the most important parts.

Tested on 26 Feb on my own Arch machine. I don't have much time these days for verifying this patch again, sorry.