### PR TITLE
Stop using print in `certbot.cli`.

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -11,6 +11,7 @@ import sys
 
 import configargparse
 import six
+import zope.component
 
 from acme import challenges
 
@@ -509,11 +510,12 @@ class HelpfulArgumentParser(object):
             apache_doc = "(the certbot apache plugin is not installed)"
 
         usage = SHORT_USAGE
+        notify = zope.component.getUtility(interfaces.IDisplay).notification
         if help_arg == True:
-            print(usage + COMMAND_OVERVIEW % (apache_doc, nginx_doc) + HELP_USAGE)
+            notify(usage + COMMAND_OVERVIEW % (apache_doc, nginx_doc) + HELP_USAGE)
             sys.exit(0)
         elif help_arg in self.COMMANDS_TOPICS:
-            print(usage + self._list_subcommands())
+            notify(usage + self._list_subcommands())
             sys.exit(0)
         elif help_arg == "all":
             # if we're doing --help all, the OVERVIEW is part of the SHORT_USAGE at

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -519,7 +519,8 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertEqual(1, mock_cert_manager.call_count)
 
     @mock.patch('certbot.cert_manager.certificates')
-    def test_certificates(self, mock_cert_manager):
+    @test_util.patch_get_utility()
+    def test_certificates(self, mock_cert_manager, unused_mock_get_utility):
         self._call_no_clientmock(['certificates'])
         self.assertEqual(1, mock_cert_manager.call_count)
 
@@ -579,7 +580,8 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         available = verified.available()
         self.assertEqual(stdout.getvalue().strip(), str(available))
 
-    def test_certonly_abspath(self):
+    @test_util.patch_get_utility()
+    def test_certonly_abspath(self, unused_mock_get_utility):
         cert = 'cert'
         key = 'key'
         chain = 'chain'
@@ -596,7 +598,8 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertEqual(config.chain_path, os.path.abspath(chain))
         self.assertEqual(config.fullchain_path, os.path.abspath(fullchain))
 
-    def test_certonly_bad_args(self):
+    @test_util.patch_get_utility()
+    def test_certonly_bad_args(self, unused_mock_get_utility):
         try:
             self._call(['-a', 'bad_auth', 'certonly'])
             assert False, "Exception should have been raised"
@@ -1024,7 +1027,8 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                     jose.ComparableX509(cert),
                     mock.ANY)
 
-    def test_agree_dev_preview_config(self):
+    @test_util.patch_get_utility()
+    def test_agree_dev_preview_config(self, unused_mock_get_utility):
         with mock.patch('certbot.main.run') as mocked_run:
             self._call(['-c', test_util.vector_path('cli.ini')])
         self.assertTrue(mocked_run.called)

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -7,6 +7,7 @@ import multiprocessing
 import os
 import pkg_resources
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -154,7 +155,8 @@ def make_lineage(config_dir, testfile):
     return conf_path
 
 
-def patch_get_utility(target='zope.component.getUtility'):
+def patch_get_utility(target='zope.component.getUtility',
+                        stdout_notification=False):
     """Patch zope.component.getUtility to use a special mock IDisplay.
 
     The mock IDisplay works like a regular mock object, except it also
@@ -166,7 +168,12 @@ def patch_get_utility(target='zope.component.getUtility'):
     :rtype: mock.MagicMock
 
     """
-    return mock.patch(target, new_callable=_create_get_utility_mock)
+    if stdout_notification:
+        return mock.patch(target, new_callable=_create_get_utility_mock,
+                              stdout_notification=True)
+    else:
+        return mock.patch(target, new_callable=_create_get_utility_mock,
+                              stdout_notification=False)
 
 
 class FreezableMock(object):
@@ -216,11 +223,14 @@ class FreezableMock(object):
         return object.__setattr__(self, name, value)
 
 
-def _create_get_utility_mock():
+def _create_get_utility_mock(stdout_notification=False):
     display = FreezableMock()
     for name in interfaces.IDisplay.names():  # pylint: disable=no-member
         if name != 'notification':
             frozen_mock = FreezableMock(frozen=True, func=_assert_valid_call)
+            setattr(display, name, frozen_mock)
+        if name == 'notification' and stdout_notification:
+            frozen_mock = FreezableMock(frozen=True, func=_stdout_notification)
             setattr(display, name, frozen_mock)
     display.freeze()
     return mock.MagicMock(return_value=display)
@@ -236,6 +246,10 @@ def _assert_valid_call(*args, **kwargs):
 
     # pylint: disable=star-args
     display_util.assert_valid_call(*assert_args, **assert_kwargs)
+
+
+def _stdout_notification(*args, **kwargs):
+    sys.stdout.write(args[0] if args else kwargs['message'])
 
 
 class TempDirTestCase(unittest.TestCase):


### PR DESCRIPTION
Changes `cerbot.tests.util.patch_get_utility` and `cerbot.tests._create_get_utility_mock` should be reviewed. They were updated to allow mock version `interfaces.IDisplay.notification` to print to stdout if needed for a test (like `certbot.tests.cli_test.ParseTest.test_help`).

Addresses #3720 