### PR TITLE
certbot: Stop using print in log module.

### DIFF
--- a/certbot/log.py
+++ b/certbot/log.py
@@ -359,11 +359,11 @@ def post_arg_parse_except_hook(exc_type, exc_value, trace, debug, log_path):
         logger.debug('Exiting abnormally:', exc_info=exc_info)
         if issubclass(exc_type, errors.Error):
             sys.exit(exc_value)
-        print('An unexpected error occurred:', file=sys.stderr)
+        logger.error('An unexpected error occurred:')
         if messages.is_acme_error(exc_value):
             # Remove the ACME error prefix from the exception
             _, _, exc_str = str(exc_value).partition(':: ')
-            print(exc_str, file=sys.stderr)
+            logger.error(exc_str)
         else:
             traceback.print_exception(exc_type, exc_value, None)
     exit_with_log_path(log_path)

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -343,11 +343,17 @@ class PostArgParseExceptHookTest(unittest.TestCase):
     def _test_common(self, error_type, debug):
         """Returns the mocked logger and stderr output."""
         mock_err = six.StringIO()
+
+        def write_err(*args, **unused_kwargs):
+            """Write error to mock_err."""
+            mock_err.write(args[0])
+
         try:
             raise error_type(self.error_msg)
         except BaseException:
             exc_info = sys.exc_info()
             with mock.patch('certbot.log.logger') as mock_logger:
+                mock_logger.error.side_effect = write_err
                 with mock.patch('certbot.log.sys.stderr', mock_err):
                     try:
                         # pylint: disable=star-args


### PR DESCRIPTION
* Update certbot.log.post_arg_parse_except_hook function.
* Update certbot.tests.log_test._test_common method.

See discussion in #3720.