### PR TITLE
Show a diff when re-creating certificate

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -254,7 +254,7 @@ def _find_lineage_for_domains_and_certname(config, domains, certname):
                     "possible certificate names.".format(certname))
 
 def _get_added_removed(after, before):
-    """Get lists of items removed from `before` 
+    """Get lists of items removed from `before`
     and a lists of items added to `after`
     """
     added = list(set(after) - set(before))

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -263,10 +263,10 @@ def _get_added_removed(after, before):
     removed.sort()
     return added, removed
 
-def _format_list(character, list):
+def _format_list(character, strings):
     """Format list with given character
     """
-    formatted = "{br}{ch} " + "{br}{ch} ".join(list)
+    formatted = "{br}{ch} " + "{br}{ch} ".join(strings)
     return formatted.format(
         ch=character,
         br=os.linesep

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -253,18 +253,39 @@ def _find_lineage_for_domains_and_certname(config, domains, certname):
                     "Use -d to specify domains, or run certbot --certificates to see "
                     "possible certificate names.".format(certname))
 
+def _get_added_removed(after, before):
+    """Get lists of items removed from `before` 
+    and a lists of items added to `after`
+    """
+    added = list(set(after) - set(before))
+    removed = list(set(before) - set(after))
+    added.sort()
+    removed.sort()
+    return added, removed
+
+def _format_list(character, list):
+    """Format list with given character
+    """
+    formatted = "{br}{ch} " + "{br}{ch} ".join(list)
+    return formatted.format(
+        ch=character,
+        br=os.linesep
+    )
+
 def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
     """Ask user to confirm update cert certname to contain new_domains.
     """
     if config.renew_with_new_domains:
         return
 
-    msg = ("You are updating certificate {0} to include domains: {1}{br}{br}"
-           "It previously included domains: {2}{br}{br}"
+    added, removed = _get_added_removed(new_domains, old_domains)
+
+    msg = ("You are updating certificate {0} to include new domain(s): {1}{br}{br}"
+           "You are also removing previously included domain(s): {2}{br}{br}"
            "Did you intend to make this change?".format(
                certname,
-               ", ".join(new_domains),
-               ", ".join(old_domains),
+               _format_list("+", added),
+               _format_list("-", removed),
                br=os.linesep))
     obj = zope.component.getUtility(interfaces.IDisplay)
     if not obj.yesno(msg, "Update cert", "Cancel", default=True):


### PR DESCRIPTION
For issue: Show a diff when re-creating certificate instead of full list of domains #5274 

Formatting is slightly different then originally proposed. Not sure if it's only my console, but using +/- gives an extra bonus of diff-like colors (green and red).

```
You are updating certificate demo.example.com to include new domain(s): 
+ demo2.example.com
+ demo4.example.com

You are also removing previously included domain(s): 
- demo3.example.com

Did you intend to make this change?
```