### PR TITLE
Specify the minimum six version in ACME

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',
-    'six',
+    'six>=1.9.0',  # needed for python_2_unicode_compatible
 ]
 
 # env markers cause problems with older pip and setuptools


### PR DESCRIPTION
Specifying this here prevents confusing error messages when someone tries to use an older version of `six`.