### PR TITLE
Tweak non-root error message.

### DIFF
--- a/certbot/util.py
+++ b/certbot/util.py
@@ -48,7 +48,7 @@ ANSI_SGR_RESET = "\033[0m"
 
 PERM_ERR_FMT = os.linesep.join((
     "The following error was encountered:", "{0}",
-    "If running as non-root, set --config-dir, "
+    "Either run as root, or set --config-dir, "
     "--work-dir, and --logs-dir to writeable paths."))
 
 


### PR DESCRIPTION
For most people, the right answer will be "run as root," so we should emphasize
that over the "how to run as non-root" instructions.