### PR TITLE
Remove reference to .new in Nginx's SSL options

### DIFF
--- a/certbot-nginx/certbot_nginx/constants.py
+++ b/certbot-nginx/certbot_nginx/constants.py
@@ -27,6 +27,7 @@ ALL_SSL_OPTIONS_HASHES = [
     'a6d9f1c7d6b36749b52ba061fff1421f9a0a3d2cfdafbd63c05d06f65b990937',
     '7f95624dd95cf5afc708b9f967ee83a24b8025dc7c8d9df2b556bbc64256b3ff',
     '394732f2bbe3e5e637c3fb5c6e980a1f1b90b01e2e8d6b7cff41dde16e2a756d',
+    '4b16fec2bcbcd8a2f3296d886f17f9953ffdcc0af54582452ca1e52f5f776f16',
 ]
 """SHA256 hashes of the contents of all versions of MOD_SSL_CONF_SRC"""
 

--- a/certbot-nginx/certbot_nginx/options-ssl-nginx.conf
+++ b/certbot-nginx/certbot_nginx/options-ssl-nginx.conf
@@ -1,7 +1,8 @@
-# This file contains important security parameters. If you modify this file manually,
-# Certbot will be unable to automatically provide future security updates.
-# Instead, you will need to manually update this file by referencing the contents of
-# options-ssl-nginx.conf.new.
+# This file contains important security parameters. If you modify this file
+# manually, Certbot will be unable to automatically provide future security
+# updates. Instead, Certbot will print and log an error message with a path to
+# the up-to-date file that you will need to refer to when manually updating
+# this file.
 
 ssl_session_cache shared:le_nginx_SSL:1m;
 ssl_session_timeout 1440m;


### PR DESCRIPTION
There's a hash in `constants.py` that we never shipped, but I think we should leave it in for the [brave](https://aur.archlinux.org/packages/certbot-git/) [people](https://gitweb.gentoo.org/repo/gentoo.git/tree/app-crypt/certbot/certbot-9999.ebuild) running Certbot from `master`.