### PR TITLE
Return str rather than bytes

### DIFF
--- a/certbot-dns-google/certbot_dns_google/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google.py
@@ -224,4 +224,7 @@ class _GoogleClient(object):
         if r.status != 200:
             raise ValueError("Invalid status code: {0}".format(r))
 
-        return content.decode()
+        if isinstance(content, bytes):
+            return content.decode()
+        else:
+            return content

--- a/certbot-dns-google/certbot_dns_google/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google.py
@@ -224,4 +224,4 @@ class _GoogleClient(object):
         if r.status != 200:
             raise ValueError("Invalid status code: {0}".format(r))
 
-        return content
+        return content.decode()

--- a/certbot-dns-google/certbot_dns_google/dns_google_test.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google_test.py
@@ -223,9 +223,13 @@ class GoogleClientTest(unittest.TestCase):
         response = DummyResponse()
         response.status = 200
 
-        with mock.patch('httplib2.Http.request', return_value=(response, 1234)):
+        with mock.patch('httplib2.Http.request', return_value=(response, 'test-test-1')):
             project_id = _GoogleClient.get_project_id()
-            self.assertEqual(project_id, 1234)
+            self.assertEqual(project_id, 'test-test-1')
+
+        with mock.patch('httplib2.Http.request', return_value=(response, b'test-test-1')):
+            project_id = _GoogleClient.get_project_id()
+            self.assertEqual(project_id, 'test-test-1')
 
         failed_response = DummyResponse()
         failed_response.status = 404


### PR DESCRIPTION
Project id is returned as bytes, which causes issues when constructing the google cloud API url, converting `b'PROJECT_ID'` to `b%27PROJECT_ID%27` causing the request to fail.