### PR TITLE
Use pipstrap to ensure pip works on older systems

### DIFF
--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -7,13 +7,11 @@ PLUGINS="certbot-apache certbot-nginx"
 PYTHON=$(command -v python2.7 || command -v python27 || command -v python2 || command -v python)
 TEMP_DIR=$(mktemp -d)
 VERSION=$(letsencrypt-auto-source/version.py)
+export VENV_ARGS="-p $PYTHON"
 
 # setup venv
-virtualenv --no-site-packages -p $PYTHON --setuptools venv
+tools/_venv_common.sh --requirement letsencrypt-auto-source/pieces/dependency-requirements.txt
 . ./venv/bin/activate
-pip install -U pip
-pip install -U setuptools
-pip install --requirement letsencrypt-auto-source/pieces/dependency-requirements.txt
 
 # build sdists
 for pkg_dir in acme . $PLUGINS; do

--- a/tools/_venv_common.sh
+++ b/tools/_venv_common.sh
@@ -15,10 +15,10 @@ mv $VENV_NAME "$VENV_NAME.$(date +%s).bak" || true
 virtualenv --no-site-packages --setuptools $VENV_NAME $VENV_ARGS
 . ./$VENV_NAME/bin/activate
 
-# Separately install setuptools and pip to make sure following
-# invocations use latest
-pip install -U pip
-pip install -U setuptools
+# Use pipstrap to update Python packaging tools to only update to a well tested
+# version and to work around https://github.com/pypa/pip/issues/4817 on older
+# systems.
+python letsencrypt-auto-source/pieces/pipstrap.py
 ./tools/pip_install.sh "$@"
 
 set +x


### PR DESCRIPTION
Addresses pypa/pip#4817 in our tools and tests when they are run on old Debian based distros.