### PR TITLE
[WIP] Alternative whitelisting approach to mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.egg-info/
 .eggs/
+.mypy_cache/
 build/
 dist*/
 /venv*/

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -1,6 +1,12 @@
 """ACME errors."""
 from acme.jose import errors as jose_errors
 
+MYPY = False
+if MYPY:
+    from typing import Any, Set, Mapping  # pylint: disable=import-error, unused-import
+    from requests import Response  # pylint: disable=unused-import
+    from acme.messages import AuthorizationResource as AR  # pylint: disable=unused-import
+
 
 class Error(Exception):
     """Generic ACME error."""
@@ -29,6 +35,7 @@ class NonceError(ClientError):
 class BadNonce(NonceError):
     """Bad nonce error."""
     def __init__(self, nonce, error, *args, **kwargs):
+        # type: (str, Any, Any, Any) -> None
         super(BadNonce, self).__init__(*args, **kwargs)
         self.nonce = nonce
         self.error = error
@@ -48,6 +55,7 @@ class MissingNonce(NonceError):
 
     """
     def __init__(self, response, *args, **kwargs):
+        # type: (Response, Any, Any) -> None
         super(MissingNonce, self).__init__(*args, **kwargs)
         self.response = response
 
@@ -70,6 +78,7 @@ class PollError(ClientError):
 
     """
     def __init__(self, exhausted, updated):
+        # type: (Set[AR], Mapping[AR, AR]) -> None
         self.exhausted = exhausted
         self.updated = updated
         super(PollError, self).__init__()

--- a/acme/acme/jose/errors.py
+++ b/acme/acme/jose/errors.py
@@ -1,5 +1,8 @@
 """JOSE errors."""
 
+MYPY = False
+if MYPY:
+    from typing import Any  # pylint: disable=import-error, unused-import
 
 class Error(Exception):
     """Generic JOSE Error."""
@@ -26,6 +29,7 @@ class UnrecognizedTypeError(DeserializationError):
     """
 
     def __init__(self, typ, jobj):
+        # type: (str, Any) -> None
         self.typ = typ
         self.jobj = jobj
         super(UnrecognizedTypeError, self).__init__(str(self))

--- a/acme/acme/jose/jwa.py
+++ b/acme/acme/jose/jwa.py
@@ -28,7 +28,7 @@ class JWA(interfaces.JSONDeSerializable):  # pylint: disable=abstract-method
     """JSON Web Algorithm."""
 
 
-class JWASignature(JWA, collections.Hashable):  # type: ignore
+class JWASignature(JWA, collections.Hashable):
     """JSON Web Signature Algorithm."""
     SIGNATURES = {}  # type: dict
 

--- a/acme/acme/jose/jws.py
+++ b/acme/acme/jose/jws.py
@@ -121,7 +121,7 @@ class Header(json_util.JSONObjectWithFields):
 
     # x5c does NOT use JOSE Base64 (4.1.6)
 
-    @x5c.encoder  # type: ignore
+    @x5c.encoder
     def x5c(value):  # pylint: disable=missing-docstring,no-self-argument
         return [base64.b64encode(OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_ASN1, cert.wrapped)) for cert in value]
@@ -157,7 +157,7 @@ class Signature(json_util.JSONObjectWithFields):
         'signature', decoder=json_util.decode_b64jose,
         encoder=json_util.encode_b64jose)
 
-    @protected.encoder  # type: ignore
+    @protected.encoder
     def protected(value):  # pylint: disable=missing-docstring,no-self-argument
         # wrong type guess (Signature, not bytes) | pylint: disable=no-member
         return json_util.encode_b64jose(value.encode('utf-8'))

--- a/acme/acme/jose/util.py
+++ b/acme/acme/jose/util.py
@@ -134,7 +134,7 @@ class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods
             return hash((self.__class__, pub.n, pub.e))
 
 
-class ImmutableMap(collections.Mapping, collections.Hashable):  # type: ignore
+class ImmutableMap(collections.Mapping, collections.Hashable):
     # pylint: disable=too-few-public-methods
     """Immutable key to value mapping with attribute access."""
 
@@ -180,7 +180,7 @@ class ImmutableMap(collections.Mapping, collections.Hashable):  # type: ignore
             for key, value in six.iteritems(self)))
 
 
-class frozendict(collections.Mapping, collections.Hashable):  # type: ignore
+class frozendict(collections.Mapping, collections.Hashable):
     # pylint: disable=invalid-name,too-few-public-methods
     """Frozen dictionary."""
     __slots__ = ('_items', '_keys')

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -98,7 +98,7 @@ class Error(jose.JSONObjectWithFields, errors.Error):
             if part is not None)
 
 
-class _Constant(jose.JSONDeSerializable, collections.Hashable):  # type: ignore
+class _Constant(jose.JSONDeSerializable, collections.Hashable):
     """ACME constant."""
     __slots__ = ('name',)
     POSSIBLE_NAMES = NotImplemented

--- a/mypy-files.txt
+++ b/mypy-files.txt
@@ -1,0 +1,4 @@
+acme/acme/jose/errors.py
+acme/acme/jose/errors_test.py
+acme/acme/errors.py
+acme/acme/errors_test.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+
+python_version = 2.7
+mypy_path = mypy-stubs
+strict_optional = True
+check_untyped_defs = True
+warn_incomplete_stub = True
+warn_unused_ignores = True
+disallow_untyped_defs = False
+disallow_untyped_calls = True
+follow_imports = silent
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 skipsdist = true
-envlist = modification,py{26,33,34,35,36},cover,lint
+envlist = modification,py{26,33,34,35,36},cover,lint,mypy
 
 # nosetest -v => more verbose output, allows to detect busy waiting
 # loops, especially on Travis
@@ -115,9 +115,9 @@ commands =
 [testenv:mypy]
 basepython = python3.4
 commands =
-    {[base]pip_install} mypy
+    {[base]pip_install} mypy==0.511
     {[base]pip_install} -q {[base]core_install_args} {[base]plugin_install_args} {[base]dns_plugin_install_args} {[base]lexicon_dns_plugin_install_args} {[base]compatibility_install_args} {[base]other_install_args}
-    mypy --py2 --ignore-missing-imports {[base]core_paths} {[base]plugin_paths} {[base]dns_plugin_paths} {[base]lexicon_dns_plugin_paths} {[base]compatibility_paths} {[base]other_paths}
+    mypy @mypy-files.txt
 
 [testenv:apacheconftest]
 #basepython = python2.7


### PR DESCRIPTION
This is an alternative approach to #4244 that attempts to incrementally add mypy typings over time by only running mypy on files specified in a whitelist, as described in https://github.com/certbot/certbot/issues/4244#issuecomment-303418574.

It also adds mypy to tox's default `testenv`, so that it's run on travis.

To do:
- [ ] Document how to add new files to the whitelist.
- [ ] Determine if the settings in `mypy.ini` ware acceptable.
