### PR TITLE
Fix --no-bootstrap on CentOS/RHEL 6

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -761,13 +761,8 @@ BootstrapMageiaCommon() {
 # Set Bootstrap to the function that installs OS dependencies on this system
 # and BOOTSTRAP_VERSION to the unique identifier for the current version of
 # that function. If Bootstrap is set to a function that doesn't install any
-# packages (either because --no-bootstrap was included on the command line or
-# we don't know how to bootstrap on this system), BOOTSTRAP_VERSION is not set.
-if [ "$NO_BOOTSTRAP" = 1 ]; then
-  Bootstrap() {
-    :
-  }
-elif [ -f /etc/debian_version ]; then
+# packages BOOTSTRAP_VERSION is not set.
+if [ -f /etc/debian_version ]; then
   Bootstrap() {
     BootstrapMessage "Debian-based OSes"
     BootstrapDebCommon
@@ -861,6 +856,17 @@ else
     error "for more info."
     exit 1
   }
+fi
+
+# We handle this case after determining the normal bootstrap version to allow
+# variables like USE_PYTHON_3 to be properly set. As described above, if the
+# Bootstrap function doesn't install any packages, BOOTSTRAP_VERSION should not
+# be set so we unset it here.
+if [ "$NO_BOOTSTRAP" = 1 ]; then
+  Bootstrap() {
+    :
+  }
+  unset BOOTSTRAP_VERSION
 fi
 
 # Sets PREV_BOOTSTRAP_VERSION to the identifier for the bootstrap script used

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -300,13 +300,8 @@ DeterminePythonVersion() {
 # Set Bootstrap to the function that installs OS dependencies on this system
 # and BOOTSTRAP_VERSION to the unique identifier for the current version of
 # that function. If Bootstrap is set to a function that doesn't install any
-# packages (either because --no-bootstrap was included on the command line or
-# we don't know how to bootstrap on this system), BOOTSTRAP_VERSION is not set.
-if [ "$NO_BOOTSTRAP" = 1 ]; then
-  Bootstrap() {
-    :
-  }
-elif [ -f /etc/debian_version ]; then
+# packages BOOTSTRAP_VERSION is not set.
+if [ -f /etc/debian_version ]; then
   Bootstrap() {
     BootstrapMessage "Debian-based OSes"
     BootstrapDebCommon
@@ -400,6 +395,17 @@ else
     error "for more info."
     exit 1
   }
+fi
+
+# We handle this case after determining the normal bootstrap version to allow
+# variables like USE_PYTHON_3 to be properly set. As described above, if the
+# Bootstrap function doesn't install any packages, BOOTSTRAP_VERSION should not
+# be set so we unset it here.
+if [ "$NO_BOOTSTRAP" = 1 ]; then
+  Bootstrap() {
+    :
+  }
+  unset BOOTSTRAP_VERSION
 fi
 
 # Sets PREV_BOOTSTRAP_VERSION to the identifier for the bootstrap script used

--- a/letsencrypt-auto-source/tests/centos6_tests.sh
+++ b/letsencrypt-auto-source/tests/centos6_tests.sh
@@ -69,5 +69,13 @@ fi
 echo "PASSED: Successfully upgraded to Python3 when only Python2.6 is present."
 echo ""
 
+export VENV_PATH=$(mktemp -d)
+"$LE_AUTO" -n --no-bootstrap --no-self-upgrade --version >/dev/null 2>&1
+if [ "$($VENV_PATH/bin/python -V 2>&1 | cut -d" " -f2 | cut -d. -f1)" != 3 ]; then
+  echo "Python 3 wasn't used with --no-bootstrap!"
+  exit 1
+fi
+unset VENV_PATH
+
 # test using python3
 pytest -v -s certbot/letsencrypt-auto-source/tests


### PR DESCRIPTION
If you take certbot-auto 0.21.0 on CentOS 6 and run
```
./certbot-auto --os-packages-only -n
./certbot-auto --no-bootstrap
```
one of two bad things will happen.

If `virtualenv` is installed, it will create the virtual environment using Python 2.6. If `virtualenv` is not installed, it exit saying that it couldn't find the `virtualenv` command.

This PR fixes that by letting the normal bootstrap selection process happen (allowing variables like `USE_PYTHON_3` to be set) and afterwards respecting `--no-bootstrap` overwriting and unsetting variables as necessary.

I think this PR is pretty straightforward, but Erik, if you can get to this PR before Erica, a review would help us out.