### PR TITLE
Install dnsmadeeasy extras from dns-lexicon

### DIFF
--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -10,7 +10,9 @@ version = '0.20.0.dev0'
 install_requires = [
     'acme=={0}'.format(version),
     'certbot=={0}'.format(version),
-    'dns-lexicon',
+    # new versions of lexicon require that we install dnsmadeeasy extras and
+    # 2.1.11 is the first version that defines them.
+    'dns-lexicon[dnsmadeeasy]>=2.1.11',
     'mock',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:

--- a/tools/pip_constraints.txt
+++ b/tools/pip_constraints.txt
@@ -1,0 +1,65 @@
+# Specifies Python package versions for packages not specified in
+# letsencrypt-auto's requirements file. We should avoid listing packages in
+# both places because if both files are used as constraints for the same pip
+# invocation, some constraints may be ignored due to pip's lack of dependency
+# resolution.
+alabaster==0.7.10
+astroid==1.3.5
+Babel==2.5.1
+backports.shutil-get-terminal-size==1.0.0
+boto3==1.4.7
+botocore==1.7.41
+cloudflare==1.8.1
+coverage==4.4.2
+decorator==4.1.2
+dns-lexicon[dnsmadeeasy]==2.1.11
+dnspython==1.15.0
+docutils==0.14
+future==0.16.0
+futures==3.1.1
+google-api-python-client==1.6.4
+httplib2==0.10.3
+imagesize==0.7.1
+ipdb==0.10.3
+ipython==5.5.0
+ipython-genutils==0.2.0
+Jinja2==2.9.6
+jmespath==0.9.3
+logilab-common==1.4.1
+MarkupSafe==1.0
+nose==1.3.7
+oauth2client==4.1.2
+pathlib2==2.3.0
+pexpect==4.2.1
+pickleshare==0.7.4
+pkg-resources==0.0.0
+pkginfo==1.4.1
+pluggy==0.5.2
+prompt-toolkit==1.0.15
+ptyprocess==0.5.2
+py==1.4.34
+pyasn1==0.3.7
+pyasn1-modules==0.1.5
+Pygments==2.2.0
+pylint==1.4.2
+python-dateutil==2.6.1
+python-digitalocean==1.12
+PyYAML==3.12
+repoze.sphinx.autointerface==0.8
+requests-file==1.4.2
+requests-toolbelt==0.8.0
+rsa==3.4.2
+s3transfer==0.1.11
+scandir==1.6
+simplegeneric==0.8.1
+snowballstemmer==1.2.1
+Sphinx==1.5.6
+sphinx-rtd-theme==0.2.4
+tldextract==2.2.0
+tox==2.9.1
+tqdm==4.19.4
+traitlets==4.3.2
+twine==1.9.1
+uritemplate==3.0.0
+virtualenv==15.1.0
+wcwidth==0.1.7

--- a/tools/pip_install.sh
+++ b/tools/pip_install.sh
@@ -1,14 +1,15 @@
 #!/bin/sh -e
-# pip installs packages using Certbot's requirements file as constraints
+# pip installs packages using pinned package versions
 
 # get the root of the Certbot repo
 my_path=$("$(dirname $0)/readlink.py" $0)
 repo_root=$(dirname $(dirname $my_path))
 requirements="$repo_root/letsencrypt-auto-source/pieces/dependency-requirements.txt"
-constraints=$(mktemp)
-trap "rm -f $constraints" EXIT
+certbot_auto_constraints=$(mktemp)
+trap "rm -f $certbot_auto_constraints" EXIT
 # extract pinned requirements without hashes
-sed -n -e 's/^\([^[:space:]]*==[^[:space:]]*\).*$/\1/p' $requirements > $constraints
+sed -n -e 's/^\([^[:space:]]*==[^[:space:]]*\).*$/\1/p' $requirements > $certbot_auto_constraints
+dev_constraints="$(dirname $my_path)/pip_constraints.txt"
 
 # install the requested packages using the pinned requirements as constraints
-pip install --constraint $constraints "$@"
+pip install --constraint $certbot_auto_constraints --constraint $dev_constraints "$@"


### PR DESCRIPTION
Fixes https://travis-ci.org/certbot/certbot/jobs/298857322#L6606.

Now with the possible exception of a couple core Python packaging libraries whose installation is handled by [pipstrap](https://github.com/certbot/certbot/blob/master/letsencrypt-auto-source/pieces/pipstrap.py), all of our Python dependencies should be pinned in the dev environment and during tests.

This also specifes the dnsmadeeasy extras as requirements for our dnsmadeeasy plugin.