### PR TITLE
Add mechanism to detect acme version

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -576,20 +576,20 @@ class BackwardsCompatibleClientV2(object):
 
     def new_account_and_tos(self, regr=None, tos_cb=None):
         def assess_tos(tos):
-            if tos_cb is not None and not tos_cb(regr.terms_of_service):
+            if tos_cb is not None and not tos_cb(tos):
                 raise errors.Error(
                     "Registration cannot proceed without accepting "
                     "Terms of Service.")
         if self.acme_version == 1:
-            # if tos in directory
-            # else if tos not in directory
             regr = self.client.register(regr)
             if regr.terms_of_service is not None:
                 assess_tos(regr.terms_of_service)
                 return self.client.agree_to_tos(regr)
         else:
-            assess_tos(self.directory['termsOfService'])
-            regr.update(terms_of_service_agreed=True)
+            assert regr is not None
+            if "terms_of_service_v2" in self.directory.meta:
+                assess_tos(self.directory.meta.terms_of_service_v2)
+                regr.update(terms_of_service_agreed=True)
             return self.client.new_account(regr)
 
     def _acme_version_from_directory(self, directory):

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -562,7 +562,7 @@ class BackwardsCompatibleClientV2(object):
     """ACME client wrapper that tends towards V2-style calls, but
        supports V1 servers.
 
-       :ivar int acme_version:
+       :ivar int acme_version: 1 or 2, corresponding to the Let's Encrypt endpoint
        :ivar .ClientBase client: either Client or ClientV2
     """
 
@@ -575,7 +575,7 @@ class BackwardsCompatibleClientV2(object):
             self.client = ClientV2(directory, net=net)
 
     def __getattr__(self, name):
-        if name in vars(self.client).keys():
+        if name in vars(self.client):
             return getattr(self.client, name)
         elif name in dir(ClientBase):
             return getattr(self.client, name)
@@ -585,11 +585,11 @@ class BackwardsCompatibleClientV2(object):
         else:
             raise AttributeError
 
-    def new_account_and_tos(self, regr=None, check_tos_cb=None):
+    def new_account_and_tos(self, regr, check_tos_cb=None):
         """Combined register and agree_tos for V1, new_account for V2
 
-        :param .NewRegistration new_account:
-        :param function check_tos_cb: callback that raises an error if
+        :param .NewRegistration regr:
+        :param callable check_tos_cb: callback that raises an error if
             the check does not work
         """
         def _assess_tos(tos):
@@ -601,10 +601,9 @@ class BackwardsCompatibleClientV2(object):
                 _assess_tos(regr.terms_of_service)
                 return self.client.agree_to_tos(regr)
         else:
-            assert regr is not None
             if "terms_of_service_v2" in self.client.directory.meta:
                 _assess_tos(self.client.directory.meta.terms_of_service_v2)
-                regr.update(terms_of_service_agreed=True)
+                regr = regr.update(terms_of_service_agreed=True)
             return self.client.new_account(regr)
 
     def _acme_version_from_directory(self, directory):

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -579,12 +579,11 @@ class BackwardsCompatibleClientV2(object):
         else:
             raise AttributeError
 
-    def new_account_and_tos(self, regr=None, tos_cb=None):
+    def new_account_and_tos(self, regr=None, check_tos_cb=None):
+        # check_tos_cb should raise an error if we want to error
         def assess_tos(tos):
-            if tos_cb is not None and not tos_cb(tos):
-                raise errors.Error(
-                    "Registration cannot proceed without accepting "
-                    "Terms of Service.")
+            if check_tos_cb is not None:
+                check_tos_cb(tos)
         if self.acme_version == 1:
             regr = self.client.register(regr)
             if regr.terms_of_service is not None:

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -562,7 +562,7 @@ class BackwardsCompatibleClientV2(object):
 
     def __init__(self, net, key, server):
         self.directory = messages.Directory.from_json(net.get(server).json())
-        self.acme_version = self._acme_version_from_directory(directory)
+        self.acme_version = self._acme_version_from_directory(self.directory)
         if self.acme_version == 1:
             self.client = Client(directory, key=key, net=net)
         else:
@@ -570,6 +570,9 @@ class BackwardsCompatibleClientV2(object):
 
     def __getattr__(self, name):
         if name in dir(ClientBase):
+            return getattr(self.client, name)
+        # temporary, for breaking changes into smaller pieces
+        elif name in dir(Client):
             return getattr(self.client, name)
         else:
             raise AttributeError

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -561,8 +561,8 @@ class ClientV2(ClientBase):
 class BackwardsCompatibleClientV2(object):
 
     def __init__(self, net, key, server):
-        self.directory = messages.Directory.from_json(net.get(server).json())
-        self.acme_version = self._acme_version_from_directory(self.directory)
+        directory = messages.Directory.from_json(net.get(server).json())
+        self.acme_version = self._acme_version_from_directory(directory)
         if self.acme_version == 1:
             self.client = Client(directory, key=key, net=net)
         else:
@@ -590,8 +590,8 @@ class BackwardsCompatibleClientV2(object):
                 return self.client.agree_to_tos(regr)
         else:
             assert regr is not None
-            if "terms_of_service_v2" in self.directory.meta:
-                assess_tos(self.directory.meta.terms_of_service_v2)
+            if "terms_of_service_v2" in self.client.directory.meta:
+                assess_tos(self.client.directory.meta.terms_of_service_v2)
                 regr.update(terms_of_service_agreed=True)
             return self.client.new_account(regr)
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -608,11 +608,10 @@ class BackwardsCompatibleClientV2(object):
             return self.client.new_account(regr)
 
     def _acme_version_from_directory(self, directory):
-        try:
-            nonce_field = directory['newNonce'] # pylint: disable=unused-variable
-        except KeyError:
+        if hasattr(directory, 'newNonce'):
+            return 2
+        else:
             return 1
-        return 2
 
 
 class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -577,70 +577,70 @@ class MultiVersionClient(object):
 
     def register(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.register(*args, **kwargs)
+            return self.client.register(*args, **kwargs)
         else:
-            self.client.new_account(*args, **kwargs)
+            return self.client.new_account(*args, **kwargs)
 
     def new_account(self, *args, **kwargs):
-        self.register(*args, **kwargs)
+        return self.register(*args, **kwargs)
 
     def agree_to_tos(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.agree_to_tos(*args, **kwargs)
+            return self.client.agree_to_tos(*args, **kwargs)
 
     def request_challenges(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.request_challenges(*args, **kwargs)
+            return self.client.request_challenges(*args, **kwargs)
 
     def request_domain_challenges(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.request_domain_challenges(*args, **kwargs)
+            return self.client.request_domain_challenges(*args, **kwargs)
 
     def request_issuance(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.request_issuance(*args, **kwargs)
+            return self.client.request_issuance(*args, **kwargs)
 
     def poll_and_request_issuance(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.poll_and_request_issuance(*args, **kwargs)
+            return self.client.poll_and_request_issuance(*args, **kwargs)
 
     def check_cert(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.check_cert(*args, **kwargs)
+            return self.client.check_cert(*args, **kwargs)
 
     def refresh(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.refresh(*args, **kwargs)
+            return self.client.refresh(*args, **kwargs)
 
     def fetch_chain(self, *args, **kwargs):
         if self.acme_version == 1:
-            self.client.fetch_chain(*args, **kwargs)
+            return self.client.fetch_chain(*args, **kwargs)
 
     ######################
     # Shared methods #
     ######################
 
     def update_registration(self, *args, **kwargs):
-        self.client.update_registration(*args, **kwargs)
+        return self.client.update_registration(*args, **kwargs)
 
     def deactivate_registration(self, *args, **kwargs):
-        self.client.deactivate_registration(*args, **kwargs)
+        return self.client.deactivate_registration(*args, **kwargs)
 
     def query_registration(self, *args, **kwargs):
-        self.client.query_registration(*args, **kwargs)
+        return self.client.query_registration(*args, **kwargs)
 
     def answer_challenge(self, *args, **kwargs):
-        self.client.answer_challenge(*args, **kwargs)
+        return self.client.answer_challenge(*args, **kwargs)
 
     @classmethod
     def retry_after(cls, *args, **kwargs):
-        class(cls).retry_after(*args, **kwargs)
+        return type(cls).retry_after(*args, **kwargs)
 
     def poll(self, *args, **kwargs):
-        self.client.poll(*args, **kwargs)
+        return self.client.poll(*args, **kwargs)
 
     def revoke(self, *args, **kwargs):
-        self.client.revoke(*args, **kwargs)
+        return self.client.revoke(*args, **kwargs)
 
 
 class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -569,7 +569,9 @@ class BackwardsCompatibleClientV2(object):
             self.client = ClientV2(directory, net=net)
 
     def __getattr__(self, name):
-        if name in dir(ClientBase):
+        if name in vars(self.client).keys():
+            return getattr(self.client, name)
+        elif name in dir(ClientBase):
             return getattr(self.client, name)
         # temporary, for breaking changes into smaller pieces
         elif name in dir(Client):
@@ -597,7 +599,7 @@ class BackwardsCompatibleClientV2(object):
 
     def _acme_version_from_directory(self, directory):
         try:
-            nonce_field = directory['newNonce']
+            nonce_field = directory['newNonce'] # pylint: disable=unused-variable
         except KeyError:
             return 1
         return 2

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -601,8 +601,8 @@ class BackwardsCompatibleClientV2(object):
                 _assess_tos(regr.terms_of_service)
                 return self.client.agree_to_tos(regr)
         else:
-            if "terms_of_service_v2" in self.client.directory.meta:
-                _assess_tos(self.client.directory.meta.terms_of_service_v2)
+            if "terms_of_service" in self.client.directory.meta:
+                _assess_tos(self.client.directory.meta.terms_of_service)
                 regr = regr.update(terms_of_service_agreed=True)
             return self.client.new_account(regr)
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -95,6 +95,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         update = regr.body if update is None else update
         body = messages.UpdateRegistration(**dict(update))
         updated_regr = self._send_recv_regr(regr, body=body)
+        self.net.account = updated_regr
         return updated_regr
 
     def deactivate_registration(self, regr):
@@ -555,7 +556,9 @@ class ClientV2(ClientBase):
             acme_version=2)
         # "Instance of 'Field' has no key/contact member" bug:
         # pylint: disable=no-member
-        return self._regr_from_response(response)
+        regr = self._regr_from_response(response)
+        self.net.account = regr
+        return regr
 
 
 class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -583,7 +583,7 @@ class BackwardsCompatibleClientV2(object):
         elif name in dir(Client):
             return getattr(self.client, name)
         else:
-            raise AttributeError
+            raise AttributeError()
 
     def new_account_and_tos(self, regr, check_tos_cb=None):
         """Combined register and agree_tos for V1, new_account for V2
@@ -600,6 +600,7 @@ class BackwardsCompatibleClientV2(object):
             if regr.terms_of_service is not None:
                 _assess_tos(regr.terms_of_service)
                 return self.client.agree_to_tos(regr)
+            return regr
         else:
             if "terms_of_service" in self.client.directory.meta:
                 _assess_tos(self.client.directory.meta.terms_of_service)

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -574,8 +574,9 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
     """Initialize.
 
     :param  key: Account private key
-    :param messages.Registration account: Account object. Required if you are
-            planning to use .post() with acme_version=2.
+    :param messages.RegistrationResource account: RegistrationResource object. Required if you are
+            planning to use .post() with acme_version=2 for anything other than creating a new
+            account; may be set later after registering.
     :param josepy.JWASignature alg: Algoritm to use in signing JWS.
     :param bool verify_ssl: Whether to verify certificates on SSL connections.
     :param str user_agent: String to send as User-Agent header.

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -562,8 +562,8 @@ class MultiVersionClient(object):
 
     def __init__(self, net, key, server):
         directory = messages.Directory.from_json(net.get(server).json())
-        acme_version = self._acme_version_from_directory(directory)
-        if acme_version == 1:
+        self.acme_version = self._acme_version_from_directory(directory)
+        if self.acme_version == 1:
             self.client = Client(directory, key=key, net=net)
         else:
             self.client = ClientV2(directory, net=net)
@@ -574,6 +574,73 @@ class MultiVersionClient(object):
         except KeyError:
             return 1
         return 2
+
+    def register(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.register(*args, **kwargs)
+        else:
+            self.client.new_account(*args, **kwargs)
+
+    def new_account(self, *args, **kwargs):
+        self.register(*args, **kwargs)
+
+    def agree_to_tos(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.agree_to_tos(*args, **kwargs)
+
+    def request_challenges(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.request_challenges(*args, **kwargs)
+
+    def request_domain_challenges(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.request_domain_challenges(*args, **kwargs)
+
+    def request_issuance(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.request_issuance(*args, **kwargs)
+
+    def poll_and_request_issuance(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.poll_and_request_issuance(*args, **kwargs)
+
+    def check_cert(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.check_cert(*args, **kwargs)
+
+    def refresh(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.refresh(*args, **kwargs)
+
+    def fetch_chain(self, *args, **kwargs):
+        if self.acme_version == 1:
+            self.client.fetch_chain(*args, **kwargs)
+
+    ######################
+    # Shared methods #
+    ######################
+
+    def update_registration(self, *args, **kwargs):
+        self.client.update_registration(*args, **kwargs)
+
+    def deactivate_registration(self, *args, **kwargs):
+        self.client.deactivate_registration(*args, **kwargs)
+
+    def query_registration(self, *args, **kwargs):
+        self.client.query_registration(*args, **kwargs)
+
+    def answer_challenge(self, *args, **kwargs):
+        self.client.answer_challenge(*args, **kwargs)
+
+    @classmethod
+    def retry_after(cls, *args, **kwargs):
+        class(cls).retry_after(*args, **kwargs)
+
+    def poll(self, *args, **kwargs):
+        self.client.poll(*args, **kwargs)
+
+    def revoke(self, *args, **kwargs):
+        self.client.revoke(*args, **kwargs)
 
 
 class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -142,10 +142,10 @@ class BackwardsCompatibleClientV2Test(ClientTestBase):
         with mock.patch('acme.client.ClientV2') as mock_client:
             mock_client().directory.meta.__contains__.return_value = True
             client = self._init()
-            def tos_cb(tos):
+            def _tos_cb(tos):
                 raise errors.Error
             self.assertRaises(errors.Error, client.new_account_and_tos,
-                self.new_reg, tos_cb)
+                self.new_reg, _tos_cb)
             mock_client().new_account.assert_not_called()
 
         # v1 yes tos

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -34,7 +34,7 @@ DIRECTORY_V1 = messages.Directory({
 
 DIRECTORY_V2 = messages.Directory({
     'newAccount': 'https://www.letsencrypt-demo.org/acme/new-account',
-    'newNonce': 'https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce'
+    'newNonce': 'https://www.letsencrypt-demo.org/acme/new-nonce'
 })
 
 
@@ -87,9 +87,6 @@ class ClientTestBase(unittest.TestCase):
 
 class BackwardsCompatibleClientV2Test(ClientTestBase):
     """Tests for  acme.client.BackwardsCompatibleClientV2."""
-
-    def setUp(self):
-        super(BackwardsCompatibleClientV2Test, self).setUp()
 
     def _init(self):
         uri = 'http://www.letsencrypt-demo.org/directory'

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -172,6 +172,7 @@ class Directory(jose.JSONDeSerializable):
     class Meta(jose.JSONObjectWithFields):
         """Directory Meta."""
         terms_of_service = jose.Field('terms-of-service', omitempty=True)
+        terms_of_service_v2 = jose.Field('termsOfService', omitempty=True)
         website = jose.Field('website', omitempty=True)
         caa_identities = jose.Field('caa-identities', omitempty=True)
 
@@ -251,7 +252,7 @@ class Registration(ResourceBody):
     contact = jose.Field('contact', omitempty=True, default=())
     agreement = jose.Field('agreement', omitempty=True)
     status = jose.Field('status', omitempty=True)
-    terms_of_service_agreed = jose.Field('terms-of-service-agreed', omitempty=True)
+    terms_of_service_agreed = jose.Field('termsOfServiceAgreed', omitempty=True)
 
     phone_prefix = 'tel:'
     email_prefix = 'mailto:'

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -171,10 +171,30 @@ class Directory(jose.JSONDeSerializable):
 
     class Meta(jose.JSONObjectWithFields):
         """Directory Meta."""
-        terms_of_service = jose.Field('terms-of-service', omitempty=True)
-        terms_of_service_v2 = jose.Field('termsOfService', omitempty=True)
+        _terms_of_service = jose.Field('terms-of-service', omitempty=True)
+        _terms_of_service_v2 = jose.Field('termsOfService', omitempty=True)
         website = jose.Field('website', omitempty=True)
         caa_identities = jose.Field('caa-identities', omitempty=True)
+
+        def __init__(self, **kwargs):
+            kwargs = dict((self._internal_name(k), v) for k, v in kwargs.items())
+            # pylint: disable=star-args
+            super(Directory.Meta, self).__init__(**kwargs)
+
+        @property
+        def terms_of_service(self):
+            """URL for the CA TOS"""
+            return self._terms_of_service or self._terms_of_service_v2
+
+        def __iter__(self):
+            # When iterating over fields, use the external name 'terms_of_service' instead of
+            # the internal '_terms_of_service'.
+            for name in super(Directory.Meta, self).__iter__():
+                yield name[1:] if name == '_terms_of_service' else name
+
+        def _internal_name(self, name):
+            return '_' + name if name == 'terms_of_service' else name
+
 
     @classmethod
     def _canon_key(cls, key):

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -165,6 +165,13 @@ class DirectoryTest(unittest.TestCase):
         from acme.messages import Directory
         Directory.from_json({'foo': 'bar'})
 
+    def test_iter_meta(self):
+        result = False
+        for k in self.dir.meta:
+            if k == 'terms_of_service':
+                result = self.dir.meta[k] == 'https://example.com/acme/terms'
+        self.assertTrue(result)
+
 
 class RegistrationTest(unittest.TestCase):
     """Tests for acme.messages.Registration."""

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -165,7 +165,7 @@ def register(config, account_storage, tos_cb=None):
     regr = perform_registration(acme, config)
 
     if regr.terms_of_service is not None:
-        if tos_cb is not None and not tos_cb(regr):
+        if tos_cb is not None and not tos_cb(regr.terms_of_service):
             raise errors.Error(
                 "Registration cannot proceed without accepting "
                 "Terms of Service.")

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -42,7 +42,7 @@ def acme_from_config_key(config, key, regr=None):
     # TODO: Allow for other alg types besides RS256
     net = acme_client.ClientNetwork(key, account=regr, verify_ssl=(not config.no_verify_ssl),
                                     user_agent=determine_user_agent(config))
-    return acme_client.MultiVersionClient(net, key, config.server)
+    return acme_client.BackwardsCompatibleClientV2(net, key, config.server)
 
 
 def determine_user_agent(config):

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -36,25 +36,13 @@ from certbot.plugins import selection as plugin_selection
 
 logger = logging.getLogger(__name__)
 
-def _acme_version_from_directory(directory):
-    try:
-        nonce_field = directory['newNonce']
-    except KeyError:
-        return 1
-    return 2
-
 
 def acme_from_config_key(config, key, regr=None):
     "Wrangle ACME client construction"
     # TODO: Allow for other alg types besides RS256
     net = acme_client.ClientNetwork(key, account=regr, verify_ssl=(not config.no_verify_ssl),
                                     user_agent=determine_user_agent(config))
-    directory = messages.Directory.from_json(net.get(config.server).json())
-    acme_version = _acme_version_from_directory(directory)
-    if acme_version == 1:
-        return acme_client.Client(directory, key=key, net=net)
-    else:
-        return acme_client.ClientV2(directory, net=net)
+    return acme_client.MultiVersionClient(net, key, config.server)
 
 
 def determine_user_agent(config):

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -495,13 +495,13 @@ def _determine_account(config):
             if config.email is None and not config.register_unsafely_without_email:
                 config.email = display_ops.get_email()
 
-            def _tos_cb(regr):
+            def _tos_cb(terms_of_service):
                 if config.tos:
                     return True
                 msg = ("Please read the Terms of Service at {0}. You "
                        "must agree in order to register with the ACME "
                        "server at {1}".format(
-                           regr.terms_of_service, config.server))
+                           terms_of_service, config.server))
                 obj = zope.component.getUtility(interfaces.IDisplay)
                 return obj.yesno(msg, "Agree", "Cancel",
                                  cli_flag="--agree-tos", force_interactive=True)

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -503,9 +503,12 @@ def _determine_account(config):
                        "server at {1}".format(
                            terms_of_service, config.server))
                 obj = zope.component.getUtility(interfaces.IDisplay)
-                return obj.yesno(msg, "Agree", "Cancel",
+                result = obj.yesno(msg, "Agree", "Cancel",
                                  cli_flag="--agree-tos", force_interactive=True)
-
+                if not result:
+                    raise errors.Error(
+                        "Registration cannot proceed without accepting "
+                        "Terms of Service.")
             try:
                 acc, acme = client.register(
                     config, account_storage, tos_cb=_tos_cb)

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -37,7 +37,7 @@ class RegisterTest(test_util.ConfigTestCase):
         return register(self.config, self.account_storage, self.tos_cb)
 
     def test_no_tos(self):
-        with mock.patch("certbot.client.acme_client.Client") as mock_client:
+        with mock.patch("certbot.client.acme_client.BackwardsCompatibleClientV2") as mock_client:
             mock_client.register().terms_of_service = "http://tos"
             with mock.patch("certbot.eff.handle_subscription") as mock_handle:
                 with mock.patch("certbot.account.report_new_account"):
@@ -54,7 +54,7 @@ class RegisterTest(test_util.ConfigTestCase):
                     self.assertEqual(mock_handle.call_count, 2)
 
     def test_it(self):
-        with mock.patch("certbot.client.acme_client.Client"):
+        with mock.patch("certbot.client.acme_client.BackwardsCompatibleClientV2"):
             with mock.patch("certbot.account.report_new_account"):
                 with mock.patch("certbot.eff.handle_subscription"):
                     self._call()
@@ -66,7 +66,7 @@ class RegisterTest(test_util.ConfigTestCase):
         self.config.noninteractive_mode = False
         msg = "DNS problem: NXDOMAIN looking up MX for example.com"
         mx_err = messages.Error.with_code('invalidContact', detail=msg)
-        with mock.patch("certbot.client.acme_client.Client") as mock_client:
+        with mock.patch("certbot.client.acme_client.BackwardsCompatibleClientV2") as mock_client:
             with mock.patch("certbot.eff.handle_subscription") as mock_handle:
                 mock_client().register.side_effect = [mx_err, mock.MagicMock()]
                 self._call()
@@ -79,7 +79,7 @@ class RegisterTest(test_util.ConfigTestCase):
         self.config.noninteractive_mode = True
         msg = "DNS problem: NXDOMAIN looking up MX for example.com"
         mx_err = messages.Error.with_code('invalidContact', detail=msg)
-        with mock.patch("certbot.client.acme_client.Client") as mock_client:
+        with mock.patch("certbot.client.acme_client.BackwardsCompatibleClientV2") as mock_client:
             with mock.patch("certbot.eff.handle_subscription"):
                 mock_client().register.side_effect = [mx_err, mock.MagicMock()]
                 self.assertRaises(errors.Error, self._call)
@@ -91,7 +91,7 @@ class RegisterTest(test_util.ConfigTestCase):
     @mock.patch("certbot.client.logger")
     def test_without_email(self, mock_logger):
         with mock.patch("certbot.eff.handle_subscription") as mock_handle:
-            with mock.patch("certbot.client.acme_client.Client"):
+            with mock.patch("certbot.client.acme_client.BackwardsCompatibleClientV2"):
                 with mock.patch("certbot.account.report_new_account"):
                     self.config.email = None
                     self.config.register_unsafely_without_email = True
@@ -104,7 +104,7 @@ class RegisterTest(test_util.ConfigTestCase):
         from acme import messages
         msg = "Test"
         mx_err = messages.Error(detail=msg, typ="malformed", title="title")
-        with mock.patch("certbot.client.acme_client.Client") as mock_client:
+        with mock.patch("certbot.client.acme_client.BackwardsCompatibleClientV2") as mock_client:
             with mock.patch("certbot.eff.handle_subscription") as mock_handle:
                 mock_client().register.side_effect = [mx_err, mock.MagicMock()]
                 self.assertRaises(messages.Error, self._call)
@@ -122,7 +122,7 @@ class ClientTestCommon(test_util.ConfigTestCase):
         self.account = mock.MagicMock(**{"key.pem": KEY})
 
         from certbot.client import Client
-        with mock.patch("certbot.client.acme_client.Client") as acme:
+        with mock.patch("certbot.client.acme_client.BackwardsCompatibleClientV2") as acme:
             self.acme_client = acme
             self.acme = acme.return_value = mock.MagicMock()
             self.client = Client(
@@ -140,7 +140,7 @@ class ClientTest(ClientTestCommon):
         self.eg_domains = ["example.com", "www.example.com"]
 
     def test_init_acme_verify_ssl(self):
-        net = self.acme_client.call_args[1]["net"]
+        net = self.acme_client.call_args[0][0]
         self.assertTrue(net.verify_ssl)
 
     def _mock_obtain_certificate(self):

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -642,10 +642,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self._cli_missing_flag(args, "specify a plugin")
         args.extend(['--standalone', '-d', 'eg.is'])
         self._cli_missing_flag(args, "register before running")
-        with mock.patch('certbot.main._get_and_save_cert'):
-            with mock.patch('certbot.main.client.acme_from_config_key'):
-                args.extend(['--email', 'io@io.is'])
-                self._cli_missing_flag(args, "--agree-tos")
 
     @mock.patch('certbot.main._report_new_cert')
     @mock.patch('certbot.main.client.acme_client.Client')

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -674,7 +674,8 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             ua = "bandersnatch"
             args += ["--user-agent", ua]
             self._call_no_clientmock(args)
-            acme_net.assert_called_once_with(mock.ANY, account=mock.ANY, verify_ssl=True, user_agent=ua)
+            acme_net.assert_called_once_with(mock.ANY, account=mock.ANY, verify_ssl=True,
+                user_agent=ua)
 
     @mock.patch('certbot.main.plug_sel.record_chosen_plugins')
     @mock.patch('certbot.main.plug_sel.pick_installer')

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -340,7 +340,7 @@ class ConfigTestCase(TempDirTestCase):
         self.config.cert_path = constants.CLI_DEFAULTS['auth_cert_path']
         self.config.fullchain_path = constants.CLI_DEFAULTS['auth_chain_path']
         self.config.chain_path = constants.CLI_DEFAULTS['auth_chain_path']
-        self.config.server = "example.com"
+        self.config.server = "https://example.com"
 
 def lock_and_call(func, lock_path):
     """Grab a lock for lock_path and call func.


### PR DESCRIPTION
Fixes #5491.

Detects acme version by checking for `newNonce` field in the directory, since it's mandatory. Also updates `ClientNetwork.account` on `register` and `update_registration`.