### PR TITLE
plugin: DNSimple DNS Authenticator

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1220,6 +1220,8 @@ def _plugins_parsing(helpful, plugins):
                 help='Obtain certs by placing files in a webroot directory.')
     helpful.add(["plugins", "certonly"], "--dns-cloudflare", action="store_true",
                 help='Obtain certs using a DNS TXT record (if you are using Cloudflare for DNS).')
+    helpful.add(["plugins", "certonly"], "--dns-cloudxns", action="store_true",
+                help='Obtain certs using a DNS TXT record (if you are using CloudXNS for DNS).')
     helpful.add(["plugins", "certonly"], "--dns-digitalocean", action="store_true",
                 help='Obtain certs using a DNS TXT record (if you are using DigitalOcean for DNS).')
     helpful.add(["plugins", "certonly"], "--dns-google", action="store_true",

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1218,6 +1218,8 @@ def _plugins_parsing(helpful, plugins):
                 help='Provide laborious manual instructions for obtaining a cert')
     helpful.add(["plugins", "certonly"], "--webroot", action="store_true",
                 help='Obtain certs by placing files in a webroot directory.')
+    helpful.add(["plugins", "certonly"], "--dns-cloudflare", action="store_true",
+                help='Obtain certs using a DNS TXT record (if you are using Cloudflare for DNS).')
 
     # things should not be reorder past/pre this comment:
     # plugins_group should be displayed in --help before plugin

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1222,6 +1222,8 @@ def _plugins_parsing(helpful, plugins):
                 help='Obtain certs using a DNS TXT record (if you are using Cloudflare for DNS).')
     helpful.add(["plugins", "certonly"], "--dns-digitalocean", action="store_true",
                 help='Obtain certs using a DNS TXT record (if you are using DigitalOcean for DNS).')
+    helpful.add(["plugins", "certonly"], "--dns-google", action="store_true",
+                help='Obtain certs using a DNS TXT record (if you are using Google Cloud DNS).')
 
     # things should not be reorder past/pre this comment:
     # plugins_group should be displayed in --help before plugin

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1220,6 +1220,8 @@ def _plugins_parsing(helpful, plugins):
                 help='Obtain certs by placing files in a webroot directory.')
     helpful.add(["plugins", "certonly"], "--dns-cloudflare", action="store_true",
                 help='Obtain certs using a DNS TXT record (if you are using Cloudflare for DNS).')
+    helpful.add(["plugins", "certonly"], "--dns-digitalocean", action="store_true",
+                help='Obtain certs using a DNS TXT record (if you are using DigitalOcean for DNS).')
 
     # things should not be reorder past/pre this comment:
     # plugins_group should be displayed in --help before plugin

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1224,6 +1224,8 @@ def _plugins_parsing(helpful, plugins):
                 help='Obtain certs using a DNS TXT record (if you are using CloudXNS for DNS).')
     helpful.add(["plugins", "certonly"], "--dns-digitalocean", action="store_true",
                 help='Obtain certs using a DNS TXT record (if you are using DigitalOcean for DNS).')
+    helpful.add(["plugins", "certonly"], "--dns-dnsimple", action="store_true",
+                help='Obtain certs using a DNS TXT record (if you are using DNSimple for DNS).')
     helpful.add(["plugins", "certonly"], "--dns-google", action="store_true",
                 help='Obtain certs using a DNS TXT record (if you are using Google Cloud DNS).')
 

--- a/certbot/display/ops.py
+++ b/certbot/display/ops.py
@@ -289,3 +289,60 @@ def _gen_https_names(domains):
             domains[-1])
 
     return ""
+
+
+def _get_validated(method, validator, message, default=None, **kwargs):
+    if default is not None:
+        try:
+            validator(default)
+        except errors.Error as error:
+            logger.debug('Encountered invalid default value "%s" when prompting for "%s"',
+                         default,
+                         message,
+                         exc_info=True)
+            raise AssertionError('Invalid default "{0}"'.format(default))
+
+    while True:
+        code, raw = method(message, default=default, **kwargs)
+        if code == display_util.OK:
+            try:
+                validator(raw)
+                return code, raw
+            except errors.Error as error:
+                logger.debug('Validator rejected "%s" when prompting for "%s"',
+                             raw,
+                             message,
+                             exc_info=True)
+                zope.component.getUtility(interfaces.IDisplay).notification(str(error), pause=False)
+        else:
+            return code, raw
+
+
+def validated_input(validator, *args, **kwargs):
+    """Like `~certbot.interfaces.IDisplay.input`, but with validation.
+
+    :param callable validator: A method which will be called on the
+        supplied input. If the method raises a `errors.Error`, its
+        text will be displayed and the user will be re-prompted.
+    :param list *args: Arguments to be passed to `~certbot.interfaces.IDisplay.input`
+    :param dict **kwargs: Arguments to be passed to `~certbot.interfaces.IDisplay.input`
+    :return: as `~certbot.interfaces.IDisplay.input`
+    :rtype: tuple
+    """
+    return _get_validated(zope.component.getUtility(interfaces.IDisplay).input,
+                          validator, *args, **kwargs)
+
+
+def validated_directory(validator, *args, **kwargs):
+    """Like `~certbot.interfaces.IDisplay.directory_select`, but with validation.
+
+    :param callable validator: A method which will be called on the
+        supplied input. If the method raises a `errors.Error`, its
+        text will be displayed and the user will be re-prompted.
+    :param list *args: Arguments to be passed to `~certbot.interfaces.IDisplay.directory_select`
+    :param dict **kwargs: Arguments to be passed to `~certbot.interfaces.IDisplay.directory_select`
+    :return: as `~certbot.interfaces.IDisplay.directory_select`
+    :rtype: tuple
+    """
+    return _get_validated(zope.component.getUtility(interfaces.IDisplay).directory_select,
+                          validator, *args, **kwargs)

--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -122,8 +122,8 @@ class FileDisplay(object):
         return code, selection - 1
 
     def input(self, message, default=None,
-              cli_flag=None, force_interactive=False, **unused_kwargs):
-        # pylint: disable=no-self-use
+              cli_flag=None, force_interactive=False, validator=None,
+              **unused_kwargs):
         """Accept input from the user.
 
         :param str message: message to display to the user
@@ -131,6 +131,9 @@ class FileDisplay(object):
         :param str cli_flag: option used to set this value with the CLI
         :param bool force_interactive: True if it's safe to prompt the user
             because it won't cause any workflow regressions
+        :param function validator: A method which will be called on the
+            supplied input. If the method raises a `errors.PluginError`, its
+            text will be displayed and the user will be re-prompted.
 
         :returns: tuple of (`code`, `input`) where
             `code` - str display exit code
@@ -141,17 +144,23 @@ class FileDisplay(object):
         if self._return_default(message, default, cli_flag, force_interactive):
             return OK, default
 
-        ans = six.moves.input(
-            textwrap.fill(
-                "%s (Enter 'c' to cancel): " % message,
-                80,
-                break_long_words=False,
-                break_on_hyphens=False))
+        while True:
+            ans = six.moves.input(
+                textwrap.fill(
+                    "%s (Enter 'c' to cancel): " % message,
+                    80,
+                    break_long_words=False,
+                    break_on_hyphens=False))
 
-        if ans == "c" or ans == "C":
-            return CANCEL, "-1"
-        else:
-            return OK, ans
+            if ans == "c" or ans == "C":
+                return CANCEL, "-1"
+            else:
+                try:
+                    if validator:
+                        validator(ans)
+                    return OK, ans
+                except errors.PluginError as error:
+                    self.notification(str(error), pause=False)
 
     def yesno(self, message, yes_label="Yes", no_label="No", default=None,
               cli_flag=None, force_interactive=False, **unused_kwargs):
@@ -292,7 +301,8 @@ class FileDisplay(object):
         return False
 
     def directory_select(self, message, default=None, cli_flag=None,
-                         force_interactive=False, **unused_kwargs):
+                         force_interactive=False, validator=None,
+                         **unused_kwargs):
         """Display a directory selection screen.
 
         :param str message: prompt to give the user
@@ -300,6 +310,9 @@ class FileDisplay(object):
         :param str cli_flag: option used to set this value with the CLI
         :param bool force_interactive: True if it's safe to prompt the user
             because it won't cause any workflow regressions
+        :param function validator: A method which will be called on the
+            supplied input. If the method raises a `errors.PluginError`, its
+            text will be displayed and the user will be re-prompted.
 
         :returns: tuple of the form (`code`, `string`) where
             `code` - display exit code
@@ -307,7 +320,7 @@ class FileDisplay(object):
 
         """
         with completer.Completer():
-            return self.input(message, default, cli_flag, force_interactive)
+            return self.input(message, default, cli_flag, force_interactive, validator)
 
     def _scrub_checklist_input(self, indices, tags):
         # pylint: disable=no-self-use

--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -122,8 +122,7 @@ class FileDisplay(object):
         return code, selection - 1
 
     def input(self, message, default=None,
-              cli_flag=None, force_interactive=False, validator=None,
-              **unused_kwargs):
+              cli_flag=None, force_interactive=False, **unused_kwargs):
         """Accept input from the user.
 
         :param str message: message to display to the user
@@ -131,9 +130,6 @@ class FileDisplay(object):
         :param str cli_flag: option used to set this value with the CLI
         :param bool force_interactive: True if it's safe to prompt the user
             because it won't cause any workflow regressions
-        :param function validator: A method which will be called on the
-            supplied input. If the method raises a `errors.PluginError`, its
-            text will be displayed and the user will be re-prompted.
 
         :returns: tuple of (`code`, `input`) where
             `code` - str display exit code
@@ -144,23 +140,17 @@ class FileDisplay(object):
         if self._return_default(message, default, cli_flag, force_interactive):
             return OK, default
 
-        while True:
-            ans = six.moves.input(
-                textwrap.fill(
-                    "%s (Enter 'c' to cancel): " % message,
-                    80,
-                    break_long_words=False,
-                    break_on_hyphens=False))
+        ans = six.moves.input(
+            textwrap.fill(
+                "%s (Enter 'c' to cancel): " % message,
+                80,
+                break_long_words=False,
+                break_on_hyphens=False))
 
-            if ans == "c" or ans == "C":
-                return CANCEL, "-1"
-            else:
-                try:
-                    if validator:
-                        validator(ans)
-                    return OK, ans
-                except errors.PluginError as error:
-                    self.notification(str(error), pause=False)
+        if ans == "c" or ans == "C":
+            return CANCEL, "-1"
+        else:
+            return OK, ans
 
     def yesno(self, message, yes_label="Yes", no_label="No", default=None,
               cli_flag=None, force_interactive=False, **unused_kwargs):
@@ -301,8 +291,7 @@ class FileDisplay(object):
         return False
 
     def directory_select(self, message, default=None, cli_flag=None,
-                         force_interactive=False, validator=None,
-                         **unused_kwargs):
+                         force_interactive=False, **unused_kwargs):
         """Display a directory selection screen.
 
         :param str message: prompt to give the user
@@ -310,9 +299,6 @@ class FileDisplay(object):
         :param str cli_flag: option used to set this value with the CLI
         :param bool force_interactive: True if it's safe to prompt the user
             because it won't cause any workflow regressions
-        :param function validator: A method which will be called on the
-            supplied input. If the method raises a `errors.PluginError`, its
-            text will be displayed and the user will be re-prompted.
 
         :returns: tuple of the form (`code`, `string`) where
             `code` - display exit code
@@ -320,7 +306,7 @@ class FileDisplay(object):
 
         """
         with completer.Completer():
-            return self.input(message, default, cli_flag, force_interactive, validator)
+            return self.input(message, default, cli_flag, force_interactive)
 
     def _scrub_checklist_input(self, indices, tags):
         # pylint: disable=no-self-use

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -422,7 +422,7 @@ class IDisplay(zope.interface.Interface):
 
         """
 
-    def input(message, default=None, cli_args=None, force_interactive=False, validator=None):
+    def input(message, default=None, cli_args=None, force_interactive=False):
         """Accept input from the user.
 
         When not setting force_interactive=True, you must provide a
@@ -432,9 +432,6 @@ class IDisplay(zope.interface.Interface):
         :param str default: default (non-interactive) response to prompt
         :param bool force_interactive: True if it's safe to prompt the user
             because it won't cause any workflow regressions
-        :param function validator: A method which will be called on the
-            supplied input. If the method raises a `errors.PluginError`, its
-            text will be displayed and the user will be re-prompted.
 
         :returns: tuple of (`code`, `input`) where
             `code` - str display exit code
@@ -495,7 +492,7 @@ class IDisplay(zope.interface.Interface):
         """
 
     def directory_select(self, message, default=None,
-                         cli_flag=None, force_interactive=False, validator=None):
+                         cli_flag=None, force_interactive=False):
         """Display a directory selection screen.
 
         When not setting force_interactive=True, you must provide a
@@ -509,9 +506,6 @@ class IDisplay(zope.interface.Interface):
             NoninteractiveDisplay
         :param bool force_interactive: True if it's safe to prompt the user
             because it won't cause any workflow regressions
-        :param function validator: A method which will be called on the
-            supplied input. If the method raises a `errors.PluginError`, its
-            text will be displayed and the user will be re-prompted.
 
         :returns: tuple of the form (`code`, `string`) where
             `code` - int display exit code

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -422,7 +422,7 @@ class IDisplay(zope.interface.Interface):
 
         """
 
-    def input(message, default=None, cli_args=None, force_interactive=False):
+    def input(message, default=None, cli_args=None, force_interactive=False, validator=None):
         """Accept input from the user.
 
         When not setting force_interactive=True, you must provide a
@@ -432,6 +432,9 @@ class IDisplay(zope.interface.Interface):
         :param str default: default (non-interactive) response to prompt
         :param bool force_interactive: True if it's safe to prompt the user
             because it won't cause any workflow regressions
+        :param function validator: A method which will be called on the
+            supplied input. If the method raises a `errors.PluginError`, its
+            text will be displayed and the user will be re-prompted.
 
         :returns: tuple of (`code`, `input`) where
             `code` - str display exit code
@@ -492,7 +495,7 @@ class IDisplay(zope.interface.Interface):
         """
 
     def directory_select(self, message, default=None,
-                         cli_flag=None, force_interactive=False):
+                         cli_flag=None, force_interactive=False, validator=None):
         """Display a directory selection screen.
 
         When not setting force_interactive=True, you must provide a
@@ -506,6 +509,9 @@ class IDisplay(zope.interface.Interface):
             NoninteractiveDisplay
         :param bool force_interactive: True if it's safe to prompt the user
             because it won't cause any workflow regressions
+        :param function validator: A method which will be called on the
+            supplied input. If the method raises a `errors.PluginError`, its
+            text will be displayed and the user will be re-prompted.
 
         :returns: tuple of the form (`code`, `string`) where
             `code` - int display exit code

--- a/certbot/plugins/dns_cloudflare.py
+++ b/certbot/plugins/dns_cloudflare.py
@@ -29,7 +29,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         super(Authenticator, self).__init__(*args, **kwargs)
 
     @classmethod
-    def add_parser_arguments(cls, add):
+    def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
         super(Authenticator, cls).add_parser_arguments(add)
         add('email',
             help='Email address associated with Cloudflare account.')

--- a/certbot/plugins/dns_cloudflare.py
+++ b/certbot/plugins/dns_cloudflare.py
@@ -10,6 +10,7 @@ from acme import challenges
 from certbot import errors
 from certbot import interfaces
 
+from certbot.display import ops
 from certbot.display import util as display_util
 
 from certbot.plugins import common
@@ -154,22 +155,19 @@ class Authenticator(common.Plugin):
         :rtype: string
         """
 
-        display = zope.component.getUtility(interfaces.IDisplay)
+        def __validator(i):
+            if not i:
+                raise errors.PluginError('Please enter an {0}.'.format(label))
 
-        while True:
-            code, response = display.input(
-                'Input Cloudflare account {0}'.format(label),
-                force_interactive=True)
-            if code == display_util.HELP:
-                # Displaying help is not currently implemented
-                return None
-            elif code == display_util.CANCEL:
-                return None
-            else:  # code == display_util.OK
-                if not response:
-                    display.notification('Please enter an {0}.'.format(label), pause=False)
-                else:
-                    return response
+        code, response = ops.validated_input(
+            __validator,
+            'Input Cloudflare account {0}'.format(label),
+            force_interactive=True)
+
+        if code == display_util.OK:
+            return response
+        else:
+            return None
 
     def _get_cloudflare_client(self):
         """

--- a/certbot/plugins/dns_cloudflare.py
+++ b/certbot/plugins/dns_cloudflare.py
@@ -1,0 +1,344 @@
+"""DNS Authenticator for Cloudflare."""
+import logging
+
+import zope.interface
+
+from time import sleep
+
+from acme import challenges
+
+from certbot import errors
+from certbot import interfaces
+
+from certbot.display import util as display_util
+
+from certbot.plugins import common
+
+import CloudFlare
+
+logger = logging.getLogger(__name__)
+
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class Authenticator(common.Plugin):
+    """DNS  Authenticator for Cloudflare
+
+    This Authenticator uses the Cloudflare API to fulfill a dns-01 challenge.
+    """
+
+    description = 'Obtain certs using a DNS TXT record (if you are using Cloudflare for DNS).'
+
+    _attempt_cleanup = False
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+
+        self.email = None
+        self.api_key = None
+
+    @classmethod
+    def add_parser_arguments(cls, add):
+        add('propagation-seconds',
+            default=10,
+            type=int,
+            help='The number of seconds to wait for DNS to propagate before asking the ACME server '
+                 'to verify the DNS record.')
+        add('email',
+            help='Email address associated with Cloudflare account.')
+        add('api-key',
+            help='API key for Cloudflare account. ' +
+                 '(Which can be obtained from https://www.cloudflare.com/a/account/my-account)')
+
+    def prepare(self): # pylint: disable=missing-docstring
+        pass
+
+    def more_info(self): # pylint: disable=missing-docstring,no-self-use
+        return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
+               'the Cloudflare API.'
+
+    def get_chall_pref(self, unused_domain): # pylint: disable=missing-docstring,no-self-use
+        return [challenges.DNS01]
+
+    def perform(self, achalls): # pylint: disable=missing-docstring
+        self._setup_credentials()
+
+        self._attempt_cleanup = True
+
+        responses = []
+        for achall in achalls:
+            self._perform_achall(achall)
+            responses.append(achall.response(achall.account_key))
+
+        # DNS updates take time to propagate and checking to see if the update has occurred is not
+        # reliable (the machine this code is running on might be able to see an update before
+        # the ACME server). So: we sleep for a short amount of time we believe to be long enough.
+        sleep(self.conf('propagation-seconds'))
+
+        return responses
+
+    def _perform_achall(self, achall):
+        """
+        Performs a dns-01 challenge by creating a DNS TXT record.
+
+        :param `~certbot.achallenges.AnnotatedChallenge` achall: the challenge to perform
+        :raises errors.PluginError: If the challenge cannot be performed
+        """
+
+        domain = achall.domain
+        record_name = achall.validation_domain_name(domain)
+        record_content = achall.validation(achall.account_key)
+        ttl = 120
+
+        self._get_cloudflare_client().add_txt_record(domain, record_name, record_content, ttl)
+
+    def cleanup(self, achalls):  # pylint: disable=missing-docstring
+        if self._attempt_cleanup:
+            for achall in achalls:
+                self._cleanup_achall(achall)
+
+    def _cleanup_achall(self, achall):
+        """
+        Deletes the DNS TXT record which would have been created by `_perform_achall`.
+
+        Fails gracefully if no such record exists.
+
+        :param `~certbot.achallenge s.AnnotatedChallenge` achall: the challenge to clean up after
+        """
+
+        domain = achall.domain
+        record_name = achall.validation_domain_name(domain)
+        record_content = achall.validation(achall.account_key)
+
+        self._get_cloudflare_client().del_txt_record(domain, record_name, record_content)
+
+    def _setup_credentials(self):
+        """
+        Establish credentials, prompting if necessary.
+        """
+
+        # XXX: We could make these optional and let CloudFlare.CloudFlare attempt to read them from
+        #      .cloudflare.cfg or ~/.cloudflare.cfg or ~/.cloudflare/cloudflare.cfg
+        #
+        #      Marking them as required seems to provide for a better user experience.
+
+        configured_email = self.conf('email')
+        if configured_email:
+            self.email = configured_email
+        else:
+            self.email = self._prompt_for_data('email address')
+
+        if self.email:
+            setattr(self.config, self.dest('email'), self.email)
+        else:
+            raise errors.PluginError('Cloudflare account email address required to proceed.')
+
+        configured_api_key = self.conf('api-key')
+        if configured_api_key:
+            self.api_key = configured_api_key
+        else:
+            self.api_key = self._prompt_for_data('API key')
+
+        if self.api_key:
+            setattr(self.config, self.dest('api-key'), self.api_key)
+        else:
+            raise errors.PluginError('Cloudflare account API key required to proceed.')
+
+    @staticmethod
+    def _prompt_for_data(label):
+        """
+        Prompt the user for a piece of information.
+
+        :param string label: The user-friendly label for this piece of information.
+        :returns: The user's response (guaranteed non-empty).
+        :rtype: string
+        """
+
+        display = zope.component.getUtility(interfaces.IDisplay)
+
+        while True:
+            code, response = display.input(
+                'Input Cloudflare account {0}'.format(label),
+                force_interactive=True)
+            if code == display_util.HELP:
+                # Displaying help is not currently implemented
+                return None
+            elif code == display_util.CANCEL:
+                return None
+            else:  # code == display_util.OK
+                if not response:
+                    display.notification('Please enter an {0}.'.format(label), pause=False)
+                else:
+                    return response
+
+    def _get_cloudflare_client(self):
+        """
+        Helper method to construct a `_CloudflareClient`.
+
+        Uses configured credentials.
+
+        :return: a new
+        :rtype: `_CloudflareClient`
+        """
+
+        return _CloudflareClient(self.email, self.api_key)
+
+
+class _CloudflareClient(object):
+    """
+    Encapsulates all communication with the Cloudflare API.
+    """
+
+    def __init__(self, email, api_key):
+        self.cf = CloudFlare.CloudFlare(email, api_key)
+
+    def add_txt_record(self, domain, record_name, record_content, record_ttl):
+        """
+        Add a TXT record using the supplied information.
+
+        :param string domain: The domain to use to look up the Cloudflare zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :param int record_ttl: The record TTL (number of seconds that the record may be cached).
+        :raises: errors.PluginError if an error occurs communicating with the Cloudflare API
+        """
+
+        zone_id = self._find_zone_id(domain)
+
+        data = {'type': 'TXT',
+                'name': record_name,
+                'content': record_content,
+                'ttl': record_ttl}
+
+        try:
+            logger.debug('Attempting to add record to zone %s: %s', zone_id, data)
+            self.cf.zones.dns_records.post(zone_id, data=data)  # zones | pylint: disable=no-member
+        except CloudFlare.exceptions.CloudFlareAPIError as e:
+            logger.error('Encountered CloudFlareAPIError adding TXT record: %d %s', e, e)
+            raise errors.PluginError('Error communicating with the Cloudflare API: {0}'.format(e))
+
+        record_id = self._find_txt_record_id(zone_id, record_name, record_content)
+        logger.debug('Successfully added TXT record with record_id: %s', record_id)
+
+    def del_txt_record(self, domain, record_name, record_content):
+        """
+        Delete a TXT record using the supplied information.
+
+        Note that both the record's name and content are used to ensure that similar records
+        created concurrently (e.g., due to concurrent invocations of this plugin) are not deleted.
+
+        Failures are logged, but not raised.
+
+        :param string domain: The domain to use to look up the Cloudflare zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        """
+
+        try:
+            zone_id = self._find_zone_id(domain)
+        except errors.PluginError as e:
+            logger.debug('Encountered error finding zone_id during deletion: %s', e)
+            return
+
+        if zone_id:
+            record_id = self._find_txt_record_id(zone_id, record_name, record_content)
+            if record_id:
+                try:
+                    # zones | pylint: disable=no-member
+                    self.cf.zones.dns_records.delete(zone_id, record_id)
+                    logger.debug('Successfully deleted TXT record.')
+                except CloudFlare.exceptions.CloudFlareAPIError as e:
+                    logger.warn('Encountered CloudFlareAPIError deleting TXT record: %s', e)
+            else:
+                logger.debug('TXT record not found; no cleanup needed.')
+        else:
+            logger.debug('Zone not found; no cleanup needed.')
+
+    def _find_zone_id(self, domain):
+        """
+        Find the zone_id for a given domain.
+
+        :param string domain: The domain for which to find the zone_id.
+        :returns: The zone_id, if found.
+        :rtype: string
+        :raises: errors.PluginError if no zone_id is found.
+        """
+
+        zone_name_guesses = self._zone_name_guesses(domain)
+
+        for zone_name in zone_name_guesses:
+            params = {'name': zone_name,
+                      'per_page': 1}
+
+            try:
+                zones = self.cf.zones.get(params=params)  # zones | pylint: disable=no-member
+            except CloudFlare.exceptions.CloudFlareAPIError as e:
+                code = int(e)
+                hint = None
+
+                if code == 6003:
+                    hint = 'Did you copy your entire API key?'
+                elif code == 9103:
+                    hint = 'Did you enter the correct email address?'
+
+                raise errors.PluginError('Error determining zone_id: {0} {1}. Please confirm that '
+                                         'you have supplied valid Cloudflare API credentials.{2}'
+                                         .format(code, e, ' ({0})'.format(hint) if hint else ''))
+
+            if len(zones) > 0:
+                zone_id = zones[0]['id']
+                logger.debug('Found zone_id of %s for %s using name %s', zone_id, domain, zone_name)
+                return zone_id
+
+        raise errors.PluginError('Unable to determine zone_id for {0} using zone names: {1}. '
+                                 'Please confirm that the domain name has been entered correctly '
+                                 'and is already associated with the supplied Cloudflare account.'
+                                 .format(domain, zone_name_guesses))
+
+    def _find_txt_record_id(self, zone_id, record_name, record_content):
+        """
+        Find the record_id for a TXT record with the given name and content.
+
+        :param string zone_id: The zone_id which contains the record.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :returns: The record_id, if found.
+        :rtype: string
+        """
+
+        params = {'type': 'TXT',
+                  'name': record_name,
+                  'content': record_content,
+                  'per_page': 1}
+        try:
+            # zones | pylint: disable=no-member
+            records = self.cf.zones.dns_records.get(zone_id, params=params)
+        except CloudFlare.exceptions.CloudFlareAPIError as e:
+            logger.debug('Encountered CloudFlareAPIError getting TXT record_id: %s', e)
+            records = []
+
+        if len(records) > 0:
+            # Cleanup is returning the system to the state we found it. If, for some reason,
+            # there are multiple matching records, we only delete one because we only added one.
+            return records[0]['id']
+        else:
+            logger.debug('Unable to find TXT record.')
+
+    @staticmethod
+    def _zone_name_guesses(domain):
+        """Return a list of progressively less-specific domain names.
+
+        One of these will probably be the Cloudflare zone name.
+
+        :Example:
+
+        >>> _zone_name_guesses('foo.bar.baz.example.com')
+        ['foo.bar.baz.example.com', 'bar.baz.example.com', 'baz.example.com', 'example.com', 'com']
+
+        :param string domain: The domain for which to return guesses.
+        :returns: The a list of less specific domain names.
+        :rtype: list
+        """
+
+        fragments = domain.split('.')
+        return ['.'.join(fragments[i:]) for i in range(0, len(fragments))]

--- a/certbot/plugins/dns_cloudflare_test.py
+++ b/certbot/plugins/dns_cloudflare_test.py
@@ -23,6 +23,7 @@ DOMAIN = 'example.com'
 EMAIL = 'example@example.com'
 KEY = jose.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
 
+
 class AuthenticatorTest(unittest.TestCase):
 
     achall = achallenges.KeyAuthorizationAnnotatedChallenge(
@@ -92,8 +93,6 @@ class AuthenticatorInputTest(unittest.TestCase):
 
         auth.perform([])
 
-        self.assertEqual(auth.email, self.supplied_email)
-
         self.assertEqual(auth.conf('email'), self.supplied_email)
         self.assertEqual(auth.conf('api-key'), API_KEY)
 
@@ -105,8 +104,6 @@ class AuthenticatorInputTest(unittest.TestCase):
         mock_display.input.return_value = (display_util.OK, self.supplied_api_key,)
 
         auth.perform([])
-
-        self.assertEqual(auth.api_key, self.supplied_api_key)
 
         self.assertEqual(auth.conf('email'), EMAIL)
         self.assertEqual(auth.conf('api-key'), self.supplied_api_key)
@@ -120,9 +117,6 @@ class AuthenticatorInputTest(unittest.TestCase):
                                           (display_util.OK, self.supplied_api_key,)]
 
         auth.perform([])
-
-        self.assertEqual(auth.email, self.supplied_email)
-        self.assertEqual(auth.api_key, self.supplied_api_key)
 
         self.assertEqual(auth.conf('email'), self.supplied_email)
         self.assertEqual(auth.conf('api-key'), self.supplied_api_key)
@@ -265,24 +259,6 @@ class CloudflareClientTest(unittest.TestCase):
 
         self.assertEqual(expected, self.cf.mock_calls)
 
-    def test_zone_name_guesses(self):
-        self.assertTrue(
-            'example.com' in
-            # _zone_name_guesses | pylint: disable=protected-access
-            self.cloudflare_client._zone_name_guesses("example.com")
-        )
-
-        self.assertTrue(
-            'example.com' in
-            # _zone_name_guesses | pylint: disable=protected-access
-            self.cloudflare_client._zone_name_guesses("foo.bar.baz.example.com")
-        )
-
-        self.assertTrue(
-            'example.co.uk' in
-            # _zone_name_guesses | pylint: disable=protected-access
-            self.cloudflare_client._zone_name_guesses("foo.bar.baz.example.co.uk")
-        )
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot/plugins/dns_cloudflare_test.py
+++ b/certbot/plugins/dns_cloudflare_test.py
@@ -1,0 +1,300 @@
+"""Tests for certbot.plugins.dns_cloudflare."""
+
+import mock
+import six
+import unittest
+
+from acme import challenges
+from acme import jose
+
+from certbot import achallenges
+from certbot import errors
+
+from certbot.display import util as display_util
+
+from certbot.tests import acme_util
+from certbot.tests import util as test_util
+
+import CloudFlare
+
+API_ERROR = CloudFlare.exceptions.CloudFlareAPIError(1000, '', '')
+API_KEY = 'an-api-key'
+DOMAIN = 'example.com'
+EMAIL = 'example@example.com'
+KEY = jose.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
+
+class AuthenticatorTest(unittest.TestCase):
+
+    achall = achallenges.KeyAuthorizationAnnotatedChallenge(
+        challb=acme_util.DNS01, domain=DOMAIN, account_key=KEY)
+
+    def setUp(self):
+        from certbot.plugins.dns_cloudflare import Authenticator
+        self.config = mock.MagicMock(cloudflare_email=EMAIL,
+                                     cloudflare_api_key=API_KEY,
+                                     cloudflare_propagation_seconds=0)  # don't wait during tests
+
+        self.auth = Authenticator(self.config, "cloudflare")
+
+        self.cfc = mock.MagicMock()
+        # _get_cloudflare_client | pylint: disable=protected-access
+        self.auth._get_cloudflare_client = mock.MagicMock(return_value=self.cfc)
+
+    def test_more_info(self):
+        self.assertTrue(isinstance(self.auth.more_info(), six.string_types))
+
+    def test_get_chall_pref(self):
+        self.assertEqual(self.auth.get_chall_pref(None), [challenges.DNS01])
+
+    def test_perform(self):
+        self.auth.perform([self.achall])
+
+        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY, mock.ANY)]
+        self.assertEqual(expected, self.cfc.mock_calls)
+
+    def test_cleanup(self):
+        # _attempt_cleanup | pylint: disable=protected-access
+        self.auth._attempt_cleanup = True
+        self.auth.cleanup([self.achall])
+
+        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.cfc.mock_calls)
+
+
+class AuthenticatorInputTest(unittest.TestCase):
+    supplied_email = 'fake@example.com'
+    supplied_api_key = 'fake-api-key'
+
+    # Not using setUp because the flow is dependent on the test case
+    def _setUp(self, email=None, api_key=None):
+        from certbot.plugins.dns_cloudflare import Authenticator
+        config = mock.MagicMock()
+        config.cloudflare_propagation_seconds = 0  # don't wait during tests
+        if email:
+            config.cloudflare_email = email
+        else:
+            config.cloudflare_email = None
+
+        if api_key:
+            config.cloudflare_api_key = api_key
+        else:
+            config.cloudflare_api_key = None
+
+        auth = Authenticator(config, "cloudflare")
+        return auth
+
+    @test_util.patch_get_utility()
+    def test_user_input_email(self, mock_get_utility):
+        auth = self._setUp(api_key=API_KEY)
+
+        mock_display = mock_get_utility()
+        mock_display.input.return_value = (display_util.OK, self.supplied_email,)
+
+        auth.perform([])
+
+        self.assertEqual(auth.email, self.supplied_email)
+
+        self.assertEqual(auth.conf('email'), self.supplied_email)
+        self.assertEqual(auth.conf('api-key'), API_KEY)
+
+    @test_util.patch_get_utility()
+    def test_user_input_api_key(self, mock_get_utility):
+        auth = self._setUp(email=EMAIL)
+
+        mock_display = mock_get_utility()
+        mock_display.input.return_value = (display_util.OK, self.supplied_api_key,)
+
+        auth.perform([])
+
+        self.assertEqual(auth.api_key, self.supplied_api_key)
+
+        self.assertEqual(auth.conf('email'), EMAIL)
+        self.assertEqual(auth.conf('api-key'), self.supplied_api_key)
+
+    @test_util.patch_get_utility()
+    def test_user_input_both(self, mock_get_utility):
+        auth = self._setUp()
+
+        mock_display = mock_get_utility()
+        mock_display.input.side_effect = [(display_util.OK, self.supplied_email,),
+                                          (display_util.OK, self.supplied_api_key,)]
+
+        auth.perform([])
+
+        self.assertEqual(auth.email, self.supplied_email)
+        self.assertEqual(auth.api_key, self.supplied_api_key)
+
+        self.assertEqual(auth.conf('email'), self.supplied_email)
+        self.assertEqual(auth.conf('api-key'), self.supplied_api_key)
+
+    @test_util.patch_get_utility()
+    def test_user_input_retrying(self, mock_get_utility):
+        auth = self._setUp(api_key=API_KEY)
+
+        mock_display = mock_get_utility()
+        mock_display.input.side_effect = [(display_util.OK, "",),
+                                          (display_util.OK, self.supplied_email,)]
+
+        auth.perform([])
+
+        self.assertEqual(auth.email, self.supplied_email)
+
+    @test_util.patch_get_utility()
+    def test_user_input_email_cancel(self, mock_get_utility):
+        auth = self._setUp(api_key=API_KEY)
+
+        mock_display = mock_get_utility()
+        mock_display.input.side_effect = [(display_util.CANCEL, "C",),]
+
+        self.assertRaises(errors.PluginError, auth.perform, [])
+
+    @test_util.patch_get_utility()
+    def test_user_input_api_key_cancel(self, mock_get_utility):
+        auth = self._setUp(email=EMAIL)
+
+        mock_display = mock_get_utility()
+        mock_display.input.side_effect = [(display_util.CANCEL, "C",),]
+
+        self.assertRaises(errors.PluginError, auth.perform, [])
+
+
+class CloudflareClientTest(unittest.TestCase):
+    record_name = "foo"
+    record_content = "bar"
+    record_ttl = 42
+    zone_id = 1
+    record_id = 2
+
+    def setUp(self):
+        from certbot.plugins.dns_cloudflare import _CloudflareClient
+
+        self.cloudflare_client = _CloudflareClient(EMAIL, API_KEY)
+
+        self.cf = mock.MagicMock()
+        self.cloudflare_client.cf = self.cf
+
+    def test_add_txt_record(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+
+        self.cloudflare_client.add_txt_record(DOMAIN, self.record_name, self.record_content,
+                                              self.record_ttl)
+
+        self.cf.zones.dns_records.post.assert_called_with(self.zone_id, data=mock.ANY)
+
+        post_data = self.cf.zones.dns_records.post.call_args[1]['data']
+
+        self.assertEqual('TXT', post_data['type'])
+        self.assertEqual(self.record_name, post_data['name'])
+        self.assertEqual(self.record_content, post_data['content'])
+        self.assertEqual(self.record_ttl, post_data['ttl'])
+
+    def test_add_txt_record_error(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+
+        self.cf.zones.dns_records.post.side_effect = API_ERROR
+
+        self.assertRaises(
+            errors.PluginError,
+            self.cloudflare_client.add_txt_record,
+            DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    def test_add_txt_record_error_during_zone_lookup(self):
+        self.cf.zones.get.side_effect = API_ERROR
+
+        self.assertRaises(
+            errors.PluginError,
+            self.cloudflare_client.add_txt_record,
+            DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    def test_add_txt_record_zone_not_found(self):
+        self.cf.zones.get.return_value = []
+
+        self.assertRaises(
+            errors.PluginError,
+            self.cloudflare_client.add_txt_record,
+            DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    def test_del_txt_record(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+        self.cf.zones.dns_records.get.return_value = [{'id': self.record_id}]
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        expected = [mock.call.zones.get(params=mock.ANY),
+                    mock.call.zones.dns_records.get(self.zone_id, params=mock.ANY),
+                    mock.call.zones.dns_records.delete(self.zone_id, self.record_id)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+        get_data = self.cf.zones.dns_records.get.call_args[1]['params']
+
+        self.assertEqual('TXT', get_data['type'])
+        self.assertEqual(self.record_name, get_data['name'])
+        self.assertEqual(self.record_content, get_data['content'])
+
+    def test_del_txt_record_error_during_zone_lookup(self):
+        self.cf.zones.get.side_effect = API_ERROR
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_during_delete(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+        self.cf.zones.dns_records.get.return_value = [{'id': self.record_id}]
+        self.cf.zones.dns_records.delete.side_effect = API_ERROR
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+        expected = [mock.call.zones.get(params=mock.ANY),
+                    mock.call.zones.dns_records.get(self.zone_id, params=mock.ANY),
+                    mock.call.zones.dns_records.delete(self.zone_id, self.record_id)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+    def test_del_txt_record_error_during_get(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+        self.cf.zones.dns_records.get.side_effect = API_ERROR
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+        expected = [mock.call.zones.get(params=mock.ANY),
+                    mock.call.zones.dns_records.get(self.zone_id, params=mock.ANY)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+    def test_del_txt_record_no_record(self):
+        self.cf.zones.get.return_value = [{'id': self.zone_id}]
+        self.cf.zones.dns_records.get.return_value = []
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+        expected = [mock.call.zones.get(params=mock.ANY),
+                    mock.call.zones.dns_records.get(self.zone_id, params=mock.ANY)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+    def test_del_txt_record_no_zone(self):
+        self.cf.zones.get.return_value = [{'id': None}]
+
+        self.cloudflare_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+        expected = [mock.call.zones.get(params=mock.ANY)]
+
+        self.assertEqual(expected, self.cf.mock_calls)
+
+    def test_zone_name_guesses(self):
+        self.assertTrue(
+            'example.com' in
+            # _zone_name_guesses | pylint: disable=protected-access
+            self.cloudflare_client._zone_name_guesses("example.com")
+        )
+
+        self.assertTrue(
+            'example.com' in
+            # _zone_name_guesses | pylint: disable=protected-access
+            self.cloudflare_client._zone_name_guesses("foo.bar.baz.example.com")
+        )
+
+        self.assertTrue(
+            'example.co.uk' in
+            # _zone_name_guesses | pylint: disable=protected-access
+            self.cloudflare_client._zone_name_guesses("foo.bar.baz.example.co.uk")
+        )
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/plugins/dns_cloudflare_test.py
+++ b/certbot/plugins/dns_cloudflare_test.py
@@ -128,18 +128,6 @@ class AuthenticatorInputTest(unittest.TestCase):
         self.assertEqual(auth.conf('api-key'), self.supplied_api_key)
 
     @test_util.patch_get_utility()
-    def test_user_input_retrying(self, mock_get_utility):
-        auth = self._setUp(api_key=API_KEY)
-
-        mock_display = mock_get_utility()
-        mock_display.input.side_effect = [(display_util.OK, "",),
-                                          (display_util.OK, self.supplied_email,)]
-
-        auth.perform([])
-
-        self.assertEqual(auth.email, self.supplied_email)
-
-    @test_util.patch_get_utility()
     def test_user_input_email_cancel(self, mock_get_utility):
         auth = self._setUp(api_key=API_KEY)
 

--- a/certbot/plugins/dns_cloudxns.py
+++ b/certbot/plugins/dns_cloudxns.py
@@ -1,10 +1,8 @@
 """DNS Authenticator for CloudXNS DNS."""
 import logging
-from requests.exceptions import HTTPError, RequestException
 
 import zope.interface
 
-from certbot import errors
 from certbot import interfaces
 
 from certbot.plugins import dns_common
@@ -54,7 +52,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         return _CloudXNSLexiconClient(self.conf('api-key'), self.conf('secret-key'), self.ttl)
 
 
-class _CloudXNSLexiconClient(object):
+class _CloudXNSLexiconClient(dns_common.LexiconClient):
     """
     Encapsulates all communication with the CloudXNS via Lexicon.
     """
@@ -66,75 +64,8 @@ class _CloudXNSLexiconClient(object):
             'ttl': ttl,
         })
 
-    def add_txt_record(self, domain, record_name, record_content):
-        """
-        Add a TXT record using the supplied information.
+    def determine_error_hint(self, e):
+        if str(e).startswith('400 Client Error:'):
+            return 'Are your API key and Secret key values correct?'
 
-        :param string domain: The domain to use to look up the managed zone.
-        :param string record_name: The record name (typically beginning with '_acme-challenge.').
-        :param string record_content: The record content (typically the challenge validation).
-        :raises: errors.PluginError if an error occurs communicating with the CloudXNS API
-        """
-        self._find_domain_id(domain)
-
-        try:
-            self.provider.create_record(type='TXT', name=record_name, content=record_content)
-        except RequestException as e:
-            logger.debug('Encountered error adding TXT record: %s', e, exc_info=True)
-            raise errors.PluginError('Error adding TXT record: {0}'.format(e))
-
-    def del_txt_record(self, domain, record_name, record_content):
-        """
-        Delete a TXT record using the supplied information.
-
-        :param string domain: The domain to use to look up the managed zone.
-        :param string record_name: The record name (typically beginning with '_acme-challenge.').
-        :param string record_content: The record content (typically the challenge validation).
-        :raises: errors.PluginError if an error occurs communicating with the CloudXNS API
-        """
-        try:
-            self._find_domain_id(domain)
-        except errors.PluginError as e:
-            logger.debug('Encountered error finding domain_id during deletion: %s', e,
-                         exc_info=True)
-            return
-
-        try:
-            self.provider.delete_record(type='TXT', name=record_name, content=record_content)
-        except RequestException as e:
-            logger.debug('Encountered error deleting TXT record: %s', e, exc_info=True)
-            raise errors.PluginError('Error deleting TXT record: {0}'.format(e))
-
-    def _find_domain_id(self, domain):
-        """
-        Find the domain_id for a given domain.
-
-        :param string domain: The domain for which to find the domain_id.
-        :raises: errors.PluginError if the domain_id cannot be found.
-        """
-
-        domain_name_guesses = dns_common.base_domain_name_guesses(domain)
-
-        for domain_name in domain_name_guesses:
-            try:
-                self.provider.options['domain'] = domain_name
-
-                self.provider.authenticate()
-
-                return  # If `authenticate` doesn't throw an exception, we've found the right name
-            except HTTPError as e:
-                hint = None
-
-                if str(e).startswith('400 Client Error:'):
-                    hint = 'Are your API key and Secret key values correct?'
-
-                raise errors.PluginError('Error determining domain_id: {0}.{1}'
-                                         .format(e, ' ({0})'.format(hint) if hint else ''))
-            except Exception as e:  # pylint: disable=broad-except
-                if str(e).startswith('No domain found'):
-                    pass
-                else:
-                    raise errors.PluginError('Unexpected error determining zone_id: {0}'.format(e))
-
-        raise errors.PluginError('Unable to determine zone_id for {0} using zone names: {1}'
-                                 .format(domain, domain_name_guesses))
+        return None

--- a/certbot/plugins/dns_cloudxns.py
+++ b/certbot/plugins/dns_cloudxns.py
@@ -1,0 +1,140 @@
+"""DNS Authenticator for CloudXNS DNS."""
+import logging
+from requests.exceptions import HTTPError, RequestException
+
+import zope.interface
+
+from certbot import errors
+from certbot import interfaces
+
+from certbot.plugins import dns_common
+
+from lexicon.providers import cloudxns
+
+logger = logging.getLogger(__name__)
+
+ACCOUNT_URL = 'https://www.cloudxns.net/en/AccountManage/apimanage.html'
+
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class Authenticator(dns_common.DNSAuthenticator):
+    """DNS  Authenticator for CloudXNS DNS
+
+    This Authenticator uses the CloudXNS DNS API to fulfill a dns-01 challenge.
+    """
+
+    description = 'Obtain certs using a DNS TXT record (if you are using CloudXNS for DNS).'
+    ttl = 60
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def add_parser_arguments(cls, add):
+        super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=20)
+        add('api-key', help='API key for CloudXNS account. (See {0}.)'.format(ACCOUNT_URL))
+        add('secret-key', help='Secret key for CloudXNS account. (See {0}.)'.format(ACCOUNT_URL))
+
+    def more_info(self):  # pylint: disable=missing-docstring,no-self-use
+        return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
+               'the CloudXNS API.'
+
+    def _setup_credentials(self):
+        self._configure('api-key', 'CloudXNS API key')
+        self._configure('secret-key', 'CloudXNS secret key')
+
+    def _perform(self, domain, validation_name, validation):
+        self._get_cloudxns_client().add_txt_record(domain, validation_name, validation)
+
+    def _cleanup(self, domain, validation_name, validation):
+        self._get_cloudxns_client().del_txt_record(domain, validation_name, validation)
+
+    def _get_cloudxns_client(self):
+        return _CloudXNSLexiconClient(self.conf('api-key'), self.conf('secret-key'), self.ttl)
+
+
+class _CloudXNSLexiconClient(object):
+    """
+    Encapsulates all communication with the CloudXNS via Lexicon.
+    """
+
+    def __init__(self, api_key, secret_key, ttl):
+        self.provider = cloudxns.Provider({
+            'auth_username': api_key,
+            'auth_token': secret_key,
+            'ttl': ttl,
+        })
+
+    def add_txt_record(self, domain, record_name, record_content):
+        """
+        Add a TXT record using the supplied information.
+
+        :param string domain: The domain to use to look up the managed zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :raises: errors.PluginError if an error occurs communicating with the CloudXNS API
+        """
+        self._find_domain_id(domain)
+
+        try:
+            self.provider.create_record(type='TXT', name=record_name, content=record_content)
+        except RequestException as e:
+            logger.debug('Encountered error adding TXT record: %s', e, exc_info=True)
+            raise errors.PluginError('Error adding TXT record: {0}'.format(e))
+
+    def del_txt_record(self, domain, record_name, record_content):
+        """
+        Delete a TXT record using the supplied information.
+
+        :param string domain: The domain to use to look up the managed zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :raises: errors.PluginError if an error occurs communicating with the CloudXNS API
+        """
+        try:
+            self._find_domain_id(domain)
+        except errors.PluginError as e:
+            logger.debug('Encountered error finding domain_id during deletion: %s', e,
+                         exc_info=True)
+            return
+
+        try:
+            self.provider.delete_record(type='TXT', name=record_name, content=record_content)
+        except RequestException as e:
+            logger.debug('Encountered error deleting TXT record: %s', e, exc_info=True)
+            raise errors.PluginError('Error deleting TXT record: {0}'.format(e))
+
+    def _find_domain_id(self, domain):
+        """
+        Find the domain_id for a given domain.
+
+        :param string domain: The domain for which to find the domain_id.
+        :raises: errors.PluginError if the domain_id cannot be found.
+        """
+
+        domain_name_guesses = dns_common.base_domain_name_guesses(domain)
+
+        for domain_name in domain_name_guesses:
+            try:
+                self.provider.options['domain'] = domain_name
+
+                self.provider.authenticate()
+
+                return  # If `authenticate` doesn't throw an exception, we've found the right name
+            except HTTPError as e:
+                hint = None
+
+                if str(e).startswith('400 Client Error:'):
+                    hint = 'Are your API key and Secret key values correct?'
+
+                raise errors.PluginError('Error determining domain_id: {0}.{1}'
+                                         .format(e, ' ({0})'.format(hint) if hint else ''))
+            except Exception as e:  # pylint: disable=broad-except
+                if str(e).startswith('No domain found'):
+                    pass
+                else:
+                    raise errors.PluginError('Unexpected error determining zone_id: {0}'.format(e))
+
+        raise errors.PluginError('Unable to determine zone_id for {0} using zone names: {1}'
+                                 .format(domain, domain_name_guesses))

--- a/certbot/plugins/dns_cloudxns_test.py
+++ b/certbot/plugins/dns_cloudxns_test.py
@@ -3,11 +3,9 @@
 import mock
 import unittest
 
-from certbot import errors
 from requests.exceptions import HTTPError, RequestException
 
 from certbot.plugins import dns_test_common
-from certbot.plugins.dns_test_common import DOMAIN
 
 DOMAIN_NOT_FOUND = Exception('No domain found')
 GENERIC_ERROR = RequestException
@@ -17,7 +15,7 @@ API_KEY = 'foo'
 SECRET_KEY = 'bar'
 
 
-class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest):
+class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseLexiconAuthenticatorTest):
 
     def setUp(self):
         from certbot.plugins.dns_cloudxns import Authenticator
@@ -31,27 +29,8 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
         # _get_cloudxns_client | pylint: disable=protected-access
         self.auth._get_cloudxns_client = mock.MagicMock(return_value=self.mock_client)
 
-    def test_perform(self):
-        # pylint: disable=duplicate-code
-        self.auth.perform([self.achall])
 
-        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
-        self.assertEqual(expected, self.mock_client.mock_calls)
-
-    def test_cleanup(self):
-        # pylint: disable=duplicate-code
-        # _attempt_cleanup | pylint: disable=protected-access
-        self.auth._attempt_cleanup = True
-        self.auth.cleanup([self.achall])
-
-        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
-        self.assertEqual(expected, self.mock_client.mock_calls)
-
-
-class CloudXNSLexiconClientTest(unittest.TestCase):
-    record_prefix = "_acme-challenge"
-    record_name = record_prefix + "." + DOMAIN
-    record_content = "bar"
+class CloudXNSLexiconClientTest(unittest.TestCase, dns_test_common.BaseLexiconClientTest):
 
     def setUp(self):
         from certbot.plugins.dns_cloudxns import _CloudXNSLexiconClient
@@ -60,83 +39,6 @@ class CloudXNSLexiconClientTest(unittest.TestCase):
 
         self.provider_mock = mock.MagicMock()
         self.client.provider = self.provider_mock
-
-    def test_add_txt_record(self):
-        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
-
-        self.provider_mock.create_record.assert_called_with(type='TXT',
-                                                            name=self.record_name,
-                                                            content=self.record_content)
-
-    def test_add_txt_record_try_twice_to_find_domain(self):
-        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND, '']
-
-        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
-
-        self.provider_mock.create_record.assert_called_with(type='TXT',
-                                                            name=self.record_name,
-                                                            content=self.record_content)
-
-    def test_add_txt_record_fail_to_find_domain(self):
-        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND,
-                                                       DOMAIN_NOT_FOUND,
-                                                       DOMAIN_NOT_FOUND,]
-
-        self.assertRaises(errors.PluginError,
-                          self.client.add_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
-
-    def test_add_txt_record_fail_to_authenticate(self):
-        self.provider_mock.authenticate.side_effect = LOGIN_ERROR
-
-        self.assertRaises(errors.PluginError,
-                          self.client.add_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
-
-    def test_add_txt_record_error_finding_domain(self):
-        self.provider_mock.authenticate.side_effect = GENERIC_ERROR
-
-        self.assertRaises(errors.PluginError,
-                          self.client.add_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
-
-    def test_add_txt_record_error_adding_record(self):
-        self.provider_mock.create_record.side_effect = GENERIC_ERROR
-
-        self.assertRaises(errors.PluginError,
-                          self.client.add_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
-
-    def test_del_txt_record(self):
-        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
-
-        self.provider_mock.delete_record.assert_called_with(type='TXT',
-                                                            name=self.record_name,
-                                                            content=self.record_content)
-
-    def test_del_txt_record_fail_to_find_domain(self):
-        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND,
-                                                       DOMAIN_NOT_FOUND,
-                                                       DOMAIN_NOT_FOUND, ]
-
-        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
-
-    def test_del_txt_record_fail_to_authenticate(self):
-        self.provider_mock.authenticate.side_effect = LOGIN_ERROR
-
-        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
-
-    def test_del_txt_record_error_finding_domain(self):
-        self.provider_mock.authenticate.side_effect = GENERIC_ERROR
-
-        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
-
-    def test_del_txt_record_error_deleting_record(self):
-        self.provider_mock.delete_record.side_effect = GENERIC_ERROR
-
-        self.assertRaises(errors.PluginError,
-                          self.client.del_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
 
 
 if __name__ == "__main__":

--- a/certbot/plugins/dns_cloudxns_test.py
+++ b/certbot/plugins/dns_cloudxns_test.py
@@ -1,0 +1,143 @@
+"""Tests for certbot.plugins.dns_cloudxns."""
+
+import mock
+import unittest
+
+from certbot import errors
+from requests.exceptions import HTTPError, RequestException
+
+from certbot.plugins import dns_test_common
+from certbot.plugins.dns_test_common import DOMAIN
+
+DOMAIN_NOT_FOUND = Exception('No domain found')
+GENERIC_ERROR = RequestException
+LOGIN_ERROR = HTTPError('400 Client Error: ...')
+
+API_KEY = 'foo'
+SECRET_KEY = 'bar'
+
+
+class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest):
+
+    def setUp(self):
+        from certbot.plugins.dns_cloudxns import Authenticator
+        self.config = mock.MagicMock(cloudxns_api_key=API_KEY,
+                                     cloudxns_secret_key=SECRET_KEY,
+                                     cloudxns_propagation_seconds=0)  # don't wait during tests
+
+        self.auth = Authenticator(self.config, "cloudxns")
+
+        self.mock_client = mock.MagicMock()
+        # _get_cloudxns_client | pylint: disable=protected-access
+        self.auth._get_cloudxns_client = mock.MagicMock(return_value=self.mock_client)
+
+    def test_perform(self):
+        # pylint: disable=duplicate-code
+        self.auth.perform([self.achall])
+
+        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+    def test_cleanup(self):
+        # pylint: disable=duplicate-code
+        # _attempt_cleanup | pylint: disable=protected-access
+        self.auth._attempt_cleanup = True
+        self.auth.cleanup([self.achall])
+
+        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+
+class CloudXNSLexiconClientTest(unittest.TestCase):
+    record_prefix = "_acme-challenge"
+    record_name = record_prefix + "." + DOMAIN
+    record_content = "bar"
+
+    def setUp(self):
+        from certbot.plugins.dns_cloudxns import _CloudXNSLexiconClient
+
+        self.client = _CloudXNSLexiconClient(API_KEY, SECRET_KEY, 0)
+
+        self.provider_mock = mock.MagicMock()
+        self.client.provider = self.provider_mock
+
+    def test_add_txt_record(self):
+        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.create_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_add_txt_record_try_twice_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND, '']
+
+        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.create_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_add_txt_record_fail_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND,
+                                                       DOMAIN_NOT_FOUND,
+                                                       DOMAIN_NOT_FOUND,]
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_fail_to_authenticate(self):
+        self.provider_mock.authenticate.side_effect = LOGIN_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_error_finding_domain(self):
+        self.provider_mock.authenticate.side_effect = GENERIC_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_error_adding_record(self):
+        self.provider_mock.create_record.side_effect = GENERIC_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record(self):
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.delete_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_del_txt_record_fail_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND,
+                                                       DOMAIN_NOT_FOUND,
+                                                       DOMAIN_NOT_FOUND, ]
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_fail_to_authenticate(self):
+        self.provider_mock.authenticate.side_effect = LOGIN_ERROR
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_finding_domain(self):
+        self.provider_mock.authenticate.side_effect = GENERIC_ERROR
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_deleting_record(self):
+        self.provider_mock.delete_record.side_effect = GENERIC_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.del_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/plugins/dns_common.py
+++ b/certbot/plugins/dns_common.py
@@ -1,0 +1,163 @@
+"""Common code for DNS Authenticator Plugins."""
+
+import abc
+
+from time import sleep
+
+import zope.interface
+
+from acme import challenges
+
+from certbot import errors
+from certbot import interfaces
+
+from certbot.display import ops
+from certbot.display import util as display_util
+
+from certbot.plugins import common
+
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class DNSAuthenticator(common.Plugin):
+    """Base class for DNS  Authenticators"""
+
+    _attempt_cleanup = False
+
+    @classmethod
+    def add_parser_arguments(cls, add):
+        add('propagation-seconds',
+            default=10,
+            type=int,
+            help='The number of seconds to wait for DNS to propagate before asking the ACME server '
+                 'to verify the DNS record.')
+
+    def get_chall_pref(self, unused_domain): # pylint: disable=missing-docstring,no-self-use
+        return [challenges.DNS01]
+
+    def prepare(self): # pylint: disable=missing-docstring
+        pass
+
+    def perform(self, achalls): # pylint: disable=missing-docstring
+        self._setup_credentials()
+
+        self._attempt_cleanup = True
+
+        responses = []
+        for achall in achalls:
+            domain = achall.domain
+            validation_domain_name = achall.validation_domain_name(domain)
+            validation = achall.validation(achall.account_key)
+
+            self._perform(domain, validation_domain_name, validation)
+            responses.append(achall.response(achall.account_key))
+
+        # DNS updates take time to propagate and checking to see if the update has occurred is not
+        # reliable (the machine this code is running on might be able to see an update before
+        # the ACME server). So: we sleep for a short amount of time we believe to be long enough.
+        sleep(self.conf('propagation-seconds'))
+
+        return responses
+
+    def cleanup(self, achalls):  # pylint: disable=missing-docstring
+        if self._attempt_cleanup:
+            for achall in achalls:
+                domain = achall.domain
+                validation_domain_name = achall.validation_domain_name(domain)
+                validation = achall.validation(achall.account_key)
+
+                self._cleanup(domain, validation_domain_name, validation)
+
+    @abc.abstractmethod
+    def _setup_credentials(self):  # pragma: no cover
+        """
+        Establish credentials, prompting if necessary.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _perform(self, domain, validation_domain_name, validation):  # pragma: no cover
+        """
+        Performs a dns-01 challenge by creating a DNS TXT record.
+
+        :param string domain: The domain being validated.
+        :param string validation_domain_name: The validation record domain name.
+        :param string validation: The validation record content.
+        :raises errors.PluginError: If the challenge cannot be performed
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _cleanup(self, domain, validation_domain_name, validation):  # pragma: no cover
+        """
+        Deletes the DNS TXT record which would have been created by `_perform_achall`.
+
+        Fails gracefully if no such record exists.
+
+        :param string domain: The domain being validated.
+        :param string validation_domain_name: The validation record domain name.
+        :param string validation: The validation record content.
+        """
+        raise NotImplementedError()
+
+    def _configure(self, key, label):
+        """
+        Ensure that a configuration value is available.
+
+        If necessary, prompts the user and stores the result.
+
+        :param string key: The configuration key.
+        :param string label: The user-friendly label for this piece of information.
+        """
+
+        configured_value = self.conf(key)
+        if not configured_value:
+            new_value = self._prompt_for_data(label)
+
+            if new_value:
+                setattr(self.config, self.dest(key), new_value)
+            else:
+                raise errors.PluginError('{0} required to proceed.'.format(label))
+
+    @staticmethod
+    def _prompt_for_data(label):
+        """
+        Prompt the user for a piece of information.
+
+        :param string label: The user-friendly label for this piece of information.
+        :returns: The user's response (guaranteed non-empty).
+        :rtype: string
+        """
+
+        def __validator(i):
+            if not i:
+                raise errors.PluginError('Please enter your {0}.'.format(label))
+
+        code, response = ops.validated_input(
+            __validator,
+            'Input your {0}'.format(label),
+            force_interactive=True)
+
+        if code == display_util.OK:
+            return response
+        else:
+            return None
+
+
+def base_domain_name_guesses(domain):
+    """Return a list of progressively less-specific domain names.
+
+    One of these will probably be the domain name known to the DNS provider.
+
+    :Example:
+
+    >>> base_domain_name_guesses('foo.bar.baz.example.com')
+    ['foo.bar.baz.example.com', 'bar.baz.example.com', 'baz.example.com', 'example.com', 'com']
+
+    :param string domain: The domain for which to return guesses.
+    :returns: The a list of less specific domain names.
+    :rtype: list
+    """
+
+    fragments = domain.split('.')
+    return ['.'.join(fragments[i:]) for i in range(0, len(fragments))]

--- a/certbot/plugins/dns_common.py
+++ b/certbot/plugins/dns_common.py
@@ -25,9 +25,9 @@ class DNSAuthenticator(common.Plugin):
     _attempt_cleanup = False
 
     @classmethod
-    def add_parser_arguments(cls, add):
+    def add_parser_arguments(cls, add, default_propagation_seconds=10):  # pylint: disable=arguments-differ
         add('propagation-seconds',
-            default=10,
+            default=default_propagation_seconds,
             type=int,
             help='The number of seconds to wait for DNS to propagate before asking the ACME server '
                  'to verify the DNS record.')

--- a/certbot/plugins/dns_common_test.py
+++ b/certbot/plugins/dns_common_test.py
@@ -1,0 +1,30 @@
+"""Tests for certbot.plugins.dns_common."""
+
+import unittest
+
+from certbot.plugins import dns_common
+
+
+class DomainNameGuessTest(unittest.TestCase):
+
+    def test_simple_case(self):
+        self.assertTrue(
+            'example.com' in
+            dns_common.base_domain_name_guesses("example.com")
+        )
+
+    def test_sub_domain(self):
+        self.assertTrue(
+            'example.com' in
+            dns_common.base_domain_name_guesses("foo.bar.baz.example.com")
+        )
+
+    def test_second_level_domain(self):
+        self.assertTrue(
+            'example.co.uk' in
+            dns_common.base_domain_name_guesses("foo.bar.baz.example.co.uk")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/plugins/dns_digitalocean.py
+++ b/certbot/plugins/dns_digitalocean.py
@@ -3,17 +3,10 @@ import logging
 
 import zope.interface
 
-from time import sleep
-
-from acme import challenges
-
 from certbot import errors
 from certbot import interfaces
 
-from certbot.display import ops
-from certbot.display import util as display_util
-
-from certbot.plugins import common
+from certbot.plugins import dns_common
 
 import digitalocean
 
@@ -22,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
-class Authenticator(common.Plugin):
+class Authenticator(dns_common.DNSAuthenticator):
     """DNS  Authenticator for DigitalOcean
 
     This Authenticator uses the DigitalOcean API to fulfill a dns-01 challenge.
@@ -30,135 +23,30 @@ class Authenticator(common.Plugin):
 
     description = 'Obtain certs using a DNS TXT record (if you are using DigitalOcean for DNS).'
 
-    _attempt_cleanup = False
-
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)
 
-        self.token = None
-
     @classmethod
     def add_parser_arguments(cls, add):
-        add('propagation-seconds',
-            default=10,
-            type=int,
-            help='The number of seconds to wait for DNS to propagate before asking the ACME server '
-                 'to verify the DNS record.')
+        super(Authenticator, cls).add_parser_arguments(add)
         add('token',
             help='DigitalOcean API Token.')
-
-    def prepare(self): # pylint: disable=missing-docstring
-        pass
 
     def more_info(self): # pylint: disable=missing-docstring,no-self-use
         return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
                'the DigitalOcean API.'
 
-    def get_chall_pref(self, unused_domain): # pylint: disable=missing-docstring,no-self-use
-        return [challenges.DNS01]
-
-    def perform(self, achalls): # pylint: disable=missing-docstring
-        self._setup_credentials()
-
-        self._attempt_cleanup = True
-
-        responses = []
-        for achall in achalls:
-            self._perform_achall(achall)
-            responses.append(achall.response(achall.account_key))
-
-        # DNS updates take time to propagate and checking to see if the update has occurred is not
-        # reliable (the machine this code is running on might be able to see an update before
-        # the ACME server). So: we sleep for a short amount of time we believe to be long enough.
-        sleep(self.conf('propagation-seconds'))
-
-        return responses
-
-    def _perform_achall(self, achall):
-        """
-        Performs a dns-01 challenge by creating a DNS TXT record.
-
-        :param `~certbot.achallenges.AnnotatedChallenge` achall: the challenge to perform
-        :raises errors.PluginError: If the challenge cannot be performed
-        """
-
-        domain = achall.domain
-        record_name = achall.validation_domain_name(domain)
-        record_content = achall.validation(achall.account_key)
-
-        self._get_digitalocean_client().add_txt_record(domain, record_name, record_content)
-
-    def cleanup(self, achalls):  # pylint: disable=missing-docstring
-        if self._attempt_cleanup:
-            for achall in achalls:
-                self._cleanup_achall(achall)
-
-    def _cleanup_achall(self, achall):
-        """foo.bar.baz.
-        Deletes the DNS TXT record which would have been created by `_perform_achall`.
-
-        Fails gracefully if no such record exists.
-
-        :param `~certbot.achallenges.AnnotatedChallenge` achall: the challenge to clean up after
-        """
-
-        domain = achall.domain
-        record_name = achall.validation_domain_name(domain)
-        record_content = achall.validation(achall.account_key)
-
-        self._get_digitalocean_client().del_txt_record(domain, record_name, record_content)
-
     def _setup_credentials(self):
-        """
-        Establish credentials, prompting if necessary.
-        """
+        self._configure('token', 'DigitalOcean API token')
 
-        configured_token = self.conf('token')
-        if configured_token:
-            self.token = configured_token
-        else:
-            self.token = self._prompt_for_data('API token')
+    def _perform(self, domain, validation_name, validation):
+        self._get_digitalocean_client().add_txt_record(domain, validation_name, validation)
 
-        if self.token:
-            setattr(self.config.namespace, self.dest('token'), self.token)
-        else:
-            raise errors.PluginError('DigitalOcean API token required to proceed.')
-
-    @staticmethod
-    def _prompt_for_data(label):
-        """
-        Prompt the user for a piece of information.
-
-        :param string label: The user-friendly label for this piece of information.
-        :returns: The user's response (guaranteed non-empty).
-        :rtype: string
-        """
-
-        def __validator(i):
-            if not i:
-                raise errors.PluginError('Please enter an {0}.'.format(label))
-
-        code, response = ops.validated_input(
-            __validator,
-            'Input DigitalOcean {0}'.format(label),
-            force_interactive=True)
-
-        if code == display_util.OK:
-            return response
-        else:
-            return None
+    def _cleanup(self, domain, validation_name, validation):
+        self._get_digitalocean_client().del_txt_record(domain, validation_name, validation)
 
     def _get_digitalocean_client(self):
-        """
-        Helper method to construct a `_DigitalOceanClient`.
-
-        Uses configured credentials.
-
-        :return: a new
-        :rtype: `_DigitalOceanClient`
-        """
-
-        return _DigitalOceanClient(self.token)
+        return _DigitalOceanClient(self.conf('token'))
 
 
 class _DigitalOceanClient(object):
@@ -250,7 +138,7 @@ class _DigitalOceanClient(object):
         :raises: errors.PluginError if no matching Domain is found.
         """
 
-        domain_name_guesses = self._domain_name_guesses(domain_name)
+        domain_name_guesses = dns_common.base_domain_name_guesses(domain_name)
 
         domains = self.manager.get_all_domains()
 
@@ -264,25 +152,6 @@ class _DigitalOceanClient(object):
 
         raise errors.PluginError('Unable to determine base domain for {0} using names: {1}.'
                                  .format(domain_name, domain_name_guesses))
-
-    @staticmethod
-    def _domain_name_guesses(domain):
-        """Return a list of progressively less-specific domain names.
-
-        One of these will probably be the DigitalOcean base domain name.
-
-        :Example:
-
-        >>> _domain_name_guesses('foo.bar.baz.example.com')
-        ['foo.bar.baz.example.com', 'bar.baz.example.com', 'baz.example.com', 'example.com', 'com']
-
-        :param string domain: The domain for which to return guesses.
-        :returns: The a list of less specific domain names.
-        :rtype: list
-        """
-
-        fragments = domain.split('.')
-        return ['.'.join(fragments[i:]) for i in range(0, len(fragments))]
 
     @staticmethod
     def _compute_record_name(domain, full_record_name):

--- a/certbot/plugins/dns_digitalocean.py
+++ b/certbot/plugins/dns_digitalocean.py
@@ -1,0 +1,290 @@
+"""DNS Authenticator for DigitalOcean."""
+import logging
+
+import zope.interface
+
+from time import sleep
+
+from acme import challenges
+
+from certbot import errors
+from certbot import interfaces
+
+from certbot.display import ops
+from certbot.display import util as display_util
+
+from certbot.plugins import common
+
+import digitalocean
+
+logger = logging.getLogger(__name__)
+
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class Authenticator(common.Plugin):
+    """DNS  Authenticator for DigitalOcean
+
+    This Authenticator uses the DigitalOcean API to fulfill a dns-01 challenge.
+    """
+
+    description = 'Obtain certs using a DNS TXT record (if you are using DigitalOcean for DNS).'
+
+    _attempt_cleanup = False
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+
+        self.token = None
+
+    @classmethod
+    def add_parser_arguments(cls, add):
+        add('propagation-seconds',
+            default=10,
+            type=int,
+            help='The number of seconds to wait for DNS to propagate before asking the ACME server '
+                 'to verify the DNS record.')
+        add('token',
+            help='DigitalOcean API Token.')
+
+    def prepare(self): # pylint: disable=missing-docstring
+        pass
+
+    def more_info(self): # pylint: disable=missing-docstring,no-self-use
+        return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
+               'the DigitalOcean API.'
+
+    def get_chall_pref(self, unused_domain): # pylint: disable=missing-docstring,no-self-use
+        return [challenges.DNS01]
+
+    def perform(self, achalls): # pylint: disable=missing-docstring
+        self._setup_credentials()
+
+        self._attempt_cleanup = True
+
+        responses = []
+        for achall in achalls:
+            self._perform_achall(achall)
+            responses.append(achall.response(achall.account_key))
+
+        # DNS updates take time to propagate and checking to see if the update has occurred is not
+        # reliable (the machine this code is running on might be able to see an update before
+        # the ACME server). So: we sleep for a short amount of time we believe to be long enough.
+        sleep(self.conf('propagation-seconds'))
+
+        return responses
+
+    def _perform_achall(self, achall):
+        """
+        Performs a dns-01 challenge by creating a DNS TXT record.
+
+        :param `~certbot.achallenges.AnnotatedChallenge` achall: the challenge to perform
+        :raises errors.PluginError: If the challenge cannot be performed
+        """
+
+        domain = achall.domain
+        record_name = achall.validation_domain_name(domain)
+        record_content = achall.validation(achall.account_key)
+
+        self._get_digitalocean_client().add_txt_record(domain, record_name, record_content)
+
+    def cleanup(self, achalls):  # pylint: disable=missing-docstring
+        if self._attempt_cleanup:
+            for achall in achalls:
+                self._cleanup_achall(achall)
+
+    def _cleanup_achall(self, achall):
+        """foo.bar.baz.
+        Deletes the DNS TXT record which would have been created by `_perform_achall`.
+
+        Fails gracefully if no such record exists.
+
+        :param `~certbot.achallenges.AnnotatedChallenge` achall: the challenge to clean up after
+        """
+
+        domain = achall.domain
+        record_name = achall.validation_domain_name(domain)
+        record_content = achall.validation(achall.account_key)
+
+        self._get_digitalocean_client().del_txt_record(domain, record_name, record_content)
+
+    def _setup_credentials(self):
+        """
+        Establish credentials, prompting if necessary.
+        """
+
+        configured_token = self.conf('token')
+        if configured_token:
+            self.token = configured_token
+        else:
+            self.token = self._prompt_for_data('API token')
+
+        if self.token:
+            setattr(self.config.namespace, self.dest('token'), self.token)
+        else:
+            raise errors.PluginError('DigitalOcean API token required to proceed.')
+
+    @staticmethod
+    def _prompt_for_data(label):
+        """
+        Prompt the user for a piece of information.
+
+        :param string label: The user-friendly label for this piece of information.
+        :returns: The user's response (guaranteed non-empty).
+        :rtype: string
+        """
+
+        def __validator(i):
+            if not i:
+                raise errors.PluginError('Please enter an {0}.'.format(label))
+
+        code, response = ops.validated_input(
+            __validator,
+            'Input DigitalOcean {0}'.format(label),
+            force_interactive=True)
+
+        if code == display_util.OK:
+            return response
+        else:
+            return None
+
+    def _get_digitalocean_client(self):
+        """
+        Helper method to construct a `_DigitalOceanClient`.
+
+        Uses configured credentials.
+
+        :return: a new
+        :rtype: `_DigitalOceanClient`
+        """
+
+        return _DigitalOceanClient(self.token)
+
+
+class _DigitalOceanClient(object):
+    """
+    Encapsulates all communication with the DigitalOcean API.
+    """
+
+    def __init__(self, token):
+        self.manager = digitalocean.Manager(token=token)
+
+    def add_txt_record(self, domain_name, record_name, record_content):
+        """
+        Add a TXT record using the supplied information.
+
+        :param string domain_name: The domain to use to associate the record with.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :raises: errors.PluginError if an error occurs communicating with the DigitalOcean API
+        """
+
+        try:
+            domain = self._find_domain(domain_name)
+        except digitalocean.Error as e:
+            logger.error('Error finding domain using the DigitalOcean API: %s', e)
+            raise errors.PluginError('Error finding domain using the DigitalOcean API: {0}'
+                                     .format(e))
+
+        try:
+            result = domain.create_new_domain_record(
+                type='TXT',
+                name=self._compute_record_name(domain, record_name),
+                data=record_content)
+
+            record_id = result['domain_record']['id']
+
+            logger.debug('Successfully added TXT record with id: %d', record_id)
+        except digitalocean.Error as e:
+            logger.error('Error adding TXT record using the DigitalOcean API: %s', e)
+            raise errors.PluginError('Error adding TXT record using the DigitalOcean API: {0}'
+                                     .format(e))
+
+    def del_txt_record(self, domain_name, record_name, record_content):
+        """
+        Delete a TXT record using the supplied information.
+
+        Note that both the record's name and content are used to ensure that similar records
+        created concurrently (e.g., due to concurrent invocations of this plugin) are not deleted.
+
+        Failures are logged, but not raised.
+
+        :param string domain_name: The domain to use to associate the record with.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        """
+
+        try:
+            domain = self._find_domain(domain_name)
+        except digitalocean.Error as e:
+            logger.error('Error finding domain using the DigitalOcean API: %s', e)
+            return
+
+        matching_records = []
+        try:
+            domain_records = domain.get_records()
+
+            matching_records = [record for record in domain_records
+                                if record.type == 'TXT'
+                                and record.name == self._compute_record_name(domain, record_name)
+                                and record.data == record_content]
+        except digitalocean.Error as e:
+            logger.error('Error getting DNS records using the DigitalOcean API: %s', e)
+            return
+
+        for record in matching_records:
+            try:
+                logger.debug('Removing TXT record with id: %s', record.id)
+                record.destroy()
+            except digitalocean.Error as e:
+                logger.error('Error deleting TXT record %s using the DigitalOcean API: %s',
+                             record.id, e)
+
+    def _find_domain(self, domain_name):
+        """
+        Find the domain object for a given domain name.
+
+        :param string domain_name: The domain name for which to find the corresponding Domain.
+        :returns: The Domain, if found.
+        :rtype: `digitalocean.Domain`
+        :raises: errors.PluginError if no matching Domain is found.
+        """
+
+        domain_name_guesses = self._domain_name_guesses(domain_name)
+
+        domains = self.manager.get_all_domains()
+
+        for guess in domain_name_guesses:
+            matches = [domain for domain in domains if domain.name == guess]
+
+            if len(matches) > 0:
+                domain = matches[0]
+                logger.debug('Found base domain for %s using name %s', domain_name, guess)
+                return domain
+
+        raise errors.PluginError('Unable to determine base domain for {0} using names: {1}.'
+                                 .format(domain_name, domain_name_guesses))
+
+    @staticmethod
+    def _domain_name_guesses(domain):
+        """Return a list of progressively less-specific domain names.
+
+        One of these will probably be the DigitalOcean base domain name.
+
+        :Example:
+
+        >>> _domain_name_guesses('foo.bar.baz.example.com')
+        ['foo.bar.baz.example.com', 'bar.baz.example.com', 'baz.example.com', 'example.com', 'com']
+
+        :param string domain: The domain for which to return guesses.
+        :returns: The a list of less specific domain names.
+        :rtype: list
+        """
+
+        fragments = domain.split('.')
+        return ['.'.join(fragments[i:]) for i in range(0, len(fragments))]
+
+    @staticmethod
+    def _compute_record_name(domain, full_record_name):
+        # The domain, from DigitalOcean's point of view, is automatically appended.
+        return full_record_name.split("." + domain.name)[0]

--- a/certbot/plugins/dns_digitalocean.py
+++ b/certbot/plugins/dns_digitalocean.py
@@ -27,7 +27,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         super(Authenticator, self).__init__(*args, **kwargs)
 
     @classmethod
-    def add_parser_arguments(cls, add):
+    def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
         super(Authenticator, cls).add_parser_arguments(add)
         add('token',
             help='DigitalOcean API Token.')

--- a/certbot/plugins/dns_digitalocean_test.py
+++ b/certbot/plugins/dns_digitalocean_test.py
@@ -1,0 +1,163 @@
+"""Tests for certbot.plugins.dns_digitalocean."""
+
+import mock
+import unittest
+
+from certbot import errors
+
+from certbot.plugins import dns_test_common
+from certbot.plugins.dns_test_common import DOMAIN
+
+import digitalocean
+
+API_ERROR = digitalocean.DataReadError()
+TOKEN = 'a-token'
+
+
+class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest):
+
+    def setUp(self):
+        from certbot.plugins.dns_digitalocean import Authenticator
+        self.config = mock.MagicMock(digitalocean_token=TOKEN,
+                                     digitalocean_propagation_seconds=0)  # don't wait during tests
+
+        self.auth = Authenticator(self.config, "digitalocean")
+
+        self.mock_client = mock.MagicMock()
+        # _get_cloudflare_client | pylint: disable=protected-access
+        self.auth._get_digitalocean_client = mock.MagicMock(return_value=self.mock_client)
+
+    def test_perform(self):
+        self.auth.perform([self.achall])
+
+        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+    def test_cleanup(self):
+        # _attempt_cleanup | pylint: disable=protected-access
+        self.auth._attempt_cleanup = True
+        self.auth.cleanup([self.achall])
+
+        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+
+class DigitalOceanClientTest(unittest.TestCase):
+    id = 1
+    record_prefix = "_acme-challenge"
+    record_name = record_prefix + "." + DOMAIN
+    record_content = "bar"
+
+    def setUp(self):
+        from certbot.plugins.dns_digitalocean import _DigitalOceanClient
+
+        self.digitalocean_client = _DigitalOceanClient(TOKEN)
+
+        self.manager = mock.MagicMock()
+        self.digitalocean_client.manager = self.manager
+
+    def test_add_txt_record(self):
+        wrong_domain_mock = mock.MagicMock()
+        wrong_domain_mock.name = "other.invalid"
+        wrong_domain_mock.create_new_domain_record.side_effect = AssertionError('Wrong Domain')
+
+        domain_mock = mock.MagicMock()
+        domain_mock.name = DOMAIN
+        domain_mock.create_new_domain_record.return_value = {'domain_record': {'id': self.id}}
+
+        self.manager.get_all_domains.return_value = [wrong_domain_mock, domain_mock]
+
+        self.digitalocean_client.add_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        domain_mock.create_new_domain_record.assert_called_with(type='TXT',
+                                                                name=self.record_prefix,
+                                                                data=self.record_content)
+
+    def test_add_txt_record_fail_to_find_domain(self):
+        self.manager.get_all_domains.return_value = []
+
+        self.assertRaises(errors.PluginError,
+                          self.digitalocean_client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_error_finding_domain(self):
+        self.manager.get_all_domains.side_effect = API_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.digitalocean_client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_error_creating_record(self):
+        domain_mock = mock.MagicMock()
+        domain_mock.name = DOMAIN
+        domain_mock.create_new_domain_record.side_effect = API_ERROR
+
+        self.manager.get_all_domains.return_value = [domain_mock]
+
+        self.assertRaises(errors.PluginError,
+                          self.digitalocean_client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record(self):
+        first_record_mock = mock.MagicMock()
+        first_record_mock.type = 'TXT'
+        first_record_mock.name = "DIFFERENT"
+        first_record_mock.data = self.record_content
+
+        correct_record_mock = mock.MagicMock()
+        correct_record_mock.type = 'TXT'
+        correct_record_mock.name = self.record_prefix
+        correct_record_mock.data = self.record_content
+
+        last_record_mock = mock.MagicMock()
+        last_record_mock.type = 'TXT'
+        last_record_mock.name = self.record_prefix
+        last_record_mock.data = "DIFFERENT"
+
+        domain_mock = mock.MagicMock()
+        domain_mock.name = DOMAIN
+        domain_mock.get_records.return_value = [first_record_mock,
+                                                correct_record_mock,
+                                                last_record_mock]
+
+        self.manager.get_all_domains.return_value = [domain_mock]
+
+        self.digitalocean_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        correct_record_mock.destroy.assert_called()
+
+        self.assertItemsEqual(first_record_mock.destroy.call_args_list, [])
+        self.assertItemsEqual(last_record_mock.destroy.call_args_list, [])
+
+    def test_del_txt_record_error_finding_domain(self):
+        self.manager.get_all_domains.side_effect = API_ERROR
+
+        self.digitalocean_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_finding_record(self):
+        domain_mock = mock.MagicMock()
+        domain_mock.name = DOMAIN
+        domain_mock.get_records.side_effect = API_ERROR
+
+        self.manager.get_all_domains.return_value = [domain_mock]
+
+        self.digitalocean_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_deleting_record(self):
+        record_mock = mock.MagicMock()
+        record_mock.type = 'TXT'
+        record_mock.name = self.record_prefix
+        record_mock.data = self.record_content
+        record_mock.destroy.side_effect = API_ERROR
+
+        domain_mock = mock.MagicMock()
+        domain_mock.name = DOMAIN
+        domain_mock.get_records.return_value = [record_mock]
+
+        self.manager.get_all_domains.return_value = [domain_mock]
+
+        self.digitalocean_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/plugins/dns_dnsimple.py
+++ b/certbot/plugins/dns_dnsimple.py
@@ -1,10 +1,8 @@
 """DNS Authenticator for DNSimple DNS."""
 import logging
-from requests.exceptions import HTTPError, RequestException
 
 import zope.interface
 
-from certbot import errors
 from certbot import interfaces
 
 from certbot.plugins import dns_common
@@ -52,7 +50,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         return _DNSimpleLexiconClient(self.conf('token'), self.ttl)
 
 
-class _DNSimpleLexiconClient(object):
+class _DNSimpleLexiconClient(dns_common.LexiconClient):
     """
     Encapsulates all communication with the DNSimple via Lexicon.
     """
@@ -63,75 +61,8 @@ class _DNSimpleLexiconClient(object):
             'ttl': ttl,
         })
 
-    def add_txt_record(self, domain, record_name, record_content):
-        """
-        Add a TXT record using the supplied information.
+    def determine_error_hint(self, e):
+        if str(e).startswith('401 Client Error: Unauthorized for url:'):
+            return 'Is your API token value correct?'
 
-        :param string domain: The domain to use to look up the managed zone.
-        :param string record_name: The record name (typically beginning with '_acme-challenge.').
-        :param string record_content: The record content (typically the challenge validation).
-        :raises: errors.PluginError if an error occurs communicating with the DNSimple API
-        """
-        self._find_domain_id(domain)
-
-        try:
-            self.provider.create_record(type='TXT', name=record_name, content=record_content)
-        except RequestException as e:
-            logger.debug('Encountered error adding TXT record: %s', e, exc_info=True)
-            raise errors.PluginError('Error adding TXT record: {0}'.format(e))
-
-    def del_txt_record(self, domain, record_name, record_content):
-        """
-        Delete a TXT record using the supplied information.
-
-        :param string domain: The domain to use to look up the managed zone.
-        :param string record_name: The record name (typically beginning with '_acme-challenge.').
-        :param string record_content: The record content (typically the challenge validation).
-        :raises: errors.PluginError if an error occurs communicating with the DNSimple API
-        """
-        try:
-            self._find_domain_id(domain)
-        except errors.PluginError as e:
-            logger.debug('Encountered error finding domain_id during deletion: %s', e,
-                         exc_info=True)
-            return
-
-        try:
-            self.provider.delete_record(type='TXT', name=record_name, content=record_content)
-        except RequestException as e:
-            logger.debug('Encountered error deleting TXT record: %s', e, exc_info=True)
-            raise errors.PluginError('Error deleting TXT record: {0}'.format(e))
-
-    def _find_domain_id(self, domain):
-        """
-        Find the domain_id for a given domain.
-
-        :param string domain: The domain for which to find the domain_id.
-        :raises: errors.PluginError if the domain_id cannot be found.
-        """
-
-        domain_name_guesses = dns_common.base_domain_name_guesses(domain)
-
-        for domain_name in domain_name_guesses:
-            try:
-                self.provider.options['domain'] = domain_name
-
-                self.provider.authenticate()
-
-                return  # If `authenticate` doesn't throw an exception, we've found the right name
-            except HTTPError as e:
-                hint = None
-
-                if str(e).startswith('401 Client Error: Unauthorized for url:'):
-                    hint = 'Is your API token value correct?'
-
-                raise errors.PluginError('Error determining domain_id: {0}.{1}'
-                                         .format(e, ' ({0})'.format(hint) if hint else ''))
-            except Exception as e:  # pylint: disable=broad-except
-                if str(e).startswith('No domain found'):
-                    pass
-                else:
-                    raise errors.PluginError('Unexpected error determining zone_id: {0}'.format(e))
-
-        raise errors.PluginError('Unable to determine zone_id for {0} using zone names: {1}'
-                                 .format(domain, domain_name_guesses))
+        return None

--- a/certbot/plugins/dns_dnsimple.py
+++ b/certbot/plugins/dns_dnsimple.py
@@ -1,0 +1,137 @@
+"""DNS Authenticator for DNSimple DNS."""
+import logging
+from requests.exceptions import HTTPError, RequestException
+
+import zope.interface
+
+from certbot import errors
+from certbot import interfaces
+
+from certbot.plugins import dns_common
+
+from lexicon.providers import dnsimple
+
+logger = logging.getLogger(__name__)
+
+ACCOUNT_URL = 'https://dnsimple.com/user'
+
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class Authenticator(dns_common.DNSAuthenticator):
+    """DNS Authenticator for DNSimple
+
+    This Authenticator uses the DNSimple v2 API to fulfill a dns-01 challenge.
+    """
+
+    description = 'Obtain certs using a DNS TXT record (if you are using DNSimple for DNS).'
+    ttl = 60
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def add_parser_arguments(cls, add):
+        super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=30)
+        add('token', help='User access token for DNSimple v2 API. (See {0}.)'.format(ACCOUNT_URL))
+
+    def more_info(self):  # pylint: disable=missing-docstring,no-self-use
+        return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
+               'the DNSimple API.'
+
+    def _setup_credentials(self):
+        self._configure('token', 'User access token (for v2 API)')
+
+    def _perform(self, domain, validation_name, validation):
+        self._get_dnsimple_client().add_txt_record(domain, validation_name, validation)
+
+    def _cleanup(self, domain, validation_name, validation):
+        self._get_dnsimple_client().del_txt_record(domain, validation_name, validation)
+
+    def _get_dnsimple_client(self):
+        return _DNSimpleLexiconClient(self.conf('token'), self.ttl)
+
+
+class _DNSimpleLexiconClient(object):
+    """
+    Encapsulates all communication with the DNSimple via Lexicon.
+    """
+
+    def __init__(self, token, ttl):
+        self.provider = dnsimple.Provider({
+            'auth_token': token,
+            'ttl': ttl,
+        })
+
+    def add_txt_record(self, domain, record_name, record_content):
+        """
+        Add a TXT record using the supplied information.
+
+        :param string domain: The domain to use to look up the managed zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :raises: errors.PluginError if an error occurs communicating with the DNSimple API
+        """
+        self._find_domain_id(domain)
+
+        try:
+            self.provider.create_record(type='TXT', name=record_name, content=record_content)
+        except RequestException as e:
+            logger.debug('Encountered error adding TXT record: %s', e, exc_info=True)
+            raise errors.PluginError('Error adding TXT record: {0}'.format(e))
+
+    def del_txt_record(self, domain, record_name, record_content):
+        """
+        Delete a TXT record using the supplied information.
+
+        :param string domain: The domain to use to look up the managed zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :raises: errors.PluginError if an error occurs communicating with the DNSimple API
+        """
+        try:
+            self._find_domain_id(domain)
+        except errors.PluginError as e:
+            logger.debug('Encountered error finding domain_id during deletion: %s', e,
+                         exc_info=True)
+            return
+
+        try:
+            self.provider.delete_record(type='TXT', name=record_name, content=record_content)
+        except RequestException as e:
+            logger.debug('Encountered error deleting TXT record: %s', e, exc_info=True)
+            raise errors.PluginError('Error deleting TXT record: {0}'.format(e))
+
+    def _find_domain_id(self, domain):
+        """
+        Find the domain_id for a given domain.
+
+        :param string domain: The domain for which to find the domain_id.
+        :raises: errors.PluginError if the domain_id cannot be found.
+        """
+
+        domain_name_guesses = dns_common.base_domain_name_guesses(domain)
+
+        for domain_name in domain_name_guesses:
+            try:
+                self.provider.options['domain'] = domain_name
+
+                self.provider.authenticate()
+
+                return  # If `authenticate` doesn't throw an exception, we've found the right name
+            except HTTPError as e:
+                hint = None
+
+                if str(e).startswith('401 Client Error: Unauthorized for url:'):
+                    hint = 'Is your API token value correct?'
+
+                raise errors.PluginError('Error determining domain_id: {0}.{1}'
+                                         .format(e, ' ({0})'.format(hint) if hint else ''))
+            except Exception as e:  # pylint: disable=broad-except
+                if str(e).startswith('No domain found'):
+                    pass
+                else:
+                    raise errors.PluginError('Unexpected error determining zone_id: {0}'.format(e))
+
+        raise errors.PluginError('Unable to determine zone_id for {0} using zone names: {1}'
+                                 .format(domain, domain_name_guesses))

--- a/certbot/plugins/dns_dnsimple_test.py
+++ b/certbot/plugins/dns_dnsimple_test.py
@@ -3,20 +3,14 @@
 import mock
 import unittest
 
-from certbot import errors
-from requests.exceptions import HTTPError, RequestException
+from requests.exceptions import HTTPError
 
 from certbot.plugins import dns_test_common
-from certbot.plugins.dns_test_common import DOMAIN
-
-DOMAIN_NOT_FOUND = Exception('No domain found')
-GENERIC_ERROR = RequestException
-LOGIN_ERROR = HTTPError('401 Client Error: Unauthorized for url: ...')
 
 TOKEN = 'foo'
 
 
-class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest):
+class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseLexiconAuthenticatorTest):
 
     def setUp(self):
         from certbot.plugins.dns_dnsimple import Authenticator
@@ -29,27 +23,10 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
         # _get_dnsimple_client | pylint: disable=protected-access
         self.auth._get_dnsimple_client = mock.MagicMock(return_value=self.mock_client)
 
-    def test_perform(self):
-        # pylint: disable=duplicate-code
-        self.auth.perform([self.achall])
 
-        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
-        self.assertEqual(expected, self.mock_client.mock_calls)
+class DNSimpleLexiconClientTest(unittest.TestCase, dns_test_common.BaseLexiconClientTest):
 
-    def test_cleanup(self):
-        # pylint: disable=duplicate-code
-        # _attempt_cleanup | pylint: disable=protected-access
-        self.auth._attempt_cleanup = True
-        self.auth.cleanup([self.achall])
-
-        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
-        self.assertEqual(expected, self.mock_client.mock_calls)
-
-
-class DNSimpleLexiconClientTest(unittest.TestCase):
-    record_prefix = "_acme-challenge"
-    record_name = record_prefix + "." + DOMAIN
-    record_content = "bar"
+    LOGIN_ERROR = HTTPError('401 Client Error: Unauthorized for url: ...')
 
     def setUp(self):
         from certbot.plugins.dns_dnsimple import _DNSimpleLexiconClient
@@ -58,83 +35,6 @@ class DNSimpleLexiconClientTest(unittest.TestCase):
 
         self.provider_mock = mock.MagicMock()
         self.client.provider = self.provider_mock
-
-    def test_add_txt_record(self):
-        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
-
-        self.provider_mock.create_record.assert_called_with(type='TXT',
-                                                            name=self.record_name,
-                                                            content=self.record_content)
-
-    def test_add_txt_record_try_twice_to_find_domain(self):
-        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND, '']
-
-        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
-
-        self.provider_mock.create_record.assert_called_with(type='TXT',
-                                                            name=self.record_name,
-                                                            content=self.record_content)
-
-    def test_add_txt_record_fail_to_find_domain(self):
-        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND,
-                                                       DOMAIN_NOT_FOUND,
-                                                       DOMAIN_NOT_FOUND,]
-
-        self.assertRaises(errors.PluginError,
-                          self.client.add_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
-
-    def test_add_txt_record_fail_to_authenticate(self):
-        self.provider_mock.authenticate.side_effect = LOGIN_ERROR
-
-        self.assertRaises(errors.PluginError,
-                          self.client.add_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
-
-    def test_add_txt_record_error_finding_domain(self):
-        self.provider_mock.authenticate.side_effect = GENERIC_ERROR
-
-        self.assertRaises(errors.PluginError,
-                          self.client.add_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
-
-    def test_add_txt_record_error_adding_record(self):
-        self.provider_mock.create_record.side_effect = GENERIC_ERROR
-
-        self.assertRaises(errors.PluginError,
-                          self.client.add_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
-
-    def test_del_txt_record(self):
-        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
-
-        self.provider_mock.delete_record.assert_called_with(type='TXT',
-                                                            name=self.record_name,
-                                                            content=self.record_content)
-
-    def test_del_txt_record_fail_to_find_domain(self):
-        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND,
-                                                       DOMAIN_NOT_FOUND,
-                                                       DOMAIN_NOT_FOUND, ]
-
-        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
-
-    def test_del_txt_record_fail_to_authenticate(self):
-        self.provider_mock.authenticate.side_effect = LOGIN_ERROR
-
-        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
-
-    def test_del_txt_record_error_finding_domain(self):
-        self.provider_mock.authenticate.side_effect = GENERIC_ERROR
-
-        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
-
-    def test_del_txt_record_error_deleting_record(self):
-        self.provider_mock.delete_record.side_effect = GENERIC_ERROR
-
-        self.assertRaises(errors.PluginError,
-                          self.client.del_txt_record,
-                          DOMAIN, self.record_name, self.record_content)
 
 
 if __name__ == "__main__":

--- a/certbot/plugins/dns_dnsimple_test.py
+++ b/certbot/plugins/dns_dnsimple_test.py
@@ -1,0 +1,141 @@
+"""Tests for certbot.plugins.dns_dnsimple."""
+
+import mock
+import unittest
+
+from certbot import errors
+from requests.exceptions import HTTPError, RequestException
+
+from certbot.plugins import dns_test_common
+from certbot.plugins.dns_test_common import DOMAIN
+
+DOMAIN_NOT_FOUND = Exception('No domain found')
+GENERIC_ERROR = RequestException
+LOGIN_ERROR = HTTPError('401 Client Error: Unauthorized for url: ...')
+
+TOKEN = 'foo'
+
+
+class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest):
+
+    def setUp(self):
+        from certbot.plugins.dns_dnsimple import Authenticator
+        self.config = mock.MagicMock(dnsimple_token=TOKEN,
+                                     dnsimple_propagation_seconds=0)  # don't wait during tests
+
+        self.auth = Authenticator(self.config, "dnsimple")
+
+        self.mock_client = mock.MagicMock()
+        # _get_dnsimple_client | pylint: disable=protected-access
+        self.auth._get_dnsimple_client = mock.MagicMock(return_value=self.mock_client)
+
+    def test_perform(self):
+        # pylint: disable=duplicate-code
+        self.auth.perform([self.achall])
+
+        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+    def test_cleanup(self):
+        # pylint: disable=duplicate-code
+        # _attempt_cleanup | pylint: disable=protected-access
+        self.auth._attempt_cleanup = True
+        self.auth.cleanup([self.achall])
+
+        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+
+class DNSimpleLexiconClientTest(unittest.TestCase):
+    record_prefix = "_acme-challenge"
+    record_name = record_prefix + "." + DOMAIN
+    record_content = "bar"
+
+    def setUp(self):
+        from certbot.plugins.dns_dnsimple import _DNSimpleLexiconClient
+
+        self.client = _DNSimpleLexiconClient(TOKEN, 0)
+
+        self.provider_mock = mock.MagicMock()
+        self.client.provider = self.provider_mock
+
+    def test_add_txt_record(self):
+        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.create_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_add_txt_record_try_twice_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND, '']
+
+        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.create_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_add_txt_record_fail_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND,
+                                                       DOMAIN_NOT_FOUND,
+                                                       DOMAIN_NOT_FOUND,]
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_fail_to_authenticate(self):
+        self.provider_mock.authenticate.side_effect = LOGIN_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_error_finding_domain(self):
+        self.provider_mock.authenticate.side_effect = GENERIC_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_error_adding_record(self):
+        self.provider_mock.create_record.side_effect = GENERIC_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record(self):
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.delete_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_del_txt_record_fail_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [DOMAIN_NOT_FOUND,
+                                                       DOMAIN_NOT_FOUND,
+                                                       DOMAIN_NOT_FOUND, ]
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_fail_to_authenticate(self):
+        self.provider_mock.authenticate.side_effect = LOGIN_ERROR
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_finding_domain(self):
+        self.provider_mock.authenticate.side_effect = GENERIC_ERROR
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_deleting_record(self):
+        self.provider_mock.delete_record.side_effect = GENERIC_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.del_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/plugins/dns_google.py
+++ b/certbot/plugins/dns_google.py
@@ -1,0 +1,184 @@
+"""DNS Authenticator for Google Cloud DNS."""
+import logging
+import json
+
+import zope.interface
+
+from certbot import errors
+from certbot import interfaces
+
+from certbot.plugins import dns_common
+
+from googleapiclient import discovery
+from googleapiclient import errors as googleapiclient_errors
+
+from oauth2client.service_account import ServiceAccountCredentials
+
+logger = logging.getLogger(__name__)
+
+ACCT_URL = 'https://developers.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount'
+PERMISSIONS_URL = 'https://cloud.google.com/dns/access-control#permissions_and_roles'
+
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class Authenticator(dns_common.DNSAuthenticator):
+    """DNS  Authenticator for Google Cloud DNS
+
+    This Authenticator uses the Google Cloud DNS API to fulfill a dns-01 challenge.
+    """
+
+    description = 'Obtain certs using a DNS TXT record (if you are using Google Cloud DNS for DNS).'
+    ttl = 60
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
+        super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=60)
+        add('account-json',
+            help=('Path to Google Cloud DNS service account JSON file. (See {0} for' +
+                  'information about creating a service account and {1} for information about the' +
+                  'required permissions.)').format(ACCT_URL, PERMISSIONS_URL))
+
+    def more_info(self): # pylint: disable=missing-docstring,no-self-use
+        return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
+               'the Google Cloud DNS API.'
+
+    def _setup_credentials(self):
+        # XXX: Do we want to do anything to ensure this file remains available during renewal?
+        self._configure('account-json', 'path to Google Cloud DNS service account JSON file')
+
+    def _perform(self, domain, validation_name, validation):
+        self._get_google_client().add_txt_record(domain, validation_name, validation, self.ttl)
+
+    def _cleanup(self, domain, validation_name, validation):
+        self._get_google_client().del_txt_record(domain, validation_name, validation, self.ttl)
+
+    def _get_google_client(self):
+        return _GoogleClient(self.conf('account-json'))
+
+
+class _GoogleClient(object):
+    """
+    Encapsulates all communication with the Google Cloud DNS API.
+    """
+
+    def __init__(self, account_json):
+
+        scopes = ['https://www.googleapis.com/auth/ndev.clouddns.readwrite']
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(account_json, scopes)
+        self.dns = discovery.build('dns', 'v1', credentials=credentials, cache_discovery=False)
+        self.project_id = json.load(open(account_json))['project_id']
+
+    def add_txt_record(self, domain, record_name, record_content, record_ttl):
+        """
+        Add a TXT record using the supplied information.
+
+        :param string domain: The domain to use to look up the managed zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :param int record_ttl: The record TTL (number of seconds that the record may be cached).
+        :raises: errors.PluginError if an error occurs communicating with the Google Cloud DNS API
+        """
+
+        zone_id = self._find_managed_zone_id(domain)
+
+        data = {
+            "kind": "dns#change",
+            "additions": [
+                {
+                    "kind": "dns#resourceRecordSet",
+                    "type": "TXT",
+                    "name": record_name + ".",
+                    "rrdatas": [record_content, ],
+                    "ttl": record_ttl,
+                },
+            ],
+        }
+
+        changes = self.dns.changes()  # changes | pylint: disable=no-member
+
+        try:
+            request = changes.create(project=self.project_id, managedZone=zone_id, body=data)
+            response = request.execute()
+
+            status = response['status']
+            change = response['id']
+            while status == 'pending':
+                request = changes.get(project=self.project_id, managedZone=zone_id, changeId=change)
+                response = request.execute()
+                status = response['status']
+        except googleapiclient_errors.Error as e:
+            logger.error('Encountered error adding TXT record: %s', e)
+            raise errors.PluginError('Error communicating with the Google Cloud DNS API: {0}'
+                                     .format(e))
+
+    def del_txt_record(self, domain, record_name, record_content, record_ttl):
+        """
+        Delete a TXT record using the supplied information.
+
+        :param string domain: The domain to use to look up the managed zone.
+        :param string record_name: The record name (typically beginning with '_acme-challenge.').
+        :param string record_content: The record content (typically the challenge validation).
+        :param int record_ttl: The record TTL (number of seconds that the record may be cached).
+        :raises: errors.PluginError if an error occurs communicating with the Google Cloud DNS API
+        """
+
+        try:
+            zone_id = self._find_managed_zone_id(domain)
+        except errors.PluginError as e:
+            logger.warn('Error finding zone. Skipping cleanup.')
+            return
+
+        data = {
+            "kind": "dns#change",
+            "deletions": [
+                {
+                    "kind": "dns#resourceRecordSet",
+                    "type": "TXT",
+                    "name": record_name + ".",
+                    "rrdatas": [record_content, ],
+                    "ttl": record_ttl,
+                },
+            ],
+        }
+
+        changes = self.dns.changes()  # changes | pylint: disable=no-member
+
+        try:
+            request = changes.create(project=self.project_id, managedZone=zone_id, body=data)
+            request.execute()
+        except googleapiclient_errors.Error as e:
+            logger.warn('Encountered error deleting TXT record: %s', e)
+
+    def _find_managed_zone_id(self, domain):
+        """
+        Find the managed zone for a given domain.
+
+        :param string domain: The domain for which to find the managed zone.
+        :returns: The ID of the managed zone, if found.
+        :rtype: string
+        :raises: errors.PluginError if the managed zone cannot be found.
+        """
+
+        zone_dns_name_guesses = dns_common.base_domain_name_guesses(domain)
+
+        mz = self.dns.managedZones()  # managedZones | pylint: disable=no-member
+        for zone_name in zone_dns_name_guesses:
+            try:
+                request = mz.list(project=self.project_id, dnsName=zone_name + '.')
+                response = request.execute()
+                zones = response['managedZones']
+            except googleapiclient_errors.Error as e:
+                raise errors.PluginError('Encountered error finding managed zone: {0}'
+                                         .format(e))
+
+            if len(zones) > 0:
+                zone_id = zones[0]['id']
+                logger.debug('Found id of %s for %s using name %s', zone_id, domain, zone_name)
+                return zone_id
+
+        raise errors.PluginError('Unable to determine managed zone for %s using zone names: %s',
+                                 domain, zone_dns_name_guesses)

--- a/certbot/plugins/dns_google_test.py
+++ b/certbot/plugins/dns_google_test.py
@@ -1,0 +1,196 @@
+"""Tests for certbot.plugins.dns_google."""
+
+import mock
+import unittest
+
+from certbot import errors
+
+from certbot.plugins import dns_test_common
+from certbot.plugins.dns_test_common import DOMAIN
+
+from googleapiclient.errors import Error
+
+ACCOUNT_JSON_PATH = '/not/a/real/path.json'
+API_ERROR = Error()
+PROJECT_ID = "test-test-1"
+
+
+class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest):
+
+    def setUp(self):
+        from certbot.plugins.dns_google import Authenticator
+        self.config = mock.MagicMock(google_account_json=ACCOUNT_JSON_PATH,
+                                     google_propagation_seconds=0)  # don't wait during tests
+
+        self.auth = Authenticator(self.config, "google")
+
+        self.mock_client = mock.MagicMock()
+        # _get_cloudflare_client | pylint: disable=protected-access
+        self.auth._get_google_client = mock.MagicMock(return_value=self.mock_client)
+
+    def test_perform(self):
+        # pylint: disable=duplicate-code
+        self.auth.perform([self.achall])
+
+        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+    def test_cleanup(self):
+        # pylint: disable=duplicate-code
+        # _attempt_cleanup | pylint: disable=protected-access
+        self.auth._attempt_cleanup = True
+        self.auth.cleanup([self.achall])
+
+        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+
+class GoogleClientTest(unittest.TestCase):
+    record_name = "foo"
+    record_content = "bar"
+    record_ttl = 42
+    zone = "ZONE_ID"
+    change = "an-id"
+
+    def _setUp_client_with_mock(self, zone_request_side_effect):
+        from certbot.plugins.dns_google import _GoogleClient
+
+        client = _GoogleClient(ACCOUNT_JSON_PATH)
+
+        # Setup
+        mock_mz = mock.MagicMock()
+        mock_mz.list.return_value.execute.side_effect = zone_request_side_effect
+
+        mock_changes = mock.MagicMock()
+
+        client.dns.managedZones = mock.MagicMock(return_value=mock_mz)
+        client.dns.changes = mock.MagicMock(return_value=mock_changes)
+
+        return client, mock_changes
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_add_txt_record(self, unused_credential_mock):
+        client, changes = self._setUp_client_with_mock([{'managedZones': [{'id': self.zone}]}])
+
+        client.add_txt_record(DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+        expected_body = {
+            "kind": "dns#change",
+            "additions": [
+                {
+                    "kind": "dns#resourceRecordSet",
+                    "type": "TXT",
+                    "name": self.record_name + ".",
+                    "rrdatas": [self.record_content, ],
+                    "ttl": self.record_ttl,
+                },
+            ],
+        }
+
+        changes.create.assert_called_with(body=expected_body,
+                                               managedZone=self.zone,
+                                               project=PROJECT_ID)
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_add_txt_record_and_poll(self, unused_credential_mock):
+        client, changes = self._setUp_client_with_mock([{'managedZones': [{'id': self.zone}]}])
+        changes.create.return_value.execute.return_value = {'status': 'pending', 'id': self.change}
+        changes.get.return_value.execute.return_value = {'status': 'done'}
+
+        client.add_txt_record(DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+        changes.create.assert_called_with(body=mock.ANY,
+                                               managedZone=self.zone,
+                                               project=PROJECT_ID)
+
+        changes.get.assert_called_with(changeId=self.change,
+                                            managedZone=self.zone,
+                                            project=PROJECT_ID)
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_add_txt_record_error_during_zone_lookup(self, unused_credential_mock):
+        client, unused_changes = self._setUp_client_with_mock(API_ERROR)
+
+        self.assertRaises(errors.PluginError, client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_add_txt_record_zone_not_found(self, unused_credential_mock):
+        client, unused_changes = self._setUp_client_with_mock([{'managedZones': []},
+                                                               {'managedZones': []}])
+
+        self.assertRaises(errors.PluginError, client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_add_txt_record_error_during_add(self, unused_credential_mock):
+        client, changes = self._setUp_client_with_mock([{'managedZones': [{'id': self.zone}]}])
+        changes.create.side_effect = API_ERROR
+
+        self.assertRaises(errors.PluginError, client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_del_txt_record(self, unused_credential_mock):
+        client, changes = self._setUp_client_with_mock([{'managedZones': [{'id': self.zone}]}])
+
+        client.del_txt_record(DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+        expected_body = {
+            "kind": "dns#change",
+            "deletions": [
+                {
+                    "kind": "dns#resourceRecordSet",
+                    "type": "TXT",
+                    "name": self.record_name + ".",
+                    "rrdatas": [self.record_content, ],
+                    "ttl": self.record_ttl,
+                },
+            ],
+        }
+
+        changes.create.assert_called_with(body=expected_body,
+                                               managedZone=self.zone,
+                                               project=PROJECT_ID)
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_del_txt_record_error_during_zone_lookup(self, unused_credential_mock):
+        client, unused_changes = self._setUp_client_with_mock(API_ERROR)
+
+        client.del_txt_record(DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_del_txt_record_zone_not_found(self, unused_credential_mock):
+        client, unused_changes = self._setUp_client_with_mock([{'managedZones': []},
+                                                               {'managedZones': []}])
+
+        client.del_txt_record(DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    @mock.patch('certbot.plugins.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'))
+    def test_del_txt_record_error_during_delete(self, unused_credential_mock):
+        client, changes = self._setUp_client_with_mock([{'managedZones': [{'id': self.zone}]}])
+        changes.create.side_effect = API_ERROR
+
+        client.del_txt_record(DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/plugins/dns_test_common.py
+++ b/certbot/plugins/dns_test_common.py
@@ -1,0 +1,44 @@
+"""Base test class for DNS authenticators."""
+
+import mock
+import six
+
+from acme import challenges
+from acme import jose
+
+from certbot import achallenges
+
+from certbot.tests import acme_util
+from certbot.tests import util as test_util
+
+DOMAIN = 'example.com'
+KEY = jose.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
+
+
+class BaseAuthenticatorTest(object):
+    """
+    A base test class to reduce duplication between test code for DNS Authenticator Plugins.
+
+    Assumes:
+     * That subclasses also subclass unittest.TestCase
+     * That the authenticator is stored as self.auth
+    """
+
+    achall = achallenges.KeyAuthorizationAnnotatedChallenge(
+        challb=acme_util.DNS01, domain=DOMAIN, account_key=KEY)
+
+    def test_more_info(self):
+        # pylint: disable=no-member
+        self.assertTrue(isinstance(self.auth.more_info(), six.string_types))
+
+    def test_get_chall_pref(self):
+        # pylint: disable=no-member
+        self.assertEqual(self.auth.get_chall_pref(None), [challenges.DNS01])
+
+    def test_parser_arguments(self):
+        m = mock.MagicMock()
+
+        # pylint: disable=no-member
+        self.auth.add_parser_arguments(m)
+
+        m.assert_any_call('propagation-seconds', type=int, default=mock.ANY, help=mock.ANY)

--- a/certbot/plugins/dns_test_common.py
+++ b/certbot/plugins/dns_test_common.py
@@ -3,16 +3,22 @@
 import mock
 import six
 
+from requests.exceptions import HTTPError, RequestException
+
 from acme import challenges
 from acme import jose
 
 from certbot import achallenges
+from certbot import errors
 
 from certbot.tests import acme_util
 from certbot.tests import util as test_util
 
 DOMAIN = 'example.com'
 KEY = jose.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
+
+# These classes are intended to be subclassed/mixed in, so not all members are defined.
+# pylint: disable=no-member
 
 
 class BaseAuthenticatorTest(object):
@@ -28,17 +34,128 @@ class BaseAuthenticatorTest(object):
         challb=acme_util.DNS01, domain=DOMAIN, account_key=KEY)
 
     def test_more_info(self):
-        # pylint: disable=no-member
         self.assertTrue(isinstance(self.auth.more_info(), six.string_types))
 
     def test_get_chall_pref(self):
-        # pylint: disable=no-member
         self.assertEqual(self.auth.get_chall_pref(None), [challenges.DNS01])
 
     def test_parser_arguments(self):
         m = mock.MagicMock()
 
-        # pylint: disable=no-member
         self.auth.add_parser_arguments(m)
 
         m.assert_any_call('propagation-seconds', type=int, default=mock.ANY, help=mock.ANY)
+
+
+class BaseLexiconAuthenticatorTest(BaseAuthenticatorTest):
+
+    def test_perform(self):
+        self.auth.perform([self.achall])
+
+        expected = [mock.call.add_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+    def test_cleanup(self):
+        self.auth._attempt_cleanup = True  # _attempt_cleanup | pylint: disable=protected-access
+        self.auth.cleanup([self.achall])
+
+        expected = [mock.call.del_txt_record(DOMAIN, '_acme-challenge.'+DOMAIN, mock.ANY)]
+        self.assertEqual(expected, self.mock_client.mock_calls)
+
+
+class BaseLexiconClientTest(object):
+    DOMAIN_NOT_FOUND = Exception('No domain found')
+    GENERIC_ERROR = RequestException
+    LOGIN_ERROR = HTTPError('400 Client Error: ...')
+    UNKNOWN_LOGIN_ERROR = HTTPError('500 Surprise! Error: ...')
+
+    record_prefix = "_acme-challenge"
+    record_name = record_prefix + "." + DOMAIN
+    record_content = "bar"
+
+    def test_add_txt_record(self):
+        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.create_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_add_txt_record_try_twice_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [self.DOMAIN_NOT_FOUND, '']
+
+        self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.create_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_add_txt_record_fail_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [self.DOMAIN_NOT_FOUND,
+                                                       self.DOMAIN_NOT_FOUND,
+                                                       self.DOMAIN_NOT_FOUND,]
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_fail_to_authenticate(self):
+        self.provider_mock.authenticate.side_effect = self.LOGIN_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_fail_to_authenticate_with_unknown_error(self):
+        self.provider_mock.authenticate.side_effect = self.UNKNOWN_LOGIN_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_error_finding_domain(self):
+        self.provider_mock.authenticate.side_effect = self.GENERIC_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_add_txt_record_error_adding_record(self):
+        self.provider_mock.create_record.side_effect = self.GENERIC_ERROR
+
+        self.assertRaises(errors.PluginError,
+                          self.client.add_txt_record,
+                          DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record(self):
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+        self.provider_mock.delete_record.assert_called_with(type='TXT',
+                                                            name=self.record_name,
+                                                            content=self.record_content)
+
+    def test_del_txt_record_fail_to_find_domain(self):
+        self.provider_mock.authenticate.side_effect = [self.DOMAIN_NOT_FOUND,
+                                                       self.DOMAIN_NOT_FOUND,
+                                                       self.DOMAIN_NOT_FOUND, ]
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_fail_to_authenticate(self):
+        self.provider_mock.authenticate.side_effect = self.LOGIN_ERROR
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_fail_to_authenticate_with_unknown_error(self):
+        self.provider_mock.authenticate.side_effect = self.UNKNOWN_LOGIN_ERROR
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_finding_domain(self):
+        self.provider_mock.authenticate.side_effect = self.GENERIC_ERROR
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
+
+    def test_del_txt_record_error_deleting_record(self):
+        self.provider_mock.delete_record.side_effect = self.GENERIC_ERROR
+
+        self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -133,7 +133,8 @@ def choose_plugin(prepared, question):
         else:
             return None
 
-noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare", "dns-digitalocean"]
+noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare", "dns-digitalocean",
+                        "dns-google"]
 
 def record_chosen_plugins(config, plugins, auth, inst):
     "Update the config entries to reflect the plugins we actually selected."
@@ -241,6 +242,8 @@ def cli_plugin_requests(config):
         req_auth = set_configurator(req_auth, "dns-cloudflare")
     if config.dns_digitalocean:
         req_auth = set_configurator(req_auth, "dns-digitalocean")
+    if config.dns_google:
+        req_auth = set_configurator(req_auth, "dns-google")
     logger.debug("Requested authenticator %s and installer %s", req_auth, req_inst)
     return req_auth, req_inst
 

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -133,7 +133,7 @@ def choose_plugin(prepared, question):
         else:
             return None
 
-noninstaller_plugins = ["webroot", "manual", "standalone"]
+noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare"]
 
 def record_chosen_plugins(config, plugins, auth, inst):
     "Update the config entries to reflect the plugins we actually selected."
@@ -237,6 +237,8 @@ def cli_plugin_requests(config):
         req_auth = set_configurator(req_auth, "webroot")
     if config.manual:
         req_auth = set_configurator(req_auth, "manual")
+    if config.dns_cloudflare:
+        req_auth = set_configurator(req_auth, "dns-cloudflare")
     logger.debug("Requested authenticator %s and installer %s", req_auth, req_inst)
     return req_auth, req_inst
 

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -134,7 +134,7 @@ def choose_plugin(prepared, question):
             return None
 
 noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare", "dns-cloudxns",
-                        "dns-digitalocean", "dns-google"]
+                        "dns-dnsimple", "dns-digitalocean", "dns-google"]
 
 def record_chosen_plugins(config, plugins, auth, inst):
     "Update the config entries to reflect the plugins we actually selected."
@@ -244,6 +244,8 @@ def cli_plugin_requests(config):
         req_auth = set_configurator(req_auth, "dns-cloudxns")
     if config.dns_digitalocean:
         req_auth = set_configurator(req_auth, "dns-digitalocean")
+    if config.dns_dnsimple:
+        req_auth = set_configurator(req_auth, "dns-dnsimple")
     if config.dns_google:
         req_auth = set_configurator(req_auth, "dns-google")
     logger.debug("Requested authenticator %s and installer %s", req_auth, req_inst)

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -133,7 +133,7 @@ def choose_plugin(prepared, question):
         else:
             return None
 
-noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare"]
+noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare", "dns-digitalocean"]
 
 def record_chosen_plugins(config, plugins, auth, inst):
     "Update the config entries to reflect the plugins we actually selected."
@@ -239,6 +239,8 @@ def cli_plugin_requests(config):
         req_auth = set_configurator(req_auth, "manual")
     if config.dns_cloudflare:
         req_auth = set_configurator(req_auth, "dns-cloudflare")
+    if config.dns_digitalocean:
+        req_auth = set_configurator(req_auth, "dns-digitalocean")
     logger.debug("Requested authenticator %s and installer %s", req_auth, req_inst)
     return req_auth, req_inst
 

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -133,8 +133,8 @@ def choose_plugin(prepared, question):
         else:
             return None
 
-noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare", "dns-digitalocean",
-                        "dns-google"]
+noninstaller_plugins = ["webroot", "manual", "standalone", "dns-cloudflare", "dns-cloudxns",
+                        "dns-digitalocean", "dns-google"]
 
 def record_chosen_plugins(config, plugins, auth, inst):
     "Update the config entries to reflect the plugins we actually selected."
@@ -240,6 +240,8 @@ def cli_plugin_requests(config):
         req_auth = set_configurator(req_auth, "manual")
     if config.dns_cloudflare:
         req_auth = set_configurator(req_auth, "dns-cloudflare")
+    if config.dns_cloudxns:
+        req_auth = set_configurator(req_auth, "dns-cloudxns")
     if config.dns_digitalocean:
         req_auth = set_configurator(req_auth, "dns-digitalocean")
     if config.dns_google:

--- a/certbot/plugins/webroot.py
+++ b/certbot/plugins/webroot.py
@@ -138,22 +138,16 @@ to serve all files under specified web root ({0})."""
     def _prompt_for_new_webroot(self, domain):
         display = zope.component.getUtility(interfaces.IDisplay)
 
-
-
-        while True:
-            code, webroot = display.directory_select(
-                "Input the webroot for {0}:".format(domain),
-                force_interactive=True)
-            if code == display_util.HELP:
-                # Displaying help is not currently implemented
-                return None
-            elif code == display_util.CANCEL:
-                return None
-            else:  # code == display_util.OK
-                try:
-                    return _validate_webroot(webroot)
-                except errors.PluginError as error:
-                    display.notification(str(error), pause=False)
+        code, webroot = display.directory_select(
+            "Input the webroot for {0}:".format(domain),
+            force_interactive=True, valdator=_validate_webroot)
+        if code == display_util.HELP:
+            # Displaying help is not currently implemented
+            return None
+        elif code == display_util.CANCEL or code == display_util.ESC:
+            return None
+        else:  # code == display_util.OK
+            return _validate_webroot(webroot)
 
     def _create_challenge_dirs(self):
         path_map = self.conf("map")

--- a/certbot/plugins/webroot.py
+++ b/certbot/plugins/webroot.py
@@ -16,6 +16,7 @@ from certbot import cli
 from certbot import errors
 from certbot import interfaces
 from certbot.display import util as display_util
+from certbot.display import ops
 from certbot.plugins import common
 
 
@@ -136,11 +137,10 @@ to serve all files under specified web root ({0})."""
                 return None if index == 0 else known_webroots[index - 1]
 
     def _prompt_for_new_webroot(self, domain):
-        display = zope.component.getUtility(interfaces.IDisplay)
-
-        code, webroot = display.directory_select(
+        code, webroot = ops.validated_directory(
+            _validate_webroot,
             "Input the webroot for {0}:".format(domain),
-            force_interactive=True, valdator=_validate_webroot)
+            force_interactive=True)
         if code == display_util.HELP:
             # Displaying help is not currently implemented
             return None

--- a/certbot/plugins/webroot.py
+++ b/certbot/plugins/webroot.py
@@ -138,6 +138,8 @@ to serve all files under specified web root ({0})."""
     def _prompt_for_new_webroot(self, domain):
         display = zope.component.getUtility(interfaces.IDisplay)
 
+
+
         while True:
             code, webroot = display.directory_select(
                 "Input the webroot for {0}:".format(domain),

--- a/certbot/plugins/webroot_test.py
+++ b/certbot/plugins/webroot_test.py
@@ -100,22 +100,14 @@ class AuthenticatorTest(unittest.TestCase):
         self.config.webroot_path = []
         self.config.webroot_map = {}
 
-        imaginary_dir = os.path.join(os.sep, "imaginary", "dir")
-
         mock_display = mock_get_utility()
         mock_display.menu.return_value = (display_util.OK, 0,)
         mock_display.directory_select.side_effect = (
-            (display_util.HELP, -1,), (display_util.CANCEL, -1,),
-            (display_util.OK, imaginary_dir,), (display_util.OK, self.path,),)
+            (display_util.HELP, -1,), (display_util.CANCEL, -1,), (display_util.OK, self.path,),)
+
         self.auth.perform([self.achall])
 
-        self.assertTrue(mock_display.notification.called)
-        for call in mock_display.notification.call_args_list:
-            self.assertTrue(imaginary_dir in call[0][0])
-
-        self.assertTrue(mock_display.directory_select.called)
-        for call in mock_display.directory_select.call_args_list:
-            self.assertTrue(self.achall.domain in call[0][0])
+        self.assertEqual(self.config.webroot_map[self.achall.domain], self.path)
 
     def test_perform_missing_root(self):
         self.config.webroot_path = None

--- a/certbot/plugins/webroot_test.py
+++ b/certbot/plugins/webroot_test.py
@@ -102,10 +102,12 @@ class AuthenticatorTest(unittest.TestCase):
 
         mock_display = mock_get_utility()
         mock_display.menu.return_value = (display_util.OK, 0,)
-        mock_display.directory_select.side_effect = (
-            (display_util.HELP, -1,), (display_util.CANCEL, -1,), (display_util.OK, self.path,),)
+        with mock.patch('certbot.display.ops.validated_directory') as m:
+            m.side_effect = ((display_util.HELP, -1),
+                             (display_util.CANCEL, -1),
+                             (display_util.OK, self.path,))
 
-        self.auth.perform([self.achall])
+            self.auth.perform([self.achall])
 
         self.assertEqual(self.config.webroot_map[self.achall.domain], self.path)
 

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -84,25 +84,6 @@ class FileOutputDisplayTest(unittest.TestCase):
         self.assertEqual(code, display_util.OK)
         self.assertEqual(input_, "domain.com")
 
-    def test_input_blank_no_validator(self):
-        with mock.patch("six.moves.input", return_value=""):
-            code, input_ = self.displayer.input("message", force_interactive=True)
-
-        self.assertEqual(code, display_util.OK)
-        self.assertEqual(input_, "")
-
-    def test_input_blank_with_validator(self):
-        def __validator(m):
-            if m == "":
-                raise errors.PluginError("Must be non-empty")
-
-        with mock.patch("six.moves.input", side_effect=["", "", "", "asdf"]):
-            code, input_ = self.displayer.input("message", force_interactive=True,
-                                                validator=__validator)
-
-        self.assertEqual(code, display_util.OK)
-        self.assertEqual(input_, "asdf")
-
     def test_input_noninteractive(self):
         default = "foo"
         code, input_ = self._force_noninteractive(
@@ -209,26 +190,6 @@ class FileOutputDisplayTest(unittest.TestCase):
         mock_input.return_value = user_input
 
         returned = self.displayer.directory_select(*args)
-        self.assertEqual(returned, (display_util.OK, user_input))
-
-    @mock.patch("certbot.display.util.six.moves.input")
-    def test_directory_select_validation(self, mock_input):
-        error = "Must be non-empty"
-
-        def __validator(m):
-            if m == "":
-                raise errors.PluginError(error)
-
-        # pylint: disable=star-args
-        args = ["msg", "/var/www/html", "--flag", True, __validator]
-        user_input = "/var/www/html"
-        mock_input.side_effect = ["", user_input]
-
-        with mock.patch("certbot.display.util.FileDisplay.notification"):
-            returned = self.displayer.directory_select(*args)
-
-            self.assertEqual(error, self.displayer.notification.call_args[0][0])
-
         self.assertEqual(returned, (display_util.OK, user_input))
 
     def test_directory_select_noninteractive(self):

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -84,6 +84,25 @@ class FileOutputDisplayTest(unittest.TestCase):
         self.assertEqual(code, display_util.OK)
         self.assertEqual(input_, "domain.com")
 
+    def test_input_blank_no_validator(self):
+        with mock.patch("six.moves.input", return_value=""):
+            code, input_ = self.displayer.input("message", force_interactive=True)
+
+        self.assertEqual(code, display_util.OK)
+        self.assertEqual(input_, "")
+
+    def test_input_blank_with_validator(self):
+        def __validator(m):
+            if m == "":
+                raise errors.PluginError("Must be non-empty")
+
+        with mock.patch("six.moves.input", side_effect=["", "", "", "asdf"]):
+            code, input_ = self.displayer.input("message", force_interactive=True,
+                                                validator=__validator)
+
+        self.assertEqual(code, display_util.OK)
+        self.assertEqual(input_, "asdf")
+
     def test_input_noninteractive(self):
         default = "foo"
         code, input_ = self._force_noninteractive(
@@ -190,6 +209,26 @@ class FileOutputDisplayTest(unittest.TestCase):
         mock_input.return_value = user_input
 
         returned = self.displayer.directory_select(*args)
+        self.assertEqual(returned, (display_util.OK, user_input))
+
+    @mock.patch("certbot.display.util.six.moves.input")
+    def test_directory_select_validation(self, mock_input):
+        error = "Must be non-empty"
+
+        def __validator(m):
+            if m == "":
+                raise errors.PluginError(error)
+
+        # pylint: disable=star-args
+        args = ["msg", "/var/www/html", "--flag", True, __validator]
+        user_input = "/var/www/html"
+        mock_input.side_effect = ["", user_input]
+
+        with mock.patch("certbot.display.util.FileDisplay.notification"):
+            returned = self.displayer.directory_select(*args)
+
+            self.assertEqual(error, self.displayer.notification.call_args[0][0])
+
         self.assertEqual(returned, (display_util.OK, user_input))
 
     def test_directory_select_noninteractive(self):

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ install_requires = [
     'parsedatetime>=1.3',  # Calendar.parseDT
     'PyOpenSSL',
     'pyrfc3339',
+    'python-digitalocean>=1.11',
     'pytz',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
@@ -126,6 +127,7 @@ setup(
             'standalone = certbot.plugins.standalone:Authenticator',
             'webroot = certbot.plugins.webroot:Authenticator',
             'dns-cloudflare = certbot.plugins.dns_cloudflare:Authenticator',
+            'dns-digitalocean = certbot.plugins.dns_digitalocean:Authenticator',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ install_requires = [
     'cryptography>=0.7',  # load_pem_x509_certificate
     'fasteners',
     'google-api-python-client',
+    'dns-lexicon',
     'mock',
     'parsedatetime>=1.3',  # Calendar.parseDT
     'PyOpenSSL',
@@ -129,6 +130,7 @@ setup(
             'standalone = certbot.plugins.standalone:Authenticator',
             'webroot = certbot.plugins.webroot:Authenticator',
             'dns-cloudflare = certbot.plugins.dns_cloudflare:Authenticator',
+            'dns-cloudxns = certbot.plugins.dns_cloudxns:Authenticator',
             'dns-digitalocean = certbot.plugins.dns_digitalocean:Authenticator',
             'dns-google = certbot.plugins.dns_google:Authenticator',
         ],

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ install_requires = [
     'ConfigArgParse>=0.9.3',
     'configobj',
     'cryptography>=0.7',  # load_pem_x509_certificate
+    'fasteners',
+    'google-api-python-client',
     'mock',
     'parsedatetime>=1.3',  # Calendar.parseDT
     'PyOpenSSL',
@@ -128,6 +130,7 @@ setup(
             'webroot = certbot.plugins.webroot:Authenticator',
             'dns-cloudflare = certbot.plugins.dns_cloudflare:Authenticator',
             'dns-digitalocean = certbot.plugins.dns_digitalocean:Authenticator',
+            'dns-google = certbot.plugins.dns_google:Authenticator',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ version = meta['version']
 install_requires = [
     'acme=={0}'.format(version),
     'argparse',
+    'cloudflare>=1.5.1',
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
     # saying so here causes a runtime error against our temporary fork of 0.9.3
     # in which we added 2.6 support (see #2243), so we relax the requirement.
@@ -124,6 +125,7 @@ setup(
             'null = certbot.plugins.null:Installer',
             'standalone = certbot.plugins.standalone:Authenticator',
             'webroot = certbot.plugins.webroot:Authenticator',
+            'dns-cloudflare = certbot.plugins.dns_cloudflare:Authenticator',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
             'dns-cloudflare = certbot.plugins.dns_cloudflare:Authenticator',
             'dns-cloudxns = certbot.plugins.dns_cloudxns:Authenticator',
             'dns-digitalocean = certbot.plugins.dns_digitalocean:Authenticator',
+            'dns-dnsimple = certbot.plugins.dns_dnsimple:Authenticator',
             'dns-google = certbot.plugins.dns_google:Authenticator',
         ],
     },


### PR DESCRIPTION
Note: This PR builds on PR #4522. (Once that has landed, I'll rebase this branch and remove this note.)

Implement an Authenticator which can fulfill a dns-01 challenge using the DNSimple API via Lexicon. Applicable only for domains using DNSimple for DNS.

Introduce abstract classes to provide base functionality for Lexicon-based DNS Authenticator plugins and corresponding test cases.

Refactor CloudXNS and DNSimple to use these new base classes.

Testing Done:
 * `tox -e py27`
 * `tox -e lint`
 * Manual Testing:
    * Used `certbot certonly --dns-dnsimple -d`, specifying an API token as a command line argument. Verified that a certificate was successfully obtained without user interaction.
    * Negative testing:
      * Invalid API token
      * Domain name not registered in DNSimple
 * `./tox.cover.sh` (1 relevant uncovered line: 50 of dns_dnsimple.py)