### PR TITLE
Put the minimum dep version in Google DNS setup.py

### DIFF
--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -10,9 +10,11 @@ version = '0.18.0.dev0'
 install_requires = [
     'acme=={0}'.format(version),
     'certbot=={0}'.format(version),
-    'google-api-python-client',
+    # 1.5 is the first version that supports oauth2client>=2.0
+    'google-api-python-client>=1.5',
     'mock',
-    'oauth2client',
+    # for oauth2client.service_account.ServiceAccountCredentials
+    'oauth2client>=2.0',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',


### PR DESCRIPTION
Continues the work from #5000 to specify things for package maintainers.