### PR TITLE
Add curl package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache --virtual .build-deps \
         openssl-dev \
         musl-dev \
         libffi-dev \
+        curl \
     && pip install --no-cache-dir \
         --editable /opt/certbot/src/acme \
         --editable /opt/certbot/src \


### PR DESCRIPTION
Without this package it is not possible to use the hooks that depend on http requests. Especially the example with Cloudflare.