### PR TITLE
ami-26d5af4c is now Ubuntu 16.04 LTS

### DIFF
--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -2,7 +2,7 @@ targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
   - ami: ami-26d5af4c
-    name: ubuntu15.10
+    name: ubuntu16.04LTS
     type: ubuntu
     virt: hvm
     user: ubuntu


### PR DESCRIPTION
Source: https://docs.docker.com/machine/drivers/aws/#default-amis