### PR TITLE
Allow reuse of private keys

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -865,6 +865,11 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
              "per Certbot run. To see certificate names, run 'certbot certificates'. "
              "When creating a new certificate, specifies the new certificate's name.")
     helpful.add(
+        [None, "run", "certonly"],
+        "--privkey-path", dest="privkey_path", default=None,
+        help="Location of an existing private key to use in this new certificate. "
+             "(If not specified, a new key pair will be created.)")
+    helpful.add(
         [None, "testing", "renew", "certonly"],
         "--dry-run", action="store_true", dest="dry_run",
         help="Perform a test run of the client, obtaining test (invalid) certs"

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -745,7 +745,6 @@ def main(cli_args=sys.argv[1:]):
 
 
 if __name__ == "__main__":
-    print("yo dog")
     err_string = main()
     if err_string:
         logger.warning("Exiting with message %s", err_string)

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -79,7 +79,9 @@ def _get_and_save_cert(le_client, config, domains=None, certname=None, lineage=N
             # TREAT AS NEW REQUEST
             assert domains is not None
             logger.info("Obtaining a new certificate")
-            lineage = le_client.obtain_and_enroll_certificate(domains, certname)
+            # config.privkey_path determines whether or not a new private key
+            # will be generated.
+            lineage = le_client.obtain_and_enroll_certificate(domains, certname, config.privkey_path)
             if lineage is False:
                 raise errors.Error("Certificate could not be obtained")
     finally:
@@ -743,6 +745,7 @@ def main(cli_args=sys.argv[1:]):
 
 
 if __name__ == "__main__":
+    print("yo dog")
     err_string = main()
     if err_string:
         logger.warning("Exiting with message %s", err_string)


### PR DESCRIPTION
This PR adds an option to allow the reuse of a specified existing private key when requesting a new certificate (other than via CSR, which is already an alternative which can achieve this function with or without direct access to the private key material).

Fixes #3788 and #3709.