### PR TITLE
Handle NoneType from Augeas better in Apache parser get_arg

### DIFF
--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -130,7 +130,7 @@ class ApacheParser(object):
                     self.modules.add(os.path.basename(mod_filename)[:-2] + "c")
                 else:
                     logger.debug("Could not read LoadModule directive from " +
-                                 "Augeas path: {}".format(match_name[6:]))
+                                 "Augeas path: {0}".format(match_name[6:]))
 
     def update_runtime_variables(self):
         """"

--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -123,9 +123,14 @@ class ApacheParser(object):
 
             for match_name, match_filename in six.moves.zip(
                     iterator, iterator):
-                self.modules.add(self.get_arg(match_name))
-                self.modules.add(
-                    os.path.basename(self.get_arg(match_filename))[:-2] + "c")
+                mod_name = self.get_arg(match_name)
+                mod_filename = self.get_arg(match_filename)
+                if mod_name and mod_filename:
+                    self.modules.add(mod_name)
+                    self.modules.add(os.path.basename(mod_filename)[:-2] + "c")
+                else:
+                    logger.debug("Could not read LoadModule directive from " +
+                                 "Augeas path: {}".format(match_name[6:]))
 
     def update_runtime_variables(self):
         """"
@@ -372,7 +377,7 @@ class ApacheParser(object):
         # Note: normal argument may be a quoted variable
         # e.g. strip now, not later
         if not value:
-            return ""
+            return None
         else:
             value = value.strip("'\"")
 

--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -371,7 +371,10 @@ class ApacheParser(object):
 
         # Note: normal argument may be a quoted variable
         # e.g. strip now, not later
-        value = value.strip("'\"")
+        if not value:
+            return ""
+        else:
+            value = value.strip("'\"")
 
         variables = ApacheParser.arg_var_interpreter.findall(value)
 

--- a/certbot-apache/certbot_apache/tests/parser_test.py
+++ b/certbot-apache/certbot_apache/tests/parser_test.py
@@ -66,6 +66,14 @@ class BasicParserTest(util.ParserTest):
         for i, match in enumerate(matches):
             self.assertEqual(self.parser.aug.get(match), str(i + 1))
 
+    def test_empty_arg(self):
+        mock_aug = mock.Mock()
+        mock_getarg = mock.Mock()
+        mock_getarg.return_value = None
+        mock_aug.get = mock_getarg
+        self.parser.aug = mock_aug
+        self.assertEquals("", self.parser.get_arg("whatever"))
+
     def test_add_dir_to_ifmodssl(self):
         """test add_dir_to_ifmodssl.
 

--- a/certbot-apache/certbot_apache/tests/parser_test.py
+++ b/certbot-apache/certbot_apache/tests/parser_test.py
@@ -67,7 +67,8 @@ class BasicParserTest(util.ParserTest):
             self.assertEqual(self.parser.aug.get(match), str(i + 1))
 
     def test_empty_arg(self):
-        self.assertEquals("", self.parser.get_arg("/files/whatever/nonexistent"))
+        self.assertEquals(None,
+                          self.parser.get_arg("/files/whatever/nonexistent"))
 
     def test_add_dir_to_ifmodssl(self):
         """test add_dir_to_ifmodssl.
@@ -116,6 +117,16 @@ class BasicParserTest(util.ParserTest):
 
             self.assertEqual(results["default"], results["listen"])
             self.assertEqual(results["default"], results["name"])
+
+    @mock.patch("certbot_apache.parser.ApacheParser.find_dir")
+    @mock.patch("certbot_apache.parser.ApacheParser.get_arg")
+    def test_init_modules_bad_syntax(self, mock_arg, mock_find):
+        mock_find.return_value = ["1", "2", "3", "4", "5", "6", "7", "8"]
+        mock_arg.return_value = None
+        with mock.patch("certbot_apache.parser.logger") as mock_logger:
+            self.parser.init_modules()
+            # Make sure that we got None return value and logged the file
+            self.assertTrue(mock_logger.debug.called)
 
     @mock.patch("certbot_apache.parser.ApacheParser._get_runtime_cfg")
     def test_update_runtime_variables(self, mock_cfg):

--- a/certbot-apache/certbot_apache/tests/parser_test.py
+++ b/certbot-apache/certbot_apache/tests/parser_test.py
@@ -67,12 +67,7 @@ class BasicParserTest(util.ParserTest):
             self.assertEqual(self.parser.aug.get(match), str(i + 1))
 
     def test_empty_arg(self):
-        mock_aug = mock.Mock()
-        mock_getarg = mock.Mock()
-        mock_getarg.return_value = None
-        mock_aug.get = mock_getarg
-        self.parser.aug = mock_aug
-        self.assertEquals("", self.parser.get_arg("whatever"))
+        self.assertEquals("", self.parser.get_arg("/files/whatever/nonexistent"))
 
     def test_add_dir_to_ifmodssl(self):
         """test add_dir_to_ifmodssl.


### PR DESCRIPTION
Handles `None` from aug.get() in a sane way.

I'm still unsure why it happens, but from the Certbot point of view, this is the correct check to add.

Fixes: #4245 