### PR TITLE
certbot: Update storage.get_link_target (#4750)

### DIFF
--- a/certbot/storage.py
+++ b/certbot/storage.py
@@ -186,8 +186,15 @@ def get_link_target(link):
     :returns: Absolute path to the target of link
     :rtype: str
 
+    :raises .CertStorageError: If link does not exists.
+
     """
-    target = os.readlink(link)
+    try:
+        target = os.readlink(link)
+    except OSError:
+        raise errors.CertStorageError(
+            "expected {0} to be a symlink".format(link))
+
     if not os.path.isabs(target):
         target = os.path.join(os.path.dirname(link), target)
     return os.path.abspath(target)

--- a/certbot/storage.py
+++ b/certbot/storage.py
@@ -193,7 +193,7 @@ def get_link_target(link):
         target = os.readlink(link)
     except OSError:
         raise errors.CertStorageError(
-            "expected {0} to be a symlink".format(link))
+            "Expected {0} to be a symlink".format(link))
 
     if not os.path.isabs(target):
         target = os.path.join(os.path.dirname(link), target)


### PR DESCRIPTION
* The `get_link_target` function raises `errors.CertStorageError` when
  link does not exists.