### PR TITLE
[Docs] restore docs for ppl just using Certbot git master

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,7 +35,10 @@ a new plugin is introduced.
    ./certbot-auto --os-packages-only
    ./tools/venv.sh
 
-Then in each shell where you're working on the client, do:
+You can now run the copy of Certbot from git either by executing
+``venv/bin/certbot``, or by activating the virtual environment. If you're
+actively modifying and testing the code, you may want to run commands like this in
+each shell where you're working:
 
 .. code-block:: shell
 
@@ -43,7 +46,8 @@ Then in each shell where you're working on the client, do:
    export SERVER=https://acme-staging.api.letsencrypt.org/directory
    source tests/integration/_common.sh
 
-After that, your shell will be using the virtual environment, and you run the
+After that, your shell will be using the virtual environment, your copy of
+Certbot will default to requesting test (staging) certificates, and you run the
 client by typing `certbot` or `certbot_test`. The latter is an alias that
 includes several flags useful for testing. For instance, it sets various output
 directories to point to /tmp/, and uses non-privileged ports for challenges, so


### PR DESCRIPTION
 - Dev / test cycles are one use case for the "running a local copy of
 the client" instructions, but simply running bleeding edge Certbot is
 another
 - So edit the docs to once again explain how to just run bleeding edge
 Certbot, without (say) always getting staging certs.