### PR TITLE
Check domains for accidental inclusion of a scheme

### DIFF
--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -420,6 +420,13 @@ class EnforceLeValidity(unittest.TestCase):
     def test_valid_domain(self):
         self.assertEqual(self._call(u"example.com"), u"example.com")
 
+    def test_input_with_scheme(self):
+        self.assertRaises(errors.ConfigurationError, self._call, u"http://example.com")
+        self.assertRaises(errors.ConfigurationError, self._call, u"https://example.com")
+
+    def test_valid_input_with_scheme_name(self):
+        self.assertEqual(self._call(u"http.example.com"), u"http.example.com")
+
 
 class EnforceDomainSanityTest(unittest.TestCase):
     """Test enforce_domain_sanity."""

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -568,6 +568,17 @@ def enforce_domain_sanity(domain):
     # Remove trailing dot
     domain = domain[:-1] if domain.endswith(u'.') else domain
 
+    # Separately check for odd "domains" like "http://example.com" to fail
+    # fast and provide a clear error message
+    for scheme in ["http", "https"]:  # Other schemes seem unlikely
+        if domain.startswith("{0}://".format(scheme)):
+            raise errors.ConfigurationError(
+                "Requested name {0} appears to be a URL, not a FQDN. "
+                "Try again without the leading \"{1}://\".".format(
+                    domain, scheme
+                )
+            )
+
     # Explain separately that IP addresses aren't allowed (apart from not
     # being FQDNs) because hope springs eternal concerning this point
     try:


### PR DESCRIPTION
Currently, accidentally including a scheme with the domain name does not produce a particularly helpful error message.

Examples without this change:
1. `certbot certonly -d https://test.example.com --webroot`:

Saving debug log to /tmp/certbot/logs/letsencrypt.log
Obtaining a new certificate
An unexpected error occurred:
The request message was malformed :: Error creating new authz :: Invalid character in DNS name
Please see the logfiles in /tmp/certbot/logs for more details.

2. `certbot certonly -d http://hoeveelmensengaveneeneuroomtezienhoeveelmenseneeneurogaven.example.com`

Requested domain http://hoeveelmensengaveneeneuroomtezienhoeveelmenseneeneurogaven.example.com is not a FQDN because label http://hoeveelmensengaveneeneuroomtezienhoeveelmenseneeneurogaven is too long.

Examples with this change:
1. `certbot certonly -d https://test.example.com --webroot`:

Requested name https://test.example.com appears to be a URL, not a FQDN. Try again without the leading "https://".

2. `certbot certonly -d http://hoeveelmensengaveneeneuroomtezienhoeveelmenseneeneurogaven.example.com`

Requested name http://hoeveelmensengaveneeneuroomtezienhoeveelmenseneeneurogaven.example.com appears to be a URL, not a FQDN. Try again without the leading "http://".

(Resolves #4785)