### PR TITLE
Remove slash from document root path in Webroot example

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -106,7 +106,7 @@ specified ``--webroot-path``. So, for instance,
 
 ::
 
-    certbot certonly --webroot -w /var/www/example/ -d www.example.com -d example.com -w /var/www/other -d other.example.net -d another.other.example.net
+    certbot certonly --webroot -w /var/www/example -d www.example.com -d example.com -w /var/www/other -d other.example.net -d another.other.example.net
 
 would obtain a single certificate for all of those names, using the
 ``/var/www/example`` webroot directory for the first two, and


### PR DESCRIPTION
It seems the document root path to the `--webroot-path`, `-w` option
can't have a trailing slash.  
Here is an example of a user who followed this example and had their
certificate signing request error out.  
https://superuser.com/questions/1273984/why-does-certbot-letsencrypt-recieve-a-403-forbidden