### PR TITLE
[WIP] Addressing #4071 by preventing FreezableMock's return_value from being set

### DIFF
--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -208,6 +208,10 @@ class FreezableMock(object):
             return getattr(object.__getattribute__(self, '_mock'), name)
 
     def __setattr__(self, name, value):
+        if name == 'return_value': # Rationale: __setattr__ takes precedence over properties
+            msg = ("Changing the return_value of a FreezableMock is forbidden because "
+                    "that would nullify callbacks important to thorough tests.")
+            raise AttributeError(msg)
         if self._frozen:
             return setattr(self._mock, name, value)
         elif name != '_frozen_set':


### PR DESCRIPTION
First of two candidate solutions for #4071. This one is simply a throwaway `if` block.

This isn't perfect because while it will prevent changing the `return_value` attribute on the FreezableMock objects, it won't prevent changing the return value of the patched `zope.component.getUtility` because it is a `mock.MagicMock`.

So I consider this incomplete. I think I'll come back to this issue with fresher eyes, or maybe someone else with sicker Python skills can sweep it.