### PR TITLE
Fix test_apache2.sh test farm test

### DIFF
--- a/tests/letstest/scripts/test_apache2.sh
+++ b/tests/letstest/scripts/test_apache2.sh
@@ -45,7 +45,7 @@ if [ $? -ne 0 ] ; then
     exit 1
 fi
 
-tools/venv.sh
+tools/_venv_common.sh -e acme[dev] -e .[dev,docs] -e certbot-apache
 sudo venv/bin/certbot -v --debug --text --agree-dev-preview --agree-tos \
                    --renew-by-default --redirect --register-unsafely-without-email \
                    --domain $PUBLIC_HOSTNAME --server $BOULDER_URL


### PR DESCRIPTION
`tools/venv.sh` cannot be used as the tests run on systems with Python 2.6 and `tools/venv.sh` installs code that is not compatible with Python 2.6.

With this change, all the test farm tests we actually run should pass. I'd like this change for 0.15.0 to stop me from making the same change locally to successfully run tests.