### PR TITLE
Remove "alpha" and "beta" qualifiers from docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,8 +132,8 @@ Current Features
 
 * Supports multiple web servers:
 
-  - apache/2.x (beta support for auto-configuration)
-  - nginx/0.8.48+ (alpha support for auto-configuration, beta support in 0.14.0)
+  - apache/2.x
+  - nginx/0.8.48+
   - webroot (adds files to webroot directories in order to prove control of
     domains and obtain certs)
   - standalone (runs its own simple webserver to prove you control a domain)

--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -405,7 +405,7 @@ plugins:
                         using Route53 for DNS). (default: False)
 
 apache:
-  Apache Web Server plugin - Beta
+  Apache Web Server plugin
 
   --apache-enmod APACHE_ENMOD
                         Path to the Apache 'a2enmod' binary. (default:
@@ -544,7 +544,7 @@ manual:
                         Automatically allows public IP logging (default: Ask)
 
 nginx:
-  Nginx Web Server plugin - Alpha
+  Nginx Web Server plugin
 
   --nginx-server-root NGINX_SERVER_ROOT
                         Nginx server root directory. (default: /etc/nginx)

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -49,7 +49,7 @@ apache_     Y    Y    | Automates obtaining and installing a certificate with Ap
 webroot_    Y    N    | Obtains a certificate by writing to the webroot directory of  http-01_ (80)
                       | an already running webserver.
 nginx_      Y    Y    | Automates obtaining and installing a certificate with Nginx.  tls-sni-01_ (443)
-                      | Alpha release shipped with Certbot 0.9.0.
+                      | Shipped with Certbot 0.9.0.
 standalone_ Y    N    | Uses a "standalone" webserver to obtain a certificate.        http-01_ (80) or
                       | Requires port 80 or 443 to be available. This is useful on    tls-sni-01_ (443)
                       | systems with no webserver, or when direct integration with
@@ -132,7 +132,7 @@ Nginx
 -----
 
 The Nginx plugin has been distributed with Certbot since version 0.9.0 and should
-work for most configurations. Because it is alpha code, we recommend backing up Nginx
+work for most configurations. We recommend backing up Nginx
 configurations before using it (though you can also revert changes to
 configurations with ``certbot --nginx rollback``). You can use it by providing
 the ``--nginx`` flag on the commandline.


### PR DESCRIPTION
Fixes #4798.