### PR TITLE
Correct message about vhost ambiguity

### DIFF
--- a/certbot-apache/certbot_apache/display_ops.py
+++ b/certbot-apache/certbot_apache/display_ops.py
@@ -88,10 +88,11 @@ def _vhost_menu(domain, vhosts):
             choices, help_label="More Info",
             ok_label="Select", force_interactive=True)
     except errors.MissingCommandlineFlag:
-        msg = ("Encountered vhost ambiguity but unable to ask for user guidance in "
-               "non-interactive mode. Currently Certbot needs each vhost to be "
-               "in its own conf file, and may need vhosts to be explicitly "
-               "labelled with ServerName or ServerAlias directives.")
+        msg = (
+            "Encountered vhost ambiguity but unable to ask for user "
+            "guidance in non-interactive mode. Certbot may need "
+            "vhosts to be explicitly labelled with ServerName or "
+            "ServerAlias directives.")
         logger.warning(msg)
         raise errors.MissingCommandlineFlag(msg)
 


### PR DESCRIPTION
When our Apache plugin is unable to determine which virtual host to use in non-interactive mode, it raises an error about vhost ambiguity with instructions on how to fix the problem. These instructions stated that we require one vhost per file which is no longer accurate since #4706 so I removed this part of the error message.