### PR TITLE
Update FreeBSD package entries

### DIFF
--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -68,7 +68,8 @@ In Fedora 23+.
 FreeBSD
 -------
 
-- https://svnweb.freebsd.org/ports/head/security/py-certbot/
+- https://www.freshports.org/security/py-acme/
+- https://www.freshports.org/security/py-certbot/
 
 Gentoo
 ------


### PR DESCRIPTION
Add port/package URL for py-acme, and use Freshports URL's instead of SVNWeb (repository) links as they provide (binary) package installation installation as well as further port/package information to users such as vulnerabilities, revision history and bug reports.