### PR TITLE
Allow boulder-fetch.sh run with `ip` from iproute2

### DIFF
--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -13,6 +13,7 @@ fi
 cd ${BOULDERPATH}
 FAKE_DNS=$(ifconfig docker0 | grep "inet addr:" | cut -d: -f2 | awk '{ print $1}')
 [ -z "$FAKE_DNS" ] && FAKE_DNS=$(ifconfig docker0 | grep "inet " | xargs | cut -d ' ' -f 2)
+[ -z "$FAKE_DNS" ] && FAKE_DNS=$(ip addr show dev docker0 | grep "inet " | xargs | cut -d ' ' -f 2 | cut -d '/' -f 1)
 [ -z "$FAKE_DNS" ] && echo Unable to find the IP for docker0 && exit 1
 sed -i "s/FAKE_DNS: .*/FAKE_DNS: ${FAKE_DNS}/" docker-compose.yml
 docker-compose up -d


### PR DESCRIPTION
On Arch Linux, `ifconfig`, which is part of the net-tools package, [2] is not within the base package group, so fresh Arch installations may come without it. This patch adds support for `ip` from the iproute2 package, [1] which is a member in the base group.

A sample output from `ip`:
```
$ ip addr show dev docker0 
3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
    link/ether 02:42:22:95:fa:79 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:22ff:fe95:fa79/64 scope link 
       valid_lft forever preferred_lft forever
```

[1] https://www.archlinux.org/packages/core/x86_64/iproute2/
[2] https://www.archlinux.org/packages/core/x86_64/net-tools/