### PR TITLE
Update example CloudFlare authenticator script

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -653,8 +653,8 @@ Example usage for DNS-01 (Cloudflare API v4) (for example purposes only, do not 
    API_KEY="your-api-key"
    EMAIL="your.email@example.com"
 
-   # Strip only the top domain to get the zone id
-   DOMAIN=$(expr match "$CERTBOT_DOMAIN" '.*\.\(.*\..*\)')
+   # Fetch the SOA domain for the domain/subdomain
+   DOMAIN=$(dig soa "$CERTBOT_DOMAIN" | grep -v ^\; | grep SOA | awk '{print $1}';)
 
    # Get the Cloudflare zone id
    ZONE_EXTRA_PARAMS="status=active&page=1&per_page=20&order=status&direction=desc&match=all"


### PR DESCRIPTION
This change removes the fairly broken regex for getting the zone name from the domain/subdomain. 

The example will now work with root domains such as `example.com` (previously `DOMAIN` was a blank string).

For CNAME-d subdomains where `sub.example1.com` -> `another-sub.example2.com`, a possible caveat is that`DOMAIN` will be `example2.com` not `example1.com`. It appears that `certbot` checks both domains anyway (I think?) but I believe returning the SOA domain is preferable because it's likely to be the origin host generating this type of certificate, not the person who set up the CNAME (if they are different people).