### PR TITLE
Fix defaults on older systems

### DIFF
--- a/certbot/plugins/standalone.py
+++ b/certbot/plugins/standalone.py
@@ -146,6 +146,10 @@ class SupportedChallengesAction(argparse.Action):
 
         unrecognized = [name for name in challs
                         if name not in challenges.Challenge.TYPES]
+
+        # argparse.ArgumentErrors raised out of argparse.Action objects
+        # are caught by argparse which prints usage information and the
+        # error that occurred before calling sys.exit.
         if unrecognized:
             raise argparse.ArgumentError(
                 self,

--- a/certbot/plugins/standalone_test.py
+++ b/certbot/plugins/standalone_test.py
@@ -65,24 +65,10 @@ class ServerManagerTest(unittest.TestCase):
 class SupportedChallengesValidatorTest(unittest.TestCase):
     """Tests for plugins.standalone.supported_challenges_validator."""
 
-    def setUp(self):
-        self.set_by_cli_patch = mock.patch(
-            "certbot.plugins.standalone.cli.set_by_cli")
-        self.stderr_patch = mock.patch("certbot.plugins.standalone.sys.stderr")
-
-        self.set_by_cli_patch.start().return_value = True
-        self.stderr = self.stderr_patch.start()
-
-    def tearDown(self):
-        self.set_by_cli_patch.stop()
-        self.stderr_patch.stop()
-
     def _call(self, data):
         from certbot.plugins.standalone import (
             supported_challenges_validator)
         return_value = supported_challenges_validator(data)
-        self.assertTrue(self.stderr.write.called)  # pylint: disable=no-member
-        self.stderr.write.reset_mock()  # pylint: disable=no-member
         return return_value
 
     def test_correct(self):

--- a/certbot/plugins/standalone_test.py
+++ b/certbot/plugins/standalone_test.py
@@ -62,14 +62,26 @@ class ServerManagerTest(unittest.TestCase):
         self.assertEqual(self.mgr.running(), {})
 
 
-class SupportedChallengesValidatorTest(unittest.TestCase):
-    """Tests for plugins.standalone.supported_challenges_validator."""
+class SupportedChallengesActionTest(unittest.TestCase):
+    """Tests for plugins.standalone.SupportedChallengesAction."""
 
-    def _call(self, data):
-        from certbot.plugins.standalone import (
-            supported_challenges_validator)
-        return_value = supported_challenges_validator(data)
-        return return_value
+    def _call(self, value):
+        with mock.patch("certbot.plugins.standalone.logger") as mock_logger:
+            # stderr is mocked to prevent potential argparse error
+            # output from cluttering test output
+            with mock.patch("sys.stderr"):
+                config = self.parser.parse_args([self.flag, value])
+
+        self.assertTrue(mock_logger.warning.called)
+        return getattr(config, self.dest)
+
+    def setUp(self):
+        self.flag = "--standalone-supported-challenges"
+        self.dest = self.flag[2:].replace("-", "_")
+        self.parser = argparse.ArgumentParser()
+
+        from certbot.plugins.standalone import SupportedChallengesAction
+        self.parser.add_argument(self.flag, action=SupportedChallengesAction)
 
     def test_correct(self):
         self.assertEqual("tls-sni-01", self._call("tls-sni-01"))
@@ -79,10 +91,10 @@ class SupportedChallengesValidatorTest(unittest.TestCase):
 
     def test_unrecognized(self):
         assert "foo" not in challenges.Challenge.TYPES
-        self.assertRaises(argparse.ArgumentTypeError, self._call, "foo")
+        self.assertRaises(SystemExit, self._call, "foo")
 
     def test_not_subset(self):
-        self.assertRaises(argparse.ArgumentTypeError, self._call, "dns")
+        self.assertRaises(SystemExit, self._call, "dns")
 
     def test_dvsni(self):
         self.assertEqual("tls-sni-01", self._call("dvsni"))


### PR DESCRIPTION
This fixes #3987 as the call to `set_by_default` can be removed entirely. Additionally, `logger.warning` can be used rather than writing to `stderr` directly because #3184 has been resolved and we're guaranteed to having logging setup. `supported_challenges_validator` was moved to `SupportedChallengesAction` so `argparse.ArgumentError` can be easily used to provide nice error output.

The easiest way to test this is on Debian 7.0 Wheezy. After installing Certbot using our developer instructions, if you run `certbot --help all` on `master`, you'll see defaults like:
```
  --nginx-server-root NGINX_SERVER_ROOT
                        Nginx server root directory. (default:
                        <certbot.cli._Default object at 0x3c89210>)
```
If you check out this branch, the problem goes away.