### PR TITLE
Remove autodocs for long-removed acme.other module

### DIFF
--- a/acme/docs/api/other.rst
+++ b/acme/docs/api/other.rst
@@ -1,5 +1,0 @@
-Other ACME objects
-------------------
-
-.. automodule:: acme.other
-   :members:


### PR DESCRIPTION
This module was removed in 22a9c7e3c2a811698ed7d63fae1cd43d0bd5d088. The autodocs are therefore unnecessary. Furthermore, they are starting to cause build failures for Fedora.