### PR TITLE
Bump min integration test coverage to 64%

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -248,4 +248,4 @@ then
     . ./certbot-nginx/tests/boulder-integration.sh
 fi
 
-coverage report --fail-under 52 -m
+coverage report --fail-under 64 -m


### PR DESCRIPTION
Nginx tests weren't run locally when I came up with 52% and I added more tests in #4855.