### PR TITLE
Stop using new mock functionality in tests

### DIFF
--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
@@ -131,7 +131,7 @@ class DigitalOceanClientTest(unittest.TestCase):
 
         self.digitalocean_client.del_txt_record(DOMAIN, self.record_name, self.record_content)
 
-        correct_record_mock.destroy.assert_called()
+        self.assertTrue(correct_record_mock.destroy.called)
 
         self.assertFalse(first_record_mock.destroy.call_args_list)
         self.assertFalse(last_record_mock.destroy.call_args_list)

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
@@ -31,7 +31,7 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
         self.auth._change_txt_record.assert_called_once_with("UPSERT",
                                                              '_acme-challenge.' + DOMAIN,
                                                              mock.ANY)
-        self.auth._wait_for_change.assert_called_once()
+        self.assertEqual(self.auth._wait_for_change.call_count, 1)
 
     def test_perform_no_credentials_error(self):
         self.auth._change_txt_record = mock.MagicMock(side_effect=NoCredentialsError)
@@ -183,7 +183,8 @@ class ClientTest(unittest.TestCase):
 
         self.client._change_txt_record("FOO", DOMAIN, "foo")
 
-        self.client.r53.change_resource_record_sets.assert_called_once()
+        call_count = self.client.r53.change_resource_record_sets.call_count
+        self.assertEqual(call_count, 1)
 
     def test_wait_for_change(self):
         self.client.r53.get_change = mock.MagicMock(

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
@@ -193,7 +193,7 @@ class ClientTest(unittest.TestCase):
 
         self.client._wait_for_change(1)
 
-        self.client.r53.get_change.assert_called()
+        self.assertTrue(self.client.r53.get_change.called)
 
 
 if __name__ == "__main__":

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -356,7 +356,7 @@ class DeleteIfAppropriateTest(unittest.TestCase):
         mock_cert_path_for_cert_name.return_value = "/some/reasonable/path"
         mock_overlapping_archive_dirs.return_value = False
         self._call(config)
-        mock_delete.assert_called_once()
+        self.assertEqual(mock_delete.call_count, 1)
 
     # pylint: disable=too-many-arguments
     @mock.patch('certbot.storage.renewal_file_for_certname')
@@ -375,7 +375,7 @@ class DeleteIfAppropriateTest(unittest.TestCase):
         mock_cert_path_to_lineage.return_value = "example.com"
         mock_overlapping_archive_dirs.return_value = False
         self._call(config)
-        mock_delete.assert_called_once()
+        self.assertEqual(mock_delete.call_count, 1)
 
     # pylint: disable=too-many-arguments
     @mock.patch('certbot.storage.renewal_file_for_certname')
@@ -396,7 +396,7 @@ class DeleteIfAppropriateTest(unittest.TestCase):
         mock_full_archive_dir.return_value = ""
         mock_match_and_check_overlaps.return_value = ""
         self._call(config)
-        mock_delete.assert_called_once()
+        self.assertEqual(mock_delete.call_count, 1)
 
     # pylint: disable=too-many-arguments
     @mock.patch('certbot.storage.renewal_file_for_certname')
@@ -415,7 +415,7 @@ class DeleteIfAppropriateTest(unittest.TestCase):
         mock_cert_path_to_lineage.return_value = config.certname
         mock_overlapping_archive_dirs.return_value = False
         self._call(config)
-        mock_delete.assert_called_once()
+        self.assertEqual(mock_delete.call_count, 1)
 
     # pylint: disable=too-many-arguments
     @mock.patch('certbot.cert_manager.match_and_check_overlaps')
@@ -442,7 +442,7 @@ class DeleteIfAppropriateTest(unittest.TestCase):
         util_mock = mock_get_utility()
         util_mock.menu.return_value = (display_util.OK, 0)
         self._call(config)
-        mock_delete.assert_called_once()
+        self.assertEqual(mock_delete.call_count, 1)
 
     # pylint: disable=too-many-arguments
     @mock.patch('certbot.cert_manager.match_and_check_overlaps')

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1062,9 +1062,10 @@ zope.interface==4.1.3 \
     --hash=sha256:928138365245a0e8869a5999fbcc2a45475a0a6ed52a494d60dbdc540335fedd \
     --hash=sha256:0d841ba1bb840eea0e6489dc5ecafa6125554971f53b5acb87764441e61bceba \
     --hash=sha256:b09c8c1d47b3531c400e0195697f1414a63221de6ef478598a4f1460f7d9a392
-mock==2.0.0 \
-    --hash=sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1 \
-    --hash=sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba
+# Using an older version of mock here prevents regressions of #5276.
+mock==1.3.0 \
+    --hash=sha256:3f573a18be94de886d1191f27c168427ef693e8dcfcecf95b170577b2eb69cbb \
+    --hash=sha256:1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6
 
 # Contains the requirements for the letsencrypt package.
 #

--- a/letsencrypt-auto-source/pieces/dependency-requirements.txt
+++ b/letsencrypt-auto-source/pieces/dependency-requirements.txt
@@ -184,6 +184,7 @@ zope.interface==4.1.3 \
     --hash=sha256:928138365245a0e8869a5999fbcc2a45475a0a6ed52a494d60dbdc540335fedd \
     --hash=sha256:0d841ba1bb840eea0e6489dc5ecafa6125554971f53b5acb87764441e61bceba \
     --hash=sha256:b09c8c1d47b3531c400e0195697f1414a63221de6ef478598a4f1460f7d9a392
-mock==2.0.0 \
-    --hash=sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1 \
-    --hash=sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba
+# Using an older version of mock here prevents regressions of #5276.
+mock==1.3.0 \
+    --hash=sha256:3f573a18be94de886d1191f27c168427ef693e8dcfcecf95b170577b2eb69cbb \
+    --hash=sha256:1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6


### PR DESCRIPTION
Fixes #5276.

Currently we test against two sets of pinned dependencies. The 1st is the versions in `certbot-auto` and the 2nd is our "oldest" tests which tests against the oldest version of our dependencies we need to support for distro packaging. Unfortunately, neither test as it is in `master` catches the problems described in #5276. The reason for this is also described in the issue.

While we could create a 3rd test that tests against versions of mock that solve this problem, after thinking about it, I think a better approach is to just reduce the pinned `mock` version in `certbot-auto`. While `mock` is required to be installed, it isn't used outside of our tests and the only reason we pin the version of `mock` we currently do in `certbot-auto` is due to my PR #4629 where I upgraded `mock` to a newer version to work around Python 3.x problems and just picked the newest version at the time.