### PR TITLE
Pin zope.interface in oldest tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ deps =
     configargparse==0.10.0
     PyOpenSSL==0.13
     requests<=2.11.1
+    zope.interface==4.0.5
 setenv =
     CERTBOT_NO_PIN=1
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ deps =
     configargparse==0.10.0
     PyOpenSSL==0.13
     requests<=2.11.1
+    zope.component==4.0.2
     zope.interface==4.0.5
 setenv =
     CERTBOT_NO_PIN=1


### PR DESCRIPTION
Fixes Travis failures.

4.0.5 is the oldest version of the package used anywhere we are packaged after checking CentOS, Debian, and Ubuntu. Minute progress on #4049.