### PR TITLE
Reduce ipdb version

### DIFF
--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -21,7 +21,7 @@ futures==3.1.1
 google-api-python-client==1.5
 httplib2==0.10.3
 imagesize==0.7.1
-ipdb==0.10.3
+ipdb==0.10.2
 ipython==5.5.0
 ipython-genutils==0.2.0
 Jinja2==2.9.6


### PR DESCRIPTION
`ipdb 0.10.3` uses environment markers with `<=` which isn't supported in older versions of `setuptools`. See https://github.com/pypa/setuptools/issues/977. Currently our oldest tests use `setuptools 1.0` because that's what's available on CentOS 7 EPEL where we're packaged.

Dropping down to `ipdb 0.10.2` fixes the problem. I have no idea why we're just hitting this problem now, but I would like to see a full, successful `test-everything` run without modifications before doing the release and this is a blocker to that. See https://travis-ci.org/certbot/certbot/builds/327394999 where it fails and https://travis-ci.org/certbot/certbot/builds/327408559 where it passes with this patch.