### PR TITLE
Fix pytest on macOS in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ tests/letstest/*.pem
 tests/letstest/venv/
 
 .venv
+
+# pytest cache
+/.cache

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --quiet

--- a/tools/install_and_test.sh
+++ b/tools/install_and_test.sh
@@ -23,5 +23,5 @@ for requirement in "$@" ; do
     # See https://travis-ci.org/certbot/certbot/jobs/308774157#L1333.
     pkg=$(echo "$pkg" | tr - _)
   fi
-  "$(dirname $0)/pytest.sh" --quiet --pyargs $pkg
+  "$(dirname $0)/pytest.sh" --pyargs $pkg
 done

--- a/tools/install_and_test.sh
+++ b/tools/install_and_test.sh
@@ -23,5 +23,5 @@ for requirement in "$@" ; do
     # See https://travis-ci.org/certbot/certbot/jobs/308774157#L1333.
     pkg=$(echo "$pkg" | tr - _)
   fi
-  pytest --numprocesses auto --quiet --pyargs $pkg
+  "$(dirname $0)/pytest.sh" --quiet --pyargs $pkg
 done

--- a/tools/pytest.sh
+++ b/tools/pytest.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Runs pytest with the provided arguments, adding --numprocesses to the command
+# line. This argument is set to "auto" if the environmnent variable TRAVIS is
+# not set, otherwise, it is set to 2. This works around
+# https://github.com/pytest-dev/pytest-xdist/issues/9. Currently every Travis
+# environnment provides two cores. See
+# https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments.
+
+if ${TRAVIS:-false}; then
+    NUMPROCESSES="2"
+else
+    NUMPROCESSES="auto"
+fi
+
+pytest --numprocesses "$NUMPROCESSES" "$@"

--- a/tox.cover.sh
+++ b/tox.cover.sh
@@ -51,7 +51,8 @@ cover () {
   fi
 
   pkg_dir=$(echo "$1" | tr _ -)
-  pytest --cov "$pkg_dir" --cov-append --cov-report= --numprocesses auto --pyargs "$1"
+  pytest="$(dirname $0)/tools/pytest.sh"
+  "$pytest" --cov "$pkg_dir" --cov-append --cov-report= --pyargs "$1"
   coverage report --fail-under="$min" --include="$pkg_dir/*" --show-missing
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ commands =
 deps =
     setuptools==36.8.0
     wheel==0.29.0
+passenv = TRAVIS
 
 [testenv]
 commands =
@@ -69,12 +70,16 @@ commands =
 setenv =
     PYTHONPATH = {toxinidir}
     PYTHONHASHSEED = 0
+passenv =
+    {[testenv:py26]passenv}
 
 [testenv:py33]
 commands =
     {[testenv]commands}
 deps =
     wheel==0.29.0
+passenv =
+    {[testenv]passenv}
 
 [testenv:py27-oldest]
 commands =
@@ -82,6 +87,8 @@ commands =
 setenv =
     {[testenv]setenv}
     CERTBOT_OLDEST=1
+passenv =
+    {[testenv]passenv}
 
 [testenv:py27_install]
 basepython = python2.7
@@ -93,6 +100,8 @@ basepython = python2.7
 commands =
     {[base]install_packages}
     ./tox.cover.sh
+passenv =
+    {[testenv]passenv}
 
 [testenv:lint]
 # recent versions of pylint do not support Python 2.6 (#97, #187)


### PR DESCRIPTION
Fixes failures on the `test-everything` branch.

Also, if you've encountered test failures locally since we switched to pytest, you may have seen a `.cache` directory created. To stop `git` from wanting to include this file, I created `pytest.ini` and added `--quiet` to it. The creation of this file allows `pytest` to properly identify the root of the project. Now it always places the cache in the root of the repo and I ignored this file in our `.gitignore`.