### PR TITLE
from botocore.exceptions import ClientError

### DIFF
--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -38,6 +38,7 @@ from multiprocessing import Manager
 import urllib2
 import yaml
 import boto3
+from botocore.exceptions import ClientError
 import fabric
 from fabric.api import run, execute, local, env, sudo, cd, lcd
 from fabric.operations import get, put
@@ -141,7 +142,7 @@ def make_instance(instance_name,
     # give instance a name
     try:
         new_instance.create_tags(Tags=[{'Key': 'Name', 'Value': instance_name}])
-    except botocore.exceptions.ClientError as e:
+    except ClientError as e:
         if "InvalidInstanceID.NotFound" in str(e):
             # This seems to be ephemeral... retry
             time.sleep(1)


### PR DESCRIPTION
Fixes undefined name 'botocore' in flake8 testing of https://github.com/certbot/certbot

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tests/letstest/multitester.py:144:12: F821 undefined name 'botocore'
    except botocore.exceptions.ClientError as e:
           ^
1     F821 undefined name 'botocore'
```