### PR TITLE
Handle more edge cases for HTTP-01 support in Nginx

### DIFF
--- a/certbot-nginx/certbot_nginx/http_01.py
+++ b/certbot-nginx/certbot_nginx/http_01.py
@@ -5,6 +5,7 @@ import os
 
 from acme import challenges
 
+from certbot import errors
 from certbot.plugins import common
 
 


### PR DESCRIPTION
Fix nginx default checking so only checks by port.
If we still can't find a default (or found too many), make a dummy block.
Don't change the behavior for anything that's not HTTP01.

Part of #5409.