### PR TITLE
Deploy hook

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1095,7 +1095,7 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         " space-delimited list of renewed certificate domains (for example,"
         " \"example.com www.example.com\"")
     helpful.add(
-        "renew", "--deploy-hook",
+        "renew", "--deploy-hook", action=_DeployHookAction,
         help="Command to be run in a shell once for each successfully"
         " issued certificate. For this command, the shell variable"
         " $RENEWED_LINEAGE will point to the config live subdirectory"
@@ -1359,3 +1359,14 @@ def parse_preferred_challenges(pref_challs):
         raise errors.Error(
             "Unrecognized challenges: {0}".format(unrecognized))
     return challs
+
+
+class _DeployHookAction(argparse.Action):
+    """Action class for parsing deploy hooks."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        renew_hook_set = namespace.deploy_hook != namespace.renew_hook
+        if renew_hook_set and namespace.renew_hook != values:
+            raise argparse.ArgumentError(
+                self, "conflicts with --renew-hook value")
+        namespace.deploy_hook = namespace.renew_hook = values

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1085,15 +1085,7 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         " run if an attempt was made to obtain/renew a certificate. If"
         " multiple renewed certificates have identical post-hooks, only"
         " one will be run.")
-    helpful.add(
-        "renew", "--renew-hook",
-        help="Command to be run in a shell once for each successfully renewed"
-        " certificate. For this command, the shell variable $RENEWED_LINEAGE"
-        " will point to the config live subdirectory (for example,"
-        " \"/etc/letsencrypt/live/example.com\") containing the new certificates"
-        " and keys; the shell variable $RENEWED_DOMAINS will contain a"
-        " space-delimited list of renewed certificate domains (for example,"
-        " \"example.com www.example.com\"")
+    helpful.add("renew", "--renew-hook", help=argparse.SUPPRESS)
     helpful.add(
         "renew", "--deploy-hook", action=_DeployHookAction,
         help="Command to be run in a shell once for each successfully"

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1095,6 +1095,16 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         " space-delimited list of renewed certificate domains (for example,"
         " \"example.com www.example.com\"")
     helpful.add(
+        "renew", "--deploy-hook",
+        help="Command to be run in a shell once for each successfully"
+        " issued certificate. For this command, the shell variable"
+        " $RENEWED_LINEAGE will point to the config live subdirectory"
+        ' (for example, "/etc/letsencrypt/live/example.com") containing'
+        " the new certificates and keys; the shell variable"
+        " $RENEWED_DOMAINS will contain a space-delimited list of"
+        ' renewed certificate domains (for example, "example.com'
+        ' www.example.com"')
+    helpful.add(
         "renew", "--disable-hook-validation",
         action='store_false', dest='validate_hooks', default=True,
         help="Ordinarily the commands specified for"

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1085,7 +1085,8 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         " run if an attempt was made to obtain/renew a certificate. If"
         " multiple renewed certificates have identical post-hooks, only"
         " one will be run.")
-    helpful.add("renew", "--renew-hook", help=argparse.SUPPRESS)
+    helpful.add("renew", "--renew-hook",
+                action=_RenewHookAction, help=argparse.SUPPRESS)
     helpful.add(
         "renew", "--deploy-hook", action=_DeployHookAction,
         help="Command to be run in a shell once for each successfully"
@@ -1363,3 +1364,14 @@ class _DeployHookAction(argparse.Action):
             raise argparse.ArgumentError(
                 self, "conflicts with --renew-hook value")
         namespace.deploy_hook = namespace.renew_hook = values
+
+
+class _RenewHookAction(argparse.Action):
+    """Action class for parsing renew hooks."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        deploy_hook_set = namespace.deploy_hook is not None
+        if deploy_hook_set and namespace.deploy_hook != values:
+            raise argparse.ArgumentError(
+                self, "conflicts with --deploy-hook value")
+        namespace.renew_hook = values

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -887,7 +887,7 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
              " in order to obtain test certificates, and reloads webservers to deploy and then"
              " roll back those changes.  It also calls --pre-hook and --post-hook commands"
              " if they are defined because they may be necessary to accurately simulate"
-             " renewal. --renew-hook commands are not called.")
+             " renewal. --deploy-hook commands are not called.")
     helpful.add(
         ["register", "automation"], "--register-unsafely-without-email", action="store_true",
         help="Specifying this flag enables registering an account with no "
@@ -1100,11 +1100,12 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         "renew", "--disable-hook-validation",
         action='store_false', dest='validate_hooks', default=True,
         help="Ordinarily the commands specified for"
-        " --pre-hook/--post-hook/--renew-hook will be checked for validity, to"
-        " see if the programs being run are in the $PATH, so that mistakes can"
-        " be caught early, even when the hooks aren't being run just yet. The"
-        " validation is rather simplistic and fails if you use more advanced"
-        " shell constructs, so you can use this switch to disable it."
+        " --pre-hook/--post-hook/--deploy-hook will be checked for"
+        " validity, to see if the programs being run are in the $PATH,"
+        " so that mistakes can be caught early, even when the hooks"
+        " aren't being run just yet. The validation is rather"
+        " simplistic and fails if you use more advanced shell"
+        " constructs, so you can use this switch to disable it."
         " (default: False)")
 
     helpful.add_deprecated_argument("--agree-dev-preview", 0)

--- a/certbot/hooks.py
+++ b/certbot/hooks.py
@@ -18,6 +18,7 @@ def validate_hooks(config):
     """Check hook commands are executable."""
     validate_hook(config.pre_hook, "pre")
     validate_hook(config.post_hook, "post")
+    validate_hook(config.deploy_hook, "deploy")
     validate_hook(config.renew_hook, "renew")
 
 
@@ -95,16 +96,30 @@ def run_saved_post_hooks():
         _run_hook(cmd)
 
 
+def deploy_hook(config, domains, lineage_path):
+    """Run post-issuance hook if defined.
+
+    :param configuration.NamespaceConfig config: Certbot settings
+    :param domains: domains in the obtained certificate
+    :type domains: `list` of `str`
+    :param str lineage_path: live directory path for the new cert
+
+    """
+    if config.deploy_hook:
+        renew_hook(config, domains, lineage_path)
+
+
 def renew_hook(config, domains, lineage_path):
     """Run post-renewal hook if defined."""
     if config.renew_hook:
         if not config.dry_run:
             os.environ["RENEWED_DOMAINS"] = " ".join(domains)
             os.environ["RENEWED_LINEAGE"] = lineage_path
-            logger.info("Running renew-hook command: %s", config.renew_hook)
+            logger.info("Running deploy-hook command: %s", config.renew_hook)
             _run_hook(config.renew_hook)
         else:
-            logger.warning("Dry run: skipping renewal hook command: %s", config.renew_hook)
+            logger.warning(
+                "Dry run: skipping deploy hook command: %s", config.renew_hook)
 
 
 def _run_hook(shell_cmd):

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -82,6 +82,8 @@ def _get_and_save_cert(le_client, config, domains=None, certname=None, lineage=N
             lineage = le_client.obtain_and_enroll_certificate(domains, certname)
             if lineage is False:
                 raise errors.Error("Certificate could not be obtained")
+            elif lineage is not None:
+                hooks.deploy_hook(config, lineage.names(), lineage.live_dir)
     finally:
         hooks.post_hook(config)
 

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -329,6 +329,14 @@ class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             self.assertRaises(SystemExit, self.parse,
                               "--renew-hook foo --deploy-hook bar".split())
 
+    def test_deploy_hook_matches_renew_hook(self):
+        value = "foo"
+        namespace = self.parse(["--renew-hook", value,
+                                "--deploy-hook", value,
+                                "--disable-hook-validation"])
+        self.assertEqual(namespace.deploy_hook, value)
+        self.assertEqual(namespace.renew_hook, value)
+
     def test_deploy_hook_sets_renew_hook(self):
         value = "foo"
         namespace = self.parse(
@@ -340,6 +348,14 @@ class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         with mock.patch("certbot.cli.sys.stderr"):
             self.assertRaises(SystemExit, self.parse,
                               "--deploy-hook foo --renew-hook bar".split())
+
+    def test_renew_hook_matches_deploy_hook(self):
+        value = "foo"
+        namespace = self.parse(["--deploy-hook", value,
+                                "--renew-hook", value,
+                                "--disable-hook-validation"])
+        self.assertEqual(namespace.deploy_hook, value)
+        self.assertEqual(namespace.renew_hook, value)
 
     def test_renew_hook_does_not_set_renew_hook(self):
         value = "foo"

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -40,7 +40,7 @@ class TestReadFile(TempDirTestCase):
 
 
 
-class ParseTest(unittest.TestCase):
+class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
     '''Test the cli args entrypoint'''
 
     _multiprocess_can_split_ = True
@@ -334,6 +334,18 @@ class ParseTest(unittest.TestCase):
         namespace = self.parse(
             ["--deploy-hook", value, "--disable-hook-validation"])
         self.assertEqual(namespace.deploy_hook, value)
+        self.assertEqual(namespace.renew_hook, value)
+
+    def test_renew_hook_conflict(self):
+        with mock.patch("certbot.cli.sys.stderr"):
+            self.assertRaises(SystemExit, self.parse,
+                              "--deploy-hook foo --renew-hook bar".split())
+
+    def test_renew_hook_does_not_set_renew_hook(self):
+        value = "foo"
+        namespace = self.parse(
+            ["--renew-hook", value, "--disable-hook-validation"])
+        self.assertEqual(namespace.deploy_hook, None)
         self.assertEqual(namespace.renew_hook, value)
 
 

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -323,6 +323,18 @@ class ParseTest(unittest.TestCase):
         self.assertRaises(
             errors.Error, self.parse, "-n --force-interactive".split())
 
+    def test_deploy_hook_conflict(self):
+        with mock.patch("certbot.cli.sys.stderr"):
+            self.assertRaises(SystemExit, self.parse,
+                              "--renew-hook foo --deploy-hook bar".split())
+
+    def test_deploy_hook_sets_renew_hook(self):
+        value = "foo"
+        namespace = self.parse(
+            ["--deploy-hook", value, "--disable-hook-validation"])
+        self.assertEqual(namespace.deploy_hook, value)
+        self.assertEqual(namespace.renew_hook, value)
+
 
 class DefaultTest(unittest.TestCase):
     """Tests for certbot.cli._Default."""

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -109,6 +109,7 @@ class ParseTest(unittest.TestCase):
         self.assertTrue("--dialog" not in out)
         self.assertTrue("%s" not in out)
         self.assertTrue("{0}" not in out)
+        self.assertTrue("--renew-hook" not in out)
 
         out = self._help_output(['-h', 'nginx'])
         if "nginx" in PLUGINS:

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -36,6 +36,19 @@ class HookTest(unittest.TestCase):
         self.assertEqual(hooks._prog("funky"), None)
         self.assertEqual(mock_ps.call_count, 1)
 
+    @mock.patch('certbot.hooks.renew_hook')
+    def test_deploy_hook(self, mock_renew_hook):
+        args = (mock.Mock(deploy_hook='foo'), ['example.org'], 'path',)
+        # pylint: disable=star-args
+        hooks.deploy_hook(*args)
+        mock_renew_hook.assert_called_once_with(*args)
+
+    @mock.patch('certbot.hooks.renew_hook')
+    def test_no_deploy_hook(self, mock_renew_hook):
+        args = (mock.Mock(deploy_hook=None), ['example.org'], 'path',)
+        hooks.deploy_hook(*args)  # pylint: disable=star-args
+        mock_renew_hook.assert_not_called()
+
     def _test_a_hook(self, config, hook_function, calls_expected, **kwargs):
         with mock.patch('certbot.hooks.logger') as mock_logger:
             mock_logger.warning = mock.MagicMock()

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -26,6 +26,19 @@ class HookTest(unittest.TestCase):
         config = mock.MagicMock(pre_hook="explodinator", post_hook="", renew_hook="")
         self.assertRaises(errors.HookCommandNotFound, hooks.validate_hooks, config)
 
+    @mock.patch('certbot.hooks.validate_hook')
+    def test_validation_order(self, mock_validate_hook):
+        # This ensures error messages are about deploy hook when appropriate
+        config = mock.Mock(deploy_hook=None, pre_hook=None,
+                           post_hook=None, renew_hook=None)
+        hooks.validate_hooks(config)
+
+        order = [call[0][1] for call in mock_validate_hook.call_args_list]
+        self.assertTrue('pre' in order)
+        self.assertTrue('post' in order)
+        self.assertTrue('deploy' in order)
+        self.assertEqual(order[-1], 'renew')
+
     @mock.patch('certbot.hooks.util.exe_exists')
     @mock.patch('certbot.hooks.plug_util.path_surgery')
     def test_prog(self, mock_ps, mock_exe_exists):

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -16,7 +16,8 @@ class HookTest(unittest.TestCase):
 
     @mock.patch('certbot.hooks._prog')
     def test_validate_hooks(self, mock_prog):
-        config = mock.MagicMock(pre_hook="", post_hook="ls -lR", renew_hook="uptime")
+        config = mock.MagicMock(deploy_hook=None, pre_hook="",
+                                post_hook="ls -lR", renew_hook="uptime")
         hooks.validate_hooks(config)
         self.assertEqual(mock_prog.call_count, 2)
         self.assertEqual(mock_prog.call_args_list[1][0][0], 'uptime')

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -397,15 +397,15 @@ unnecessarily stopping your webserver.
 
 ``--pre-hook`` and ``--post-hook`` hooks run before and after every renewal
 attempt. If you want your hook to run only after a successful renewal, use
-``--renew-hook`` in a command like this.
+``--deploy-hook`` in a command like this.
 
-``certbot renew --renew-hook /path/to/renew-hook-script``
+``certbot renew --deploy-hook /path/to/deploy-hook-script``
 
 For example, if you have a daemon that does not read its certificates as the
 root user, a renew hook like this can copy them to the correct location and
 apply appropriate file permissions.
 
-/path/to/renew-hook-script
+/path/to/deploy-hook-script
 
 .. code-block:: none
 
@@ -504,7 +504,7 @@ renewal configuration file, located at ``/etc/letsencrypt/renewal/CERTNAME``.
 .. warning:: Modifying any files in ``/etc/letsencrypt`` can damage them so Certbot can no longer properly manage its certificates, and we do not recommend doing so.
 
 For most tasks, it is safest to limit yourself to pointing symlinks at the files there, or using
-``--renew-hook`` to copy / make new files based upon those files, if your operational situation requires it
+``--deploy-hook`` to copy / make new files based upon those files, if your operational situation requires it
 (for instance, combining certificates and keys in different way, or having copies of things with different
 specific permissions that are demanded by other programs).
 
@@ -598,7 +598,7 @@ The following files are available:
 .. note:: All files are PEM-encoded.
    If you need other format, such as DER or PFX, then you
    could convert using ``openssl``. You can automate that with
-   ``--renew-hook`` if you're using automatic renewal_.
+   ``--deploy-hook`` if you're using automatic renewal_.
 
 .. _hooks:
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -402,7 +402,7 @@ attempt. If you want your hook to run only after a successful renewal, use
 ``certbot renew --deploy-hook /path/to/deploy-hook-script``
 
 For example, if you have a daemon that does not read its certificates as the
-root user, a renew hook like this can copy them to the correct location and
+root user, a deploy hook like this can copy them to the correct location and
 apply appropriate file permissions.
 
 /path/to/deploy-hook-script
@@ -438,7 +438,7 @@ apply appropriate file permissions.
            esac
    done
 
-More information about renewal hooks can be found by running
+More information about hooks can be found by running
 ``certbot --help renew``.
 
 If you're sure that this command executes successfully without human

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -2,12 +2,13 @@
 # the kernel to use.
 root=${root:-$(mktemp -d -t leitXXXX)}
 echo "Root integration tests directory: $root"
-store_flags="--config-dir $root/conf --work-dir $root/work"
+config_dir="$root/conf"
+store_flags="--config-dir $config_dir --work-dir $root/work"
 store_flags="$store_flags --logs-dir $root/logs"
 tls_sni_01_port=5001
 http_01_port=5002
 sources="acme/,$(ls -dm certbot*/ | tr -d ' \n')"
-export root store_flags tls_sni_01_port http_01_port sources
+export root config_dir store_flags tls_sni_01_port http_01_port sources
 
 certbot_test () {
     certbot_test_no_force_renew \


### PR DESCRIPTION
Fixes #3947.

This PR hides `--renew-hook` and adds `--deploy-hook`. They work the same way except `--deploy-hook` is also run with the `certonly` and `run` subcommands.

Deploy hooks are still saved in the renewal configuration file as `renew_hook`. This is important for forwards compatibility as it is fairly common for people to downgrade their Certbot version when switching from `certbot-auto` to OS packages. Deploy hooks are not saved as `deploy_hook` as well to prevent confusion and mismatched values.

@ynasser, do you have time to review this or would you like me to ask Erica?