### PR TITLE
Use static directory under workdir for HTTP challenges

### DIFF
--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -1956,7 +1956,6 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             self.revert_challenge_config()
             self.restart()
             self.parser.reset_modules()
-            self.http_doer.cleanup()
 
     def install_ssl_options_conf(self, options_ssl, options_ssl_digest):
         """Copy Certbot's SSL options file into the system's config dir if required."""

--- a/certbot-apache/certbot_apache/http_01.py
+++ b/certbot-apache/certbot_apache/http_01.py
@@ -101,9 +101,9 @@ Alias /.well-known/acme-challenge {0}
 
         name = os.path.join(self.challenge_dir, achall.chall.encode("token"))
 
+        self.configurator.reverter.register_file_creation(True, name)
         with open(name, 'wb') as f:
             f.write(validation.encode())
-            self.configurator.reverter.register_file_creation(True, name)
         os.chmod(name, 0o644)
 
         return response

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -747,7 +747,6 @@ class MultipleVhostsTest(util.ApacheTest):
     def test_cleanup(self, mock_cfg, mock_restart):
         mock_cfg.return_value = ""
         _, achalls = self.get_key_and_achalls()
-        self.config.http_doer = mock.MagicMock()
 
         for achall in achalls:
             self.config._chall_out.add(achall)  # pylint: disable=protected-access
@@ -756,10 +755,8 @@ class MultipleVhostsTest(util.ApacheTest):
             self.config.cleanup([achall])
             if i == len(achalls) - 1:
                 self.assertTrue(mock_restart.called)
-                self.assertTrue(self.config.http_doer.cleanup.called)
             else:
                 self.assertFalse(mock_restart.called)
-                self.assertFalse(self.config.http_doer.cleanup.called)
 
     @mock.patch("certbot_apache.configurator.ApacheConfigurator.restart")
     @mock.patch("certbot_apache.parser.ApacheParser._get_runtime_cfg")
@@ -773,11 +770,9 @@ class MultipleVhostsTest(util.ApacheTest):
 
         self.config.cleanup([achalls[-1]])
         self.assertFalse(mock_restart.called)
-        self.assertFalse(self.config.http_doer.cleanup.called)
 
         self.config.cleanup(achalls)
         self.assertTrue(mock_restart.called)
-        self.assertTrue(self.config.http_doer.cleanup.called)
 
     @mock.patch("certbot.util.run_script")
     def test_get_version(self, mock_script):

--- a/certbot-apache/certbot_apache/tests/http_01_test.py
+++ b/certbot-apache/certbot_apache/tests/http_01_test.py
@@ -100,6 +100,8 @@ class ApacheHttp01Test(util.ApacheTest):
 
     def common_perform_test(self, achalls):
         """Tests perform with the given achalls."""
+        challenge_dir = self.http.challenge_dir
+        self.assertFalse(os.path.exists(challenge_dir))
         for achall in achalls:
             self.http.add_chall(achall)
 
@@ -114,9 +116,7 @@ class ApacheHttp01Test(util.ApacheTest):
         for achall in achalls:
             self._test_challenge_file(achall)
 
-        challenge_dir = self.http.challenge_dir
-        self.http.cleanup()
-        self.assertFalse(os.path.exists(challenge_dir))
+        self.assertTrue(os.path.exists(challenge_dir))
 
     def _test_challenge_conf(self):
         self.assertEqual(


### PR DESCRIPTION
Instead of using randomly generated temporary directory for HTTP challenge files, use a directory under Certbot work directory. This fixes issues with systemd PrivateTmp.

Fixes: #5427