### PR TITLE
Print stdout when running a hook (#4167, #4487)

### DIFF
--- a/certbot/hooks.py
+++ b/certbot/hooks.py
@@ -126,11 +126,13 @@ def execute(shell_cmd):
     cmd = Popen(shell_cmd, shell=True, stdout=PIPE,
                 stderr=PIPE, universal_newlines=True)
     out, err = cmd.communicate()
+    base_cmd = os.path.basename(shell_cmd.split(None, 1)[0])
+    if out:
+        logger.info('Output from %s:\n%s', base_cmd, out)
     if cmd.returncode != 0:
         logger.error('Hook command "%s" returned error code %d',
                      shell_cmd, cmd.returncode)
     if err:
-        base_cmd = os.path.basename(shell_cmd.split(None, 1)[0])
         logger.error('Error output from %s:\n%s', base_cmd, err)
     return (err, out)
 


### PR DESCRIPTION
I think this is expected behaviour (the two linked issue reporters, do also).
Since this is my first contribution, please tell me if I need to change something.