### PR TITLE
Fix configargparse 0.12.0

### DIFF
--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -6,6 +6,7 @@ import shutil
 import stat
 import unittest
 
+import configargparse
 import mock
 import six
 from six.moves import reload_module  # pylint: disable=import-error
@@ -367,6 +368,22 @@ class AddDeprecatedArgumentTest(unittest.TestCase):
             except SystemExit:
                 pass
         self.assertTrue("--old-option" not in stdout.getvalue())
+
+    def test_when_configargparse_set(self):
+        '''In configargparse versions < 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE is a set.'''
+        orig = configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE
+        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = set()
+        self._call("--old-option", 1)
+        self.assertEqual(len(configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE), 1)
+        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = orig
+
+    def test_when_configargparse_tuple(self):
+        '''In configargparse versions >= 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE is a tuple.'''
+        orig = configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE
+        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = tuple()
+        self._call("--old-option", 1)
+        self.assertEqual(len(configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE), 1)
+        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = orig
 
 
 class EnforceLeValidity(unittest.TestCase):

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -6,7 +6,6 @@ import shutil
 import stat
 import unittest
 
-import configargparse
 import mock
 import six
 from six.moves import reload_module  # pylint: disable=import-error
@@ -369,21 +368,28 @@ class AddDeprecatedArgumentTest(unittest.TestCase):
                 pass
         self.assertTrue("--old-option" not in stdout.getvalue())
 
-    def test_when_configargparse_set(self):
-        '''In configargparse versions < 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE is a set.'''
-        orig = configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE
-        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = set()
-        self._call("--old-option", 1)
-        self.assertEqual(len(configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE), 1)
-        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = orig
+    def test_set_constant(self):
+        """Test when ACTION_TYPES_THAT_DONT_NEED_A_VALUE is a set.
 
-    def test_when_configargparse_tuple(self):
-        '''In configargparse versions >= 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE is a tuple.'''
-        orig = configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE
-        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = tuple()
-        self._call("--old-option", 1)
-        self.assertEqual(len(configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE), 1)
-        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = orig
+        This variable is a set in configargparse versions < 0.12.0.
+
+        """
+        self._test_constant_common(set)
+
+    def test_tuple_constant(self):
+        """Test when ACTION_TYPES_THAT_DONT_NEED_A_VALUE is a tuple.
+
+        This variable is a tuple in configargparse versions >= 0.12.0.
+
+        """
+        self._test_constant_common(tuple)
+
+    def _test_constant_common(self, typ):
+        with mock.patch("certbot.util.configargparse") as mock_configargparse:
+            mock_configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = typ()
+            self._call("--old-option", 1)
+        self.assertEqual(
+            len(mock_configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE), 1)
 
 
 class EnforceLeValidity(unittest.TestCase):

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -477,9 +477,10 @@ def add_deprecated_argument(add_argument, argument_name, nargs):
             sys.stderr.write(
                 "Use of {0} is deprecated.\n".format(option_string))
 
-    # In version 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE was changed from a set
-    # to a tuple.
+    # In version 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE was changed from a
+    # set to a tuple.
     if isinstance(configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE, set):
+        # pylint: disable=no-member
         configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE.add(ShowWarning)
     else:
         configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE += (ShowWarning,)

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -477,7 +477,12 @@ def add_deprecated_argument(add_argument, argument_name, nargs):
             sys.stderr.write(
                 "Use of {0} is deprecated.\n".format(option_string))
 
-    configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE.add(ShowWarning)
+    # In version 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE was changed from a set
+    # to a tuple.
+    if isinstance(configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE, set):
+        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE.add(ShowWarning)
+    else:
+        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE += (ShowWarning,)
     add_argument(argument_name, action=ShowWarning,
                  help=argparse.SUPPRESS, nargs=nargs)
 


### PR DESCRIPTION
Built on #4650.

Because we define the `ShowWarning` class inside the function, we actually are adding multiple different `ShowWarning` classes to the object. This doesn't hurt anything besides performance and I started to fix it but we should only apply the minimal patch for now. This is not a behavior change.