### PR TITLE
Include plugin selection at the info logging level

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -487,7 +487,7 @@ def install(config, plugins):
     except errors.PluginSelectionError as e:
         return str(e)
 
-    logger.info('Plugins used: Installer: %s'. installer.__class__)
+    logger.info("Plugins used: Installer: %s", installer.__class__)
 
     domains, _ = _find_domains_or_certname(config, installer)
     le_client = _init_le_client(config, authenticator=None, installer=installer)
@@ -596,8 +596,8 @@ def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
     except errors.PluginSelectionError as e:
         return str(e)
 
-    logger.info('Plugins used: Authenticator: %s; Installer: %s' authenticator.__class__,
-        installer.__class__)
+    logger.info("Plugins used: Authenticator: %s; Installer: %s",
+         authenticator.__class__, installer.__class__)
 
     # TODO: Handle errors from _init_le_client?
     le_client = _init_le_client(config, authenticator, installer)
@@ -651,8 +651,8 @@ def renew_cert(config, plugins, lineage):
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
 
-    logger.info('Plugins used: Authenticator: %s; Installer: %s', auth.__class__,
-        installer.__class__)
+    logger.info("Plugins used: Authenticator: %s; Installer: %s",
+         auth.__class__, installer.__class__)
 
     le_client = _init_le_client(config, auth, installer)
 
@@ -683,8 +683,8 @@ def certonly(config, plugins):
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
 
-    logger.info('Plugins used: Authenticator: %s; Installer: %s', auth.__class__,
-        installer.__class__)
+    logger.info("Plugins used: Authenticator: %s; Installer: %s",
+         auth.__class__, installer.__class__)
 
     le_client = _init_le_client(config, auth, installer)
 

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -487,8 +487,6 @@ def install(config, plugins):
     except errors.PluginSelectionError as e:
         return str(e)
 
-    logger.info("Plugins used: Installer: %s", installer.__class__)
-
     domains, _ = _find_domains_or_certname(config, installer)
     le_client = _init_le_client(config, authenticator=None, installer=installer)
     _install_cert(config, le_client, domains)
@@ -596,9 +594,6 @@ def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
     except errors.PluginSelectionError as e:
         return str(e)
 
-    logger.info("Plugins used: Authenticator: %s; Installer: %s",
-         authenticator.__class__, installer.__class__)
-
     # TODO: Handle errors from _init_le_client?
     le_client = _init_le_client(config, authenticator, installer)
 
@@ -651,9 +646,6 @@ def renew_cert(config, plugins, lineage):
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
 
-    logger.info("Plugins used: Authenticator: %s; Installer: %s",
-         auth.__class__, installer.__class__)
-
     le_client = _init_le_client(config, auth, installer)
 
     _get_and_save_cert(le_client, config, lineage=lineage)
@@ -682,9 +674,6 @@ def certonly(config, plugins):
     except errors.PluginSelectionError as e:
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
-
-    logger.info("Plugins used: Authenticator: %s; Installer: %s",
-         auth.__class__, installer.__class__)
 
     le_client = _init_le_client(config, auth, installer)
 

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -487,6 +487,8 @@ def install(config, plugins):
     except errors.PluginSelectionError as e:
         return str(e)
 
+    logger.info('Plugins used: Installer: {0}'.format(installer.__class__))
+
     domains, _ = _find_domains_or_certname(config, installer)
     le_client = _init_le_client(config, authenticator=None, installer=installer)
     _install_cert(config, le_client, domains)
@@ -594,6 +596,9 @@ def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
     except errors.PluginSelectionError as e:
         return str(e)
 
+    logger.info('Plugins used: Authenticator: {0}; Installer: {1}'.format(
+        authenticator.__class__, installer.__class__))
+
     # TODO: Handle errors from _init_le_client?
     le_client = _init_le_client(config, authenticator, installer)
 
@@ -645,6 +650,10 @@ def renew_cert(config, plugins, lineage):
     except errors.PluginSelectionError as e:
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
+
+    logger.info('Plugins used: Authenticator: {0}; Installer: {1}'.format(
+        auth.__class__, installer.__class__))
+
     le_client = _init_le_client(config, auth, installer)
 
     _get_and_save_cert(le_client, config, lineage=lineage)
@@ -673,6 +682,10 @@ def certonly(config, plugins):
     except errors.PluginSelectionError as e:
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
+
+    logger.info('Plugins used: Authenticator: {0}; Installer: {1}'.format(
+        auth.__class__, installer.__class__))
+
     le_client = _init_le_client(config, auth, installer)
 
     if config.csr:

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -487,7 +487,7 @@ def install(config, plugins):
     except errors.PluginSelectionError as e:
         return str(e)
 
-    logger.info('Plugins used: Installer: {0}'.format(installer.__class__))
+    logger.info('Plugins used: Installer: %s'. installer.__class__)
 
     domains, _ = _find_domains_or_certname(config, installer)
     le_client = _init_le_client(config, authenticator=None, installer=installer)
@@ -596,8 +596,8 @@ def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
     except errors.PluginSelectionError as e:
         return str(e)
 
-    logger.info('Plugins used: Authenticator: {0}; Installer: {1}'.format(
-        authenticator.__class__, installer.__class__))
+    logger.info('Plugins used: Authenticator: %s; Installer: %s' authenticator.__class__,
+        installer.__class__)
 
     # TODO: Handle errors from _init_le_client?
     le_client = _init_le_client(config, authenticator, installer)
@@ -651,8 +651,8 @@ def renew_cert(config, plugins, lineage):
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
 
-    logger.info('Plugins used: Authenticator: {0}; Installer: {1}'.format(
-        auth.__class__, installer.__class__))
+    logger.info('Plugins used: Authenticator: %s; Installer: %s', auth.__class__,
+        installer.__class__)
 
     le_client = _init_le_client(config, auth, installer)
 
@@ -683,8 +683,8 @@ def certonly(config, plugins):
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
 
-    logger.info('Plugins used: Authenticator: {0}; Installer: {1}'.format(
-        auth.__class__, installer.__class__))
+    logger.info('Plugins used: Authenticator: %s; Installer: %s', auth.__class__,
+        installer.__class__)
 
     le_client = _init_le_client(config, auth, installer)
 

--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -142,6 +142,8 @@ def record_chosen_plugins(config, plugins, auth, inst):
     "Update the config entries to reflect the plugins we actually selected."
     config.authenticator = plugins.find_init(auth).name if auth else "None"
     config.installer = plugins.find_init(inst).name if inst else "None"
+    logger.info("Plugins selected: Authenticator %s, Installer %s",
+         config.authenticator, config.installer)
 
 
 def choose_configurator_plugins(config, plugins, verb):


### PR DESCRIPTION
Quick fix for #4988

@bmw I included the classnames of the used plugins (`.__class__`) for all the major subcommands  certonly, run, renew and install
