### PR TITLE
Forcing pip to use https on older docker images (Wheezy & Precise)

### DIFF
--- a/letsencrypt-auto-source/Dockerfile.precise
+++ b/letsencrypt-auto-source/Dockerfile.precise
@@ -10,6 +10,8 @@ RUN useradd --create-home --home-dir /home/lea --shell /bin/bash --groups sudo -
 RUN apt-get update && \
     apt-get -q -y install python-pip sudo openssl && \
     apt-get clean
+
+ENV PIP_INDEX_URL https://pypi.python.org/simple
 RUN pip install nose
 
 # Let that user sudo:

--- a/letsencrypt-auto-source/Dockerfile.wheezy
+++ b/letsencrypt-auto-source/Dockerfile.wheezy
@@ -10,6 +10,8 @@ RUN useradd --create-home --home-dir /home/lea --shell /bin/bash --groups sudo -
 RUN apt-get update && \
     apt-get -q -y install python-pip sudo openssl && \
     apt-get clean
+
+ENV PIP_INDEX_URL https://pypi.python.org/simple
 RUN pip install nose
 
 # Let that user sudo:


### PR DESCRIPTION
As was pointed out in PR #5205, certain integration tests on Travis tests are failing because it seems PyPi now requires HTTPS, and the default for pip on Wheezy and Precise is to use HTTP. This PR updates the Dockerfiles to use HTTPS.