### PR TITLE
Fix sphinx build failures

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,12 +16,6 @@ Welcome to the Certbot documentation!
 
    api
 
-.. toctree::
-   :hidden:
-
-   challenges
-   ciphers
-
 
 Indices and tables
 ==================


### PR DESCRIPTION
These few lines makes Sphinx thoroughly unhappy when trying to build latex docs. All they do is silence Sphinx errors about a file not being included in the toctree with the idea being you're linking the file somewhere else. We're doing this for one of the files, but not the other so arguably this is a valid error to begin with.