### PR TITLE
Make Certbot's log rotation configurable

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -440,8 +440,8 @@ class HelpfulArgumentParser(object):
         }
 
         # List of topics for which additional help can be provided
-        HELP_TOPICS = ["all", "security", "paths", "automation", "testing"] + list(self.VERBS)
-        HELP_TOPICS += self.COMMANDS_TOPICS + ["manage"]
+        HELP_TOPICS = ["all", "security", "paths", "automation", "testing"]
+        HELP_TOPICS += list(self.VERBS) + self.COMMANDS_TOPICS + ["manage"]
 
         plugin_names = list(plugins)
         self.help_topics = HELP_TOPICS + plugin_names + [None]
@@ -849,6 +849,16 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
     helpful.add(
         None, "-t", "--text", dest="text_mode", action="store_true",
         help=argparse.SUPPRESS)
+    helpful.add(
+        # Note, 1 is subtracted from max_log_count in certbot/main.py
+        #> to correct an off by one error.
+        [None, "paths"],
+        "--max-log-count", dest="max_log_count",
+        type=int, default=1000,
+        help="Specifies the maximum number of certbot log files "
+               "that will be kept. 0 disables log rotation. 1 causes "
+               "only the log from the most recent run to be kept. "
+               "2+ enables log rotation at start of certbot execution.")
     helpful.add(
         [None, "automation", "run", "certonly"], "-n", "--non-interactive", "--noninteractive",
         dest="noninteractive_mode", action="store_true",

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -850,15 +850,11 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         None, "-t", "--text", dest="text_mode", action="store_true",
         help=argparse.SUPPRESS)
     helpful.add(
-        # Note, 1 is subtracted from max_log_count in certbot/main.py
-        #> to correct an off by one error.
-        [None, "paths"],
-        "--max-log-count", dest="max_log_count",
-        type=int, default=1000,
-        help="Specifies the maximum number of certbot log files "
-               "that will be kept. 0 disables log rotation. 1 causes "
-               "only the log from the most recent run to be kept. "
-               "2+ enables log rotation at start of certbot execution.")
+        None, "--max-log-backups", type=nonnegative_int, default=1000,
+        help="Specifies the maximum number of backup logs that should "
+             "be kept by Certbot's built in log rotation. Setting this "
+             "flag to 0 disables log rotation entirely, causing "
+             "Certbot to always append to the same log file.")
     helpful.add(
         [None, "automation", "run", "certonly"], "-n", "--non-interactive", "--noninteractive",
         dest="noninteractive_mode", action="store_true",
@@ -1385,3 +1381,27 @@ class _RenewHookAction(argparse.Action):
             raise argparse.ArgumentError(
                 self, "conflicts with --deploy-hook value")
         namespace.renew_hook = values
+
+
+def nonnegative_int(value):
+    """Converts value to an int and checks that it is not negative.
+
+    This function should used as the type parameter for argparse
+    arguments.
+
+    :param str value: value provided on the command line
+
+    :returns: integer representation of value
+    :rtype: int
+
+    :raises argparse.ArgumentTypeError: if value isn't a non-negative integer
+
+    """
+    try:
+        int_value = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("value must be an integer")
+
+    if int_value < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return int_value

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -138,7 +138,8 @@ def setup_log_file_handler(config, logfile, fmt):
     log_file_path = os.path.join(config.logs_dir, logfile)
     try:
         handler = logging.handlers.RotatingFileHandler(
-            log_file_path, maxBytes=2 ** 20, backupCount=1000)
+            log_file_path, maxBytes=2 ** 20,
+            backupCount=config.max_log_backups)
     except IOError as error:
         raise errors.Error(util.PERM_ERR_FMT.format(error))
     # rotate on each invocation, rollover only possible when maxBytes

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -364,6 +364,18 @@ class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         self.assertEqual(namespace.deploy_hook, None)
         self.assertEqual(namespace.renew_hook, value)
 
+    def test_max_log_backups_error(self):
+        with mock.patch('certbot.cli.sys.stderr'):
+            self.assertRaises(
+                SystemExit, self.parse, "--max-log-backups foo".split())
+            self.assertRaises(
+                SystemExit, self.parse, "--max-log-backups -42".split())
+
+    def test_max_log_backups_success(self):
+        value = "42"
+        namespace = self.parse(["--max-log-backups", value])
+        self.assertEqual(namespace.max_log_backups, int(value))
+
 
 class DefaultTest(unittest.TestCase):
     """Tests for certbot.cli._Default."""


### PR DESCRIPTION
Fixes #2292 and #3602. Built on #4195.

This PR adds a single flag to allow the user to control Certbot's log rotation. This PR functionally implements most of the desired features discussed in #3602. We'd be open to well written PRs for the missing functionality.

This PR should be merged and not squashed to preserve authorship.