### PR TITLE
Change "Attempting to parse" warning to info.

### DIFF
--- a/certbot/storage.py
+++ b/certbot/storage.py
@@ -417,7 +417,7 @@ class RenewableCert(object):
         conf_version = self.configuration.get("version")
         if (conf_version is not None and
                 util.get_strict_version(conf_version) > CURRENT_VERSION):
-            logger.warning(
+            logger.info(
                 "Attempting to parse the version %s renewal configuration "
                 "file found at %s with version %s of Certbot. This might not "
                 "work.", conf_version, config_filename, certbot.__version__)

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -158,8 +158,8 @@ class RenewableCertTests(BaseRenewableCertTest):
 
         with mock.patch("certbot.storage.logger") as mock_logger:
             storage.RenewableCert(self.config_file.filename, self.config)
-        self.assertTrue(mock_logger.warning.called)
-        self.assertTrue("version" in mock_logger.warning.call_args[0][0])
+        self.assertTrue(mock_logger.info.called)
+        self.assertTrue("version" in mock_logger.info.call_args[0][0])
 
     def test_consistent(self):
         # pylint: disable=too-many-statements,protected-access


### PR DESCRIPTION
This message shows up on every renewal run when the config was updated
by a newer version of Certbot than the one being run. For instance, if a
user has the certbot packages installed from PPA (currently 0.18.2), but
runs certbot-auto once to try out the latest version (0.21.1), they will
start getting this message via email every 12 hours.