### PR TITLE
Fix Certbot with new versions of PyOpenSSL

### DIFF
--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -2,6 +2,7 @@
 import binascii
 import contextlib
 import logging
+import os
 import re
 import socket
 import sys
@@ -243,7 +244,7 @@ def gen_ss_cert(key, domains, not_before=None,
     """
     assert domains, "Must provide one or more hostnames for the cert."
     cert = OpenSSL.crypto.X509()
-    cert.set_serial_number(int(binascii.hexlify(OpenSSL.rand.bytes(16)), 16))
+    cert.set_serial_number(int(binascii.hexlify(os.urandom(16)), 16))
     cert.set_version(2)
 
     extensions = [


### PR DESCRIPTION
See #5111 and [PyOpenSSL's changelog](https://github.com/pyca/pyopenssl/blob/master/CHANGELOG.rst).

When distros upgrade to PyOpenSSL 17.3.0, Certbot will be unable to solve TLS-SNI challenges or make SSL server blocks in Nginx. While no distros have done this yet, some are working on it (e.g. [Arch Linux](https://www.archlinux.org/packages/testing/any/python2-pyopenssl/)) so I think we should get this fix out to ASAP avoid breakage.

I've been talking to Erik in IRC about how we missed deprecation warnings and how to prevent this in the future.