### PR TITLE
[#4382] Install git into Docker development file

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -67,4 +67,7 @@ RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
 # this might also help in debugging: you can "docker run --entrypoint
 # bash" and investigate, apply patches, etc.
 
+# installs git into the Docker image, as required by tox
+RUN apt-get update && apt-get install git -y
+
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -23,7 +23,7 @@ WORKDIR /opt/certbot/src
 # TODO: Install Apache/Nginx for plugin development.
 COPY letsencrypt-auto-source/letsencrypt-auto /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto
 RUN /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto --os-packages-only && \
-    apt-get install python3-dev -y && \
+    apt-get install python3-dev git -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \
            /tmp/* \
@@ -66,8 +66,5 @@ RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
 # "rm -rf /opt/certbot/src" (it's stays in the underlaying image);
 # this might also help in debugging: you can "docker run --entrypoint
 # bash" and investigate, apply patches, etc.
-
-# installs git into the Docker image, as required by tox
-RUN apt-get update && apt-get install git -y
 
 ENV PATH /opt/certbot/venv/bin:$PATH


### PR DESCRIPTION
The first command listed in the docs at https://certbot.eff.org/docs/contributing.html#running-the-client-with-docker: `docker-compose run --rm --service-ports development bash -c 'tox -e lint'`
will fail without git installed.

```sh
 ❯ docker-compose run --rm --service-ports development bash -c 'tox -e lint'   [09:39:06]
lint create: /opt/certbot/src/.tox/lint
lint installed: appdirs==1.4.3,packaging==16.8,pyparsing==2.2.0,six==1.10.0
lint runtests: PYTHONHASHSEED='0'
lint runtests: commands[0] | /opt/certbot/src/tools/pip_install.sh -q -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-dns-cloudflare -e certbot-dns-digitalocean -e certbot-dns-google -e certbot-dns-cloudxns -e certbot-compatibility-test -e letshelp-certbot
/opt/certbot/src/tools/pip_install.sh: 5: /opt/certbot/src/tools/pip_install.sh: git: not found
ERROR: InvocationError: '/opt/certbot/src/tools/pip_install.sh -q -e acme[dev] -e .[dev] -e certbot-apache -e certbot-nginx -e certbot-dns-cloudflare -e certbot-dns-digitalocean -e certbot-dns-google -e certbot-dns-cloudxns -e certbot-compatibility-test -e letshelp-certbot'
________________________________________ summary _________________________________________
ERROR:   lint: commands failed
```
I've added git to the Dockerfile-dev which addresses this. Linter runs fine now:

```sh
lint runtests: commands[1] | pylint --reports=n --rcfile=.pylintrc acme/acme certbot certbot-apache/certbot_apache certbot-nginx/certbot_nginx certbot-dns-cloudflare/certbot_dns_cloudflare certbot-dns-digitalocean/certbot_dns_digitalocean certbot-dns-google/certbot_dns_google certbot-dns-cloudxns/certbot_dns_cloudxns certbot-compatibility-test/certbot_compatibility_test letshelp-certbot/letshelp_certbot tests/lock_test.py
________________________________________ summary _________________________________________
  lint: commands succeeded
  congratulations :)
```