### PR TITLE
Use "certificate" instead of "cert" in docs.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -116,7 +116,7 @@ certbot-auto_ method, which enables you to use installer plugins
 that cover both of those hard topics.
 
 If you're still not convinced and have decided to use this method,
-from the server that the domain you're requesting a cert for resolves
+from the server that the domain you're requesting a certficate for resolves
 to, `install Docker`_, then issue the following command:
 
 .. code-block:: shell

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -557,8 +557,8 @@ apologize for any inconvenience you encounter in integrating these
 commands into your individual environment.
 
 .. note:: ``certbot renew`` exit status will only be 1 if a renewal attempt failed.
-  This means ``certbot renew`` exit status will be 0 if no cert needs to be updated.
-  If you write a custom script and expect to run a command only after a cert was actually renewed
+  This means ``certbot renew`` exit status will be 0 if no certificate needs to be updated.
+  If you write a custom script and expect to run a command only after a certificate was actually renewed
   you will need to use the ``--post-hook`` since the exit status will be 0 both on successful renewal
   and when renewal is not necessary.
 


### PR DESCRIPTION
Fixes #4519 