### PR TITLE
Fixes #4719

### DIFF
--- a/certbot/log.py
+++ b/certbot/log.py
@@ -320,6 +320,10 @@ def pre_arg_parse_except_hook(memory_handler, *args, **kwargs):
     command line argument was invalid or -h, --help, or --version was
     provided on the command line.
 
+    :param MemoryHandler memory_handler: memory handler to flush
+    :param tuple args: args for post_arg_parse_except_hook
+    :param dict kwargs: kwargs for post_arg_parse_except_hook
+
     """
     try:
         post_arg_parse_except_hook(*args, **kwargs)

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -209,6 +209,17 @@ class MemoryHandler(logging.handlers.MemoryHandler):
         else:
             super(MemoryHandler, self).__init__(capacity, target=target)
 
+    def close(self):
+        """Close the memory handler, but don't set the target to None."""
+        # This allows the logging module which may only have a weak
+        # reference to the target handler to properly flush and close it.
+        target = self.target
+        if sys.version_info < (2, 7):  # pragma: no cover
+            logging.handlers.MemoryHandler.close(self)
+        else:
+            super(MemoryHandler, self).close()
+        self.target = target
+
     def flush(self, force=False):  # pylint: disable=arguments-differ
         """Flush the buffer if force=True.
 

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -203,12 +203,13 @@ class MemoryHandlerTest(unittest.TestCase):
 
     def test_flush(self):
         self._test_log_debug()
-        self.handler.flush()
+        self.handler.flush(force=True)
         self.assertEqual(self.stream.getvalue(), self.msg + '\n')
 
     def test_not_flushed(self):
         # By default, logging.ERROR messages and higher are flushed
         self.logger.critical(self.msg)
+        self.handler.flush()
         self.assertEqual(self.stream.getvalue(), '')
 
     def test_target_reset(self):
@@ -217,7 +218,7 @@ class MemoryHandlerTest(unittest.TestCase):
         new_stream = six.StringIO()
         new_stream_handler = logging.StreamHandler(new_stream)
         self.handler.setTarget(new_stream_handler)
-        self.handler.flush()
+        self.handler.flush(force=True)
         self.assertEqual(self.stream.getvalue(), '')
         self.assertEqual(new_stream.getvalue(), self.msg + '\n')
         new_stream_handler.close()

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -234,21 +234,19 @@ class TempHandlerTest(unittest.TestCase):
         self.handler = TempHandler()
 
     def tearDown(self):
-        if not self.closed:
-            self.handler.delete_and_close()
+        self.handler.close()
 
     def test_permissions(self):
         self.assertTrue(
             util.check_permissions(self.handler.path, 0o600, os.getuid()))
 
     def test_delete(self):
-        self.handler.delete_and_close()
-        self.closed = True
+        self.handler.close()
         self.assertFalse(os.path.exists(self.handler.path))
 
     def test_no_delete(self):
+        self.handler.emit(mock.MagicMock())
         self.handler.close()
-        self.closed = True
         self.assertTrue(os.path.exists(self.handler.path))
         os.remove(self.handler.path)
 


### PR DESCRIPTION
In #4446, we fixed issues with errors and dropped logging messages caused by parts of Certbot code trying to log messages before logging was fully configured. The reason we can't configure logging right away is we need to parse command line arguments to determine how logging should be set up.

The way we fixed this is we buffered messages in memory and once logging was setup, we sent them to our normal file handler. If for some reason we crashed before these file handlers were created, we sent them to a temporary log file as to not lose these messages.

The problem with this was if the user provided an invalid command line argument, `-h/--help`, or `--version` on the command line, Certbot would exit before logging was fully configured, create this temporary file, and not even tell them about it.

Not telling the user about it is a bug, but creating a temporary log file in these instances seems excessive. This is especially a problem for `certbot-auto` which runs `certbot --version` to determine if we needed to upgrade Certbot. This meant that for every run of `certbot-auto` a temporary file was created. This PR fixes the problem.

Note: See #4738 for a problem not fixed by this PR.