### PR TITLE
route53: make sleep duration configurable like other DNS authenticators

### DIFF
--- a/certbot-route53/certbot_route53/authenticator.py
+++ b/certbot-route53/certbot_route53/authenticator.py
@@ -26,7 +26,9 @@ class Authenticator(dns_common.DNSAuthenticator):
     Route53.
     """
 
-    description = "Obtain certificates using a DNS TXT record (if you are using AWS Route53 for DNS)."
+    description = ("Obtain certificates using a DNS TXT record (if you are using AWS Route53 for "
+                   "DNS).")
+    ttl = 10
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)

--- a/certbot-route53/certbot_route53/authenticator.py
+++ b/certbot-route53/certbot_route53/authenticator.py
@@ -12,8 +12,6 @@ from certbot.plugins import dns_common
 
 logger = logging.getLogger(__name__)
 
-TTL = 10
-
 INSTRUCTIONS = (
     "To use certbot-route53, configure credentials as described at "
     "https://boto3.readthedocs.io/en/latest/guide/configuration.html#best-practices-for-configuring-credentials "  # pylint: disable=line-too-long
@@ -27,7 +25,8 @@ class Authenticator(dns_common.DNSAuthenticator):
     This authenticator solves a DNS01 challenge by uploading the answer to AWS
     Route53.
     """
-    description = "Obtain certs using a DNS TXT record (if you are using AWS Route53 for DNS)."
+
+    description = "Obtain certificates using a DNS TXT record (if you are using AWS Route53 for DNS)."
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)
@@ -97,7 +96,7 @@ class Authenticator(dns_common.DNSAuthenticator):
                         "ResourceRecordSet": {
                             "Name": validation_domain_name,
                             "Type": "TXT",
-                            "TTL": TTL,
+                            "TTL": self.ttl,
                             "ResourceRecords": [
                                 # For some reason TXT records need to be
                                 # manually quoted.

--- a/certbot-route53/certbot_route53/authenticator.py
+++ b/certbot-route53/certbot_route53/authenticator.py
@@ -4,12 +4,11 @@ import time
 
 import boto3
 import zope.interface
-from acme import challenges
 from botocore.exceptions import NoCredentialsError, ClientError
 
 from certbot import errors
 from certbot import interfaces
-from certbot.plugins import common
+from certbot.plugins import dns_common
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ INSTRUCTIONS = (
 
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
-class Authenticator(common.Plugin):
+class Authenticator(dns_common.DNSAuthenticator):
     """Route53 Authenticator
 
     This authenticator solves a DNS01 challenge by uploading the answer to AWS
@@ -34,42 +33,26 @@ class Authenticator(common.Plugin):
         super(Authenticator, self).__init__(*args, **kwargs)
         self.r53 = boto3.client("route53")
 
-    def prepare(self):  # pylint: disable=missing-docstring,no-self-use
-        pass  # pragma: no cover
-
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
         return "Solve a DNS01 challenge using AWS Route53"
 
-    def get_chall_pref(self, domain):
-        # pylint: disable=missing-docstring,no-self-use,unused-argument
-        return [challenges.DNS01]
+    def _setup_credentials(self):
+        pass
 
-    def perform(self, achalls):  # pylint: disable=missing-docstring
-        responses = []
-        for achall in achalls:
-            try:
-                change_id = self._change_txt_record("UPSERT", achall)
+    def _perform(self, domain, validation_domain_name, validation):
+        try:
+            change_id = self._change_txt_record("UPSERT", validation_domain_name, validation)
 
-                self._wait_for_change(change_id)
-            except (NoCredentialsError, ClientError) as e:
-                logger.debug('Encountered error during perform: %s', e, exc_info=True)
-                raise errors.PluginError("\n".join([str(e), INSTRUCTIONS]))
+            self._wait_for_change(change_id)
+        except (NoCredentialsError, ClientError) as e:
+            logger.debug('Encountered error during perform: %s', e, exc_info=True)
+            raise errors.PluginError("\n".join([str(e), INSTRUCTIONS]))
 
-            responses.append(achall.response(achall.account_key))
-
-        # Sleep for at least the TTL, to ensure that any records cached by
-        # the ACME server after previous validation attempts are gone. In
-        # most cases we'll need to wait at least this long for the Route53
-        # records to propagate, so this doesn't delay us much.
-        time.sleep(TTL)
-        return responses
-
-    def cleanup(self, achalls):  # pylint: disable=missing-docstring
-        for achall in achalls:
-            try:
-                self._change_txt_record("DELETE", achall)
-            except (NoCredentialsError, ClientError) as e:
-                logger.debug('Encountered error during cleanup: %s', e, exc_info=True)
+    def _cleanup(self, domain, validation_domain_name, validation):
+        try:
+            self._change_txt_record("DELETE", validation_domain_name, validation)
+        except (NoCredentialsError, ClientError) as e:
+            logger.debug('Encountered error during cleanup: %s', e, exc_info=True)
 
     def _find_zone_id_for_domain(self, domain):
         """Find the zone id responsible a given FQDN.
@@ -101,11 +84,8 @@ class Authenticator(common.Plugin):
         zones.sort(key=lambda z: len(z[0]), reverse=True)
         return zones[0][1]
 
-    def _change_txt_record(self, action, achall):
-        domain = achall.validation_domain_name(achall.domain)
-        value = achall.validation(achall.account_key)
-
-        zone_id = self._find_zone_id_for_domain(domain)
+    def _change_txt_record(self, action, validation_domain_name, validation):
+        zone_id = self._find_zone_id_for_domain(validation_domain_name)
 
         response = self.r53.change_resource_record_sets(
             HostedZoneId=zone_id,
@@ -115,13 +95,13 @@ class Authenticator(common.Plugin):
                     {
                         "Action": action,
                         "ResourceRecordSet": {
-                            "Name": domain,
+                            "Name": validation_domain_name,
                             "Type": "TXT",
                             "TTL": TTL,
                             "ResourceRecords": [
                                 # For some reason TXT records need to be
                                 # manually quoted.
-                                {"Value": '"{0}"'.format(value)}
+                                {"Value": '"{0}"'.format(validation)}
                             ],
                         }
                     }


### PR DESCRIPTION
This series of commits (which can be squashed, but are separated to allow for easier review) refactors the Route 53 plugin to use `dns_common` and makes its sleep duration configurable, for consistency with other DNS authenticators.

Part of #4688.