### PR TITLE
Do not halt in Centos6 test script if there is updates offered by package repository

### DIFF
--- a/letsencrypt-auto-source/tests/centos6_tests.sh
+++ b/letsencrypt-auto-source/tests/centos6_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Start by making sure your system is up-to-date:
-yum update > /dev/null
+yum update -y > /dev/null
 yum install -y centos-release-scl > /dev/null
 yum install -y python27 > /dev/null 2> /dev/null
 


### PR DESCRIPTION
Automatically install updates in Centos 6 test script.

Fixes: #5393 