### PR TITLE
Turn on IRC notifications for Travis failures in master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,4 +180,3 @@ notifications:
     on_success: never
     on_failure: always
     use_notice: true
-    skip_join: true


### PR DESCRIPTION
This should work according to instructions at https://docs.travis-ci.com/user/notifications/#Configuring-IRC-notifications. According to that section, pull request builds don't trigger failure messages so I'm unfortunately not sure how to test this without merging this PR.