### PR TITLE
Hide exceptions that occur during session.close() option 2

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -519,11 +519,11 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         self._default_timeout = timeout
 
     def __del__(self):
-        # Try to close the session, but don't show exceptions to the
-        # user if the call to close() fails. See #4840.
+        # Try to close the session, but don't show ReferenceErrors that
+        # may be raised out of close(). See #4840.
         try:
             self.session.close()
-        except:  # pylint: disable=bare-except
+        except ReferenceError:
             pass
 
     def _wrap_in_jws(self, obj, nonce):

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -519,7 +519,12 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         self._default_timeout = timeout
 
     def __del__(self):
-        self.session.close()
+        # Try to close the session, but don't show exceptions to the
+        # user if the call to close() fails. See #4840.
+        try:
+            self.session.close()
+        except:  # pylint: disable=bare-except
+            pass
 
     def _wrap_in_jws(self, obj, nonce):
         """Wrap `JSONDeSerializable` object in JWS.

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -600,11 +600,18 @@ class ClientNetworkTest(unittest.TestCase):
             mock.ANY, mock.ANY, verify=mock.ANY, headers=mock.ANY,
             timeout=45)
 
-    def test_del(self):
+    def test_del(self, close_exception=None):
         sess = mock.MagicMock()
+
+        if close_exception is not None:
+            sess.close.side_effect = close_exception
+
         self.net.session = sess
         del self.net
         sess.close.assert_called_once_with()
+
+    def test_del_error(self):
+        self.test_del(ReferenceError)
 
     @mock.patch('acme.client.requests')
     def test_requests_error_passthrough(self, mock_requests):


### PR DESCRIPTION
Fixes #4840. See #4891.