### PR TITLE
[#5154] Enable certificate verification (incl. revocation) on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY certbot src/certbot
 RUN apk add --no-cache --virtual .certbot-deps \
         libffi \
         libssl1.0 \
+        openssl \
         ca-certificates \
         binutils
 RUN apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
Fixes #5154 .

I tested the revised Docker image feat `openssl` on the staging server where I created a certificate for a domain that I control, and revoked it.

Upon verification, `certbot` did not issue the notice about openssl not being installed, and instead proceeded to verify the certificate, correctly reporting it as revoked:

```
/opt/certbot # certbot  certificates
Saving debug log to /var/log/letsencrypt/letsencrypt.log

-------------------------------------------------------------------------------
Found the following certs:
  Certificate Name: <cert name>
    Domains: <cert path>
    Expiry Date: 2017-12-31 <time> (INVALID: TEST_CERT, REVOKED)
    Certificate Path: /etc/letsencrypt/live/<cert name>fullchain.pem
    Private Key Path: /etc/letsencrypt/live/<cert name>/privkey.pem
-------------------------------------------------------------------------------
```

Please let me know whether I need to carry out other tests, document behavior in the User Guide.