### PR TITLE
Show expiration dates for cert when skipping its renewal

### DIFF
--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -425,7 +425,10 @@ def handle_renewal_request(config):
                     main.renew_cert(lineage_config, plugins, renewal_candidate)
                     renew_successes.append(renewal_candidate.fullchain)
                 else:
-                    renew_skipped.append(renewal_candidate.fullchain)
+                    expiry = crypto_util.notAfter(renewal_candidate.version(
+                        "cert", renewal_candidate.latest_common_version()))
+                    renew_skipped.append("%s expires on %s" % (renewal_candidate.fullchain,
+                                         expiry.strftime("%Y-%m-%d")))
         except Exception as e:  # pylint: disable=broad-except
             # obtain_cert (presumably) encountered an unanticipated problem.
             logger.warning("Attempting to renew cert (%s) from %s produced an "


### PR DESCRIPTION
a reasonable fix for #5045 
I don't think it's necessary to include the length of the renewal window to the output, since users shouldn't get concerned about lack of renewal until the cert is within days of expiration, and maybe not even then. Additionally listing the renewal window length would require considerable parsing.
This will at least give the user a sense of why a certificate was not renewed.
Note that this has not been tested by anything but unit tests.