### PR TITLE
Unhide Nginx

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -87,8 +87,6 @@ class NginxConfigurator(common.Plugin):
 
     description = "Nginx Web Server plugin - Alpha"
 
-    hidden = True
-
     DEFAULT_LISTEN_PORT = '80'
 
     @classmethod

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -112,7 +112,7 @@ def choose_plugin(prepared, question):
 
     while True:
         disp = z_util(interfaces.IDisplay)
-        if names == set(("apache", "nginx")):
+        if "CERTBOT_AUTO" in os.environ and names == set(("apache", "nginx")):
             # The possibility of being offered exactly apache and nginx here
             # is new interactivity brought by https://github.com/certbot/certbot/issues/4079,
             # so set apache as a default for those kinds of non-interactive use

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -108,11 +108,19 @@ def choose_plugin(prepared, question):
     opts = [plugin_ep.description_with_name +
             (" [Misconfigured]" if plugin_ep.misconfigured else "")
             for plugin_ep in prepared]
+    names = set(plugin_ep.name for plugin_ep in prepared)
 
     while True:
         disp = z_util(interfaces.IDisplay)
-        code, index = disp.menu(
-            question, opts, force_interactive=True)
+        if names == set(("apache", "nginx")):
+            # The possibility of being offered exactly apache and nginx here
+            # is new interactivity brought by https://github.com/certbot/certbot/issues/4079,
+            # so set apache as a default for those kinds of non-interactive use
+            # (the user will get a warning to set --non-interactive or --force-interactive)
+            apache_idx = [n for n, p in enumerate(prepared) if p.name == "apache"][0]
+            code, index = disp.menu(question, opts, default=apache_idx)
+        else:
+            code, index = disp.menu(question, opts, force_interactive=True)
 
         if code == display_util.OK:
             plugin_ep = prepared[index]

--- a/certbot/plugins/selection_test.py
+++ b/certbot/plugins/selection_test.py
@@ -1,4 +1,5 @@
 """Tests for letsencrypt.plugins.selection"""
+import os
 import sys
 import unittest
 
@@ -156,7 +157,16 @@ class ChoosePluginTest(unittest.TestCase):
         mock_nginx.name = "nginx"
         self.plugins[1] = mock_nginx
         mock_util().menu.return_value = (display_util.CANCEL, 0)
-        self._call()
+
+        unset_cb_auto = os.environ.get("CERTBOT_AUTO") is None
+        if unset_cb_auto:
+            os.environ["CERTBOT_AUTO"] = "foo"
+        try:
+            self._call()
+        finally:
+            if unset_cb_auto:
+                del os.environ["CERTBOT_AUTO"]
+
         self.assertTrue("default" in mock_util().menu.call_args[1])
 
 if __name__ == "__main__":

--- a/certbot/plugins/selection_test.py
+++ b/certbot/plugins/selection_test.py
@@ -115,6 +115,7 @@ class ChoosePluginTest(unittest.TestCase):
                                                                False))
         self.mock_apache = mock.Mock(
             description_with_name="a", misconfigured=True)
+        self.mock_apache.name = "apache"
         self.mock_stand = mock.Mock(
             description_with_name="s", misconfigured=False)
         self.mock_stand.init().more_info.return_value = "standalone"
@@ -146,3 +147,17 @@ class ChoosePluginTest(unittest.TestCase):
     def test_no_choice(self, mock_util):
         mock_util().menu.return_value = (display_util.CANCEL, 0)
         self.assertTrue(self._call() is None)
+
+    @test_util.patch_get_utility("certbot.plugins.selection.z_util")
+    def test_new_interaction_avoidance(self, mock_util):
+        mock_nginx = mock.Mock(
+            description_with_name="n", misconfigured=False)
+        mock_nginx.init().more_info.return_value = "nginx plugin"
+        mock_nginx.name = "nginx"
+        self.plugins[1] = mock_nginx
+        mock_util().menu.return_value = (display_util.CANCEL, 0)
+        self._call()
+        self.assertTrue("default" in mock_util().menu.call_args[1])
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover


### PR DESCRIPTION
Fixes #4079. This is #4543 with a couple of changes.

First, I removed our nginx plugin's `hidden` attribute so it is found during plugin discovery.

Second, this code is now only used when using `certbot-auto`. In my opinion, having to do this is at all a wart and I'd like to make its scope as small as possible. OS packages will get the normal experience which I believe is safe because for this to be a breaking change, they'd have to have both web servers installed, both of our plugins installed (which are always packaged separately), and be running `certbot` non-interactively without setting `-n`. I think it's highly unlikely (m)any of these users exist. If they do, we have timeouts on our interactions so Certbot will exit with a warning rather than hanging indefinitely on their server.

Using the `CERTBOT_AUTO` environment variable is a reliable way to check if we're being run from `certbot-auto` as it was added in our 0.6.0 release before we ever started shipping the nginx plugin. Old `letsencrypt-auto` users that don't receive updates won't have the nginx plugin installed.