### PR TITLE
Relax setuptools dependency

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -17,9 +17,7 @@ install_requires = [
     'pyrfc3339',
     'pytz',
     'requests[security]>=2.4.1',  # security extras added in 2.4.1
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',  # pkg_resources
     'six>=1.9.0',  # needed for python_2_unicode_compatible
 ]
 

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'mock',
     'python-augeas',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',  # pkg_resources
     'zope.component',
     'zope.interface',
 ]

--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'cloudflare>=1.5.1',
     'mock',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
 ]
 

--- a/certbot-dns-cloudxns/setup.py
+++ b/certbot-dns-cloudxns/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'dns-lexicon',
     'mock',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
 ]
 

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'mock',
     'python-digitalocean>=1.11',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'six',
     'zope.interface',
 ]

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'dns-lexicon',
     'mock',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
 ]
 

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'dns-lexicon',
     'mock',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
 ]
 

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -15,9 +15,7 @@ install_requires = [
     'mock',
     # for oauth2client.service_account.ServiceAccountCredentials
     'oauth2client>=2.0',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
     # already a dependency of google-api-python-client, but added for consistency
     'httplib2'

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'dns-lexicon',
     'mock',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
 ]
 

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'dns-lexicon',
     'mock',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
 ]
 

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -12,9 +12,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'dnspython',
     'mock',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
 ]
 

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -10,9 +10,7 @@ install_requires = [
     'certbot=={0}'.format(version),
     'boto3',
     'mock',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',
     'zope.interface',
 ]
 

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -13,9 +13,7 @@ install_requires = [
     'mock',
     'PyOpenSSL',
     'pyparsing>=1.5.5',  # Python3 support; perhaps unnecessary?
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',  # pkg_resources
     'zope.interface',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,7 @@ install_requires = [
     'PyOpenSSL',
     'pyrfc3339',
     'pytz',
-    # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-    # will tolerate; see #2599:
-    'setuptools>=1.0',
+    'setuptools',  # pkg_resources
     'six',
     'zope.component',
     'zope.interface',


### PR DESCRIPTION
I feel like I've been saying this a lot lately: We did this due to pip's lack of dependency resolution.

The problem as described in #2599 was `cryptography` specified a minimum `setuptools` version in their package which was being overridden Certbot's unrestricted dependency on `setuptools`. Since these changes landed, `cryptography` has stopped specifying a minimum version in their requirements, both in [master](https://github.com/pyca/cryptography/blob/9aec3f918a1c89e86732303a0cfaf50de930ce74/setup.py) and in the [version pinned in certbot-auto](https://github.com/pyca/cryptography/blob/2.0.2/setup.py).

This pinning of `setuptools>=1.0` caused some minor problems for package maintainers as described in #2599 and is causing me problems in [our tests](https://travis-ci.org/certbot/certbot/jobs/310342309#L9925) where we're testing against `setuptools 0.9.8` to keep compatibility for CentOS/RHEL 7. Since it's no longer needed to satisfy `pip`, let's remove it.