### PR TITLE
Correctly test for existing Certbot redirect when adding an Nginx redirect block

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -30,7 +30,7 @@ from certbot_nginx import parser
 logger = logging.getLogger(__name__)
 
 REDIRECT_BLOCK = [[
-    ['\n    ', 'if', ' ', '($scheme', ' ', '!=', ' ', '"https") '],
+    ['\n    ', 'if', ' ', '($scheme', ' ', '!=', ' ', '"https")'],
     [['\n        ', 'return', ' ', '301', ' ', 'https://$host$request_uri'],
      '\n    ']
 ], ['\n']]

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -527,7 +527,7 @@ class NginxConfiguratorTest(util.NginxTest):
         ]
         generated_conf = self.config.parser.parsed[example_conf]
         for line in unexpected:
-          self.assertFalse(util.contains_at_depth(generated_conf, line, 2))
+            self.assertFalse(util.contains_at_depth(generated_conf, line, 2))
 
     def test_staple_ocsp_bad_version(self):
         self.config.version = (1, 3, 1)

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -429,7 +429,7 @@ class NginxConfiguratorTest(util.NginxTest):
         # Test that we successfully add a redirect when there is
         # a listen directive
         expected = [
-            ['if', '($scheme', '!=', '"https") '],
+            ['if', '($scheme', '!=', '"https")'],
             [['return', '301', 'https://$host$request_uri']]
         ]
 


### PR DESCRIPTION
Fixes #5156.