### PR TITLE
Reuse dynamic install_requires

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -8,7 +8,6 @@ version = '0.14.0.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'argparse',
     # load_pem_private/public_key (>=0.6)
     # rsa_recover_prime_factors (>=0.8)
     'cryptography>=0.8',
@@ -27,6 +26,10 @@ install_requires = [
     'setuptools>=1.0',
     'six',
 ]
+
+# env markers cause problems with older pip and setuptools
+if sys.version_info < (2, 7):
+    install_requires.append('argparse')
 
 dev_extras = [
     'nose',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ version = meta['version']
 # https://github.com/pypa/pip/issues/988 for more info.
 install_requires = [
     'acme=={0}'.format(version),
-    'argparse',
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
     # saying so here causes a runtime error against our temporary fork of 0.9.3
     # in which we added 2.6 support (see #2243), so we relax the requirement.
@@ -55,6 +54,10 @@ install_requires = [
     'zope.component',
     'zope.interface',
 ]
+
+# env markers cause problems with older pip and setuptools
+if sys.version_info < (2, 7):
+    install_requires.append('argparse')
 
 dev_extras = [
     # Pin astroid==1.3.5, pylint==1.4.2 as a workaround for #289


### PR DESCRIPTION
Relevant discussion was in #4379 and IRC.

I'm going to be building #4449 off of this because I need to add a conditional dependency on `ordereddict` for Python 2.6 systems.