### PR TITLE
Cleanup dockerfile-dev

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -9,7 +9,7 @@ WORKDIR /opt/certbot/src
 # TODO: Install Apache/Nginx for plugin development.
 COPY . .
 RUN apt-get update && \
-    apt-get install apache2 git nginx-light python3-dev -y && \
+    apt-get install apache2 git nginx-light -y && \
     letsencrypt-auto-source/letsencrypt-auto --os-packages-only && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,70 +1,21 @@
 # This Dockerfile builds an image for development.
-FROM ubuntu:trusty
-MAINTAINER Jakub Warmuz <jakub@warmuz.org>
-MAINTAINER William Budington <bill@eff.org>
-MAINTAINER Yan <yan@eff.org>
+FROM ubuntu:xenial
 
-# Note: this only exposes the port to other docker containers. You
-# still have to bind to 443@host at runtime, as per the ACME spec.
-EXPOSE 443
-
-# TODO: make sure --config-dir and --work-dir cannot be changed
-# through the CLI (certbot-docker wrapper that uses standalone
-# authenticator and text mode only?)
-VOLUME /etc/letsencrypt /var/lib/letsencrypt
+# Note: this only exposes the port to other docker containers.
+EXPOSE 80 443
 
 WORKDIR /opt/certbot/src
 
-# no need to mkdir anything:
-# https://docs.docker.com/reference/builder/#copy
-# If <dest> doesn't exist, it is created along with all missing
-# directories in its path.
-
 # TODO: Install Apache/Nginx for plugin development.
-COPY letsencrypt-auto-source/letsencrypt-auto /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto
-RUN /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto --os-packages-only && \
-    apt-get install python3-dev git -y && \
+COPY . .
+RUN apt-get update && \
+    apt-get install apache2 git nginx-light python3-dev -y && \
+    letsencrypt-auto-source/letsencrypt-auto --os-packages-only && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \
            /tmp/* \
            /var/tmp/*
 
-# the above is not likely to change, so by putting it further up the
-# Dockerfile we make sure we cache as much as possible
-
-COPY setup.py README.rst CHANGES.rst MANIFEST.in linter_plugin.py tox.cover.sh tox.ini .pylintrc /opt/certbot/src/
-
-# all above files are necessary for setup.py, however, package source
-# code directory has to be copied separately to a subdirectory...
-# https://docs.docker.com/reference/builder/#copy: "If <src> is a
-# directory, the entire contents of the directory are copied,
-# including filesystem metadata. Note: The directory itself is not
-# copied, just its contents." Order again matters, three files are far
-# more likely to be cached than the whole project directory
-
-COPY certbot /opt/certbot/src/certbot/
-COPY acme /opt/certbot/src/acme/
-COPY certbot-apache /opt/certbot/src/certbot-apache/
-COPY certbot-nginx /opt/certbot/src/certbot-nginx/
-COPY letshelp-certbot /opt/certbot/src/letshelp-certbot/
-COPY certbot-compatibility-test /opt/certbot/src/certbot-compatibility-test/
-COPY tests /opt/certbot/src/tests/
-
-RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
-    /opt/certbot/venv/bin/pip install -U pip && \
-    /opt/certbot/venv/bin/pip install -U setuptools && \
-    /opt/certbot/venv/bin/pip install \
-    -e /opt/certbot/src/acme \
-    -e /opt/certbot/src \
-    -e /opt/certbot/src/certbot-apache \
-    -e /opt/certbot/src/certbot-nginx \
-    -e /opt/certbot/src/letshelp-certbot \
-    -e /opt/certbot/src/certbot-compatibility-test \
-    -e /opt/certbot/src[dev,docs]
-
-# install in editable mode (-e) to save space: it's not possible to
-# "rm -rf /opt/certbot/src" (it's stays in the underlaying image);
-# this might also help in debugging: you can "docker run --entrypoint
-# bash" and investigate, apply patches, etc.
+RUN VENV_NAME="../venv" tools/venv.sh
 
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       context: .
       dockerfile: Dockerfile-dev
     ports:
+      - "80:80"
       - "443:443"
     volumes:
       - .:/opt/certbot/src


### PR DESCRIPTION
I'm using this currently and hit a number of snags. Changes are:

* Upgrade to Xenial which has Python libraries with real SSL support.
* Stop storing default Certbot directories as volumes as this is rarely (if ever) necessary in development.
* Expose port 80 as well for testing internal web servers.
* Install apache and nginx (this causes Augeas to be installed and makes Apache tests work).
* Copy all files from the repo so tools continue to work as they begin to rely on more files.
* Use `tools/venv.sh` which pins all dependency versions for increased stability and installs all plugins.