### PR TITLE
Implement TCP keepalives in ACME client

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -12,6 +12,7 @@ from six.moves import http_client  # pylint: disable=import-error
 
 import OpenSSL
 import requests
+import socket
 import sys
 
 from acme import errors
@@ -516,6 +517,10 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         self._nonces = set()
         self.user_agent = user_agent
         self.session = requests.Session()
+        adapter = HTTPAdapterWithSocketOptions(
+            socket_options=[(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)])
+        self.session.mount('http://', adapter)
+        self.session.mount('https://', adapter)
         self._default_timeout = timeout
 
     def __del__(self):
@@ -693,3 +698,15 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         response = self._send_request('POST', url, data=data, **kwargs)
         self._add_nonce(response)
         return self._check_response(response, content_type=content_type)
+
+
+class HTTPAdapterWithSocketOptions(requests.adapters.HTTPAdapter):
+    """Adapter allowing custom socket options."""
+    def __init__(self, *args, **kwargs):
+        self.socket_options = kwargs.pop("socket_options", None)
+        super(HTTPAdapterWithSocketOptions, self).__init__(*args, **kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        if self.socket_options is not None:
+            kwargs["socket_options"] = self.socket_options
+        super(HTTPAdapterWithSocketOptions, self).init_poolmanager(*args, **kwargs)


### PR DESCRIPTION
Fixes #5110.

This PR implements TCP keepalives in the ACME client via setting of the `SO_KEEPALIVE` socket option. This is not implemented in requests, see requests/requests#3808. 

_Note:_ It is **also** necessary on most operating systems to set the keepalive time via an option. For example, on Linux this is set via `/proc/sys/net/ipv4/tcp_keepalive_time`.

When executing long-lived certbot sessions, for example, using certbot-dns-route53 for auth against 16 different domains, the ACME client holds open an idle connection to the server for several minutes. (The issuance process in this example case takes 12 minutes.)

In some environments, including AWS, firewalls and NAT devices may have arbitrary timeouts on idle TCP sessions. In the case of the AWS NAT Gateway, this is [five minutes](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html#nat-gateway-troubleshooting-timeout). There is no option to change it.

A failure scenario looks like:
```
Found credentials in environment variables.
Plugins selected: Authenticator dns-route53, Installer None
Obtaining a new certificate
Performing the following challenges:
dns-01 challenge for test1.0x1.net
dns-01 challenge for test2.0x1.net
dns-01 challenge for test3.0x1.net
dns-01 challenge for test4.0x1.net
dns-01 challenge for test5.0x1.net
dns-01 challenge for test6.0x1.net
dns-01 challenge for test7.0x1.net
dns-01 challenge for test8.0x1.net
dns-01 challenge for test9.0x1.net
dns-01 challenge for test10.0x1.net
dns-01 challenge for test11.0x1.net
dns-01 challenge for test12.0x1.net
dns-01 challenge for test13.0x1.net
dns-01 challenge for test14.0x1.net
dns-01 challenge for test15.0x1.net
dns-01 challenge for test16.0x1.net
Starting new HTTPS connection (1): route53.amazonaws.com
Resetting dropped connection: route53.amazonaws.com
Resetting dropped connection: route53.amazonaws.com
Resetting dropped connection: route53.amazonaws.com
Waiting 10 seconds for DNS changes to propagate
Waiting for verification...
An unexpected error occurred:
ConnectionError: ('Connection aborted.', error("(104, 'ECONNRESET')",))
```

