### PR TITLE
Parse variables without whitespace separator correctly for CentOS/RHEL/Fedora

### DIFF
--- a/certbot-apache/certbot_apache/apache_util.py
+++ b/certbot-apache/certbot_apache/apache_util.py
@@ -93,4 +93,8 @@ def parse_define_file(filepath, varname):
         if v == "-D" and len(a_opts) >= i+2:
             var_parts = a_opts[i+1].partition("=")
             return_vars[var_parts[0]] = var_parts[2]
+        elif len(v) > 2 and v.startswith("-D"):
+            # Found var with no whitespace separator
+            var_parts = v[2:].partition("=")
+            return_vars[var_parts[0]] = var_parts[2]
     return return_vars

--- a/certbot-apache/certbot_apache/tests/centos_test.py
+++ b/certbot-apache/certbot_apache/tests/centos_test.py
@@ -118,6 +118,8 @@ class MultipleVhostsTestCentOS(util.ApacheTest):
         self.assertTrue("mock_define_too" in self.config.parser.variables.keys())
         self.assertTrue("mock_value" in self.config.parser.variables.keys())
         self.assertEqual("TRUE", self.config.parser.variables["mock_value"])
+        self.assertTrue("MOCK_NOSEP" in self.config.parser.variables.keys())
+        self.assertEqual("NOSEP_VAL", self.config.parser.variables["NOSEP_TWO"])
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot-apache/certbot_apache/tests/testdata/centos7_apache/apache/sysconfig/httpd
+++ b/certbot-apache/certbot_apache/tests/testdata/centos7_apache/apache/sysconfig/httpd
@@ -14,7 +14,7 @@
 # To pass additional options (for instance, -D definitions) to the
 # httpd binary at startup, set OPTIONS here.
 #
-OPTIONS="-D mock_define -D mock_define_too -D mock_value=TRUE"
+OPTIONS="-D mock_define -D mock_define_too -D mock_value=TRUE -DMOCK_NOSEP -DNOSEP_TWO=NOSEP_VAL"
 
 #
 # This setting ensures the httpd process is started in the "C" locale


### PR DESCRIPTION
When parsing /etc/sysconfig/httpd to find out Define statements on Apache command line, Certbot fails to parse variables without whitespace separator, for example -DSSL compared to -D SSL.

Fixes: #5317 