### PR TITLE
Have letsencrypt-auto do a real upgrade in leauto-upgrades

### DIFF
--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -35,7 +35,7 @@ SERVER_PID=$!
 trap 'kill "$SERVER_PID" && rm -rf "$MY_TEMP_DIR"' EXIT
 cd ~-
 
-# Next, we set up the files to be served.
+# Then, we set up the files to be served.
 FAKE_VERSION_NUM="99.99.99"
 echo "{\"releases\": {\"$FAKE_VERSION_NUM\": null}}" > "$MY_TEMP_DIR/json"
 LE_AUTO_SOURCE_DIR="$MY_TEMP_DIR/v$FAKE_VERSION_NUM"
@@ -45,7 +45,7 @@ cp letsencrypt-auto-source/letsencrypt-auto "$LE_AUTO_SOURCE_DIR/letsencrypt-aut
 SIGNING_KEY="letsencrypt-auto-source/tests/signing.key"
 openssl dgst -sha256 -sign "$SIGNING_KEY" -out "$NEW_LE_AUTO_PATH.sig" "$NEW_LE_AUTO_PATH"
 
-# Finally, we set the necessary certbot-auto environment variables.
+# Next, we set the necessary certbot-auto environment variables.
 export LE_AUTO_DIR_TEMPLATE="http://localhost:$SERVER_PORT/%s/"
 export LE_AUTO_JSON_URL="http://localhost:$SERVER_PORT/json"
 export LE_AUTO_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
@@ -58,6 +58,9 @@ Z5o/NDiQB11m91yNB0MmPYY9QSbnOA9j7IaaC97AwRLuwXY+/R2ablTcxurWou68
 iQIDAQAB
 -----END PUBLIC KEY-----
 "
+
+# Finally, we wait for the server to start.
+sleep 5s
 
 if ! ./letsencrypt-auto -v --debug --version || ! diff letsencrypt-auto letsencrypt-auto-source/letsencrypt-auto ; then
     echo upgrade appeared to fail

--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -59,9 +59,7 @@ iQIDAQAB
 -----END PUBLIC KEY-----
 "
 
-EXPECTED_VERSION=$(grep -m1 LE_AUTO_VERSION certbot-auto | cut -d\" -f2)
-./letsencrypt-auto -v --debug --version
-if ! diff letsencrypt-auto letsencrypt-auto-source/letsencrypt-auto ; then
+if ! ./letsencrypt-auto -v --debug --version || ! diff letsencrypt-auto letsencrypt-auto-source/letsencrypt-auto ; then
     echo upgrade appeared to fail
     exit 1
 fi

--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -15,19 +15,53 @@ if ! command -v git ; then
         exit 1
     fi
 fi
-BRANCH=`git rev-parse --abbrev-ref HEAD`
 # 0.5.0 is the oldest version of letsencrypt-auto that can be used because it's
 # the first version that pins package versions, properly supports
 # --no-self-upgrade, and works with newer versions of pip.
-git checkout -f v0.5.0
+git checkout -f v0.5.0 letsencrypt-auto
 if ! ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | grep 0.5.0 ; then
     echo initial installation appeared to fail
     exit 1
 fi
 
-git checkout -f "$BRANCH"
-EXPECTED_VERSION=$(grep -m1 LE_AUTO_VERSION letsencrypt-auto | cut -d\" -f2)
-if ! ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | grep $EXPECTED_VERSION ; then
+# Now that python and openssl have been installed, we can set up a fake server
+# to provide a new version of letsencrypt-auto. First, we start the server and
+# directory to be served.
+MY_TEMP_DIR=$(mktemp -d)
+SERVER_PORT=12345
+cd "$MY_TEMP_DIR"
+python -m SimpleHTTPServer "$SERVER_PORT" &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" && rm -rf "$MY_TEMP_DIR"' EXIT
+cd ~-
+
+# Next, we set up the files to be served.
+FAKE_VERSION_NUM="99.99.99"
+echo "{\"releases\": {\"$FAKE_VERSION_NUM\": null}}" > "$MY_TEMP_DIR/json"
+LE_AUTO_SOURCE_DIR="$MY_TEMP_DIR/v$FAKE_VERSION_NUM"
+NEW_LE_AUTO_PATH="$LE_AUTO_SOURCE_DIR/letsencrypt-auto"
+mkdir "$LE_AUTO_SOURCE_DIR"
+cp letsencrypt-auto-source/letsencrypt-auto "$LE_AUTO_SOURCE_DIR/letsencrypt-auto"
+SIGNING_KEY="letsencrypt-auto-source/tests/signing.key"
+openssl dgst -sha256 -sign "$SIGNING_KEY" -out "$NEW_LE_AUTO_PATH.sig" "$NEW_LE_AUTO_PATH"
+
+# Finally, we set the necessary certbot-auto environment variables.
+export LE_AUTO_DIR_TEMPLATE="http://localhost:$SERVER_PORT/%s/"
+export LE_AUTO_JSON_URL="http://localhost:$SERVER_PORT/json"
+export LE_AUTO_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsMoSzLYQ7E1sdSOkwelg
+tzKIh2qi3bpXuYtcfFC0XrvWig071NwIj+dZiT0OLZ2hPispEH0B7ISuuWg1ll7G
+hFW0VdbxL6JdGzS2ShNWkX9hE9z+j8VqwDPOBn3ZHm03qwpYkBDwQib3KqOdYbTT
+uUtJmmGcuk3a9Aq/sCT6DdfmTSdP5asdQYwIcaQreDrOosaS84DTWI3IU+UYJVgl
+LsIVPBuy9IcgHidUQ96hJnoPsDCWsHwX62495QKEarauyKQrJzFes0EY95orDM47
+Z5o/NDiQB11m91yNB0MmPYY9QSbnOA9j7IaaC97AwRLuwXY+/R2ablTcxurWou68
+iQIDAQAB
+-----END PUBLIC KEY-----
+"
+
+EXPECTED_VERSION=$(grep -m1 LE_AUTO_VERSION certbot-auto | cut -d\" -f2)
+./letsencrypt-auto -v --debug --version
+if ! diff letsencrypt-auto letsencrypt-auto-source/letsencrypt-auto ; then
     echo upgrade appeared to fail
     exit 1
 fi


### PR DESCRIPTION
Rather than replacing the file with `git`, let's have `letsencrypt-auto` download a new version of itself from a dummy server.

This PR takes advantage of #5370, but:

1. The version we're upgrading from is as old as possible so even if we fix #5370 in `master`, this will still work.
2. To use HTTPS with Python 2.7.9+ we need something like `NO_CERT_VERIFY` from #5329 which obviously isn't available in older versions of `certbot-auto`.

I tested this successfully with both `master` and the #5329 branch.