### PR TITLE
Fix mypy failures

### DIFF
--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
@@ -50,7 +50,7 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
 
 class DigitalOceanClientTest(unittest.TestCase):
-    id = 1
+    _id = 1
     record_prefix = "_acme-challenge"
     record_name = record_prefix + "." + DOMAIN
     record_content = "bar"
@@ -70,7 +70,7 @@ class DigitalOceanClientTest(unittest.TestCase):
 
         domain_mock = mock.MagicMock()
         domain_mock.name = DOMAIN
-        domain_mock.create_new_domain_record.return_value = {'domain_record': {'id': self.id}}
+        domain_mock.create_new_domain_record.return_value = {'domain_record': {'id': self._id}}
 
         self.manager.get_all_domains.return_value = [wrong_domain_mock, domain_mock]
 

--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
@@ -50,7 +50,7 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
 
 class DigitalOceanClientTest(unittest.TestCase):
-    _id = 1
+    id = 1  # type: ignore
     record_prefix = "_acme-challenge"
     record_name = record_prefix + "." + DOMAIN
     record_content = "bar"
@@ -70,7 +70,7 @@ class DigitalOceanClientTest(unittest.TestCase):
 
         domain_mock = mock.MagicMock()
         domain_mock.name = DOMAIN
-        domain_mock.create_new_domain_record.return_value = {'domain_record': {'id': self._id}}
+        domain_mock.create_new_domain_record.return_value = {'domain_record': {'id': self.id}}
 
         self.manager.get_all_domains.return_value = [wrong_domain_mock, domain_mock]
 

--- a/certbot/plugins/disco.py
+++ b/certbot/plugins/disco.py
@@ -13,11 +13,11 @@ from certbot import errors
 from certbot import interfaces
 
 try:
-    from collections import OrderedDict
+    from collections import OrderedDict  # type: ignore
 except ImportError:  # pragma: no cover
     # OrderedDict was added in Python 2.7
-    from ordereddict import OrderedDict  # pylint: disable=import-error
-
+    from ordereddict import OrderedDict as _OrderedDict  # pylint: disable=import-error
+    OrderedDict = _OrderedDict  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/certbot/plugins/dns_common_test.py
+++ b/certbot/plugins/dns_common_test.py
@@ -32,8 +32,8 @@ class DNSAuthenticatorTest(util.TempDirTestCase, dns_test_common.BaseAuthenticat
     class _FakeConfig(object):
         fake_propagation_seconds = 0
         fake_config_key = 1
-        fake_other_key = None
-        fake_file_path = None
+        fake_other_key = None  # type: ignore
+        fake_file_path = None  # type: ignore
 
     def setUp(self):
         super(DNSAuthenticatorTest, self).setUp()
@@ -122,7 +122,7 @@ class DNSAuthenticatorTest(util.TempDirTestCase, dns_test_common.BaseAuthenticat
 
 class CredentialsConfigurationTest(util.TempDirTestCase):
     class _MockLoggingHandler(logging.Handler):
-        messages = None
+        messages = None  # type: ignore
 
         def __init__(self, *args, **kwargs):
             self.reset()

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -23,11 +23,11 @@ from certbot import errors
 from certbot import lock
 
 try:
-    from collections import OrderedDict
+    from collections import OrderedDict  # type: ignore
 except ImportError:  # pragma: no cover
     # OrderedDict was added in Python 2.7
-    from ordereddict import OrderedDict  # pylint: disable=import-error
-
+    from ordereddict import OrderedDict  as _OrderedDict # pylint: disable=import-error
+    OrderedDict = _OrderedDict  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ _INITIAL_PID = os.getpid()
 # the dict are attempted to be cleaned up at program exit. If the
 # program exits before the lock is cleaned up, it is automatically
 # released, but the file isn't deleted.
-_LOCKS = OrderedDict()
+_LOCKS = OrderedDict()  # type: OrderedDict
 
 
 def run_script(params, log=logger.error):

--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ commands =
 [testenv:mypy]
 basepython = python3.4
 commands =
-    {[base]pip_install} mypy
+    {[base]pip_install} mypy==0.501
     {[base]pip_install} -q {[base]core_install_args} {[base]plugin_install_args} {[base]dns_plugin_install_args} {[base]lexicon_dns_plugin_install_args} {[base]compatibility_install_args} {[base]other_install_args}
     mypy --py2 --ignore-missing-imports {[base]core_paths} {[base]plugin_paths} {[base]dns_plugin_paths} {[base]lexicon_dns_plugin_paths} {[base]compatibility_paths} {[base]other_paths}
 


### PR DESCRIPTION
So I started adding mypy support as per #4244, but partway through that I noticed that mypy support was actually added in #4386, it just wasn't mentioned anywhere in #4244.

However, it seems the tox `mypy` testenv isn't actually run as part of the tox `envlist`, nor is it mentioned anywhere in `.travis.yml`... so I think it might not be run under CI at all.

In any case, when I ran `tox -e mypy`, there were a number of breakages.

This PR attempts to fix the breakages.