### PR TITLE
fix dns-rfc2136 plugin not respecting cnames

### DIFF
--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136.py
@@ -208,7 +208,7 @@ class _RFC2136Client(object):
             rcode = response.rcode()
 
             # Authoritative Answer bit should be set
-            if (rcode == dns.rcode.NOERROR and len(response.answer) > 0 and
+            if (rcode == dns.rcode.NOERROR and response.get_rrset(response.answer, domain, dns.rdataclass.IN, dns.rdatatype.SOA) and
                     response.flags & dns.flags.AA):
                 logger.debug('Received authoritative SOA response for %s', domain_name)
                 return True

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136.py
@@ -208,8 +208,8 @@ class _RFC2136Client(object):
             rcode = response.rcode()
 
             # Authoritative Answer bit should be set
-            if (rcode == dns.rcode.NOERROR and response.get_rrset(response.answer, domain, dns.rdataclass.IN, dns.rdatatype.SOA) and
-                    response.flags & dns.flags.AA):
+            if (rcode == dns.rcode.NOERROR and response.get_rrset(response.answer,
+                domain, dns.rdataclass.IN, dns.rdatatype.SOA) and response.flags & dns.flags.AA):
                 logger.debug('Received authoritative SOA response for %s', domain_name)
                 return True
 


### PR DESCRIPTION
The plugin does not work if the domain of a certificate is found to have a cname record in dns.
That is because when plugin tries to find zone boundary, it searches from the domain up for the SOA record, and each DNS response is checked for the answer being empty, assuming that empty answer means no SOA record is present and the higher level domain has to be checked, and non empty answer section means that this domain is a zone root.
However, if the initial domain, or any upper level domain except the zone root has a cname record pointing to the zone root, then the server will, instead of returning an empty answer, return one containing two records, first a cname pointing to the zone root, then the SOA record of zone root, and that will make the check fail and use a wrong domain as a zone name during update.
Fix that by replacing a check for empty answer with explicitly searching in response's answer section for a SOA record matching the domain that is being checked.