### PR TITLE
First Devuan integration

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -236,6 +236,9 @@ Bootstrap() {
   elif [ -f /etc/debian_version ]; then
     BootstrapMessage "Debian-based OSes"
     BootstrapDebCommon
+  elif [ -f /etc/devuan_version ]; then
+    BootstrapMessage "Devuan"
+    BootstrapDebCommon
   elif [ -f /etc/mageia-release ]; then
     # Mageia has both /etc/mageia-release and /etc/redhat-release
     ExperimentalBootstrap "Mageia" BootstrapMageiaCommon

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -7,6 +7,8 @@ BootstrapDebCommon() {
   # - Debian
   #     - 7.9 "wheezy" (x64)
   #     - sid (2015-10-21) (x64)
+  # - Devuan
+  #     - 1.0 "Jessie" (x64)
 
   # Past versions tested with:
   #


### PR DESCRIPTION
Devuan 1.0 (https://devuan.org/) is now officially released and it has with long term support.
It's time to add it to the supported OSes and being a Debian fork the integration effort is minimal.
It already ships the recent version of the certbot requirements:

```
root@devuan:~# lsb_release  -a
No LSB modules are available.
Distributor ID:	Devuan
Description:	Devuan GNU/Linux 1.0 (jessie)
Release:	1.0
Codename:	jessie
root@devuan:~# LC_ALL=C apt-cache show --no-all-versions libaugeas0 | grep ^Version: | cut -d" " -f2
1.2.0-0.2+deb8u1
root@devuan:~# LC_ALL=C apt-cache show --no-all-versions python | grep ^Version: | cut -d" " -f2
2.7.9-1
```

if you want to test it in AWS, there's an AMI ready (ami-9bafb8ff London region, ami-9bafb8ff N Virginia region, ami-e043e78f Frankfurt region)

