### PR TITLE
Pin packaging tools that have dropped support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,9 @@ source_paths =
 commands =
     {[base]install_and_test} {[base]py26_packages}
     python tests/lock_test.py
+deps =
+    setuptools==36.8.0
+    wheel==0.29.0
 
 [testenv]
 commands =
@@ -70,6 +73,12 @@ commands =
 setenv =
     PYTHONPATH = {toxinidir}
     PYTHONHASHSEED = 0
+
+[testenv:py33]
+commands =
+    {[testenv]commands}
+deps =
+    wheel==0.29.0
 
 [testenv:py27-oldest]
 commands =


### PR DESCRIPTION
Some of the versions of Python we support are so old that even core Python packaging tools have dropped support. This causes problems like the ones seen at https://travis-ci.org/jsha/certbot/jobs/308723670#L5811. (The reason we haven't seen failures on our repo yet is because of our pip cache saved between runs.)

We're actively working on dropping support for these two versions of Python ourselves, but in the meantime, this pins these packages to the latest version that still supports the platform.

Here's the documentation for [setuptools](https://setuptools.readthedocs.io/en/latest/history.html#v37-0-0) and [wheel](https://pypi.python.org/pypi/wheel) showing that they have dropped support.