### PR TITLE
Use apache2ctl modules for Gentoo systems.

### DIFF
--- a/certbot-apache/certbot_apache/override_gentoo.py
+++ b/certbot-apache/certbot_apache/override_gentoo.py
@@ -49,6 +49,7 @@ class GentooParser(parser.ApacheParser):
     def update_runtime_variables(self):
         """ Override for update_runtime_variables for custom parsing """
         self.parse_sysconfig_var()
+        self.update_modules()
 
     def parse_sysconfig_var(self):
         """ Parses Apache CLI options from Gentoo configuration file """
@@ -58,6 +59,8 @@ class GentooParser(parser.ApacheParser):
             self.variables[k] = defines[k]
 
     def update_modules(self):
-        """ NOOP for update_modules as Gentoo does not provide a way to dump
-        module list from Apache binary"""
-        pass
+        """Get loaded modules from httpd process, and add them to DOM"""
+        mod_cmd = [self.configurator.constant("apache_cmd"), "modules"]
+        matches = self.parse_from_subprocess(mod_cmd, r"(.*)_module")
+        for mod in matches:
+            self.add_mod(mod.strip())

--- a/certbot-apache/certbot_apache/override_gentoo.py
+++ b/certbot-apache/certbot_apache/override_gentoo.py
@@ -56,3 +56,8 @@ class GentooParser(parser.ApacheParser):
                                                 "APACHE2_OPTS")
         for k in defines.keys():
             self.variables[k] = defines[k]
+
+    def update_modules(self):
+        """ NOOP for update_modules as Gentoo does not provide a way to dump
+        module list from Apache binary"""
+        pass

--- a/certbot-apache/certbot_apache/tests/gentoo_test.py
+++ b/certbot-apache/certbot_apache/tests/gentoo_test.py
@@ -2,6 +2,8 @@
 import os
 import unittest
 
+import mock
+
 from certbot_apache import override_gentoo
 from certbot_apache import obj
 from certbot_apache.tests import util
@@ -81,6 +83,15 @@ class MultipleVhostsTestGentoo(util.ApacheTest):
         self.config.parser.update_runtime_variables()
         for define in defines:
             self.assertTrue(define in self.config.parser.variables.keys())
+
+    @mock.patch("certbot_apache.parser.ApacheParser.parse_from_subprocess")
+    def test_no_binary_configdump(self, mock_subprocess):
+        """Make sure we don't call binary dumps from Apache as this is not
+        supported in Gentoo currently"""
+
+        self.config.parser.update_runtime_variables()
+        self.config.parser.reset_modules()
+        self.assertFalse(mock_subprocess.called)
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
Fixes #5344 