### PR TITLE
Fix configargparse 0.12.0 part 2

### DIFF
--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -388,6 +388,7 @@ class AddDeprecatedArgumentTest(unittest.TestCase):
         with mock.patch("certbot.util.configargparse") as mock_configargparse:
             mock_configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE = typ()
             self._call("--old-option", 1)
+            self._call("--old-option2", 2)
         self.assertEqual(
             len(mock_configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE), 1)
 

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -458,6 +458,13 @@ def safe_email(email):
         return False
 
 
+class _ShowWarning(argparse.Action):
+    """Action to log a warning when an argument is used."""
+    def __call__(self, unused1, unused2, unused3, option_string=None):
+        sys.stderr.write(
+            "Use of {0} is deprecated.\n".format(option_string))
+
+
 def add_deprecated_argument(add_argument, argument_name, nargs):
     """Adds a deprecated argument with the name argument_name.
 
@@ -471,20 +478,17 @@ def add_deprecated_argument(add_argument, argument_name, nargs):
     :param nargs: Value for nargs when adding the argument to argparse.
 
     """
-    class ShowWarning(argparse.Action):
-        """Action to log a warning when an argument is used."""
-        def __call__(self, unused1, unused2, unused3, option_string=None):
-            sys.stderr.write(
-                "Use of {0} is deprecated.\n".format(option_string))
-
-    # In version 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE was changed from a
-    # set to a tuple.
-    if isinstance(configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE, set):
-        # pylint: disable=no-member
-        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE.add(ShowWarning)
-    else:
-        configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE += (ShowWarning,)
-    add_argument(argument_name, action=ShowWarning,
+    if _ShowWarning not in configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE:
+        # In version 0.12.0 ACTION_TYPES_THAT_DONT_NEED_A_VALUE was
+        # changed from a set to a tuple.
+        if isinstance(configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE, set):
+            # pylint: disable=no-member
+            configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE.add(
+                _ShowWarning)
+        else:
+            configargparse.ACTION_TYPES_THAT_DONT_NEED_A_VALUE += (
+                _ShowWarning,)
+    add_argument(argument_name, action=_ShowWarning,
                  help=argparse.SUPPRESS, nargs=nargs)
 
 


### PR DESCRIPTION
Builds on #4652 and cleans up the code a bit so we only modify `ACTION_TYPES_THAT_DONT_NEED_A_VALUE` once.