### PR TITLE
Add __main__.py

### DIFF
--- a/certbot/__main__.py
+++ b/certbot/__main__.py
@@ -23,4 +23,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    main()  # pragma: no cover

--- a/certbot/__main__.py
+++ b/certbot/__main__.py
@@ -1,0 +1,26 @@
+"""Runs Certbot."""
+import logging
+import sys
+
+import certbot.main
+
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    """Runs Certbot, logs any returned message, and calls sys.exit.
+
+    If certbot.main.main returns a non-empty string, it is passed to
+    sys.exit causing a non-zero status code and the string to be
+    printed to stderr.
+
+    """
+    err_string = certbot.main.main()
+    if err_string:
+        logger.debug('Exiting with message %s', err_string)
+    sys.exit(err_string)
+
+
+if __name__ == '__main__':
+    main()

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -741,10 +741,3 @@ def main(cli_args=sys.argv[1:]):
     util.atexit_register(report.print_messages)
 
     return config.func(config, plugins)
-
-
-if __name__ == "__main__":
-    err_string = main()
-    if err_string:
-        logger.warning("Exiting with message %s", err_string)
-    sys.exit(err_string)  # pragma: no cover

--- a/certbot/tests/dunder_main_test.py
+++ b/certbot/tests/dunder_main_test.py
@@ -1,0 +1,31 @@
+"""Tests for certbot.__main__."""
+import unittest
+
+import mock
+
+
+class MainTest(unittest.TestCase):
+    """Tests for certbot.__main__.main."""
+
+    def test_failure(self):
+        self._test_helper('error message')
+
+    def test_success(self):
+        self._test_helper(None)
+
+    def _test_helper(self, return_value):
+        with mock.patch('certbot.__main__.logger') as mock_logger:
+            with mock.patch('certbot.main.main') as mock_certbot_main:
+                mock_certbot_main.return_value = return_value
+                with mock.patch('sys.exit') as mock_exit:
+                    from certbot.__main__ import main
+                    main()
+
+        mock_certbot_main.assert_called_once_with()
+        if return_value:
+            self.assertTrue(mock_logger.debug.called)
+        mock_exit.assert_called_once_with(return_value)
+
+
+if __name__ == '__main__':
+    unittest.main()  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'certbot = certbot.main:main',
+            'certbot = certbot.__main__:main',
         ],
         'certbot.plugins': [
             'manual = certbot.plugins.manual:Authenticator',


### PR DESCRIPTION
Adding this file allows Certbot to easily be invoked from something like `coverage run certbot` which will look for `__main__.py` to know which file to run as described briefly [here](https://docs.python.org/3/library/__main__.html).

This also fixes us not actually logging the return value of `certbot.main.main` as our entry point was on `certbot.main:main` so the `if __name__ == '__main__'` code at the bottom of the file was silently ignored.