### PR TITLE
Add order support and tests

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1,6 +1,7 @@
 """ACME client API."""
 import base64
 import collections
+import cryptography
 import datetime
 from email.utils import parsedate_tz
 import heapq
@@ -119,11 +120,11 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         """
         return self._send_recv_regr(regr, messages.UpdateRegistration())
 
-    def _authzr_from_response(self, response, identifier, uri=None):
+    def _authzr_from_response(self, response, identifier=None, uri=None):
         authzr = messages.AuthorizationResource(
             body=messages.Authorization.from_json(response.json()),
             uri=response.headers.get('Location', uri))
-        if authzr.body.identifier != identifier:
+        if identifier is not None and authzr.body.identifier != identifier:
             raise errors.UnexpectedUpdate(authzr)
         return authzr
 
@@ -233,8 +234,8 @@ class Client(ClientBase):
        instances of `.DeserializationError` raised in `from_json()`.
 
     :ivar messages.Directory directory:
-    :ivar key: `.JWK` (private)
-    :ivar alg: `.JWASignature`
+    :ivar key: `josepy.JWK` (private)
+    :ivar alg: `josepy.JWASignature`
     :ivar bool verify_ssl: Verify SSL certificates?
     :ivar .ClientNetwork net: Client network. Useful for testing. If not
         supplied, it will be initialized using `key`, `alg` and
@@ -550,7 +551,6 @@ class ClientV2(ClientBase):
 
         :returns: Registration Resource.
         :rtype: `.RegistrationResource`
-
         """
         response = self.net.post(self.directory['newAccount'], new_account,
             acme_version=2)
@@ -559,6 +559,84 @@ class ClientV2(ClientBase):
         regr = self._regr_from_response(response)
         self.net.account = regr
         return regr
+
+    def new_order(self, csr_pem):
+        """Request a new Order object from the server.
+
+        :param str csr_pem: A CSR in PEM format.
+
+        :returns: The newly created order.
+        :rtype: OrderResource
+        """
+        csr = cryptography.x509.load_pem_x509_csr(csr_pem,
+            cryptography.hazmat.backends.default_backend())
+        san_extension = next(ext for ext in csr.extensions
+            if ext.oid == cryptography.x509.oid.ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+        dnsNames = san_extension.value.get_values_for_type(cryptography.x509.DNSName)
+
+        identifiers = []
+        for name in dnsNames:
+            identifiers.append(messages.Identifier(typ=messages.IDENTIFIER_FQDN,
+                value=name))
+        order = messages.NewOrder(identifiers=identifiers)
+        response = self.net.post(self.directory['newOrder'], order)
+        body = messages.Order.from_json(response.json())
+        authorizations = []
+        for url in body.authorizations:
+            authorizations.append(self._authzr_from_response(self.net.get(url)))
+        return messages.OrderResource(
+            body=body,
+            uri=response.headers.get('Location', uri),
+            fullchain_pem=fullchain_pem,
+            authorizations=authorizations,
+            csr_pem=csr_pem)
+
+    def poll_and_finalize(self, orderr, deadline=None):
+        if deadline is None:
+            deadline = datetime.datetime.now() + datetime.timedelta(seconds=90)
+        orderr = self.poll_authorizations(orderr, deadline)
+        return self.finalize_order(orderr, deadline)
+
+    def poll_authorizations(self, orderr, deadline):
+        """Poll Order Resource for status."""
+        responses = []
+        for url in orderr.body.authorizations:
+            while datetime.datetime.now() < deadline:
+                authzr = self._authzr_from_response(self.net.get(url), uri=url)
+                if authzr.body.status != messages.STATUS_PENDING:
+                    responses.append(authzr)
+                    break
+                time.sleep(1)
+        # If we didn't get a response for every authorization, we fell through
+        # the bottom of the loop due to hitting the deadline.
+        if len(responses) > orderr.body.authorizations:
+            raise TimeoutError()
+        failed = []
+        for authzr in responses:
+            if authzr.body.status != messages.STATUS_VALID:
+                for chall in authzr.body.challenges:
+                    if chall.error != None:
+                        failed.append(authzr)
+        if len(failed) > 0:
+            raise ValidationError(failed)
+        return orderr.update(authorizations=responses)
+
+    def finalize_order(self, orderr, deadline):
+        csr = OpenSSL.crypto.load_certificate_request(
+            OpenSSL.crypto.FILETYPE_PEM, orderr.csr_pem)
+        wrapped_csr = messages.CertificateRequest(csr=jose.ComparableX509(csr))
+        self.net.post(latest.body.finalize, wrapped_csr)
+        while datetime.datetime.now() < deadline:
+            time.sleep(1)
+            response = self.net.get(orderr.uri)
+            body = messages.Order.from_json(response.json())
+            if body.error is not None:
+                raise IssuanceError(body.error)
+            if body.certificate is not None:
+                certificate_response = self.net.get(body.certificate).text
+                return orderr.update(fullchain_pem=certificate_response)
+        raise TimeoutError()
+
 
 class BackwardsCompatibleClientV2(object):
     """ACME client wrapper that tends towards V2-style calls, but
@@ -628,10 +706,10 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
 
     """Initialize.
 
-    :param  key: Account private key
+    :param josepy.JWK key: Account private key
     :param messages.RegistrationResource account: Account object. Required if you are
-            planning to use .post() with acme_version=2 for anything other than creating a new
-            account; may be set later after registering.
+            planning to use .post() with acme_version=2 for anything other than
+            creating a new account; may be set later after registering.
     :param josepy.JWASignature alg: Algoritm to use in signing JWS.
     :param bool verify_ssl: Whether to verify certificates on SSL connections.
     :param str user_agent: String to send as User-Agent header.
@@ -662,10 +740,10 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
 
         .. todo:: Implement ``acmePath``.
 
-        :param .JSONDeSerializable obj:
+        :param josepy.JSONDeSerializable obj:
         :param str url: The URL to which this object will be POSTed
         :param bytes nonce:
-        :rtype: `.JWS`
+        :rtype: `josepy.JWS`
 
         """
         jobj = obj.json_dumps(indent=2).encode()

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -83,6 +83,27 @@ class PollError(ClientError):
         return '{0}(exhausted={1!r}, updated={2!r})'.format(
             self.__class__.__name__, self.exhausted, self.updated)
 
+class ValidationError(Error):
+    """Error for authorization failures. Contains a list of authorization
+    resources, each of which is invalid and should have an error field.
+    """
+    def __init__(self, failed_authzrs):
+        self.failed_authzrs = failed_authzrs
+        super(ClientError, self).__init__()
+
+class TimeoutError(Error):
+    """Error for when polling an authorization or an order times out."""
+
+class IssuanceError(Error):
+    """Error sent by the server after requesting issuance of a certificate."""
+
+    def __init__(self, error):
+        """Initialize.
+
+        :param messages.Error error: The error provided by the server.
+        """
+        self.error = error
+
 class ConflictError(ClientError):
     """Error for when the server returns a 409 (Conflict) HTTP status.
 

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -89,7 +89,7 @@ class ValidationError(Error):
     """
     def __init__(self, failed_authzrs):
         self.failed_authzrs = failed_authzrs
-        super(ClientError, self).__init__()
+        super(ValidationError, self).__init__()
 
 class TimeoutError(Error):
     """Error for when polling an authorization or an order times out."""
@@ -103,6 +103,7 @@ class IssuanceError(Error):
         :param messages.Error error: The error provided by the server.
         """
         self.error = error
+        super(IssuanceError, self).__init__()
 
 class ConflictError(ClientError):
     """Error for when the server returns a 409 (Conflict) HTTP status.

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -509,9 +509,6 @@ class Revocation(jose.JSONObjectWithFields):
 class Order(ResourceBody):
     """Order Resource Body.
 
-    .. note:: Parsing of identifiers on response doesn't work right now; to make
-        it work we would need to set up the equivalent of Identifier.from_json, but
-        for a list.
     :ivar list of .Identifier: List of identifiers for the certificate.
     :ivar acme.messages.Status status:
     :ivar list of str authorizations: URLs of authorizations.
@@ -529,6 +526,10 @@ class Order(ResourceBody):
     finalize = jose.Field('finalize', omitempty=True)
     expires = fields.RFC3339Field('expires', omitempty=True)
     error = jose.Field('error', omitempty=True, decoder=Error.from_json)
+
+    @identifiers.decoder
+    def identifiers(value):  # pylint: disable=missing-docstring,no-self-argument
+        return tuple(Identifier.from_json(identifier) for identifier in value)
 
 class OrderResource(ResourceWithURI):
     """Order Resource.

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -157,7 +157,7 @@ class DirectoryTest(unittest.TestCase):
             'meta': {
                 'terms-of-service': 'https://example.com/acme/terms',
                 'website': 'https://www.example.com/',
-                'caa-identities': ['example.com'],
+                'caaIdentities': ['example.com'],
             },
         })
 
@@ -406,6 +406,22 @@ class RevocationTest(unittest.TestCase):
     def test_from_json_hashable(self):
         from acme.messages import Revocation
         hash(Revocation.from_json(self.rev.to_json()))
+
+
+class OrderResourceTest(unittest.TestCase):
+    """Tests for acme.messages.OrderResource."""
+
+    def setUp(self):
+        from acme.messages import OrderResource
+        self.regr = OrderResource(
+            body=mock.sentinel.body, uri=mock.sentinel.uri)
+
+    def test_to_partial_json(self):
+        self.assertEqual(self.regr.to_json(), {
+            'body': mock.sentinel.body,
+            'uri': mock.sentinel.uri,
+            'authorizations': None,
+        })
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Built on #5374. Fixes a couple bugs and adds tests.

One thing I noticed here which I didn't fix is we don't extract the common name from the CSR. We should do this before the release, especially since users can provide their own CSR on the command line.

EDIT: This PR should be merged rather than squashed to preserve authorship.