### PR TITLE
Revert requiring dnsmadeeasy extras for lexicon

### DIFF
--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -10,9 +10,7 @@ version = '0.20.0.dev0'
 install_requires = [
     'acme=={0}'.format(version),
     'certbot=={0}'.format(version),
-    # new versions of lexicon require that we install dnsmadeeasy extras and
-    # 2.1.11 is the first version that defines them.
-    'dns-lexicon[dnsmadeeasy]>=2.1.11',
+    'dns-lexicon',
     'mock',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:

--- a/tools/pip_constraints.txt
+++ b/tools/pip_constraints.txt
@@ -13,7 +13,7 @@ botocore==1.7.41
 cloudflare==1.8.1
 coverage==4.4.2
 decorator==4.1.2
-dns-lexicon[dnsmadeeasy]==2.1.11
+dns-lexicon==2.1.14
 dnspython==1.15.0
 docutils==0.14
 execnet==1.5.0


### PR DESCRIPTION
Fixes failures at https://travis-ci.org/certbot/certbot/jobs/310248574#L1558.

Additional context can be found at #5230 and https://github.com/AnalogJ/lexicon/commit/604584521a487dd0b8814320b3f1af52b82ad205#diff-2eeaed663bd0d25b7e608891384b7298.