### PR TITLE
Remove all but one BOULDER_INTEGRATION, and macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ before_install:
 before_script:
   - 'if [ $TRAVIS_OS_NAME = osx ] ; then ulimit -n 1024 ; fi'
 
-# using separate envs with different TOXENVs creates 4x1 Travis build
-# matrix, which allows us to clearly distinguish which component under
-# test has failed
 matrix:
   include:
     - python: "2.7"
@@ -20,14 +17,14 @@ matrix:
     - python: "2.7"
       env: TOXENV=lint
     - python: "2.7"
-      env: TOXENV=py27-oldest BOULDER_INTEGRATION=1
+      env: TOXENV=py27-oldest
       sudo: required
       after_failure:
         - sudo cat /var/log/mysql/error.log
         - ps aux | grep mysql
       services: docker
     - python: "2.6"
-      env: TOXENV=py26 BOULDER_INTEGRATION=1
+      env: TOXENV=py26
       sudo: required
       after_failure:
         - sudo cat /var/log/mysql/error.log
@@ -108,12 +105,6 @@ matrix:
       services: docker
     - python: "2.7"
       env: TOXENV=nginxroundtrip
-    - language: generic
-      env: TOXENV=py27
-      os: osx
-    - language: generic
-      env: TOXENV=py36
-      os: osx
 
 
 # Only build pushes to the master branch, PRs, and branches beginning with

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=cover
+      env: TOXENV=cover FYI="this also tests py27"
     - python: "2.7"
       env: TOXENV=lint
     - python: "2.7"
@@ -67,19 +67,19 @@ matrix:
       env: TOXENV=apacheconftest
       sudo: required
     - python: "3.3"
-      env: TOXENV=py33 BOULDER_INTEGRATION=1
+      env: TOXENV=py33
       sudo: required
       services: docker
     - python: "3.4"
-      env: TOXENV=py34 BOULDER_INTEGRATION=1
+      env: TOXENV=py34
       sudo: required
       services: docker
     - python: "3.5"
-      env: TOXENV=py35 BOULDER_INTEGRATION=1
+      env: TOXENV=py35
       sudo: required
       services: docker
     - python: "3.6"
-      env: TOXENV=py36 BOULDER_INTEGRATION=1
+      env: TOXENV=py36
       sudo: required
       services: docker
     - python: "2.7"


### PR DESCRIPTION
These tests are retained in the test-everything branch, which has a Travis cron
job to run nightly.

Removing these speeds up the Certbot Travis builds dramatically for two reasons:
 - The Boulder integration tests are slow (10-12 minutes), and it's exceedingly
   rare for them to fail on one Python environment but not another.
 - The macOS tests take a very long time to run, because they need to wait for
   build slots on the limited number of macOS instances, which are often in high
   demand.