### PR TITLE
Add sudo to certbot-auto instructions.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -32,7 +32,7 @@ a new plugin is introduced.
 .. code-block:: shell
 
    cd certbot
-   ./certbot-auto --os-packages-only
+   sudo ./certbot-auto --os-packages-only
    ./tools/venv.sh
 
 Then in each shell where you're working on the client, do:


### PR DESCRIPTION
This makes it slightly clearer that the user will be prompted for sudo access on running it.