### PR TITLE
route53: re-use boto3 client in wait

### DIFF
--- a/certbot-route53/certbot_route53/authenticator.py
+++ b/certbot-route53/certbot_route53/authenticator.py
@@ -137,9 +137,8 @@ class Authenticator(common.Plugin):
         """Wait for a change to be propagated to all Route53 DNS servers.
            https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetChange.html
         """
-        client = boto3.client("route53")
         for n in range(0, 120):
-            response = client.get_change(Id=change_id)
+            response = self.r53.get_change(Id=change_id)
             if response["ChangeInfo"]["Status"] == "INSYNC":
                 return
             time.sleep(5)


### PR DESCRIPTION
This change re-uses the boto3 client in the wait method of the route53 authenticator in order to make it more mock-able for testing purposes.

I'm posting this change in a separate PR since I'm still learning how this class works and this refactoring may have non-obvious/unexpected side effects.

Part of #4688.