### PR TITLE
Remove Default Detector log line.

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -207,7 +207,6 @@ def set_by_cli(var):
         # propagate plugin requests: eg --standalone modifies config.authenticator
         detector.authenticator, detector.installer = (
             plugin_selection.cli_plugin_requests(detector))
-        logger.debug("Default Detector is %r", detector)
 
     if not isinstance(getattr(detector, var), _Default):
         return True

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -209,10 +209,14 @@ def set_by_cli(var):
             plugin_selection.cli_plugin_requests(detector))
 
     if not isinstance(getattr(detector, var), _Default):
+        logger.debug("Var %s=%s (set by user)." % (
+            var, getattr(detector, var)))
         return True
 
     for modifier in VAR_MODIFIERS.get(var, []):
         if set_by_cli(modifier):
+            logger.debug("Var %s=%s (set by user)." % (
+                var, VAR_MODIFIERS.get(var, [])))
             return True
 
     return False

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -209,14 +209,13 @@ def set_by_cli(var):
             plugin_selection.cli_plugin_requests(detector))
 
     if not isinstance(getattr(detector, var), _Default):
-        logger.debug("Var %s=%s (set by user)." % (
-            var, getattr(detector, var)))
+        logger.debug("Var %s=%s (set by user).", var, getattr(detector, var))
         return True
 
     for modifier in VAR_MODIFIERS.get(var, []):
         if set_by_cli(modifier):
-            logger.debug("Var %s=%s (set by user)." % (
-                var, VAR_MODIFIERS.get(var, [])))
+            logger.debug("Var %s=%s (set by user).",
+                var, VAR_MODIFIERS.get(var, []))
             return True
 
     return False


### PR DESCRIPTION
This produces a super-long log line that wraps to 30-60 lines, depending on
screen width. Even though it's just at debug level, it clutters up the integration
test output without providing proportional debugging value.