### PR TITLE
More pip dependency resolution workarounds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ changes = read_file(os.path.join(here, 'CHANGES.rst'))
 version = meta['version']
 
 # Please update tox.ini when modifying dependency version requirements
-# This package relies on requests, however, it isn't specified here to avoid
-# masking the more specific request requirements in acme. See
-# https://github.com/pypa/pip/issues/988 for more info.
+# This package relies on PyOpenSSL, requests, and six, however, it isn't
+# specified here to avoid masking the more specific request requirements in
+# acme. See https://github.com/pypa/pip/issues/988 for more info.
 install_requires = [
     'acme=={0}'.format(version),
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
@@ -44,13 +44,11 @@ install_requires = [
     'cryptography>=1.2',  # load_pem_x509_certificate
     'mock',
     'parsedatetime>=1.3',  # Calendar.parseDT
-    'PyOpenSSL',
     'pyrfc3339',
     'pytz',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',
-    'six',
     'zope.component',
     'zope.interface',
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ readme = read_file(os.path.join(here, 'README.rst'))
 changes = read_file(os.path.join(here, 'CHANGES.rst'))
 version = meta['version']
 
-# Please update tox.ini when modifying dependency version requirements
 # This package relies on PyOpenSSL, requests, and six, however, it isn't
 # specified here to avoid masking the more specific request requirements in
 # acme. See https://github.com/pypa/pip/issues/988 for more info.


### PR DESCRIPTION
I also removed an outdated comment about dependency version requirements being specified in `tox.ini`.

You can reproduce the problem by running:
```
virtualenv venv
venv/bin/pip install six==1.8
venv/bin/pip install certbot
venv/bin/pip check
```
Output should include:
```
acme 0.20.0 has requirement six>=1.9.0, but you have six 1.8.0.
```
Some users have hit this problem as seen in #4036.

The same problem can happen with `PyOpenSSL`, but getting an old enough version to trigger this problem to compile on modern machines is difficult.