### PR TITLE
Encrypt the IRC channel to send notifications to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,7 @@ notifications:
   email: false
   irc:
     channels:
-      - "chat.freenode.net#letsencrypt-dev"
+      - secure: "HeXUVxLjB5dLl7JdTvY3EicLkZM5ZNtEa75x4Eud8a656y/6cpuhJli+devRwaAhq7fx7WkkZWWtcm9bJFx/vKwUYr7OCN2OJBNKviQfLxtBENt3gcMHALA+MNi5pQPw5ARe4NvEHABfyGTn6oti+5iFXcgAMGDq11RgDpHR+Bk="
     on_success: never
     on_failure: always
     use_notice: true


### PR DESCRIPTION
We got a flood of notifications last night in IRC due to builds failing in Travis on Certbot forks. It's currently an open feature request to directly configure Travis to only trigger notifications for builds from a specific repo (the main issue for this is travis-ci/travis-ci#1094).

The current workaround though is to encrypt the necessary values in `.travis.yml`. These encrypted values aren't available to forks ([source](https://docs.travis-ci.com/user/encryption-keys/)) so no notifications will be sent.

Like my initial PR enabling this (#4865), I'm not aware of a way to test this without trying it from `master`.