### PR TITLE
Remove py26 oldest tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,6 @@ matrix:
         - sudo cat /var/log/mysql/error.log
         - ps aux | grep mysql
       services: docker
-    - python: "2.6"
-      env: TOXENV=py26-oldest BOULDER_INTEGRATION=1
-      sudo: required
-      after_failure:
-        - sudo cat /var/log/mysql/error.log
-        - ps aux | grep mysql
-      services: docker
     - python: "2.7"
       env: TOXENV=py27_install BOULDER_INTEGRATION=1
       sudo: required

--- a/tox.ini
+++ b/tox.ini
@@ -63,24 +63,6 @@ commands =
     {[base]install_and_test} {[base]py26_packages}
     python tests/lock_test.py
 
-[testenv:py26-oldest]
-commands =
-    {[testenv:py26]commands}
-# cffi<=1.7 is required for oldest tests due to
-# https://bitbucket.org/cffi/cffi/commits/18cdf37d6b2691301a15b0e54f49757ebd4ed0f2?at=default
-# requests<=2.11.1 required for oldest tests due to
-# https://github.com/shazow/urllib3/pull/930
-deps =
-    cffi<=1.7
-    cryptography==1.2
-    configargparse==0.10.0
-    PyOpenSSL==0.13
-    requests<=2.11.1
-    zope.component==4.0.2
-    zope.interface==4.0.5
-setenv =
-    CERTBOT_NO_PIN=1
-
 [testenv]
 commands =
     {[testenv:py26]commands}
@@ -88,10 +70,20 @@ commands =
 setenv =
     PYTHONPATH = {toxinidir}
     PYTHONHASHSEED = 0
-    py27-oldest: {[testenv:py26-oldest]setenv}
-# https://testrun.org/tox/latest/example/basic.html#special-handling-of-pythonhas
+    py27-oldest: CERTBOT_NO_PIN=1
+# cffi<=1.7 is required for oldest tests due to
+# https://bitbucket.org/cffi/cffi/commits/18cdf37d6b2691301a15b0e54f49757ebd4ed0f2?at=default
+# requests<=2.11.1 required for oldest tests due to
+# https://github.com/shazow/urllib3/pull/930
 deps =
-    py27-oldest: {[testenv:py26-oldest]deps}
+    py27-oldest:
+        cffi<=1.7
+        cryptography==1.2
+        configargparse==0.10.0
+        PyOpenSSL==0.13
+        requests<=2.11.1
+        zope.component==4.0.2
+        zope.interface==4.0.5
 
 [testenv:py27_install]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -70,20 +70,25 @@ commands =
 setenv =
     PYTHONPATH = {toxinidir}
     PYTHONHASHSEED = 0
-    py27-oldest: CERTBOT_NO_PIN=1
+
+[testenv:py27-oldest]
+commands =
+    {[testenv]commands}
+setenv =
+    {[testenv]setenv}
+    CERTBOT_NO_PIN=1
 # cffi<=1.7 is required for oldest tests due to
 # https://bitbucket.org/cffi/cffi/commits/18cdf37d6b2691301a15b0e54f49757ebd4ed0f2?at=default
 # requests<=2.11.1 required for oldest tests due to
 # https://github.com/shazow/urllib3/pull/930
 deps =
-    py27-oldest:
-        cffi<=1.7
-        cryptography==1.2
-        configargparse==0.10.0
-        PyOpenSSL==0.13
-        requests<=2.11.1
-        zope.component==4.0.2
-        zope.interface==4.0.5
+    cffi<=1.7
+    cryptography==1.2
+    configargparse==0.10.0
+    PyOpenSSL==0.13
+    requests<=2.11.1
+    zope.component==4.0.2
+    zope.interface==4.0.5
 
 [testenv:py27_install]
 basepython = python2.7


### PR DESCRIPTION
The only systems where we support Python 2.6 use certbot-auto so the oldest supported versions of our dependencies are never used when using supported installation methods. Let's remove this unnecessary and slow test.