### PR TITLE
Handle releasing of DNS subpackages not yet included in certbot-auto

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -46,7 +46,7 @@ PORT=${PORT:-1234}
 
 # subpackages to be released (the way developers think about them)
 SUBPKGS_IN_AUTO_NO_CERTBOT="acme certbot-apache certbot-nginx"
-SUBPKGS_NOT_IN_AUTO="certbot-dns-cloudxns certbot-dns-dnsimple certbot-dns-nsone"
+SUBPKGS_NOT_IN_AUTO="certbot-dns-cloudflare certbot-dns-cloudxns certbot-dns-digitalocean certbot-dns-dnsimple certbot-dns-google certbot-dns-nsone certbot-dns-route53"
 
 # subpackages to be released (the way the script thinks about them)
 SUBPKGS_IN_AUTO="certbot $SUBPKGS_IN_AUTO_NO_CERTBOT"


### PR DESCRIPTION
Add the DNS subpackages being considered for future inclusion in certbot-auto as non-certbot-auto packages for the 0.15.0 release.