### PR TITLE
Skip menu in webroot plugin when there's nothing to choose from

### DIFF
--- a/certbot/plugins/webroot_test.py
+++ b/certbot/plugins/webroot_test.py
@@ -96,7 +96,7 @@ class AuthenticatorTest(unittest.TestCase):
     @test_util.patch_get_utility()
     def test_new_webroot(self, mock_get_utility):
         self.config.webroot_path = []
-        self.config.webroot_map = {}
+        self.config.webroot_map = {"something.com": self.path}
 
         mock_display = mock_get_utility()
         mock_display.menu.return_value = (display_util.OK, 0,)
@@ -107,6 +107,19 @@ class AuthenticatorTest(unittest.TestCase):
             self.auth.perform([self.achall])
 
         self.assertEqual(self.config.webroot_map[self.achall.domain], self.path)
+
+    @test_util.patch_get_utility()
+    def test_new_webroot_empty_map_cancel(self, mock_get_utility):
+        self.config.webroot_path = []
+        self.config.webroot_map = {}
+
+        mock_display = mock_get_utility()
+        mock_display.menu.return_value = (display_util.OK, 0,)
+        with mock.patch('certbot.display.ops.validated_directory') as m:
+            m.return_value = (display_util.CANCEL, -1)
+            self.assertRaises(errors.PluginError,
+                              self.auth.perform,
+                              [self.achall])
 
     def test_perform_missing_root(self):
         self.config.webroot_path = None


### PR DESCRIPTION
Do not present user a webroot map menu when the only thing to select is "Enter a new webroot". This might confuse the user to try and input webroot path here, which then again will result into somewhat uninformative error message: `** Invalid input **`. 

I stumbled upon this while helping on IRC, and figured it'd be a trivial fix.

Old behaviour:
```
$ certbot certonly --webroot -d example.com
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator webroot, Installer None
Obtaining a new certificate
Performing the following challenges:
http-01 challenge for example.com

Select the webroot for example.com:
-------------------------------------------------------------------------------
1: Enter a new webroot
-------------------------------------------------------------------------------
Press 1 [enter] to confirm the selection (press 'c' to cancel): 1
Input the webroot for example.com: (Enter 'c' to cancel): /path/to/webroot
...
```

New behaviour:
```
$ certbot certonly --staging --webroot -d example.com
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator webroot, Installer None
Obtaining a new certificate
Performing the following challenges:
http-01 challenge for example.com
Input the webroot for example.com: (Enter 'c' to cancel): /path/to/webroot
...
```