### PR TITLE
Fix space in quiet check in BootstrapArchCommon

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -492,7 +492,7 @@ BootstrapArchCommon() {
   fi
 
   if [ "$missing" ]; then
-    if [ "$QUIET" = 1]; then
+    if [ "$QUIET" = 1 ]; then
       $SUDO pacman -S --needed $missing $noconfirm > /dev/null
     else
       $SUDO pacman -S --needed $missing $noconfirm

--- a/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
@@ -25,7 +25,7 @@ BootstrapArchCommon() {
   fi
 
   if [ "$missing" ]; then
-    if [ "$QUIET" = 1]; then
+    if [ "$QUIET" = 1 ]; then
       $SUDO pacman -S --needed $missing $noconfirm > /dev/null
     else
       $SUDO pacman -S --needed $missing $noconfirm


### PR DESCRIPTION
When testing something on Arch Linux, I saw this output:
```
./letsencrypt-auto-source/letsencrypt-auto: line 495: [: missing `]'
```
This PR fixes the problem.