### PR TITLE
Domain change wording

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -260,7 +260,8 @@ def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
            "Did you intend to make this change?".format(
                certname,
                ", ".join(new_domains),
-               ", ".join(old_domains)))
+               ", ".join(old_domains),
+               br=os.linesep))
     obj = zope.component.getUtility(interfaces.IDisplay)
     if not obj.yesno(msg, "Update cert", "Cancel", default=True):
         raise errors.ConfigurationError("Specified mismatched cert name and domains.")

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -254,12 +254,13 @@ def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
     """
     if config.renew_with_new_domains:
         return
-    msg = ("Confirm that you intend to update certificate {0} "
-           "to include domains {1}. Note that it previously "
-           "contained domains {2}.".format(
+
+    msg = ("You are updating certificate {0} to include domains: {1}"
+           "It previously included domains: {2}"
+           "Did you intend to make this change?".format(
                certname,
-               new_domains,
-               old_domains))
+               ", ".join(new_domains),
+               ", ".join(old_domains)))
     obj = zope.component.getUtility(interfaces.IDisplay)
     if not obj.yesno(msg, "Update cert", "Cancel", default=True):
         raise errors.ConfigurationError("Specified mismatched cert name and domains.")

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -255,8 +255,8 @@ def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
     if config.renew_with_new_domains:
         return
 
-    msg = ("You are updating certificate {0} to include domains: {1}"
-           "It previously included domains: {2}"
+    msg = ("You are updating certificate {0} to include domains: {1}{br}{br}"
+           "It previously included domains: {2}{br}{br}"
            "Did you intend to make this change?".format(
                certname,
                ", ".join(new_domains),


### PR DESCRIPTION
Per #4192, updates the formatting of the message displayed when renewing with a different set of domains.

Contrary to the issue, I changed the formatting to be more consistent with other cases where multiple domains are displayed. It will now appear as:

```
You are updating certificate preview.example.com to include domains: preview.example.com

It previously included domains: preview.example.com, preview.example.org, www.preview.example.org, preview.example.net, refresh.example.net, test.example.net

Did you intend to make this change?
```