### PR TITLE
Improve bad preferred challenge error message

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1295,7 +1295,7 @@ class _PrefChallAction(argparse.Action):
         try:
             challs = parse_preferred_challenges(pref_challs.split(","))
         except errors.Error as error:
-            raise argparse.ArgumentTypeError(str(error))
+            raise argparse.ArgumentError(self, str(error))
         namespace.pref_challs.extend(challs)
 
 

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -211,7 +211,10 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(namespace.pref_challs, expected)
 
         short_args = ['--preferred-challenges', 'jumping-over-the-moon']
-        self.assertRaises(argparse.ArgumentTypeError, self.parse, short_args)
+        # argparse.ArgumentError makes argparse print more information
+        # to stderr and call sys.exit()
+        with mock.patch('sys.stderr'):
+            self.assertRaises(SystemExit, self.parse, short_args)
 
     def test_server_flag(self):
         namespace = self.parse('--server example.com'.split())


### PR DESCRIPTION
Using ArgumentTypeError causes Certbot to report an unexpected error occurred while using ArgumentError causes argparse to print more usage information and call sys.exit().