### PR TITLE
Add --no-self-upgrade to test farm test.

### DIFF
--- a/tests/letstest/scripts/test_letsencrypt_auto_certonly_standalone.sh
+++ b/tests/letstest/scripts/test_letsencrypt_auto_certonly_standalone.sh
@@ -38,7 +38,7 @@ if [ "$REVOKED" != 1 ] ; then
     exit 1
 fi
 
-if ! letsencrypt-auto --help | grep -F "letsencrypt-auto [SUBCOMMAND]"; then
+if ! letsencrypt-auto --help --no-self-upgrade | grep -F "letsencrypt-auto [SUBCOMMAND]"; then
     echo "letsencrypt-auto not included in help output!"
     exit 1
 fi


### PR DESCRIPTION
While tests should pass without this flag, we want to be testing the version of the script from `git`.