### PR TITLE
Fix print() and xrange() for Python 3

### DIFF
--- a/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
@@ -10,6 +10,8 @@ import sys
 
 import OpenSSL
 
+from six.moves import xrange  # pylint: disable=import-error,redefined-builtin
+
 from acme import challenges
 from acme import crypto_util
 from acme import messages

--- a/certbot-compatibility-test/certbot_compatibility_test/validator.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/validator.py
@@ -5,6 +5,7 @@ import requests
 import zope.interface
 
 import six
+from six.moves import xrange  # pylint: disable=import-error,redefined-builtin
 
 from acme import crypto_util
 from acme import errors as acme_errors

--- a/certbot-compatibility-test/nginx/roundtrip.py
+++ b/certbot-compatibility-test/nginx/roundtrip.py
@@ -8,7 +8,7 @@ from certbot_nginx import nginxparser
 def roundtrip(stuff):
     success = True
     for t in stuff:
-        print t
+        print(t)
         if not os.path.isfile(t):
             continue
         with open(t, "r") as f:

--- a/letsencrypt-auto-source/tests/auto_test.py
+++ b/letsencrypt-auto-source/tests/auto_test.py
@@ -18,6 +18,7 @@ from threading import Thread
 from unittest import TestCase
 
 from pytest import mark
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 
 @mark.skip

--- a/tools/simple_http_server.py
+++ b/tools/simple_http_server.py
@@ -14,7 +14,7 @@ def serve_forever(port=0):
 
     """
     server = HTTPServer(('', port), SimpleHTTPRequestHandler)
-    print 'Serving HTTP on {0} port {1} ...'.format(*server.server_address)
+    print('Serving HTTP on {0} port {1} ...'.format(*server.server_address))
     sys.stdout.flush()
     server.serve_forever()
 


### PR DESCRIPTION
* __print()__ is a function in modern Python
* __from six.moves import xrange__ because __xrange()__ was removed in Python 3

$ __python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tools/simple_http_server.py:17:44: E999 SyntaxError: invalid syntax
    print 'Serving HTTP on {0} port {1} ...'.format(*server.server_address)
                                           ^
./letsencrypt-auto-source/tests/auto_test.py:84:17: F821 undefined name 'xrange'
    for port in xrange(4443, 4543):
                ^
./certbot-compatibility-test/certbot_compatibility_test/validator.py:69:40: F821 undefined name 'xrange'
        return response.status_code in xrange(300, 309)
                                       ^
./certbot-compatibility-test/certbot_compatibility_test/test_driver.py:59:14: F821 undefined name 'xrange'
    for i in xrange(len(responses)):
             ^
./certbot-compatibility-test/nginx/roundtrip.py:11:15: E999 SyntaxError: invalid syntax
        print t
              ^
2     E999 SyntaxError: invalid syntax
3     F821 undefined name 'xrange'
5
```