### PR TITLE
Create a different CODE-OF-CONDUCT.md

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -43,4 +43,4 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-This code of conduct is released under MIT license.
+This code of conduct is released by @koops76 under MIT license.

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,20 @@
+This document provides community guidelines for a safe, respectful, productive and collaborative place for any person who is willing to contribute to the certbot project. It applies to all “collaborative space”, which is defined as community communications channels (such as mailing lists, submitted patches, commit comments, etc.).
+
+* Participants will be respectful of different views and backgrounds.
+* Participants will accept constructive criticism of their contributions.
+* Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
+* Behavior which can be reasonably considered harassment will not be tolerated, including:
+    * Derogatory remarks about anyone's protected characteristics.
+    * Publishing others' private information, such as a physical address or social security number, without explicit permission
+    * Threats against anyone's life and safety.
+    
+* For the purpose of these guidelines, protected characteristics are:
+    * gender identity, sexual identity or sexual orientation
+    * level of experience in any field
+    * age, physical appearance or disability
+    * race, ethnicity or nationality
+    * political or religious views
+
+Instances of harassing or otherwise unacceptable behavior may be reported by contacting the project team (Noah Swartz, Peter Eckersley, Brad Warren, Erica Portnoy) at their eff.org emails, which can be found at https://www.eff.org/about/staff
+
+**If you believe you are in an immediate danger please contact the police.**

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -19,28 +19,4 @@ Instances of harassing or otherwise unacceptable behavior may be reported by con
 
 **If you believe you are in an immediate danger please contact the police.**
 
-This code of conduct is partially based on Opal code of conduct.
-
-Opal license:
-
-Copyright (C) 2013 by Adam Beynon
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-This code of conduct is released by @koops76 under MIT license.
+This code of conduct is partially based on [Opal code of conduct](https://github.com/opal/opal/blob/master/CONDUCT.md). Opal is released under the [MIT license](https://github.com/opal/opal/blob/master/LICENSE). Changes are released under the [Apache Version 2.0](https://github.com/certbot/certbot/blob/master/LICENSE.txt).

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -18,3 +18,29 @@ This document provides community guidelines for a safe, respectful, productive a
 Instances of harassing or otherwise unacceptable behavior may be reported by contacting the project team (Noah Swartz, Peter Eckersley, Brad Warren, Erica Portnoy) at their eff.org emails, which can be found at https://www.eff.org/about/staff
 
 **If you believe you are in an immediate danger please contact the police.**
+
+This code of conduct is partially based on Opal code of conduct.
+
+Opal license:
+
+Copyright (C) 2013 by Adam Beynon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+This code of conduct is released under MIT license.

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -19,4 +19,4 @@ Instances of harassing or otherwise unacceptable behavior may be reported by con
 
 **If you believe you are in an immediate danger please contact the police.**
 
-This code of conduct is partially based on [Opal code of conduct](https://github.com/opal/opal/blob/master/CONDUCT.md). Opal is released under the [MIT license](https://github.com/opal/opal/blob/master/LICENSE). Changes are released under the [Apache Version 2.0](https://github.com/certbot/certbot/blob/master/LICENSE.txt).
+This code of conduct is partially based on [Ruby code of conduct](https://www.ruby-lang.org/en/conduct/). Changes are released under the [Apache Version 2.0](https://github.com/certbot/certbot/blob/master/LICENSE.txt).


### PR DESCRIPTION
This is a draft for Certbot's code of conduct made by me as an alternative to the currently proposed (#4841). Feel free to comment and suggest improvements, especially on the licensing part. Should a code of conduct be released under MIT license or CC0 instead to make using it in other projects easier?

This is the text of the proposed code:

This document provides community guidelines for a safe, respectful, productive and collaborative place for any person who is willing to contribute to the certbot project. It applies to all “collaborative space”, which is defined as community communications channels (such as mailing lists, submitted patches, commit comments, etc.).

* Participants will be respectful of different views and backgrounds.
* Participants will accept constructive criticism of their contributions.
* Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
* Behavior which can be reasonably considered harassment will not be tolerated, including:
    * Derogatory remarks about anyone's protected characteristics.
    * Publishing others' private information, such as a physical address or social security number, without explicit permission
    * Threats against anyone's life and safety.
    
* For the purpose of these guidelines, protected characteristics are:
    * gender identity, sexual identity or sexual orientation
    * level of experience in any field
    * age, physical appearance or disability
    * race, ethnicity or nationality
    * political or religious views

Instances of harassing or otherwise unacceptable behavior may be reported by contacting the project team (Noah Swartz, Peter Eckersley, Brad Warren, Erica Portnoy) at their eff.org emails, which can be found at https://www.eff.org/about/staff

**If you believe you are in an immediate danger please contact the police.**

This code of conduct is partially based on [Ruby code of conduct](https://www.ruby-lang.org/en/conduct/). Changes are released under the [Apache Version 2.0](https://github.com/certbot/certbot/blob/master/LICENSE.txt).