### PR TITLE
Remove unnecessary closes causing logging problems

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -410,8 +410,6 @@ class MainTest(test_util.TempDirTestCase):  # pylint: disable=too-many-public-me
                 finally:
                     output = toy_out.getvalue() or toy_err.getvalue()
                     self.assertTrue("certbot" in output, "Output is {0}".format(output))
-        toy_out.close()
-        toy_err.close()
 
     def _cli_missing_flag(self, args, message):
         "Ensure that a particular error raises a missing cli flag error containing message"


### PR DESCRIPTION
Depending on how the tests are run, these two lines are causing test failures on Python 2.6. The issue is `logging.shutdown`. This function is called when Certbot exits to flush and close our logging handlers. In Python 2.6, however, errors that occur while doing this [aren't caught](https://github.com/python/cpython/blob/2.6/Lib/logging/__init__.py#L1515) but in future Python versions [they are](https://github.com/python/cpython/blob/2.7/Lib/logging/__init__.py#L1653).

The error that occurs is:
```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/usr/lib64/python2.6/logging/__init__.py", line 1524, in shutdown
    h.flush()
  File "/usr/lib64/python2.6/logging/__init__.py", line 770, in flush
    self.stream.flush()
  File "/usr/lib64/python2.6/StringIO.py", line 256, in flush
    _complain_ifclosed(self.closed)
  File "/usr/lib64/python2.6/StringIO.py", line 40, in _complain_ifclosed
    raise ValueError, "I/O operation on closed file"
ValueError: I/O operation on closed file
```

Calling `close` in our main tests causes the problem and it isn't necessary to do this because:

* it's automatically done at program exit
* `StringIO` is just a string buffer that is automatically garbage collected by Python