### PR TITLE
route53: avoid listing the plugin twice in the UI

### DIFF
--- a/certbot-dns-route53/certbot_dns_route53/authenticator.py
+++ b/certbot-dns-route53/certbot_dns_route53/authenticator.py
@@ -1,11 +1,19 @@
 """Shim around `~certbot_dns_route53.dns_route53` for backwards compatibility."""
 import warnings
 
+import zope.interface
+
+from certbot import interfaces
 from certbot_dns_route53 import dns_route53
 
 
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_route53.Authenticator):
     """Shim around `~certbot_dns_route53.dns_route53.Authenticator` for backwards compatibility."""
+
+    hidden = True
+
     def __init__(self, *args, **kwargs):
         warnings.warn("The 'authenticator' module was renamed 'dns_route53'",
                       DeprecationWarning)

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -53,7 +53,7 @@ setup(
     entry_points={
         'certbot.plugins': [
             'dns-route53 = certbot_dns_route53.dns_route53:Authenticator',
-            'certbot-route53:auth = certbot_dns_route53.dns_route53:Authenticator'
+            'certbot-route53:auth = certbot_dns_route53.authenticator:Authenticator'
         ],
     },
     test_suite='certbot_dns_route53',


### PR DESCRIPTION
Without this change, the Route53 plugin is listed twice when running
Certbot interactively (once under the old name, once under the new name).

This change ensures only the new name is shown, while maintaining hidden
backwards compatibility with the old name.