### PR TITLE
Fix letsencrypt-auto name and long forms of -n

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -68,10 +68,12 @@ for arg in "$@" ; do
       NO_BOOTSTRAP=1;;
     --help)
       HELP=1;;
-    --noninteractive|--non-interactive|renew)
-      ASSUME_YES=1;;
+    --noninteractive|--non-interactive)
+      NONINTERACTIVE=1;;
     --quiet)
       QUIET=1;;
+    renew)
+      ASSUME_YES=1;;
     --verbose)
       VERBOSE=1;;
     -[!-]*)
@@ -93,7 +95,7 @@ done
 
 if [ $BASENAME = "letsencrypt-auto" ]; then
   # letsencrypt-auto does not respect --help or --yes for backwards compatibility
-  ASSUME_YES=1
+  NONINTERACTIVE=1
   HELP=0
 fi
 

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -68,10 +68,12 @@ for arg in "$@" ; do
       NO_BOOTSTRAP=1;;
     --help)
       HELP=1;;
-    --noninteractive|--non-interactive|renew)
-      ASSUME_YES=1;;
+    --noninteractive|--non-interactive)
+      NONINTERACTIVE=1;;
     --quiet)
       QUIET=1;;
+    renew)
+      ASSUME_YES=1;;
     --verbose)
       VERBOSE=1;;
     -[!-]*)
@@ -93,7 +95,7 @@ done
 
 if [ $BASENAME = "letsencrypt-auto" ]; then
   # letsencrypt-auto does not respect --help or --yes for backwards compatibility
-  ASSUME_YES=1
+  NONINTERACTIVE=1
   HELP=0
 fi
 


### PR DESCRIPTION
I added `NONINTERACTIVE` in addition to `ASSUME_YES` because while we want `certbot-auto renew` to be non-interactive, I don't want every cron job in the world to rebootstrap without the user's permission. This fixes the long forms `--noninteractive` and `--non-interactive` and also makes `letsencrypt-auto` auto-upgrade as its behavior has always been install things without prompting the user.

I tested this by merging this and #5329 together and making the following changes:
```
diff --git a/letsencrypt-auto-source/tests/centos6_tests.sh b/letsencrypt-auto-source/tests/centos6_tests.sh
index e3ebbae..9ca8043 100644
--- a/letsencrypt-auto-source/tests/centos6_tests.sh
+++ b/letsencrypt-auto-source/tests/centos6_tests.sh
@@ -25,7 +25,7 @@ if [ $RESULT -ne 0 ]; then
 fi
 
 # bootstrap, but don't install python 3.
-certbot/letsencrypt-auto-source/letsencrypt-auto --no-self-upgrade -n > /dev/null 2> /dev/null
+certbot/letsencrypt-auto-source/letsencrypt-auto --no-self-upgrade > /dev/null 2> /dev/null
 
 # ensure python 3 isn't installed
 python3 --version 2> /dev/null
@@ -47,8 +47,18 @@ if [ $RESULT -eq 0 ]; then
   exit 1
 fi
 
+cp certbot/letsencrypt-auto-source/letsencrypt-auto ./certbot-auto
+./certbot-auto --no-self-upgrade >/dev/null 2>&1
+# ensure python 3 isn't installed
+python3 --version 2> /dev/null
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+  error "Python3 is already installed."
+  exit 1
+fi
+
 # bootstrap, this time installing python3
-certbot/letsencrypt-auto-source/letsencrypt-auto --no-self-upgrade -n > /dev/null 2> /dev/null
+./certbot-auto --no-self-upgrade --non-interactive > /dev/null 2> /dev/null
 
 # ensure python 3 is installed
 python3 --version > /dev/null
```
  