### PR TITLE
Enable unit tests on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
         - $HOME/.cache/pip
 
 before_install:
-  - 'dpkg -s libaugeas0'
+  - '[ $TRAVIS_OS_NAME == linux ] && dpkg -s libaugeas0 || brew install augeas'
 
 # using separate envs with different TOXENVs creates 4x1 Travis build
 # matrix, which allows us to clearly distinguish which component under
@@ -112,6 +112,9 @@ matrix:
       services: docker
     - python: "2.7"
       env: TOXENV=nginxroundtrip
+    - language: generic
+      env: TOXENV=py27
+      os: osx
 
 
 # Only build pushes to the master branch, PRs, and branches beginning with

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
         - $HOME/.cache/pip
 
 before_install:
-  - '[ $TRAVIS_OS_NAME == linux ] && dpkg -s libaugeas0 || brew install augeas'
+  - '[ $TRAVIS_OS_NAME == linux ] && dpkg -s libaugeas0 || brew install augeas python3'
 
 # using separate envs with different TOXENVs creates 4x1 Travis build
 # matrix, which allows us to clearly distinguish which component under
@@ -114,6 +114,9 @@ matrix:
       env: TOXENV=nginxroundtrip
     - language: generic
       env: TOXENV=py27
+      os: osx
+    - language: generic
+      env: TOXENV=py36
       os: osx
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ cache:
 before_install:
   - '[ $TRAVIS_OS_NAME == linux ] && dpkg -s libaugeas0 || brew install augeas python3'
 
+before_script:
+  - 'if [ $TRAVIS_OS_NAME = osx ] ; then ulimit -n 1024 ; fi'
+
 # using separate envs with different TOXENVs creates 4x1 Travis build
 # matrix, which allows us to clearly distinguish which component under
 # test has failed

--- a/certbot/plugins/common.py
+++ b/certbot/plugins/common.py
@@ -275,9 +275,20 @@ def setup_ssl_options(config_dir, src, dest):  # pragma: no cover
 
 def dir_setup(test_dir, pkg):  # pragma: no cover
     """Setup the directories necessary for the configurator."""
-    temp_dir = tempfile.mkdtemp("temp")
-    config_dir = tempfile.mkdtemp("config")
-    work_dir = tempfile.mkdtemp("work")
+    def expanded_tempdir(prefix):
+        """Return the real path of a temp directory with the specified prefix
+
+        Some plugins rely on real paths of symlinks for working correctly. For
+        example, certbot-apache uses real paths of configuration files to tell
+        a virtual host from another. On systems where TMP itself is a symbolic
+        link, (ex: OS X) such plugins will be confused. This function prevents
+        such a case.
+        """
+        return os.path.realpath(tempfile.mkdtemp(prefix))
+
+    temp_dir = expanded_tempdir("temp")
+    config_dir = expanded_tempdir("config")
+    work_dir = expanded_tempdir("work")
 
     os.chmod(temp_dir, constants.CONFIG_DIRS_MODE)
     os.chmod(config_dir, constants.CONFIG_DIRS_MODE)

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -427,11 +427,19 @@ def get_python_os_info():
         if info[1]:
             os_ver = info[1]
     elif os_type.startswith('darwin'):
-        os_ver = subprocess.Popen(
-            ["sw_vers", "-productVersion"],
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-        ).communicate()[0].rstrip('\n')
+        try:
+            proc = subprocess.Popen(
+                ["/usr/bin/sw_vers", "-productVersion"],
+                stdout=subprocess.PIPE,
+                universal_newlines=True,
+            )
+        except OSError:
+            proc = subprocess.Popen(
+                ["sw_vers", "-productVersion"],
+                stdout=subprocess.PIPE,
+                universal_newlines=True,
+            )
+        os_ver = proc.communicate()[0].rstrip('\n')
     elif os_type.startswith('freebsd'):
         # eg "9.3-RC3-p1"
         os_ver = os_ver.partition("-")[0]


### PR DESCRIPTION
Another try for #2978. Currently only the latest Python 2 and 3 are tested. Travis CI workers are already installed with Python 2 from Homebrew and I use a similar trick to install Python 3. As I've mentioned in #2978, testing on older Python versions requires a missing feature on the Travis CI side. It's possible to build older Python versions via third party Python version managers like pyenv, but I'm reluctant to make .travis.yml even messy.

About the mess in pip_install.sh: by default pip uses the prebuilt wheel for cryptography, which brings segmentation fault when running acme tests. Here I decide to use Homebrew to install OpenSSL and build cryptography against it. Homebrew is the recommended way to install certbot on Mac OS X, and the Homebrew team already uses [its own OpenSSL](https://github.com/Homebrew/homebrew-core/blob/master/Formula/certbot.rb#L19) to build certbot. (certbot uses openssl@1.1 while the default openssl target is still 1.0 on Homebrew - I'm not sure which I should use here) A drawback is that certbot-auto won't support MacPorts anymore. Those who prefer MacPorts need to use the certbot package from MacPorts instead.

The --no-binary flag requires pip 0.7.0. As Homebrew updates packages very fast and this flag is used on OS X only, I don't think it can be a problem.

After this PR certbot-auto should be updated to install openssl. 