### PR TITLE
Improve test_tests.sh

### DIFF
--- a/tests/letstest/scripts/test_tests.sh
+++ b/tests/letstest/scripts/test_tests.sh
@@ -1,11 +1,13 @@
 #!/bin/sh -xe
 
+LE_AUTO="letsencrypt/letsencrypt-auto-source/letsencrypt-auto"
+LE_AUTO="$LE_AUTO --debug --no-self-upgrade --non-interactive"
 MODULES="acme certbot certbot_apache certbot_nginx"
 VENV_NAME=venv
 
 # *-auto respects VENV_PATH
-letsencrypt/certbot-auto --debug --os-packages-only --non-interactive
-LE_AUTO_SUDO="" VENV_PATH=$VENV_NAME letsencrypt/certbot-auto --debug --no-bootstrap --non-interactive --version
+$LE_AUTO --os-packages-only
+LE_AUTO_SUDO="" VENV_PATH="$VENV_NAME" $LE_AUTO --no-bootstrap --version
 . $VENV_NAME/bin/activate
 
 # change to an empty directory to ensure CWD doesn't affect tests


### PR DESCRIPTION
While not the main purpose of this test, we could have caught #5476 during the release process if this script would have been using `letsencrypt-auto-source/letsencrypt-auto`. In general, we should probably have tests like this use the version of `letsencrypt-auto` in master to help us catch bugs.

Also, after #5476 (or an equivalent PR is merged) tests will fail without this PR until we do a release to move those changes to certbot-auto in the root of the repo.