### PR TITLE
[#5155] - replaces isinstance(x, str) with isinstance(x, six.string_types)

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -142,14 +142,14 @@ def report_config_interaction(modified, modifiers):
     between config options.
 
     :param modified: config options that can be modified by modifiers
-    :type modified: iterable or str
+    :type modified: iterable or str (string_types)
     :param modifiers: config options that modify modified
-    :type modifiers: iterable or str
+    :type modifiers: iterable or str (string_types)
 
     """
-    if isinstance(modified, str):
+    if isinstance(modified, six.string_types):
         modified = (modified,)
-    if isinstance(modifiers, str):
+    if isinstance(modifiers, six.string_types):
         modifiers = (modifiers,)
 
     for var in modified:
@@ -477,7 +477,7 @@ class HelpfulArgumentParser(object):
         if isinstance(help1, bool) and isinstance(help2, bool):
             self.help_arg = help1 or help2
         else:
-            self.help_arg = help1 if isinstance(help1, str) else help2
+            self.help_arg = help1 if isinstance(help1, six.string_types) else help2
 
         short_usage = self._usage_string(plugins, self.help_arg)
 

--- a/certbot/plugins/null_test.py
+++ b/certbot/plugins/null_test.py
@@ -1,5 +1,6 @@
 """Tests for certbot.plugins.null."""
 import unittest
+import six
 
 import mock
 
@@ -12,7 +13,7 @@ class InstallerTest(unittest.TestCase):
         self.installer = Installer(config=mock.MagicMock(), name="null")
 
     def test_it(self):
-        self.assertTrue(isinstance(self.installer.more_info(), str))
+        self.assertTrue(isinstance(self.installer.more_info(), six.string_types))
         self.assertEqual([], self.installer.get_all_names())
         self.assertEqual([], self.installer.supported_enhancements())
 

--- a/certbot/plugins/webroot_test.py
+++ b/certbot/plugins/webroot_test.py
@@ -50,7 +50,7 @@ class AuthenticatorTest(unittest.TestCase):
 
     def test_more_info(self):
         more_info = self.auth.more_info()
-        self.assertTrue(isinstance(more_info, str))
+        self.assertTrue(isinstance(more_info, six.string_types))
         self.assertTrue(self.path in more_info)
 
     def test_add_parser_arguments(self):

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -108,7 +108,7 @@ def _restore_webroot_config(config, renewalparams):
     elif "webroot_path" in renewalparams:
         logger.debug("Ancient renewal conf file without webroot-map, restoring webroot-path")
         wp = renewalparams["webroot_path"]
-        if isinstance(wp, str):  # prior to 0.1.0, webroot_path was a string
+        if isinstance(wp, six.string_types):  # prior to 0.1.0, webroot_path was a string
             wp = [wp]
         config.webroot_path = wp
 
@@ -194,7 +194,7 @@ def _restore_pref_challs(unused_name, value):
     # If pref_challs has only one element, configobj saves the value
     # with a trailing comma so it's parsed as a list. If this comma is
     # removed by the user, the value is parsed as a str.
-    value = [value] if isinstance(value, str) else value
+    value = [value] if isinstance(value, six.string_types) else value
     return cli.parse_preferred_challenges(value)
 
 

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -258,7 +258,7 @@ class UniqueLineageNameTest(test_util.TempDirTestCase):
         for _ in six.moves.range(10):
             f, name = self._call("wow")
         self.assertTrue(isinstance(f, file_type))
-        self.assertTrue(isinstance(name, str))
+        self.assertTrue(isinstance(name, six.string_types))
         self.assertTrue("wow-0009.conf" in name)
 
     @mock.patch("certbot.util.os.fdopen")


### PR DESCRIPTION
as proposed by @ohemorange in #5155 to be Python3 safe.