### PR TITLE
Fix macOS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,7 +160,7 @@ addons:
     - libapache2-mod-wsgi
     - libapache2-mod-macro
 
-install: "travis_retry pip install tox coveralls"
+install: "travis_retry $(command -v pip || command -v pip3) install tox coveralls"
 script:
     - travis_retry tox
     - '[ -z "${BOULDER_INTEGRATION+x}" ] || (travis_retry tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'


### PR DESCRIPTION
Apparently Homebrew made a change where `brew install python3` no longer puts a `pip` executable in your PATH and instead you have to use `pip3`. This change causes us to try both `pip` and `pip3` to install testing tools like `tox` and `coveralls`.