### PR TITLE
route53: update setup.py to follow repo conventions

### DIFF
--- a/certbot-route53/setup.py
+++ b/certbot-route53/setup.py
@@ -20,7 +20,6 @@ setup(
     name='certbot-route53',
     version=version,
     description="Route53 DNS Authenticator plugin for Certbot",
-    url='https://github.com/lifeonmarspt/certbot-route53',
     url='https://github.com/certbot/certbot',
     author="Certbot Project",
     author_email='client-dev@letsencrypt.org',

--- a/certbot-route53/setup.py
+++ b/certbot-route53/setup.py
@@ -3,23 +3,28 @@ import sys
 from distutils.core import setup
 from setuptools import find_packages
 
-version = '0.1.5'
+version = '0.15.0.dev0'
 
 install_requires = [
-    'acme>=0.9.0',
-    'certbot>=0.9.0',
-    'zope.interface',
+    'acme=={0}'.format(version),
+    'certbot=={0}'.format(version),
     'boto3',
+    'mock',
+    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
+    # will tolerate; see #2599:
+    'setuptools>=1.0',
+    'zope.interface',
 ]
 
 setup(
     name='certbot-route53',
     version=version,
-    description="Route53 plugin for certbot",
+    description="Route53 DNS Authenticator plugin for Certbot",
     url='https://github.com/lifeonmarspt/certbot-route53',
-    author="Hugo Peixoto",
-    author_email='hugo@lifeonmars.pt',
-    license='Apache2.0',
+    url='https://github.com/certbot/certbot',
+    author="Certbot Project",
+    author_email='client-dev@letsencrypt.org',
+    license='Apache License 2.0',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Plugins',
@@ -28,7 +33,13 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Security',
         'Topic :: System :: Installation/Setup',
@@ -37,6 +48,7 @@ setup(
         'Topic :: Utilities',
     ],
     packages=find_packages(),
+    include_package_data=True,
     install_requires=install_requires,
     keywords=['certbot', 'route53', 'aws'],
     entry_points={
@@ -44,4 +56,5 @@ setup(
             'auth = certbot_route53.authenticator:Authenticator'
         ],
     },
+    test_suite='certbot_route53',
 )


### PR DESCRIPTION
This change updates the setup script for the route53 plugin to more closely match conventions from other packages in the repository.

Notable changes:
 * The version number is bumped to match the rest of Certbot.
 * The package now requires a matching version of ACME and core Certbot.
 * Contact information is updated.
 * Additional versions of Python are listed.

Part of #4688.