### PR TITLE
Fix oldest tests by pinning Google DNS deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -85,11 +85,14 @@ deps =
     configobj==4.7.2
     cryptography==1.2.3
     enum34==0.9.23
+    google-python-api-client==1.5
     idna==2.0
     ipaddress==1.0.16
     mock==1.0.1
     ndg-httpsclient==0.3.2
+    oauth2client==2.0
     parsedatetime==1.4
+    pyasn1-modules==0.0.5
     pyasn1==0.1.9
     pyparsing==1.5.6
     pyrfc3339==1.0

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
     configobj==4.7.2
     cryptography==1.2.3
     enum34==0.9.23
-    google-python-api-client==1.5
+    google-api-python-client==1.5
     idna==2.0
     ipaddress==1.0.16
     mock==1.0.1


### PR DESCRIPTION
Our plugin requires `oauth2client >= 2.0` to be able to import `ServiceAccountCredentials`. `google-python-api-client 1.5` is the [first version that supports oauth2client>=2.0](https://github.com/google/google-api-python-client/blob/master/CHANGELOG#L89). `pyasn1-modules==0.0.5` is oldest version allowed by `oauth2client`'s `setup.py`.