### PR TITLE
Fix test inconsistency in Apache plugin configurator_test

### DIFF
--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -474,7 +474,11 @@ class MultipleVhostsTest(util.ApacheTest):
         self.assertEqual(mock_add_dir.call_count, 3)
         self.assertTrue(mock_add_dir.called)
         self.assertEqual(mock_add_dir.call_args[0][1], "Listen")
-        self.assertEqual(mock_add_dir.call_args[0][2], ['1.2.3.4:8080'])
+        call_found = False
+        for mock_call in mock_add_dir.mock_calls:
+            if mock_call[1][2] == ['1.2.3.4:8080']:
+                call_found = True
+        self.assertTrue(call_found)
 
     def test_prepare_server_https(self):
         mock_enable = mock.Mock()


### PR DESCRIPTION
This test had a bug because of assumption of certain order of calls made, even though the actual order was undefined because of `set()` usage underneath, as `set()` is unordered. This caused tests on Python 3 to randomly error out. 

Fixes: #5510