### PR TITLE
Align input and output format of domain names

### DIFF
--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -205,7 +205,7 @@ def _report_human_readable(config, parsed_certs):
                         "    Certificate Path: {3}\n"
                         "    Private Key Path: {4}".format(
                             cert.lineagename,
-                            " ".join(cert.names()),
+                            ",".join(cert.names()),
                             valid_string,
                             cert.fullchain,
                             cert.privkey))


### PR DESCRIPTION
The command line takes a comma separated list of domain names. But `certbot-auto certificates` prints a comma separated list of the domain names. To be able to use the list of existing domain names it would be helpful to get a list that is comma separated.

Sample use case: If you would like to add a new domain to an existing certificate you need to list all existing domain names.