### PR TITLE
Fix nginx --dry-run

### DIFF
--- a/certbot-nginx/certbot_nginx/tests/util.py
+++ b/certbot-nginx/certbot_nginx/tests/util.py
@@ -65,7 +65,6 @@ def get_nginx_configurator(
                     in_progress_dir=os.path.join(backups, "IN_PROGRESS"),
                     server="https://acme-server.org:443/new",
                     tls_sni_01_port=5001,
-                    dry_run=False,
                 ),
                 name="nginx",
                 version=version)

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -321,7 +321,8 @@ class Client(object):
 
         # Create CSR from names
         if self.config.dry_run:
-            key = crypto_util.make_key(self.config.rsa_key_size)
+            key = util.Key(file=None,
+                           pem=crypto_util.make_key(self.config.rsa_key_size))
             csr = acme_crypto_util.make_csr(key.pem,
                                             domains, self.config.must_staple)
         else:

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -323,8 +323,9 @@ class Client(object):
         if self.config.dry_run:
             key = util.Key(file=None,
                            pem=crypto_util.make_key(self.config.rsa_key_size))
-            csr = acme_crypto_util.make_csr(key.pem,
-                                            domains, self.config.must_staple)
+            csr = util.CSR(file=None, form="pem",
+                           data=acme_crypto_util.make_csr(
+                               key.pem, domains, self.config.must_staple))
         else:
             key = crypto_util.init_save_key(
                 self.config.rsa_key_size, self.config.key_dir)

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -18,7 +18,6 @@ CLI_DEFAULTS = dict(
         os.path.join(os.environ.get("XDG_CONFIG_HOME", "~/.config"),
                      "letsencrypt", "cli.ini"),
     ],
-    dry_run=False,
     verbose_count=-int(logging.INFO / 10),
     server="https://acme-v01.api.letsencrypt.org/directory",
     rsa_key_size=2048,

--- a/certbot/crypto_util.py
+++ b/certbot/crypto_util.py
@@ -55,15 +55,11 @@ def init_save_key(key_size, key_dir, keyname="key-certbot.pem"):
     # Save file
     util.make_or_verify_dir(key_dir, 0o700, os.geteuid(),
                             config.strict_permissions)
-    if config.dry_run:
-        key_path = None
-        logger.debug("Generating key (%d bits), not saving to file", key_size)
-    else:
-        key_f, key_path = util.unique_file(
-            os.path.join(key_dir, keyname), 0o600, "wb")
-        with key_f:
-            key_f.write(key_pem)
-        logger.debug("Generating key (%d bits): %s", key_size, key_path)
+    key_f, key_path = util.unique_file(
+        os.path.join(key_dir, keyname), 0o600, "wb")
+    with key_f:
+        key_f.write(key_pem)
+    logger.debug("Generating key (%d bits): %s", key_size, key_path)
 
     return util.Key(key_path, key_pem)
 
@@ -90,15 +86,11 @@ def init_save_csr(privkey, names, path):
     # Save CSR
     util.make_or_verify_dir(path, 0o755, os.geteuid(),
                                config.strict_permissions)
-    if config.dry_run:
-        csr_filename = None
-        logger.debug("Creating CSR: not saving to file")
-    else:
-        csr_f, csr_filename = util.unique_file(
-            os.path.join(path, "csr-certbot.pem"), 0o644, "wb")
-        with csr_f:
-            csr_f.write(csr_pem)
-        logger.debug("Creating CSR: %s", csr_filename)
+    csr_f, csr_filename = util.unique_file(
+        os.path.join(path, "csr-certbot.pem"), 0o644, "wb")
+    with csr_f:
+        csr_f.write(csr_pem)
+    logger.debug("Creating CSR: %s", csr_filename)
 
     return util.CSR(csr_filename, csr_pem, "pem")
 

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -144,6 +144,7 @@ class ClientTest(ClientTestCommon):
 
         self.config.allow_subset_of_names = False
         self.config.config_dir = "/etc/letsencrypt"
+        self.config.dry_run = False
         self.eg_domains = ["example.com", "www.example.com"]
 
     def test_init_acme_verify_ssl(self):

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -258,7 +258,7 @@ class ClientTest(ClientTestCommon):
     @mock.patch("certbot.client.acme_crypto_util")
     def test_obtain_certificate_dry_run(self, mock_acme_crypto, mock_crypto):
         csr = util.CSR(form="pem", file=None, data=CSR_SAN)
-        mock_acme_crypto.make_csr.return_value = csr
+        mock_acme_crypto.make_csr.return_value = CSR_SAN
         mock_crypto.make_key.return_value = mock.sentinel.key_pem
         key = util.Key(file=None, pem=mock.sentinel.key_pem)
 

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -30,8 +30,7 @@ class InitSaveKeyTest(test_util.TempDirTestCase):
 
         logging.disable(logging.CRITICAL)
         zope.component.provideUtility(
-            mock.Mock(strict_permissions=True, dry_run=False),
-            interfaces.IConfig)
+            mock.Mock(strict_permissions=True), interfaces.IConfig)
 
     def tearDown(self):
         super(InitSaveKeyTest, self).tearDown()
@@ -52,16 +51,6 @@ class InitSaveKeyTest(test_util.TempDirTestCase):
         self.assertTrue(os.path.exists(os.path.join(self.tempdir, key.file)))
 
     @mock.patch('certbot.crypto_util.make_key')
-    def test_success_dry_run(self, mock_make):
-        zope.component.provideUtility(
-            mock.Mock(strict_permissions=True, dry_run=True),
-            interfaces.IConfig)
-        mock_make.return_value = b'key_pem'
-        key = self._call(1024, self.tempdir)
-        self.assertEqual(key.pem, b'key_pem')
-        self.assertTrue(key.file is None)
-
-    @mock.patch('certbot.crypto_util.make_key')
     def test_key_failure(self, mock_make):
         mock_make.side_effect = ValueError
         self.assertRaises(ValueError, self._call, 431, self.tempdir)
@@ -74,12 +63,11 @@ class InitSaveCSRTest(test_util.TempDirTestCase):
         super(InitSaveCSRTest, self).setUp()
 
         zope.component.provideUtility(
-            mock.Mock(strict_permissions=True, dry_run=False),
-            interfaces.IConfig)
+            mock.Mock(strict_permissions=True), interfaces.IConfig)
 
     @mock.patch('acme.crypto_util.make_csr')
     @mock.patch('certbot.crypto_util.util.make_or_verify_dir')
-    def test_success(self, unused_mock_verify, mock_csr):
+    def test_it(self, unused_mock_verify, mock_csr):
         from certbot.crypto_util import init_save_csr
 
         mock_csr.return_value = b'csr_pem'
@@ -89,22 +77,6 @@ class InitSaveCSRTest(test_util.TempDirTestCase):
 
         self.assertEqual(csr.data, b'csr_pem')
         self.assertTrue('csr-certbot.pem' in csr.file)
-
-    @mock.patch('acme.crypto_util.make_csr')
-    @mock.patch('certbot.crypto_util.util.make_or_verify_dir')
-    def test_success_dry_run(self, unused_mock_verify, mock_csr):
-        from certbot.crypto_util import init_save_csr
-
-        zope.component.provideUtility(
-            mock.Mock(strict_permissions=True, dry_run=True),
-            interfaces.IConfig)
-        mock_csr.return_value = b'csr_pem'
-
-        csr = init_save_csr(
-            mock.Mock(pem='dummy_key'), 'example.com', self.tempdir)
-
-        self.assertEqual(csr.data, b'csr_pem')
-        self.assertTrue(csr.file is None)
 
 
 class ValidCSRTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #4846.

This reverts #4380 and moves conditionally saving CSRs and keys out of `init_save_*`. I think this makes sense as both of these functions take the directory where the file should be saved. Whether or not the file should be saved during a dry run really depends on the directory used, so let's push this decision into the caller and have the functions actually do what they say: create and save a CSR/key.