### PR TITLE
Handle need to rebootstrap before fetch.py

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -246,10 +246,14 @@ DeprecationBootstrap() {
   fi
 }
 
+MIN_PYTHON_VERSION="2.6"
+MIN_PYVER=$(echo "$MIN_PYTHON_VERSION" | sed 's/\.//')
 # Sets LE_PYTHON to Python version string and PYVER to the first two
 # digits of the python version
 DeterminePythonVersion() {
   # Arguments: "NOCRASH" if we shouldn't crash if we don't find a good python
+  #
+  # If no Python is found, PYVER is set to 0.
   if [ -n "$USE_PYTHON_3" ]; then
     for LE_PYTHON in "$LE_PYTHON" python3; do
       # Break (while keeping the LE_PYTHON value) if found.
@@ -273,10 +277,12 @@ DeterminePythonVersion() {
   export LE_PYTHON
 
   PYVER=`"$LE_PYTHON" -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//'`
-  if [ "$PYVER" -lt 26 ]; then
-    error "You have an ancient version of Python entombed in your operating system..."
-    error "This isn't going to work; you'll need at least version 2.6."
-    exit 1
+  if [ "$PYVER" -lt "$MIN_PYVER" ]; then
+    if [ "$1" != "NOCRASH" ]; then
+      error "You have an ancient version of Python entombed in your operating system..."
+      error "This isn't going to work; you'll need at least version $MIN_PYTHON_VERSION."
+      exit 1
+    fi
   fi
 }
 
@@ -1575,8 +1581,10 @@ if __name__ == '__main__':
 
 UNLIKELY_EOF
     # ---------------------------------------------------------------------------
-    DeterminePythonVersion
-    if ! REMOTE_VERSION=`"$LE_PYTHON" "$TEMP_DIR/fetch.py" --latest-version` ; then
+    DeterminePythonVersion "NOCRASH"
+    if [ "$PYVER" -lt "$MIN_PYVER" ]; then
+      error "WARNING: couldn't find Python $MIN_PYTHON_VERSION+ to check for updates."
+    elif ! REMOTE_VERSION=`"$LE_PYTHON" "$TEMP_DIR/fetch.py" --latest-version` ; then
       error "WARNING: unable to check for updates."
     elif [ "$LE_AUTO_VERSION" != "$REMOTE_VERSION" ]; then
       say "Upgrading certbot-auto $LE_AUTO_VERSION to $REMOTE_VERSION..."

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -246,10 +246,14 @@ DeprecationBootstrap() {
   fi
 }
 
+MIN_PYTHON_VERSION="2.6"
+MIN_PYVER=$(echo "$MIN_PYTHON_VERSION" | sed 's/\.//')
 # Sets LE_PYTHON to Python version string and PYVER to the first two
 # digits of the python version
 DeterminePythonVersion() {
   # Arguments: "NOCRASH" if we shouldn't crash if we don't find a good python
+  #
+  # If no Python is found, PYVER is set to 0.
   if [ -n "$USE_PYTHON_3" ]; then
     for LE_PYTHON in "$LE_PYTHON" python3; do
       # Break (while keeping the LE_PYTHON value) if found.
@@ -273,10 +277,12 @@ DeterminePythonVersion() {
   export LE_PYTHON
 
   PYVER=`"$LE_PYTHON" -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//'`
-  if [ "$PYVER" -lt 26 ]; then
-    error "You have an ancient version of Python entombed in your operating system..."
-    error "This isn't going to work; you'll need at least version 2.6."
-    exit 1
+  if [ "$PYVER" -lt "$MIN_PYVER" ]; then
+    if [ "$1" != "NOCRASH" ]; then
+      error "You have an ancient version of Python entombed in your operating system..."
+      error "This isn't going to work; you'll need at least version $MIN_PYTHON_VERSION."
+      exit 1
+    fi
   fi
 }
 
@@ -586,8 +592,10 @@ else
 {{ fetch.py }}
 UNLIKELY_EOF
     # ---------------------------------------------------------------------------
-    DeterminePythonVersion
-    if ! REMOTE_VERSION=`"$LE_PYTHON" "$TEMP_DIR/fetch.py" --latest-version` ; then
+    DeterminePythonVersion "NOCRASH"
+    if [ "$PYVER" -lt "$MIN_PYVER" ]; then
+      error "WARNING: couldn't find Python $MIN_PYTHON_VERSION+ to check for updates."
+    elif ! REMOTE_VERSION=`"$LE_PYTHON" "$TEMP_DIR/fetch.py" --latest-version` ; then
       error "WARNING: unable to check for updates."
     elif [ "$LE_AUTO_VERSION" != "$REMOTE_VERSION" ]; then
       say "Upgrading certbot-auto $LE_AUTO_VERSION to $REMOTE_VERSION..."

--- a/letsencrypt-auto-source/tests/centos6_tests.sh
+++ b/letsencrypt-auto-source/tests/centos6_tests.sh
@@ -4,6 +4,8 @@ yum update > /dev/null
 yum install -y centos-release-scl > /dev/null
 yum install -y python27 > /dev/null 2> /dev/null
 
+LE_AUTO="certbot/letsencrypt-auto-source/letsencrypt-auto"
+
 # we're going to modify env variables, so do this in a subshell
 (
 source /opt/rh/python27/enable
@@ -25,7 +27,7 @@ if [ $RESULT -ne 0 ]; then
 fi
 
 # bootstrap, but don't install python 3.
-certbot/letsencrypt-auto-source/letsencrypt-auto --no-self-upgrade -n > /dev/null 2> /dev/null
+"$LE_AUTO" --no-self-upgrade -n > /dev/null 2> /dev/null
 
 # ensure python 3 isn't installed
 python3 --version 2> /dev/null
@@ -48,13 +50,13 @@ if [ $RESULT -eq 0 ]; then
 fi
 
 # Skip self upgrade due to Python 3 not being available.
-if ! certbot/letsencrypt-auto-source/letsencrypt-auto 2>&1 | grep -q "WARNING: couldn't find Python"; then
+if ! "$LE_AUTO" 2>&1 | grep -q "WARNING: couldn't find Python"; then
   echo "Python upgrade failure warning not printed!"
   exit 1
 fi
 
 # bootstrap, this time installing python3
-certbot/letsencrypt-auto-source/letsencrypt-auto --no-self-upgrade -n > /dev/null 2> /dev/null
+"$LE_AUTO" --no-self-upgrade -n > /dev/null 2> /dev/null
 
 # ensure python 3 is installed
 python3 --version > /dev/null

--- a/letsencrypt-auto-source/tests/centos6_tests.sh
+++ b/letsencrypt-auto-source/tests/centos6_tests.sh
@@ -47,8 +47,8 @@ if [ $RESULT -eq 0 ]; then
   exit 1
 fi
 
-# Skip self upgrade due to LE_PYTHON value
-if ! LE_PYTHON=nonexistant certbot/letsencrypt-auto-source/letsencrypt-auto 2>&1 | grep -q "WARNING: couldn't find Python"; then
+# Skip self upgrade due to Python 3 not being available.
+if ! certbot/letsencrypt-auto-source/letsencrypt-auto 2>&1 | grep -q "WARNING: couldn't find Python"; then
   echo "Python upgrade failure warning not printed!"
   exit 1
 fi

--- a/letsencrypt-auto-source/tests/centos6_tests.sh
+++ b/letsencrypt-auto-source/tests/centos6_tests.sh
@@ -47,6 +47,12 @@ if [ $RESULT -eq 0 ]; then
   exit 1
 fi
 
+# Skip self upgrade due to LE_PYTHON value
+if ! LE_PYTHON=nonexistant certbot/letsencrypt-auto-source/letsencrypt-auto 2>&1 | grep -q "WARNING: couldn't find Python"; then
+  echo "Python upgrade failure warning not printed!"
+  exit 1
+fi
+
 # bootstrap, this time installing python3
 certbot/letsencrypt-auto-source/letsencrypt-auto --no-self-upgrade -n > /dev/null 2> /dev/null
 


### PR DESCRIPTION
Fixes #5387.

The
```
# bootstrap, this time installing python3
 certbot/letsencrypt-auto-source/letsencrypt-auto --no-self-upgrade -n > /dev/null 2> /dev/null
```
lines in `centos6_tests.sh` after the test I added may or may not be necessary depending on how #5388 is resolved, but in the worst case `letsencrypt-auto` should effectively be a noop and will just run Certbot.
