### PR TITLE
Add AAAA record check suggestion

### DIFF
--- a/certbot/auth_handler.py
+++ b/certbot/auth_handler.py
@@ -444,7 +444,7 @@ def _report_no_chall_path():
 
 _ERROR_HELP_COMMON = (
     "To fix these errors, please make sure that your domain name was entered "
-    "correctly and the DNS A record(s) for that domain contain(s) the "
+    "correctly and the DNS A/AAAA record(s) for that domain contain(s) the "
     "right IP address.")
 
 


### PR DESCRIPTION
This would undo PR #1135.
I think now, people should be hinted again to check their AAAA DNSv6 records. I was initially confused by the common hint to check (only) my A-records, when I tried to figure out what's wrong with my IPv6-only host. Now everything works (with `webroot`), and apparently in all other plugins too.
