### PR TITLE
Make it easier to add new packages to the release script

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -45,7 +45,8 @@ export GPG_TTY=$(tty)
 PORT=${PORT:-1234}
 
 # subpackages to be released
-SUBPKGS=${SUBPKGS:-"acme certbot-apache certbot-nginx"}
+SUBPKGS_NO_CERTBOT="acme certbot-apache certbot-nginx"
+SUBPKGS="certbot $SUBPKGS_NO_CERTBOT"
 subpkgs_modules="$(echo $SUBPKGS | sed s/-/_/g)"
 # certbot_compatibility_test is not packaged because:
 # - it is not meant to be used by anyone else than Certbot devs
@@ -83,21 +84,22 @@ git checkout "$RELEASE_BRANCH"
 
 SetVersion() {
     ver="$1"
-    for pkg_dir in $SUBPKGS certbot-compatibility-test
+    # bumping Certbot's version number is done differently
+    for pkg_dir in $SUBPKGS_NO_CERTBOT certbot-compatibility-test
     do
       sed -i "s/^version.*/version = '$ver'/" $pkg_dir/setup.py
     done
     sed -i "s/^__version.*/__version__ = '$ver'/" certbot/__init__.py
 
     # interactive user input
-    git add -p certbot $SUBPKGS certbot-compatibility-test
+    git add -p $SUBPKGS certbot-compatibility-test
 
 }
 
 SetVersion "$version"
 
 echo "Preparing sdists and wheels"
-for pkg_dir in . $SUBPKGS
+for pkg_dir in . $SUBPKGS_NO_CERTBOT
 do
   cd $pkg_dir
 
@@ -118,7 +120,7 @@ done
 
 mkdir "dist.$version"
 mv dist "dist.$version/certbot"
-for pkg_dir in $SUBPKGS
+for pkg_dir in $SUBPKGS_NO_CERTBOT
 do
   mv $pkg_dir/dist "dist.$version/$pkg_dir/"
 done
@@ -140,7 +142,7 @@ pip install -U pip
 pip install \
   --no-cache-dir \
   --extra-index-url http://localhost:$PORT \
-  certbot $SUBPKGS
+  $SUBPKGS
 # stop local PyPI
 kill $!
 cd ~-
@@ -160,20 +162,22 @@ mkdir kgs
 kgs="kgs/$version"
 pip freeze | tee $kgs
 pip install nose
-for module in certbot $subpkgs_modules ; do
+for module in $subpkgs_modules ; do
     echo testing $module
     nosetests $module
 done
 cd ~-
 
 # pin pip hashes of the things we just built
-for pkg in acme certbot certbot-apache certbot-nginx ; do
+for pkg in $SUBPKGS ; do
     echo $pkg==$version \\
     pip hash dist."$version/$pkg"/*.{whl,gz} | grep "^--hash" | python2 -c 'from sys import stdin; input = stdin.read(); print "   ", input.replace("\n--hash", " \\\n    --hash"),'
 done > letsencrypt-auto-source/pieces/certbot-requirements.txt
 deactivate
 
-if ! wc -l letsencrypt-auto-source/pieces/certbot-requirements.txt | grep -qE "^\s*12 " ; then
+# there should be one requirement specifier and two hashes for each subpackage
+expected_count=$(expr $(echo $SUBPKGS | wc -w) \* 3)
+if ! wc -l letsencrypt-auto-source/pieces/certbot-requirements.txt | grep -qE "^\s*$expected_count " ; then
     echo Unexpected pip hash output
     exit 1
 fi


### PR DESCRIPTION
Prep work for packaging all of the DNS plugins. After this PR, the only change that needs to be made to the release script to package a plugin is to add it to the `SUBPKGS_NO_CERTBOT` string.

Merging this single commit PR rather than squashing it prevents the need for handling merge conflicts in ~~my incoming PR that builds off of this to package `certbot-dns-cloudflare`~~ #4644.