### PR TITLE
Provide basic DNS authenticator documentation

### DIFF
--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -1,17 +1,35 @@
-"""Cloudflare DNS Authenticator
+"""
+The `~certbot_dns_cloudflare.dns_cloudflare` plugin automates the process of
+completing a `dns-01` challenge (`~acme.challenges.DNS01`) using the Cloudflare
+API.
 
-This plugin automates the process of completing a dns-01 challenge
-(`~acme.challenges.DNS01`) using the Cloudflare API.
+
+Credentials
+-----------
 
 Use of this plugin requires a configuration file containing Cloudflare API
 credentials, obtained from your Cloudflare
 `account page <https://www.cloudflare.com/a/account/my-account>`_.
 
-Example:
-
 .. code-block:: ini
+   :name: credentials.ini
+   :caption: Example credentials file:
 
-  dns_cloudflare_email = cloudflare@example.com
-  dns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234567
+   # Cloudflare API credentials used by Certbot
+   dns_cloudflare_email = cloudflare@example.com
+   dns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234567
+
+The path to this file can be provided interactively or using the
+`--dns-cloudflare-credentials` command-line argument. Certbot records the path
+to this file for use during renewal, but does not store the file's contents.
+
+.. caution::
+   You should protect these API credentials as you would the password to your
+   Cloudflare account. Users who can read this file can use these credentials
+   to issue API calls on your behalf. Users who can cause Certbot to run using
+   these credentials can complete a `dns-01` challenge to acquire new
+   certificates or revoke existing certificates for associated domains.
+
+
 
 """

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -4,6 +4,20 @@ completing a `dns-01` challenge (`~acme.challenges.DNS01`) using the Cloudflare
 API.
 
 
+Named Arguments
+---------------
+
+======================================  =======  ==============================
+Argument                                Default  Description
+======================================  =======  ==============================
+`--dns-cloudflare-credentials`          None     Cloudflare credentials INI
+                                                 file. (See Credentials_.)
+`--dns-cloudflare-propagation-seconds`  10       The number of seconds to wait
+                                                 for DNS to propagate before
+                                                 asking the ACME server to
+                                                 verify the DNS record.
+======================================  =======  ==============================
+
 Credentials
 -----------
 

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -1,7 +1,7 @@
 """
 The `~certbot_dns_cloudflare.dns_cloudflare` plugin automates the process of
-completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) using the
-Cloudflare API.
+completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) by creating, and
+subsequently removing, TXT records using the Cloudflare API.
 
 
 Named Arguments
@@ -38,9 +38,10 @@ to this file for use during renewal, but does not store the file's contents.
 .. caution::
    You should protect these API credentials as you would the password to your
    Cloudflare account. Users who can read this file can use these credentials
-   to issue API calls on your behalf. Users who can cause Certbot to run using
-   these credentials can complete a ``dns-01`` challenge to acquire new
-   certificates or revoke existing certificates for associated domains.
+   to issue arbitrary API calls on your behalf. Users who can cause Certbot to
+   run using these credentials can complete a ``dns-01`` challenge to acquire
+   new certificates or revoke existing certificates for associated domains,
+   even if those domains aren't being managed by this server.
 
 Examples
 --------

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -16,6 +16,7 @@ Named Arguments
                                           (Default: 10)
 ========================================  =====================================
 
+
 Credentials
 -----------
 
@@ -42,6 +43,14 @@ to this file for use during renewal, but does not store the file's contents.
    run using these credentials can complete a ``dns-01`` challenge to acquire
    new certificates or revoke existing certificates for associated domains,
    even if those domains aren't being managed by this server.
+
+Certbot will emit a warning if it detects that the credentials file can be
+accessed by other users on your system. The warning reads "Unsafe permissions
+on credentials configuration file", followed by the path to the credentials
+file. This warning will be emitted each time Certbot uses the credentials file,
+including for renewal, and cannot be silenced except by addressing the issue
+(e.g., by using a command like ``chmod 600`` to restrict access to the file).
+
 
 Examples
 --------

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -1,1 +1,17 @@
-"""Cloudflare DNS Authenticator"""
+"""Cloudflare DNS Authenticator
+
+This plugin automates the process of completing a dns-01 challenge
+(`~acme.challenges.DNS01`) using the Cloudflare API.
+
+Use of this plugin requires a configuration file containing Cloudflare API
+credentials, obtained from your Cloudflare
+`account page <https://www.cloudflare.com/a/account/my-account>`_.
+
+Example:
+
+.. code-block:: ini
+
+  dns_cloudflare_email = cloudflare@example.com
+  dns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234567
+
+"""

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -1,22 +1,20 @@
 """
 The `~certbot_dns_cloudflare.dns_cloudflare` plugin automates the process of
-completing a `dns-01` challenge (`~acme.challenges.DNS01`) using the Cloudflare
-API.
+completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) using the
+Cloudflare API.
 
 
 Named Arguments
 ---------------
 
-======================================  =======  ==============================
-Argument                                Default  Description
-======================================  =======  ==============================
-`--dns-cloudflare-credentials`          None     Cloudflare credentials INI
-                                                 file. (See Credentials_.)
-`--dns-cloudflare-propagation-seconds`  10       The number of seconds to wait
-                                                 for DNS to propagate before
-                                                 asking the ACME server to
-                                                 verify the DNS record.
-======================================  =======  ==============================
+========================================  =====================================
+``--dns-cloudflare-credentials``          Cloudflare credentials_ INI file.
+                                          (Required)
+``--dns-cloudflare-propagation-seconds``  The number of seconds to wait for DNS
+                                          to propagate before asking the ACME
+                                          server to verify the DNS record.
+                                          (Default: 10)
+========================================  =====================================
 
 Credentials
 -----------
@@ -34,16 +32,45 @@ credentials, obtained from your Cloudflare
    dns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234567
 
 The path to this file can be provided interactively or using the
-`--dns-cloudflare-credentials` command-line argument. Certbot records the path
+``--dns-cloudflare-credentials`` command-line argument. Certbot records the path
 to this file for use during renewal, but does not store the file's contents.
 
 .. caution::
    You should protect these API credentials as you would the password to your
    Cloudflare account. Users who can read this file can use these credentials
    to issue API calls on your behalf. Users who can cause Certbot to run using
-   these credentials can complete a `dns-01` challenge to acquire new
+   these credentials can complete a ``dns-01`` challenge to acquire new
    certificates or revoke existing certificates for associated domains.
 
+Examples
+--------
 
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``
+
+   certbot certonly \\
+     --dns-cloudflare \\
+     --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com``
+
+   certbot certonly \\
+     --dns-cloudflare \\
+     --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``, waiting 60 seconds
+             for DNS propagation
+
+   certbot certonly \\
+     --dns-cloudflare \\
+     --dns-cloudflare-credentials ~/.secrets/certbot/cloudflare.ini \\
+     --dns-cloudflare-propagation-seconds 60 \\
+     -d example.com
 
 """

--- a/certbot-dns-cloudflare/docs/api/dns_cloudflare.rst
+++ b/certbot-dns-cloudflare/docs/api/dns_cloudflare.rst
@@ -1,5 +1,5 @@
 :mod:`certbot_dns_cloudflare.dns_cloudflare`
---------------------------------------
+--------------------------------------------
 
 .. automodule:: certbot_dns_cloudflare.dns_cloudflare
    :members:

--- a/certbot-dns-cloudxns/certbot_dns_cloudxns/__init__.py
+++ b/certbot-dns-cloudxns/certbot_dns_cloudxns/__init__.py
@@ -16,6 +16,7 @@ Named Arguments
                                           (Default: 30)
 ========================================  =====================================
 
+
 Credentials
 -----------
 
@@ -42,6 +43,14 @@ to this file for use during renewal, but does not store the file's contents.
    using these credentials can complete a ``dns-01`` challenge to acquire new
    certificates or revoke existing certificates for associated domains, even if
    those domains aren't being managed by this server.
+
+Certbot will emit a warning if it detects that the credentials file can be
+accessed by other users on your system. The warning reads "Unsafe permissions
+on credentials configuration file", followed by the path to the credentials
+file. This warning will be emitted each time Certbot uses the credentials file,
+including for renewal, and cannot be silenced except by addressing the issue
+(e.g., by using a command like ``chmod 600`` to restrict access to the file).
+
 
 Examples
 --------

--- a/certbot-dns-cloudxns/certbot_dns_cloudxns/__init__.py
+++ b/certbot-dns-cloudxns/certbot_dns_cloudxns/__init__.py
@@ -1,1 +1,77 @@
-"""CloudXNS DNS Authenticator"""
+"""
+The `~certbot_dns_cloudxns.dns_cloudxns` plugin automates the process of
+completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) by creating, and
+subsequently removing, TXT records using the CloudXNS API.
+
+
+Named Arguments
+---------------
+
+========================================  =====================================
+``--dns-cloudxns-credentials`  `          CloudXNS credentials_ INI file.
+                                          (Required)
+``--dns-cloudxns-propagation-seconds``    The number of seconds to wait for DNS
+                                          to propagate before asking the ACME
+                                          server to verify the DNS record.
+                                          (Default: 30)
+========================================  =====================================
+
+Credentials
+-----------
+
+Use of this plugin requires a configuration file containing CloudXNS API
+credentials, obtained from your CloudXNS
+`API page <https://www.cloudxns.net/en/AccountManage/apimanage.html>`_.
+
+.. code-block:: ini
+   :name: credentials.ini
+   :caption: Example credentials file:
+
+   # CloudXNS API credentials used by Certbot
+   dns_cloudxns_api_key = 1234567890abcdef1234567890abcdef
+   dns_cloudxns_secret_key = 1122334455667788
+
+The path to this file can be provided interactively or using the
+``--dns-cloudxns-credentials`` command-line argument. Certbot records the path
+to this file for use during renewal, but does not store the file's contents.
+
+.. caution::
+   You should protect these API credentials as you would the password to your
+   CloudXNS account. Users who can read this file can use these credentials to
+   issue arbitrary API calls on your behalf. Users who can cause Certbot to run
+   using these credentials can complete a ``dns-01`` challenge to acquire new
+   certificates or revoke existing certificates for associated domains, even if
+   those domains aren't being managed by this server.
+
+Examples
+--------
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``
+
+   certbot certonly \\
+     --dns-cloudxns \\
+     --dns-cloudxns-credentials ~/.secrets/certbot/cloudxns.ini \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com``
+
+   certbot certonly \\
+     --dns-cloudxns \\
+     --dns-cloudxns-credentials ~/.secrets/certbot/cloudxns.ini \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``, waiting 60 seconds
+             for DNS propagation
+
+   certbot certonly \\
+     --dns-cloudxns \\
+     --dns-cloudxns-credentials ~/.secrets/certbot/cloudxns.ini \\
+     --dns-cloudxns-propagation-seconds 60 \\
+     -d example.com
+
+"""

--- a/certbot-dns-cloudxns/certbot_dns_cloudxns/__init__.py
+++ b/certbot-dns-cloudxns/certbot_dns_cloudxns/__init__.py
@@ -8,7 +8,7 @@ Named Arguments
 ---------------
 
 ========================================  =====================================
-``--dns-cloudxns-credentials`  `          CloudXNS credentials_ INI file.
+``--dns-cloudxns-credentials``            CloudXNS credentials_ INI file.
                                           (Required)
 ``--dns-cloudxns-propagation-seconds``    The number of seconds to wait for DNS
                                           to propagate before asking the ACME

--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/__init__.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/__init__.py
@@ -17,6 +17,7 @@ Named Arguments
                                             (Default: 10)
 ==========================================  ===================================
 
+
 Credentials
 -----------
 
@@ -42,6 +43,14 @@ path to this file for use during renewal, but does not store the file's contents
    run using these credentials can complete a ``dns-01`` challenge to acquire
    new certificates or revoke existing certificates for associated domains,
    even if those domains aren't being managed by this server.
+
+Certbot will emit a warning if it detects that the credentials file can be
+accessed by other users on your system. The warning reads "Unsafe permissions
+on credentials configuration file", followed by the path to the credentials
+file. This warning will be emitted each time Certbot uses the credentials file,
+including for renewal, and cannot be silenced except by addressing the issue
+(e.g., by using a command like ``chmod 600`` to restrict access to the file).
+
 
 Examples
 --------

--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/__init__.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/__init__.py
@@ -1,1 +1,77 @@
-"""DigitalOcean DNS Authenticator"""
+"""
+The `~certbot_dns_digitalocean.dns_digitalocean` plugin automates the process of
+completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) by creating, and
+subsequently removing, TXT records using the DigitalOcean API.
+
+
+Named Arguments
+---------------
+
+==========================================  ===================================
+``--dns-digitalocean-credentials``          DigitalOcean credentials_ INI file.
+                                            (Required)
+``--dns-digitalocean-propagation-seconds``  The number of seconds to wait for
+                                            DNS to propagate before asking the
+                                            ACME server to verify the DNS
+                                            record.
+                                            (Default: 10)
+==========================================  ===================================
+
+Credentials
+-----------
+
+Use of this plugin requires a configuration file containing DigitalOcean API
+credentials, obtained from your DigitalOcean account's `Applications & API
+Tokens page <https://cloud.digitalocean.com/settings/api/tokens>`_.
+
+.. code-block:: ini
+   :name: credentials.ini
+   :caption: Example credentials file:
+
+   # DigitalOcean API credentials used by Certbot
+   dns_digitalocean_token = 0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff
+
+The path to this file can be provided interactively or using the
+``--dns-digitalocean-credentials`` command-line argument. Certbot records the
+path to this file for use during renewal, but does not store the file's contents.
+
+.. caution::
+   You should protect these API credentials as you would the password to your
+   DigitalOcean account. Users who can read this file can use these credentials
+   to issue arbitrary API calls on your behalf. Users who can cause Certbot to
+   run using these credentials can complete a ``dns-01`` challenge to acquire
+   new certificates or revoke existing certificates for associated domains,
+   even if those domains aren't being managed by this server.
+
+Examples
+--------
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``
+
+   certbot certonly \\
+     --dns-digitalocean \\
+     --dns-digitalocean-credentials ~/.secrets/certbot/digitalocean.ini \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com``
+
+   certbot certonly \\
+     --dns-digitalocean \\
+     --dns-digitalocean-credentials ~/.secrets/certbot/digitalocean.ini \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``, waiting 60 seconds
+             for DNS propagation
+
+   certbot certonly \\
+     --dns-digitalocean \\
+     --dns-digitalocean-credentials ~/.secrets/certbot/digitalocean.ini \\
+     --dns-digitalocean-propagation-seconds 60 \\
+     -d example.com
+
+"""

--- a/certbot-dns-dnsimple/certbot_dns_dnsimple/__init__.py
+++ b/certbot-dns-dnsimple/certbot_dns_dnsimple/__init__.py
@@ -16,6 +16,7 @@ Named Arguments
                                           (Default: 30)
 ========================================  =====================================
 
+
 Credentials
 -----------
 
@@ -41,6 +42,14 @@ to this file for use during renewal, but does not store the file's contents.
    run using these credentials can complete a ``dns-01`` challenge to acquire
    new certificates or revoke existing certificates for associated domains,
    even if those domains aren't being managed by this server.
+
+Certbot will emit a warning if it detects that the credentials file can be
+accessed by other users on your system. The warning reads "Unsafe permissions
+on credentials configuration file", followed by the path to the credentials
+file. This warning will be emitted each time Certbot uses the credentials file,
+including for renewal, and cannot be silenced except by addressing the issue
+(e.g., by using a command like ``chmod 600`` to restrict access to the file).
+
 
 Examples
 --------

--- a/certbot-dns-dnsimple/certbot_dns_dnsimple/__init__.py
+++ b/certbot-dns-dnsimple/certbot_dns_dnsimple/__init__.py
@@ -1,1 +1,76 @@
-"""DNSimple DNS Authenticator"""
+"""
+The `~certbot_dns_dnsimple.dns_dnsimple` plugin automates the process of
+completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) by creating, and
+subsequently removing, TXT records using the DNSimple API.
+
+
+Named Arguments
+---------------
+
+========================================  =====================================
+``--dns-dnsimple-credentials``            DNSimple credentials_ INI file.
+                                          (Required)
+``--dns-dnsimple-propagation-seconds``    The number of seconds to wait for DNS
+                                          to propagate before asking the ACME
+                                          server to verify the DNS record.
+                                          (Default: 30)
+========================================  =====================================
+
+Credentials
+-----------
+
+Use of this plugin requires a configuration file containing DNSimple API
+credentials, obtained from your DNSimple
+`account page <https://dnsimple.com/user>`_.
+
+.. code-block:: ini
+   :name: credentials.ini
+   :caption: Example credentials file:
+
+   # DNSimple API credentials used by Certbot
+   dns_dnsimple_token = MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw
+
+The path to this file can be provided interactively or using the
+``--dns-dnsimple-credentials`` command-line argument. Certbot records the path
+to this file for use during renewal, but does not store the file's contents.
+
+.. caution::
+   You should protect these API credentials as you would the password to your
+   DNSimple account. Users who can read this file can use these credentials
+   to issue arbitrary API calls on your behalf. Users who can cause Certbot to
+   run using these credentials can complete a ``dns-01`` challenge to acquire
+   new certificates or revoke existing certificates for associated domains,
+   even if those domains aren't being managed by this server.
+
+Examples
+--------
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``
+
+   certbot certonly \\
+     --dns-dnsimple \\
+     --dns-dnsimple-credentials ~/.secrets/certbot/dnsimple.ini \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com``
+
+   certbot certonly \\
+     --dns-dnsimple \\
+     --dns-dnsimple-credentials ~/.secrets/certbot/dnsimple.ini \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``, waiting 60 seconds
+             for DNS propagation
+
+   certbot certonly \\
+     --dns-dnsimple \\
+     --dns-dnsimple-credentials ~/.secrets/certbot/dnsimple.ini \\
+     --dns-dnsimple-propagation-seconds 60 \\
+     -d example.com
+
+"""

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -17,6 +17,7 @@ Named Arguments
                                           (Default: 60)
 ========================================  =====================================
 
+
 Credentials
 -----------
 
@@ -54,6 +55,14 @@ to this file for use during renewal, but does not store the file's contents.
    can cause Certbot to run using these credentials can complete a ``dns-01``
    challenge to acquire new certificates or revoke existing certificates for
    domains these credentials are authorized to manage.
+
+Certbot will emit a warning if it detects that the credentials file can be
+accessed by other users on your system. The warning reads "Unsafe permissions
+on credentials configuration file", followed by the path to the credentials
+file. This warning will be emitted each time Certbot uses the credentials file,
+including for renewal, and cannot be silenced except by addressing the issue
+(e.g., by using a command like ``chmod 600`` to restrict access to the file).
+
 
 Examples
 --------

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -96,4 +96,3 @@ Examples
      -d example.com
 
 """
-# pylint: disable=line-too-long

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -30,10 +30,10 @@ Platform API credentials for an account with the following permissions:
 * ``dns.resourceRecordSets.create``
 * ``dns.resourceRecordSets.delete``
 
-Google provides instructions for
-`creating a service account <https://developers.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`_
-and
-`information about the required permissions <https://cloud.google.com/dns/access-control#permissions_and_roles>`_.
+Google provides instructions for `creating a service account <https://developers
+.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`_ and
+`information about the required permissions <https://cloud.google.com/dns/access
+-control#permissions_and_roles>`_.
 
 .. code-block:: json
    :name: credentials.json
@@ -96,3 +96,4 @@ Examples
      -d example.com
 
 """
+# pylint: disable=line-too-long

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -1,1 +1,89 @@
-"""Google Cloud DNS Authenticator"""
+"""
+The `~certbot_dns_google.dns_google` plugin automates the process of
+completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) by creating, and
+subsequently removing, TXT records using the Google Cloud DNS API.
+
+
+Named Arguments
+---------------
+
+========================================  =====================================
+``--dns-google-credentials``              Google Cloud Platform credentials_
+                                          JSON file.
+                                          (Required)
+``--dns-google-propagation-seconds``      The number of seconds to wait for DNS
+                                          to propagate before asking the ACME
+                                          server to verify the DNS record.
+                                          (Default: 60)
+========================================  =====================================
+
+Credentials
+-----------
+
+Use of this plugin requires a configuration file containing Google Cloud
+Platform API credentials for an account with the following permissions:
+
+* ``dns.changes.create``
+* ``dns.changes.get``
+* ``dns.managedZones.list``
+* ``dns.resourceRecordSets.create``
+* ``dns.resourceRecordSets.delete``
+
+Google provides instructions for
+`creating a service account <https://developers.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`_
+and
+`information about the required permissions <https://cloud.google.com/dns/access-control#permissions_and_roles>`_.
+
+.. code-block:: json
+   :name: credentials.json
+   :caption: Example credentials file:
+
+   {
+     "type": "service_account",
+     ...
+   }
+
+The path to this file can be provided interactively or using the
+``--dns-google-credentials`` command-line argument. Certbot records the path
+to this file for use during renewal, but does not store the file's contents.
+
+.. caution::
+   You should protect these API credentials as you would a password. Users who
+   can read this file can use these credentials to issue some types of API calls
+   on your behalf, limited by the permissions assigned to the account. Users who
+   can cause Certbot to run using these credentials can complete a ``dns-01``
+   challenge to acquire new certificates or revoke existing certificates for
+   domains these credentials are authorized to manage.
+
+Examples
+--------
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``
+
+   certbot certonly \\
+     --dns-google \\
+     --dns-google-credentials ~/.secrets/certbot/google.json \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com``
+
+   certbot certonly \\
+     --dns-google \\
+     --dns-google-credentials ~/.secrets/certbot/google.json \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``, waiting 120 seconds
+             for DNS propagation
+
+   certbot certonly \\
+     --dns-google \\
+     --dns-google-credentials ~/.secrets/certbot/google.ini \\
+     --dns-google-propagation-seconds 120 \\
+     -d example.com
+
+"""

--- a/certbot-dns-google/docs/_ext/jsonlexer.py
+++ b/certbot-dns-google/docs/_ext/jsonlexer.py
@@ -1,0 +1,16 @@
+"""Copied from https://stackoverflow.com/a/16863232"""
+
+def setup(app):
+    # enable Pygments json lexer
+    try:
+        import pygments
+        if pygments.__version__ >= '1.5':
+            # use JSON lexer included in recent versions of Pygments
+            from pygments.lexers import JsonLexer
+        else:
+            # use JSON lexer from pygments-json if installed
+            from pygson.json_lexer import JSONLexer as JsonLexer
+    except ImportError:
+        pass  # not fatal if we have old (or no) Pygments and no pygments-json
+    else:
+        app.add_lexer('json', JsonLexer())

--- a/certbot-dns-google/docs/conf.py
+++ b/certbot-dns-google/docs/conf.py
@@ -17,8 +17,8 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import sys
+sys.path.insert(0, os.path.abspath('_ext'))
 
 
 # -- General configuration ------------------------------------------------
@@ -34,7 +34,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'jsonlexer']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance', 'private-members']

--- a/certbot-dns-nsone/certbot_dns_nsone/__init__.py
+++ b/certbot-dns-nsone/certbot_dns_nsone/__init__.py
@@ -1,1 +1,85 @@
-"""NS1 DNS Authenticator"""
+"""
+The `~certbot_dns_nsone.dns_nsone` plugin automates the process of completing
+a ``dns-01`` challenge (`~acme.challenges.DNS01`) by creating, and subsequently
+removing, TXT records using the NS1 API.
+
+
+Named Arguments
+---------------
+
+========================================  =====================================
+``--dns-nsone-credentials``               NS1 credentials_ INI file.
+                                          (Required)
+``--dns-nsone-propagation-seconds``       The number of seconds to wait for DNS
+                                          to propagate before asking the ACME
+                                          server to verify the DNS record.
+                                          (Default: 30)
+========================================  =====================================
+
+
+Credentials
+-----------
+
+Use of this plugin requires a configuration file containing NS1 API credentials,
+obtained from your NS1
+`account page <https://my.nsone.net/#/account/settings>`_.
+
+.. code-block:: ini
+   :name: credentials.ini
+   :caption: Example credentials file:
+
+   # NS1 API credentials used by Certbot
+   dns_nsone_api_key = MDAwMDAwMDAwMDAwMDAw
+
+The path to this file can be provided interactively or using the
+``--dns-nsone-credentials`` command-line argument. Certbot records the path
+to this file for use during renewal, but does not store the file's contents.
+
+.. caution::
+   You should protect these API credentials as you would the password to your
+   NS1 account. Users who can read this file can use these credentials to issue
+   arbitrary API calls on your behalf. Users who can cause Certbot to run using
+   these credentials can complete a ``dns-01`` challenge to acquire new
+   certificates or revoke existing certificates for associated domains, even if
+   those domains aren't being managed by this server.
+
+Certbot will emit a warning if it detects that the credentials file can be
+accessed by other users on your system. The warning reads "Unsafe permissions
+on credentials configuration file", followed by the path to the credentials
+file. This warning will be emitted each time Certbot uses the credentials file,
+including for renewal, and cannot be silenced except by addressing the issue
+(e.g., by using a command like ``chmod 600`` to restrict access to the file).
+
+
+Examples
+--------
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``
+
+   certbot certonly \\
+     --dns-nsone \\
+     --dns-nsone-credentials ~/.secrets/certbot/nsone.ini \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com``
+
+   certbot certonly \\
+     --dns-nsone \\
+     --dns-nsone-credentials ~/.secrets/certbot/nsone.ini \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``, waiting 60 seconds
+             for DNS propagation
+
+   certbot certonly \\
+     --dns-nsone \\
+     --dns-nsone-credentials ~/.secrets/certbot/nsone.ini \\
+     --dns-nsone-propagation-seconds 60 \\
+     -d example.com
+
+"""


### PR DESCRIPTION
This commit provides documentation for the following DNS authenticator plugins:

* Cloudflare
* CloudXNS
* DigitalOcean
* DNSimple
* Google
* NS1

The documentation provides basic information about each of these plugins, information about the command line arguments for each of these plugins and the default values for those arguments, and information about the credentials used by each of these plugins.

The documentation is placed in the modules' `__init__.py` files so that the information is available from python contexts (e.g., from `help(certbot_dns_cloudflare)`) in addition to being included in the generated documentation by Sphinx.