### PR TITLE
Quiet pip install output.

### DIFF
--- a/tools/install_and_test.sh
+++ b/tools/install_and_test.sh
@@ -6,11 +6,12 @@
 # constraints.
 
 if [ "$CERTBOT_NO_PIN" = 1 ]; then
-  pip_install="pip install -e"
+  pip_install="pip install -q -e"
 else
   pip_install="$(dirname $0)/pip_install_editable.sh"
 fi
 
+set -x
 for requirement in "$@" ; do
   $pip_install $requirement
   pkg=$(echo $requirement | cut -f1 -d\[)  # remove any extras such as [dev]

--- a/tools/pip_install.sh
+++ b/tools/pip_install.sh
@@ -11,5 +11,7 @@ trap "rm -f $certbot_auto_constraints" EXIT
 sed -n -e 's/^\([^[:space:]]*==[^[:space:]]*\).*$/\1/p' $requirements > $certbot_auto_constraints
 dev_constraints="$(dirname $my_path)/pip_constraints.txt"
 
+set -x
+
 # install the requested packages using the pinned requirements as constraints
-pip install --constraint $certbot_auto_constraints --constraint $dev_constraints "$@"
+pip install -q --constraint $certbot_auto_constraints --constraint $dev_constraints "$@"


### PR DESCRIPTION
pip install generates a lot of lines of output that make it harder to see what
tox is running in general. This adds the -q flag to pip install.

At the same time, add `set -x` in install_and_test.sh and pip_install.sh so they
echo the commands they are running. This makes it a little clearer what's going
on in tests.

I didn't put `set -x` at the top or in the shebang, because moving it lower lets
us avoid echoing some of the messy if/then setup statements in these scripts,
which focussed attention on the pip install command.