### PR TITLE
acme-v2-integration: Fix incorrect `authz` reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ branches:
     - master
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
+    - acme-v2
+    - acme-v2-integration
 
 # container-based infrastructure
 sudo: false

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -350,7 +350,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
                     break
         for authzr in responses:
             if authzr.body.status != messages.STATUS_VALID:
-                for chall in authz.body.challenges:
+                for chall in authzr.body.challenges:
                     if chall.error != None:
                         raise Exception("failed challenge for %s: %s" %
                             (authz.body.identifier.value, chall.error))

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -353,8 +353,8 @@ class Client(object):  # pylint: disable=too-many-instance-attributes
                 for chall in authzr.body.challenges:
                     if chall.error != None:
                         raise Exception("failed challenge for %s: %s" %
-                            (authz.body.identifier.value, chall.error))
-                raise Exception("failed authorization: %s" % authz.body)
+                            (authzr.body.identifier.value, chall.error))
+                raise Exception("failed authorization: %s" % authzr.body)
         latest = self._order_resource_from_response(self.net.get(orderr.uri), uri=orderr.uri)
         self.net.post(latest.body.finalize, messages.CertificateRequest(csr=orderr.csr))
         while datetime.datetime.now() < deadline:


### PR DESCRIPTION
The error case incorrectly referred to `authz` when it meant to refer to `authzr`.