### PR TITLE
Handle releasing subpackages not included in certbot-auto

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -44,9 +44,14 @@ export GPG_TTY=$(tty)
 # port for a local Python Package Index (used in testing)
 PORT=${PORT:-1234}
 
-# subpackages to be released
-SUBPKGS_NO_CERTBOT="acme certbot-apache certbot-nginx"
-SUBPKGS="certbot $SUBPKGS_NO_CERTBOT"
+# subpackages to be released (the way developers think about them)
+SUBPKGS_IN_AUTO_NO_CERTBOT="acme certbot-apache certbot-nginx"
+SUBPKGS_NOT_IN_AUTO="certbot-dns-cloudxns certbot-dns-dnsimple certbot-dns-nsone"
+
+# subpackages to be released (the way the script thinks about them)
+SUBPKGS_IN_AUTO="certbot $SUBPKGS_IN_AUTO_NO_CERTBOT"
+SUBPKGS_NO_CERTBOT="$SUBPKGS_IN_AUTO_NO_CERTBOT $SUBPKGS_NOT_IN_AUTO"
+SUBPKGS="$SUBPKGS_IN_AUTO $SUBPKGS_NOT_IN_AUTO"
 subpkgs_modules="$(echo $SUBPKGS | sed s/-/_/g)"
 # certbot_compatibility_test is not packaged because:
 # - it is not meant to be used by anyone else than Certbot devs
@@ -169,14 +174,14 @@ done
 cd ~-
 
 # pin pip hashes of the things we just built
-for pkg in $SUBPKGS ; do
+for pkg in $SUBPKGS_IN_AUTO ; do
     echo $pkg==$version \\
     pip hash dist."$version/$pkg"/*.{whl,gz} | grep "^--hash" | python2 -c 'from sys import stdin; input = stdin.read(); print "   ", input.replace("\n--hash", " \\\n    --hash"),'
 done > letsencrypt-auto-source/pieces/certbot-requirements.txt
 deactivate
 
 # there should be one requirement specifier and two hashes for each subpackage
-expected_count=$(expr $(echo $SUBPKGS | wc -w) \* 3)
+expected_count=$(expr $(echo $SUBPKGS_IN_AUTO | wc -w) \* 3)
 if ! wc -l letsencrypt-auto-source/pieces/certbot-requirements.txt | grep -qE "^\s*$expected_count " ; then
     echo Unexpected pip hash output
     exit 1


### PR DESCRIPTION
This change refactors the release script to handle subpackages which are not bundled as a part of cerbot-auto.

The script now allows developers to define subpackages as either being included in certbot-auto, or not.

The script then uses one of three sets of subpackages for each operation:
 * The version number is updated for all non-certbot subpackages (and certbot itself is handled separately)
 * sdists and wheels are created for all non-certbot subpackages (and certbot itself is handled separately)
 * Testing is performed for all subpackages
 * Hashes are pinned for certbot-auto subpackages (including certbot itself)