### PR TITLE
Stop using print in `certbot.main` module.

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -1,5 +1,6 @@
 """Certbot main entry point."""
 from __future__ import print_function
+import functools
 import logging.handlers
 import os
 import sys
@@ -492,7 +493,7 @@ def install(config, plugins):
     _install_cert(config, le_client, domains)
 
 
-def plugins_cmd(config, plugins):  # TODO: Use IDisplay rather than print
+def plugins_cmd(config, plugins):
     """List server software plugins."""
     logger.debug("Expected interfaces: %s", config.ifaces)
 
@@ -500,8 +501,10 @@ def plugins_cmd(config, plugins):  # TODO: Use IDisplay rather than print
     filtered = plugins.visible().ifaces(ifaces)
     logger.debug("Filtered plugins: %r", filtered)
 
+    notify = functools.partial(zope.component.getUtility(
+        interfaces.IDisplay).notification, pause=False)
     if not config.init and not config.prepare:
-        print(str(filtered))
+        notify(str(filtered))
         return
 
     filtered.init(config)
@@ -509,13 +512,13 @@ def plugins_cmd(config, plugins):  # TODO: Use IDisplay rather than print
     logger.debug("Verified plugins: %r", verified)
 
     if not config.prepare:
-        print(str(verified))
+        notify(str(verified))
         return
 
     verified.prepare()
     available = verified.available()
     logger.debug("Prepared plugins: %s", available)
-    print(str(available))
+    notify(str(available))
 
 
 def rollback(config, plugins):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -540,13 +540,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         plugins = mock_disco.PluginsRegistry.find_all()
 
         stdout = six.StringIO()
-        def write_msg(message, *args, **kwargs):
-            """Write message to stdout"""
-            _, _ = args, kwargs
-            stdout.write(message)
-
-        with test_util.patch_get_utility() as mock_get_utility:
-            mock_get_utility().notification.side_effect = write_msg
+        with test_util.patch_get_utility_with_stdout(stdout=stdout):
             _, stdout, _, _ = self._call(['plugins'], stdout)
 
         plugins.visible.assert_called_once_with()
@@ -566,16 +560,9 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             raise errors.Error()
 
         stdout = six.StringIO()
-        def write_msg(message, *args, **kwargs):
-            """Write message to stdout"""
-            _, _ = args, kwargs
-            stdout.write(message)
-
         with mock.patch('certbot.util.set_up_core_dir') as mock_set_up_core_dir:
-            with test_util.patch_get_utility() as mock_get_utility:
+            with test_util.patch_get_utility_with_stdout(stdout=stdout):
                 mock_set_up_core_dir.side_effect = throw_error
-                mock_get_utility().notification.side_effect = write_msg
-
                 _, stdout, _, _ = self._call(['plugins'], stdout)
 
         plugins.visible.assert_called_once_with()
@@ -590,13 +577,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         plugins = mock_disco.PluginsRegistry.find_all()
 
         stdout = six.StringIO()
-        def write_msg(message, *args, **kwargs):
-            """Write message to stdout"""
-            _, _ = args, kwargs
-            stdout.write(message)
-
-        with test_util.patch_get_utility() as mock_get_utility:
-            mock_get_utility().notification.side_effect = write_msg
+        with test_util.patch_get_utility_with_stdout(stdout=stdout):
             _, stdout, _, _ = self._call(['plugins', '--init'], stdout)
 
         plugins.visible.assert_called_once_with()
@@ -614,13 +595,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         plugins = mock_disco.PluginsRegistry.find_all()
 
         stdout = six.StringIO()
-        def write_msg(message, *args, **kwargs):
-            """Write message to stdout"""
-            _, _ = args, kwargs
-            stdout.write(message)
-
-        with test_util.patch_get_utility() as mock_get_utility:
-            mock_get_utility().notification.side_effect = write_msg
+        with test_util.patch_get_utility_with_stdout(stdout=stdout):
             _, stdout, _, _ = self._call(['plugins', '--init', '--prepare'], stdout)
 
         plugins.visible.assert_called_once_with()

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -539,7 +539,16 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         ifaces = []
         plugins = mock_disco.PluginsRegistry.find_all()
 
-        _, stdout, _, _ = self._call(['plugins'])
+        stdout = six.StringIO()
+        def write_msg(message, *args, **kwargs):
+            """Write message to stdout"""
+            _, _ = args, kwargs
+            stdout.write(message)
+
+        with test_util.patch_get_utility() as mock_get_utility:
+            mock_get_utility().notification.side_effect = write_msg
+            _, stdout, _, _ = self._call(['plugins'], stdout)
+
         plugins.visible.assert_called_once_with()
         plugins.visible().ifaces.assert_called_once_with(ifaces)
         filtered = plugins.visible().ifaces()
@@ -556,14 +565,23 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             _, _, _, _ = directory, mode, uid, strict
             raise errors.Error()
 
-        with mock.patch('certbot.util.set_up_core_dir') as mock_set_up_core_dir:
-            mock_set_up_core_dir.side_effect = throw_error
+        stdout = six.StringIO()
+        def write_msg(message, *args, **kwargs):
+            """Write message to stdout"""
+            _, _ = args, kwargs
+            stdout.write(message)
 
-            _, stdout, _, _ = self._call(['plugins'])
-            plugins.visible.assert_called_once_with()
-            plugins.visible().ifaces.assert_called_once_with(ifaces)
-            filtered = plugins.visible().ifaces()
-            self.assertEqual(stdout.getvalue().strip(), str(filtered))
+        with mock.patch('certbot.util.set_up_core_dir') as mock_set_up_core_dir:
+            with test_util.patch_get_utility() as mock_get_utility:
+                mock_set_up_core_dir.side_effect = throw_error
+                mock_get_utility().notification.side_effect = write_msg
+
+                _, stdout, _, _ = self._call(['plugins'], stdout)
+
+        plugins.visible.assert_called_once_with()
+        plugins.visible().ifaces.assert_called_once_with(ifaces)
+        filtered = plugins.visible().ifaces()
+        self.assertEqual(stdout.getvalue().strip(), str(filtered))
 
     @mock.patch('certbot.main.plugins_disco')
     @mock.patch('certbot.main.cli.HelpfulArgumentParser.determine_help_topics')
@@ -571,7 +589,16 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         ifaces = []
         plugins = mock_disco.PluginsRegistry.find_all()
 
-        _, stdout, _, _ = self._call(['plugins', '--init'])
+        stdout = six.StringIO()
+        def write_msg(message, *args, **kwargs):
+            """Write message to stdout"""
+            _, _ = args, kwargs
+            stdout.write(message)
+
+        with test_util.patch_get_utility() as mock_get_utility:
+            mock_get_utility().notification.side_effect = write_msg
+            _, stdout, _, _ = self._call(['plugins', '--init'], stdout)
+
         plugins.visible.assert_called_once_with()
         plugins.visible().ifaces.assert_called_once_with(ifaces)
         filtered = plugins.visible().ifaces()
@@ -585,7 +612,17 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
     def test_plugins_prepare(self, _det, mock_disco):
         ifaces = []
         plugins = mock_disco.PluginsRegistry.find_all()
-        _, stdout, _, _ = self._call(['plugins', '--init', '--prepare'])
+
+        stdout = six.StringIO()
+        def write_msg(message, *args, **kwargs):
+            """Write message to stdout"""
+            _, _ = args, kwargs
+            stdout.write(message)
+
+        with test_util.patch_get_utility() as mock_get_utility:
+            mock_get_utility().notification.side_effect = write_msg
+            _, stdout, _, _ = self._call(['plugins', '--init', '--prepare'], stdout)
+
         plugins.visible.assert_called_once_with()
         plugins.visible().ifaces.assert_called_once_with(ifaces)
         filtered = plugins.visible().ifaces()

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -278,16 +278,16 @@ def _create_get_utility_mock_with_stdout(stdout):
     def _write_msg(message, *unused_args, **unused_kwargs):
         """Write to message to stdout.
         """
-        stdout.write(message)
+        if message:
+            stdout.write(message)
 
     def mock_method(*args, **kwargs):
         """
         Mock function for IDisplay methods.
         """
-        message = args[0] if args else kwargs.get('message', None)
-        if message:
-            _write_msg(message, args, kwargs)
         _assert_valid_call(args, kwargs)
+        _write_msg(*args, **kwargs)
+
 
     display = FreezableMock()
     for name in interfaces.IDisplay.names():  # pylint: disable=no-member

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -171,11 +171,14 @@ def patch_get_utility(target='zope.component.getUtility'):
 
 
 def patch_get_utility_with_stdout(target='zope.component.getUtility',
-                                  stdout=six.StringIO()):
+                                  stdout=None):
     """Patch zope.component.getUtility to use a special mock IDisplay.
 
     The mock IDisplay works like a regular mock object, except it also
     also asserts that methods are called with valid arguments.
+
+    The `message` argument passed to the IDisplay methods is passed to
+    stdout's write method.
 
     :param str target: path to patch
     :param object stdout: object to write standard output to; it is
@@ -185,6 +188,7 @@ def patch_get_utility_with_stdout(target='zope.component.getUtility',
     :rtype: mock.MagicMock
 
     """
+    stdout = stdout if stdout else six.StringIO()
 
     freezable_mock = _create_get_utility_mock_with_stdout(stdout)
     return mock.patch(target, new=freezable_mock)

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -276,6 +276,15 @@ def _create_get_utility_mock_with_stdout(stdout):
         """
         stdout.write(message)
 
+    def mock_method(*args, **kwargs):
+        """
+        Mock function for IDisplay methods.
+        """
+        message = args[0] if args else kwargs.get('message', None)
+        if message:
+            _write_msg(message, args, kwargs)
+        _assert_valid_call(args, kwargs)
+
     display = FreezableMock()
     for name in interfaces.IDisplay.names():  # pylint: disable=no-member
         if name == 'notification':
@@ -284,7 +293,7 @@ def _create_get_utility_mock_with_stdout(stdout):
             setattr(display, name, frozen_mock)
         else:
             frozen_mock = FreezableMock(frozen=True,
-                                        func=_assert_valid_call)
+                                        func=mock_method)
             setattr(display, name, frozen_mock)
     display.freeze()
 


### PR DESCRIPTION
* Update certbot.main.plugins_cmd` function.

* Update test methods `test_plugins_no_args`,
`test_plugins_no_args_unprivileged`, `test_plugins_init` and
`test_plugins_prepare` in `cerbot.tests.MainTest` class.

Addresses #3720.