### PR TITLE
fix #5111 AttributeError occured with >=pyOpenSSL-17.2.0

### DIFF
--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -2,6 +2,7 @@
 import binascii
 import contextlib
 import logging
+import os
 import re
 import socket
 import sys
@@ -243,7 +244,7 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    cert.set_serial_number(int(binascii.hexlify(OpenSSL.rand.bytes(16)), 16))
+    cert.set_serial_number(int(binascii.hexlify(os.urandom(16)), 16))
     cert.set_version(2)
 
     extensions = [


### PR DESCRIPTION
pyOpenSSL's ChangeLog says that,
```
Deprecated OpenSSL.rand - callers should use os.urandom() instead.
```
for version 17.2.0, released at July 20th, 2017.

so I changed OpenSSL.rand to os.urandom() and I removed error message.
please review this patch.

Thank you for advance.

shcho@gnome.org