### PR TITLE
Broader git ignore for pytest cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ tests/letstest/venv/
 .venv
 
 # pytest cache
-/.cache
+.cache


### PR DESCRIPTION
Make gitignore take pytest cache directories in to account, even if they reside in subdirectories.

If pytest is run for a certain module, ie. `pytest certbot-apache` the cache directory is created under `certbot-apache` directory.