### PR TITLE
Don't send IRC notifications from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,7 @@ notifications:
   email: false
   irc:
     channels:
-      - "chat.freenode.net#letsencrypt-dev"
+      - secure: "SGWZl3ownKx9xKVV2VnGt7DqkTmutJ89oJV9tjKhSs84kLijU6EYdPnllqISpfHMTxXflNZuxtGo0wTDYHXBuZL47w1O32W6nzuXdra5zC+i4sYQwYULUsyfOv9gJX8zWAULiK0Z3r0oho45U+FR5ZN6TPCidi8/eGU+EEPwaAw="
     on_success: never
     on_failure: always
     use_notice: true


### PR DESCRIPTION
A tested version of #5061.

https://travis-ci.org/certbot/certbot/builds/270095169 caused an IRC notification but https://travis-ci.org/bmw/letsencrypt/builds/270096320 did not.