### PR TITLE
Use universal_newlines=True whereever the output is used

### DIFF
--- a/certbot/util.py
+++ b/certbot/util.py
@@ -429,7 +429,8 @@ def get_python_os_info():
     elif os_type.startswith('darwin'):
         os_ver = subprocess.Popen(
             ["sw_vers", "-productVersion"],
-            stdout=subprocess.PIPE
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
         ).communicate()[0].rstrip('\n')
     elif os_type.startswith('freebsd'):
         # eg "9.3-RC3-p1"

--- a/letshelp-certbot/letshelp_certbot/apache.py
+++ b/letshelp-certbot/letshelp_certbot/apache.py
@@ -183,19 +183,22 @@ def setup_tempdir(args):
         config_fd.write(args.config_file + "\n")
 
     proc = subprocess.Popen([args.apache_ctl, "-v"],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            universal_newlines=True)
     with open(os.path.join(tempdir, "version"), "w") as version_fd:
         version_fd.write(proc.communicate()[0])
 
     proc = subprocess.Popen([args.apache_ctl, "-d", args.server_root, "-f",
                              args.config_file, "-M"],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            universal_newlines=True)
     with open(os.path.join(tempdir, "modules"), "w") as modules_fd:
         modules_fd.write(proc.communicate()[0])
 
     proc = subprocess.Popen([args.apache_ctl, "-d", args.server_root, "-f",
                              args.config_file, "-t", "-D", "DUMP_VHOSTS"],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            universal_newlines=True)
     with open(os.path.join(tempdir, "vhosts"), "w") as vhosts_fd:
         vhosts_fd.write(proc.communicate()[0])
 
@@ -231,7 +234,8 @@ def locate_config(apache_ctl):
     """
     try:
         proc = subprocess.Popen([apache_ctl, "-V"],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                universal_newlines=True)
         output, _ = proc.communicate()
     except OSError:
         sys.exit(_NO_APACHECTL)


### PR DESCRIPTION
That fixes:

1. The letshelp command on Python 3. This is a preparation work for #4586
2. Most certbot commands on Python 3 on macOS

This topic should be revisited when #4516 is going to be implemented as ```universal_newlines=True``` implements a "bytes for Python 2 and unicode for Python 3" model.

Cross-ref: #3179