### PR TITLE
Ignore .docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ tests/letstest/venv/
 
 # pytest cache
 .cache
+
+# docker files
+.docker


### PR DESCRIPTION
I couldn't quickly find Docker documentation about these files, but I've observed docker creating them on macOS. Let's ignore them.