### PR TITLE
Avoid crashing on SIGWINCH

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -1,6 +1,7 @@
 """Certbot main entry point."""
 from __future__ import print_function
 import logging.handlers
+import signal
 import os
 import sys
 
@@ -728,6 +729,7 @@ def set_displayer(config):
 
 def main(cli_args=sys.argv[1:]):
     """Command line argument parsing and main script execution."""
+    signal.signal(signal.SIGWINCH, signal.SIG_IGN)
     log.pre_arg_parse_setup()
 
     plugins = plugins_disco.PluginsRegistry.find_all()


### PR DESCRIPTION
When terminals are resized, the terminal will usually send a SIGWINCH -
the Window Change signal. This usually gives interactive applications a
chance to render the UI with the new width and height. However, if this
sinal isn't handled or trapped, the default behavior tends to be
aborting the process.

This change hooks SIGWINCH up to SIG_IGN, which ignores the signal. This
is safe, because we don't really care that the terminal has been
resized.