### PR TITLE
Remove unused readlink environment variable

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -13,12 +13,6 @@ set -eux
 . ./tests/integration/_common.sh
 export PATH="$PATH:/usr/sbin"  # /usr/sbin/nginx
 
-if [ `uname` = "Darwin" ];then
-  readlink="greadlink"
-else
-  readlink="readlink"
-fi
-
 cleanup_and_exit() {
     EXIT_STATUS=$?
     if SERVER_STILL_RUNNING=`ps -p $python_server_pid -o pid=`


### PR DESCRIPTION
The program readlink used to be used in integration tests so an environment variable was used to handle differences in the executable on different systems. This command is no longer used though so the variable can be removed.