### PR TITLE
Force nginx tests to run during CI

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -203,7 +203,9 @@ common revoke --cert-path "$root/conf/live/le2.wtf/cert.pem" \
 
 common unregister
 
-if type nginx;
+# Most CI systems set this variable to true.
+# If the tests are running as part of CI, Nginx should be available.
+if $CI || type nginx;
 then
     . ./certbot-nginx/tests/boulder-integration.sh
 fi

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -205,7 +205,7 @@ common unregister
 
 # Most CI systems set this variable to true.
 # If the tests are running as part of CI, Nginx should be available.
-if $CI || type nginx;
+if ${CI:-false} || type nginx;
 then
     . ./certbot-nginx/tests/boulder-integration.sh
 fi


### PR DESCRIPTION
If for some reason our Nginx set up gets broken in Travis, our tests will currently silently pass without making us aware of the issue. Let's fix this!

[Travis source](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables)
[Circle source](https://circleci.com/docs/1.0/environment-variables/)