### PR TITLE
Deduplicate package lists in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,21 +9,40 @@ envlist = modification,py{26,33,34,35,36},cover,lint
 # nosetest -v => more verbose output, allows to detect busy waiting
 # loops, especially on Travis
 
-[testenv]
+[base]
 # packages installed separately to ensure that downstream deps problems
 # are detected, c.f. #1002
-commands =
+core_commands =
     pip install -e acme[dev]
     nosetests -v acme --processes=-1
     pip install -e .[dev]
     nosetests -v certbot --processes=-1 --process-timeout=100
+core_install_args = -e acme[dev] -e .[dev]
+core_paths = acme/acme certbot
+
+plugin_commands =
     pip install -e certbot-apache
     nosetests -v certbot_apache --processes=-1 --process-timeout=80
     pip install -e certbot-nginx
     nosetests -v certbot_nginx --processes=-1
+plugin_install_args = -e certbot-apache -e certbot-nginx
+plugin_paths = certbot-apache/certbot_apache certbot-nginx/certbot_nginx
+
+compatibility_install_args = -e certbot-compatibility-test
+compatibility_paths = certbot-compatibility-test/certbot_compatibility_test
+
+other_commands =
     pip install -e letshelp-certbot
     nosetests -v letshelp_certbot --processes=-1
     python tests/lock_test.py
+other_install_args = -e letshelp-certbot
+other_paths =  letshelp-certbot/letshelp_certbot tests/lock_test.py
+
+[testenv]
+commands =
+    {[base]core_commands}
+    {[base]plugin_commands}
+    {[base]other_commands}
 
 setenv =
     PYTHONPATH = {toxinidir}
@@ -44,12 +63,12 @@ deps =
 [testenv:py27_install]
 basepython = python2.7
 commands =
-    pip install -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e letshelp-certbot
+    pip install {[base]core_install_args} {[base]plugin_install_args} {[base]other_install_args}
 
 [testenv:cover]
 basepython = python2.7
 commands =
-    pip install -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e letshelp-certbot
+    pip install {[base]core_install_args} {[base]plugin_install_args} {[base]other_install_args}
     ./tox.cover.sh
 
 [testenv:lint]
@@ -59,25 +78,25 @@ basepython = python2.7
 # duplicate code checking; if one of the commands fails, others will
 # continue, but tox return code will reflect previous error
 commands =
-    pip install -q -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-compatibility-test -e letshelp-certbot
-    pylint --reports=n --rcfile=.pylintrc acme/acme certbot certbot-apache/certbot_apache certbot-nginx/certbot_nginx certbot-compatibility-test/certbot_compatibility_test letshelp-certbot/letshelp_certbot tests/lock_test.py
+    pip install -q {[base]core_install_args} {[base]plugin_install_args} {[base]compatibility_install_args} {[base]other_install_args}
+    pylint --reports=n --rcfile=.pylintrc {[base]core_paths} {[base]plugin_paths} {[base]compatibility_paths} {[base]other_paths}
 
 [testenv:mypy]
 basepython = python3.4
 commands =
     pip install mypy
-    pip install -q -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-compatibility-test -e letshelp-certbot
-    mypy --py2 --ignore-missing-imports acme/acme certbot certbot-apache/certbot_apache certbot-nginx/certbot_nginx certbot-compatibility-test/certbot_compatibility_test letshelp-certbot/letshelp_certbot
+    pip install -q {[base]core_install_args} {[base]plugin_install_args} {[base]compatibility_install_args} {[base]other_install_args}
+    mypy --py2 --ignore-missing-imports {[base]core_paths} {[base]plugin_paths} {[base]compatibility_paths} {[base]other_paths}
 
 [testenv:apacheconftest]
 #basepython = python2.7
 commands =
-    pip install -e acme -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-compatibility-test -e letshelp-certbot
+    pip install {[base]core_install_args} {[base]plugin_install_args} {[base]compatibility_install_args} {[base]other_install_args}
     {toxinidir}/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test --debian-modules
 
 [testenv:nginxroundtrip]
 commands =
-    pip install -e acme[dev] -e .[dev] -e certbot-nginx
+    pip install {[base]core_install_args} -e certbot-nginx
     python certbot-compatibility-test/nginx/roundtrip.py certbot-compatibility-test/nginx/nginx-roundtrip-testdata
 
 # This is a duplication of the command line in testenv:le_auto to


### PR DESCRIPTION
Use substitution of values form other sections[[1](https://tox.readthedocs.io/en/latest/config.html#substitution-for-values-from-other-sections)] to deduplicate information in tox.ini, including pip install arguments and package paths.

As more packages are introduced as a result of the [DNS](https://github.com/certbot/certbot/projects/1) work, deduplication will become even more useful.