### PR TITLE
certbot: Flush output after write in IDisplay methods.

### DIFF
--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -117,6 +117,7 @@ class FileDisplay(object):
         self.outfile.write(
             "{line}{frame}{line}{msg}{line}{frame}{line}".format(
                 line=os.linesep, frame=side_frame, msg=message))
+        self.outfile.flush()
         if pause:
             if self._can_interact(force_interactive):
                 input_with_timeout("Press Enter to Continue")
@@ -213,6 +214,7 @@ class FileDisplay(object):
 
         self.outfile.write("{0}{frame}{msg}{0}{frame}".format(
             os.linesep, frame=side_frame, msg=message))
+        self.outfile.flush()
 
         while True:
             ans = input_with_timeout("{yes}/{no}: ".format(
@@ -267,6 +269,7 @@ class FileDisplay(object):
                 else:
                     self.outfile.write(
                         "** Error - Invalid selection **%s" % os.linesep)
+                    self.outfile.flush()
             else:
                 return code, []
 
@@ -395,6 +398,7 @@ class FileDisplay(object):
             self.outfile.write(os.linesep)
 
         self.outfile.write(side_frame)
+        self.outfile.flush()
 
     def _get_valid_int_ans(self, max_):
         """Get a numerical selection.
@@ -428,6 +432,7 @@ class FileDisplay(object):
             except ValueError:
                 self.outfile.write(
                     "{0}** Invalid input **{0}".format(os.linesep))
+                self.outfile.flush()
 
         return OK, selection
 
@@ -483,6 +488,7 @@ class NoninteractiveDisplay(object):
         self.outfile.write(
             "{line}{frame}{line}{msg}{line}{frame}{line}".format(
                 line=os.linesep, frame=side_frame, msg=message))
+        self.outfile.flush()
 
     def menu(self, message, choices, ok_label=None, cancel_label=None,
              help_label=None, default=None, cli_flag=None, **unused_kwargs):


### PR DESCRIPTION
- Update `notification`, `yesno`, `checklist`, `_print_menu`, and
  `_get_valid_int_ans` methods in `certbot.display.util.FileDisplay`.
- Update `notification` method in
  `certbot.display.util.NoninteractiveDisplay`.

Addresses issue #4879.