### PR TITLE
Make Travis builds faster in master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,22 +39,7 @@ matrix:
       before_install:
       addons:
     - sudo: required
-      env: TOXENV=le_auto_precise
-      services: docker
-      before_install:
-      addons:
-    - sudo: required
       env: TOXENV=le_auto_trusty
-      services: docker
-      before_install:
-      addons:
-    - sudo: required
-      env: TOXENV=le_auto_wheezy
-      services: docker
-      before_install:
-      addons:
-    - sudo: required
-      env: TOXENV=le_auto_centos6
       services: docker
       before_install:
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,6 @@ matrix:
       services: docker
       before_install:
       addons:
-    - sudo: required
-      env: TOXENV=docker_dev
-      services: docker
-      before_install:
-      addons:
     - python: "2.7"
       env: TOXENV=apacheconftest
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,36 @@ before_script:
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=cover FYI="this also tests py27"
-    - python: "2.7"
-      env: TOXENV=lint
-    - python: "2.7"
-      env: TOXENV=py27-oldest
+      env: TOXENV=py27_install BOULDER_INTEGRATION=1
       sudo: required
       services: docker
+    - python: "2.7"
+      env: TOXENV=cover FYI="this also tests py27"
+    - sudo: required
+      env: TOXENV=nginx_compat
+      services: docker
+      before_install:
+      addons:
+    - python: "2.7"
+      env: TOXENV=lint
     - python: "2.6"
       env: TOXENV=py26
       sudo: required
       services: docker
     - python: "2.7"
-      env: TOXENV=py27_install BOULDER_INTEGRATION=1
+      env: TOXENV=py27-oldest
+      sudo: required
+      services: docker
+    - python: "3.3"
+      env: TOXENV=py33
+      sudo: required
+      services: docker
+    - python: "3.6"
+      env: TOXENV=py36
       sudo: required
       services: docker
     - sudo: required
       env: TOXENV=apache_compat
-      services: docker
-      before_install:
-      addons:
-    - sudo: required
-      env: TOXENV=nginx_compat
       services: docker
       before_install:
       addons:
@@ -46,14 +54,6 @@ matrix:
     - python: "2.7"
       env: TOXENV=apacheconftest
       sudo: required
-    - python: "3.3"
-      env: TOXENV=py33
-      sudo: required
-      services: docker
-    - python: "3.6"
-      env: TOXENV=py36
-      sudo: required
-      services: docker
     - python: "2.7"
       env: TOXENV=nginxroundtrip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,14 +50,6 @@ matrix:
       env: TOXENV=py33
       sudo: required
       services: docker
-    - python: "3.4"
-      env: TOXENV=py34
-      sudo: required
-      services: docker
-    - python: "3.5"
-      env: TOXENV=py35
-      sudo: required
-      services: docker
     - python: "3.6"
       env: TOXENV=py36
       sudo: required


### PR DESCRIPTION
The changes here were:

1. Remove all but one `letsencrypt-auto` test. They all do the same thing except run on different OSes in Docker and I cannot recall ever seeing one fail and the others succeed (besides the fact that `tests/modification-check.sh` runs in the `le_auto_trusty` environment and sometimes catches bugs so I've left that one in).
2. Remove the `dockerfile-dev` test which is just to make sure that our developer dockerfile still works.
3. Rather than testing on all versions of Python 3, let's test on the newest and the oldest. If it works on both, it's likely to work on all Python 3 versions.
4. I reorderd the Travis jobs based on runtime, keeping `lint` slightly higher than normal just because it fails more often.