### PR TITLE
Pin Python package dependencies. Close #4433.

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -8,24 +8,24 @@ version = '0.14.0.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'argparse',
+    'argparse<2.0',
     # load_pem_private/public_key (>=0.6)
     # rsa_recover_prime_factors (>=0.8)
-    'cryptography>=0.8',
+    'cryptography>=0.8,<2.0',
     # Connection.set_tlsext_host_name (>=0.13)
-    'mock',
-    'PyOpenSSL>=0.13',
-    'pyrfc3339',
+    'mock<3.0',
+    'PyOpenSSL>=0.13,<17.0',
+    'pyrfc3339<2.0',
     'pytz',
     # requests>=2.10 is required to fix
     # https://github.com/shazow/urllib3/issues/556. This requirement can be
     # relaxed to 'requests[security]>=2.4.1', however, less useful errors
     # will be raised for some network/SSL errors.
-    'requests[security]>=2.10',
+    'requests[security]>=2.10,<3.0',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',
-    'six',
+    'six<2.0',
 ]
 
 dev_extras = [

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -10,13 +10,13 @@ version = '0.14.0.dev0'
 install_requires = [
     'acme=={0}'.format(version),
     'certbot=={0}'.format(version),
-    'mock',
+    'mock<3.0',
     'python-augeas<=0.5.0',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',
-    'zope.component',
-    'zope.interface',
+    'zope.component<5.0',
+    'zope.interface<5.0',
 ]
 
 docs_extras = [

--- a/certbot-compatibility-test/setup.py
+++ b/certbot-compatibility-test/setup.py
@@ -9,16 +9,16 @@ version = '0.14.0.dev0'
 install_requires = [
     'certbot',
     'certbot-apache',
-    'mock',
-    'six',
-    'requests',
-    'zope.interface',
+    'mock<3.0',
+    'six<2.0',
+    'requests>=2.0,<3.0',
+    'zope.interface<5.0',
 ]
 
 if sys.version_info < (2, 7, 9):
     # For secure SSL connexion with Python 2.7 (InsecurePlatformWarning)
-    install_requires.append('ndg-httpsclient')
-    install_requires.append('pyasn1')
+    install_requires.append('ndg-httpsclient<0.5')
+    install_requires.append('pyasn1<0.3')
 
 docs_extras = [
     'repoze.sphinx.autointerface',

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -10,13 +10,13 @@ version = '0.14.0.dev0'
 install_requires = [
     'acme=={0}'.format(version),
     'certbot=={0}'.format(version),
-    'mock',
-    'PyOpenSSL',
-    'pyparsing>=1.5.5',  # Python3 support; perhaps unnecessary?
+    'mock<3.0',
+    'PyOpenSSL<17.0',
+    'pyparsing>=1.5.5,<3.0',  # Python3 support; perhaps unnecessary?
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',
-    'zope.interface',
+    'zope.interface<5.0',
 ]
 
 docs_extras = [

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -6,7 +6,7 @@ setup(
     package='certbot_example_plugins.py',
     install_requires=[
         'certbot',
-        'zope.interface',
+        'zope.interface<5.0',
     ],
     entry_points={
         'certbot.plugins': [

--- a/letshelp-certbot/setup.py
+++ b/letshelp-certbot/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 version = '0.7.0.dev0'
 
 install_requires = [
-    'mock',
+    'mock<3.0',
     'setuptools',  # pkg_resources
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -36,24 +36,25 @@ version = meta['version']
 # https://github.com/pypa/pip/issues/988 for more info.
 install_requires = [
     'acme=={0}'.format(version),
-    'argparse',
+    'argparse<2.0',
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
     # saying so here causes a runtime error against our temporary fork of 0.9.3
     # in which we added 2.6 support (see #2243), so we relax the requirement.
-    'ConfigArgParse>=0.9.3',
-    'configobj',
-    'cryptography>=0.7',  # load_pem_x509_certificate
-    'mock',
-    'parsedatetime>=1.3',  # Calendar.parseDT
-    'PyOpenSSL',
-    'pyrfc3339',
+    'ConfigArgParse>=0.9.3,<0.12',
+    'configobj<6.0',
+    'cryptography>=0.7,<2.0',  # load_pem_x509_certificate
+    'mock<3.0',
+    'parsedatetime>=1.3,<3.0',  # Calendar.parseDT
+    'PyOpenSSL<17.0',
+    'pyrfc3339<2.0',
+    # pytz provides a dataset that changes over time, so we don't pin it:
     'pytz',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',
-    'six',
-    'zope.component',
-    'zope.interface',
+    'six<2.0',
+    'zope.component<5.0',
+    'zope.interface<5.0',
 ]
 
 dev_extras = [

--- a/tox.ini
+++ b/tox.ini
@@ -35,9 +35,9 @@ setenv =
 # https://github.com/shazow/urllib3/pull/930
 deps =
     py{26,27}-oldest: cffi<=1.7
-    py{26,27}-oldest: cryptography==0.8
+    py{26,27}-oldest: cryptography==1.8.1
     py{26,27}-oldest: configargparse==0.10.0
-    py{26,27}-oldest: PyOpenSSL==0.13
+    py{26,27}-oldest: PyOpenSSL==16.2.0
     py{26,27}-oldest: requests<=2.11.1
 
 [testenv:py27_install]


### PR DESCRIPTION
This keeps backward-incompatible versions from sneaking in and causing crashes for (new) devs when using venv.sh.

Allowed newer versions (than in certbot-auto) of some things that are already published, figuring we have already accidentally tested them in the real world. We can always tighten later if we continue to get bug reports from devs.

I'm afraid to pin pytz because (1) their versioning scheme cannot possibly be construed as semver and (2) it would damn us to old timezone definitions, which would be bad. Libraries which essentially provide mutable-over-time datasets are Special, I posit.

Don't pin versions of the dev dependencies, since we don't import and use those; they're tools that are largely decoupled from assumptions in our codebase. I could hear arguments about nose.