### PR TITLE
Remove dependency on git from pip_install.sh.

### DIFF
--- a/tools/pip_install.sh
+++ b/tools/pip_install.sh
@@ -2,7 +2,8 @@
 # pip installs packages using Certbot's requirements file as constraints
 
 # get the root of the Certbot repo
-repo_root=$(dirname $(dirname $(readlink -f $0)))
+my_path=$("$(dirname $0)/readlink.py" $0)
+repo_root=$(dirname $(dirname $my_path))
 requirements="$repo_root/letsencrypt-auto-source/pieces/dependency-requirements.txt"
 constraints=$(mktemp)
 trap "rm -f $constraints" EXIT

--- a/tools/pip_install.sh
+++ b/tools/pip_install.sh
@@ -2,7 +2,7 @@
 # pip installs packages using Certbot's requirements file as constraints
 
 # get the root of the Certbot repo
-repo_root=$(git rev-parse --show-toplevel)
+repo_root=$(dirname $(dirname $(readlink -f $0)))
 requirements="$repo_root/letsencrypt-auto-source/pieces/dependency-requirements.txt"
 constraints=$(mktemp)
 trap "rm -f $constraints" EXIT

--- a/tools/readlink.py
+++ b/tools/readlink.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""Canonicalizes a path and follows any symlinks.
+
+This is the equivalent of `readlink -f` on many Linux systems. This is
+useful as there are often differences in readlink on different
+platforms.
+
+"""
+from __future__ import print_function
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))


### PR DESCRIPTION
Using git allowed this file to continue to work even if it was moved to another
directory. This slight increase in robustness wasn't worth it though as it
broke our development Dockerfile (see #4703), the certbot website's Dockerfile
(see certbot/website#226), and our test farm tests (see
certbot/tests/letstest/scripts/test_apache2.sh for an example that calls
tools/venv.sh without installing git). Rather than continuing to find and patch
these things, let's just allow this script to fail if it's moved rather than
propagating the git dependency all over the place.