### PR TITLE
Demote PEM generation to logger.debug

### DIFF
--- a/certbot/crypto_util.py
+++ b/certbot/crypto_util.py
@@ -54,13 +54,13 @@ def init_save_key(key_size, key_dir, keyname="key-certbot.pem"):
                             config.strict_permissions)
     if config.dry_run:
         key_path = None
-        logger.info("Generating key (%d bits), not saving to file", key_size)
+        logger.debug("Generating key (%d bits), not saving to file", key_size)
     else:
         key_f, key_path = util.unique_file(
             os.path.join(key_dir, keyname), 0o600, "wb")
         with key_f:
             key_f.write(key_pem)
-        logger.info("Generating key (%d bits): %s", key_size, key_path)
+        logger.debug("Generating key (%d bits): %s", key_size, key_path)
 
     return util.Key(key_path, key_pem)
 
@@ -89,13 +89,13 @@ def init_save_csr(privkey, names, path):
                                config.strict_permissions)
     if config.dry_run:
         csr_filename = None
-        logger.info("Creating CSR: not saving to file")
+        logger.debug("Creating CSR: not saving to file")
     else:
         csr_f, csr_filename = util.unique_file(
             os.path.join(path, "csr-certbot.pem"), 0o644, "wb")
         with csr_f:
             csr_f.write(csr_pem)
-        logger.info("Creating CSR: %s", csr_filename)
+        logger.debug("Creating CSR: %s", csr_filename)
 
     return util.CSR(csr_filename, csr_pem, "pem")
 


### PR DESCRIPTION
Fixes #4548.

When `crypto_util` generates PEM objects, log this action at DEBUG rather than INFO severity to avoid telling users about files that, in fact, they probably shouldn't be using.