### PR TITLE
Fix Apache configurator test

### DIFF
--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -473,8 +473,13 @@ class MultipleVhostsTest(util.ApacheTest):
         self.config.ensure_listen("8080")
         self.assertEqual(mock_add_dir.call_count, 3)
         self.assertTrue(mock_add_dir.called)
-        self.assertEqual(mock_add_dir.call_args[0][1], "Listen")
-        self.assertEqual(mock_add_dir.call_args[0][2], ['1.2.3.4:8080'])
+        call_args_list = [list(mock_add_dir.call_args_list[i][0][1:]) for i in
+                range(3)]
+        self.assertEqual(
+            sorted(call_args_list),
+            sorted([["Listen", ["1.2.3.4:8080"]],
+                    ["Listen", ["[::1]:8080"]],
+                    ["Listen", ["1.1.1.1:8080"]]]))
 
     def test_prepare_server_https(self):
         mock_enable = mock.Mock()


### PR DESCRIPTION
One of the Apache configurator tests was relying on the order in which calls are made by `ensure_listen()` to `parser.add_dir()`. Under the hood, the order is determined by [creating a list] and [a set], [adding some items to the set][adding], and then [iterating] over [the difference (itself a set) between the set and the list][difference]. Unfortunately, sets are unordered collections, and iteration order is therefore not guaranteed. This resulted in test failures when the iteration order was not as the test writer had anticipated. We deal with this by instead building a list of all the calls to `parser_dir()` and comparing it to a list of expected calls. This has the extra benefit of ensuring that no extraneous calls are added and no expected calls are missing.

[creating a list]: https://github.com/certbot/certbot/blob/45613fd31c3649ac5fb08a52153a8893f394af0b/certbot-apache/certbot_apache/configurator.py#L789-L790
[a set]: https://github.com/certbot/certbot/blob/45613fd31c3649ac5fb08a52153a8893f394af0b/certbot-apache/certbot_apache/configurator.py#L796
[adding]: https://github.com/certbot/certbot/blob/45613fd31c3649ac5fb08a52153a8893f394af0b/certbot-apache/certbot_apache/configurator.py#L801-L814
[iterating]: https://github.com/certbot/certbot/blob/45613fd31c3649ac5fb08a52153a8893f394af0b/certbot-apache/certbot_apache/configurator.py#L838-L843
[difference]: https://github.com/certbot/certbot/blob/45613fd31c3649ac5fb08a52153a8893f394af0b/certbot-apache/certbot_apache/configurator.py#L829