### PR TITLE
Retry boulder-fetch.sh to prevent test failures

### DIFF
--- a/tests/travis-integration.sh
+++ b/tests/travis-integration.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-./tests/boulder-fetch.sh
+travis_retry ./tests/boulder-fetch.sh
 
 source .tox/$TOXENV/bin/activate
 


### PR DESCRIPTION
Prevents issues like the one seen at https://travis-ci.org/certbot/certbot/jobs/282923098.