### PR TITLE
Alternative: Work around Basic Authentication for challenge dir

### DIFF
--- a/certbot-apache/certbot_apache/http_01.py
+++ b/certbot-apache/certbot_apache/http_01.py
@@ -19,6 +19,10 @@ class ApacheHttp01(common.TLSSNI01):
             Order Allow,Deny
             Allow from all
         </Directory>
+        <Location /.well-known/acme-challenge>
+            Order Allow,Deny
+            Allow from all
+        </Location>
     """
 
     CONFIG_TEMPLATE24 = """\
@@ -28,6 +32,9 @@ class ApacheHttp01(common.TLSSNI01):
         <Directory {0}>
             Require all granted
         </Directory>
+        <Location /.well-known/acme-challenge>
+            Require all granted
+        </Location>
     """
 
     def __init__(self, *args, **kwargs):
@@ -146,5 +153,7 @@ class ApacheHttp01(common.TLSSNI01):
                 "Adding a temporary challenge validation Include for name: %s " +
                 "in: %s", vhost.name, vhost.filep)
             self.configurator.parser.add_dir_beginning(
+                vhost.path, "Include", self.challenge_conf)
+            self.configurator.parser.add_dir(
                 vhost.path, "Include", self.challenge_conf)
             self.moded_vhosts.add(vhost)

--- a/certbot-apache/certbot_apache/tests/http_01_test.py
+++ b/certbot-apache/certbot_apache/tests/http_01_test.py
@@ -160,7 +160,7 @@ class ApacheHttp01Test(util.ApacheTest):
                 matches = self.config.parser.find_dir("Include",
                                                       self.http.challenge_conf,
                                                       vhost.path)
-                self.assertEqual(len(matches), 1)
+                self.assertEqual(len(matches), 2)
 
         self.assertTrue(os.path.exists(challenge_dir))
 


### PR DESCRIPTION
This is an alternative to #5461

Unfortunately, the way that Apache merges the configuration directives is different for mod_rewrite and <Location> / <Directory> directives.

To work around basic auth in VirtualHosts, the challenge override `Include` now has an added `<Location>` block, and is included twice in the `<VirtualHost>`: once in the beginning to tackle `mod_rewrite` issues, and once in the end to fix issues with `<Directory>` and `<Location>`.