### PR TITLE
Use certificate instead of cert in DNS plugin descriptions

### DIFF
--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/dns_cloudflare.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/dns_cloudflare.py
@@ -21,7 +21,8 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the Cloudflare API to fulfill a dns-01 challenge.
     """
 
-    description = 'Obtain certs using a DNS TXT record (if you are using Cloudflare for DNS).'
+    description = ('Obtain certificates using a DNS TXT record (if you are using Cloudflare for '
+                   'DNS).')
     ttl = 120
 
     def __init__(self, *args, **kwargs):

--- a/certbot-dns-cloudxns/certbot_dns_cloudxns/dns_cloudxns.py
+++ b/certbot-dns-cloudxns/certbot_dns_cloudxns/dns_cloudxns.py
@@ -22,7 +22,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the CloudXNS DNS API to fulfill a dns-01 challenge.
     """
 
-    description = 'Obtain certs using a DNS TXT record (if you are using CloudXNS for DNS).'
+    description = 'Obtain certificates using a DNS TXT record (if you are using CloudXNS for DNS).'
     ttl = 60
 
     def __init__(self, *args, **kwargs):

--- a/certbot-dns-dnsimple/certbot_dns_dnsimple/dns_dnsimple.py
+++ b/certbot-dns-dnsimple/certbot_dns_dnsimple/dns_dnsimple.py
@@ -22,7 +22,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the DNSimple v2 API to fulfill a dns-01 challenge.
     """
 
-    description = 'Obtain certs using a DNS TXT record (if you are using DNSimple for DNS).'
+    description = 'Obtain certificates using a DNS TXT record (if you are using DNSimple for DNS).'
     ttl = 60
 
     def __init__(self, *args, **kwargs):

--- a/certbot-dns-google/certbot_dns_google/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google.py
@@ -25,7 +25,8 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the Google Cloud DNS API to fulfill a dns-01 challenge.
     """
 
-    description = 'Obtain certs using a DNS TXT record (if you are using Google Cloud DNS for DNS).'
+    description = ('Obtain certificates using a DNS TXT record (if you are using Google Cloud DNS '
+                   'for DNS).')
     ttl = 60
 
     def __init__(self, *args, **kwargs):

--- a/certbot-dns-nsone/certbot_dns_nsone/dns_nsone.py
+++ b/certbot-dns-nsone/certbot_dns_nsone/dns_nsone.py
@@ -22,7 +22,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the NS1 API to fulfill a dns-01 challenge.
     """
 
-    description = 'Obtain certs using a DNS TXT record (if you are using NS1 for DNS).'
+    description = 'Obtain certificates using a DNS TXT record (if you are using NS1 for DNS).'
     ttl = 60
 
     def __init__(self, *args, **kwargs):

--- a/certbot-route53/certbot_route53/authenticator.py
+++ b/certbot-route53/certbot_route53/authenticator.py
@@ -28,7 +28,7 @@ class Authenticator(common.Plugin):
     This authenticator solves a DNS01 challenge by uploading the answer to AWS
     Route53.
     """
-    description = "Obtain certs using a DNS TXT record (if you are using AWS Route53 for DNS)."
+    description = "Obtain certificates using a DNS TXT record (if you are using AWS Route53 for DNS)."
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)


### PR DESCRIPTION
As #4783, but for descriptions.