### PR TITLE
ACMEv2: Allow "uri" or "url" in challenge part 2

### DIFF
--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -181,7 +181,7 @@ class ClientTest(unittest.TestCase):
 
         # TODO: split here and separate test
         self.assertRaises(errors.UnexpectedUpdate, self.client.answer_challenge,
-                          self.challr.body.update(uri='foo'), chall_response)
+                          self.challr.body.update(_uri='foo'), chall_response)
 
     def test_answer_challenge_missing_next(self):
         self.assertRaises(

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -181,7 +181,7 @@ class ClientTest(unittest.TestCase):
 
         # TODO: split here and separate test
         self.assertRaises(errors.UnexpectedUpdate, self.client.answer_challenge,
-                          self.challr.body.update(_uri='foo'), chall_response)
+                          self.challr.body.update(uri='foo'), chall_response)
 
     def test_answer_challenge_missing_next(self):
         self.assertRaises(

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -325,12 +325,25 @@ class ChallengeBody(ResourceBody):
 
     """
     __slots__ = ('chall',)
-    uri = jose.Field('uri')
+    # ACMEv1 has a "uri" field in challenges. ACMEv2 has a "url" field. This
+    # challenge object supports either one. In Client.answer_challenge,
+    # whichever one is set will be used.
+    _uri = jose.Field('uri', omitempty=True, default=None)
+    _url = jose.Field('url', omitempty=True, default=None)
     status = jose.Field('status', decoder=Status.from_json,
                         omitempty=True, default=STATUS_PENDING)
     validated = fields.RFC3339Field('validated', omitempty=True)
     error = jose.Field('error', decoder=Error.from_json,
                        omitempty=True, default=None)
+
+    def __init__(self, **kwargs):
+        new_kwargs = {}
+        for k, v in kwargs.items():
+            if k in ('uri', 'url',):
+                k = '_' + k
+            new_kwargs[k] = v
+        # pylint: disable=star-args
+        super(ChallengeBody, self).__init__(**new_kwargs)
 
     def to_partial_json(self):
         jobj = super(ChallengeBody, self).to_partial_json()
@@ -342,6 +355,11 @@ class ChallengeBody(ResourceBody):
         jobj_fields = super(ChallengeBody, cls).fields_from_json(jobj)
         jobj_fields['chall'] = challenges.Challenge.from_json(jobj)
         return jobj_fields
+
+    @property
+    def uri(self):
+        """The URL of this challenge."""
+        return self._url or self._uri
 
     def __getattr__(self, name):
         return getattr(self.chall, name)
@@ -358,10 +376,10 @@ class ChallengeResource(Resource):
     authzr_uri = jose.Field('authzr_uri')
 
     @property
-    def uri(self):  # pylint: disable=missing-docstring,no-self-argument
-        # bug? 'method already defined line None'
-        # pylint: disable=function-redefined
-        return self.body.uri  # pylint: disable=no-member
+    def uri(self):
+        """The URL of the challenge body."""
+        # pylint: disable=function-redefined,no-member
+        return self.body.uri
 
 
 class Authorization(ResourceBody):

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -283,6 +283,9 @@ class ChallengeBodyTest(unittest.TestCase):
             'detail': 'Unable to communicate with DNS server',
         }
 
+    def test_encode(self):
+        self.assertEqual(self.challb.encode('uri'), self.challb.uri)
+
     def test_to_partial_json(self):
         self.assertEqual(self.jobj_to, self.challb.to_partial_json())
 


### PR DESCRIPTION
This builds on #5258. This PR should be merged rather than squashed to preserve authorship.

In addition to the work from #5258, this PR modifies the methods necessary to hide the fact that uri and url are protected fields. The user can access them without the leading underscore in all public methods.

EDIT: Since the url attribute needs to be accessible through the public API for things like `__init__` and `encode`, I went ahead and made a `url` property that only returns the `_url` attribute. I didn't make it automatically use `_uri` or `_url` based on what was set because if you're asking for the `url`, you're explicitly requesting something from ACMEv2 rather than something from ACMEv1 where we're trying to keep backwards compatibility.