### PR TITLE
Fix digitalocean plugin tests for Python 3

### DIFF
--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
@@ -5,6 +5,7 @@ import unittest
 
 import digitalocean
 import mock
+import six
 
 from certbot import errors
 from certbot.plugins import dns_test_common
@@ -133,8 +134,8 @@ class DigitalOceanClientTest(unittest.TestCase):
 
         correct_record_mock.destroy.assert_called()
 
-        self.assertItemsEqual(first_record_mock.destroy.call_args_list, [])
-        self.assertItemsEqual(last_record_mock.destroy.call_args_list, [])
+        six.assertCountEqual(self, first_record_mock.destroy.call_args_list, [])
+        six.assertCountEqual(self, last_record_mock.destroy.call_args_list, [])
 
     def test_del_txt_record_error_finding_domain(self):
         self.manager.get_all_domains.side_effect = API_ERROR

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',
+    'six',
     'zope.interface',
 ]
 


### PR DESCRIPTION
assertItemsEqual() doesn't exist in Python 3.x. Travis didn't fail because of some nose errors (so not all tests were run).