### PR TITLE
Fix Certbot Apache plugin on Oracle Linux Server, a clone of CentOS, RHEL

### DIFF
--- a/certbot-apache/certbot_apache/entrypoint.py
+++ b/certbot-apache/certbot_apache/entrypoint.py
@@ -17,6 +17,7 @@ OVERRIDE_CLASSES = {
     "centos": override_centos.CentOSConfigurator,
     "centos linux": override_centos.CentOSConfigurator,
     "fedora": override_centos.CentOSConfigurator,
+    "ol": override_centos.CentOSConfigurator,
     "red hat enterprise linux server": override_centos.CentOSConfigurator,
     "rhel": override_centos.CentOSConfigurator,
     "amazon": override_centos.CentOSConfigurator,


### PR DESCRIPTION
[Oracle Linux Server](https://en.wikipedia.org/wiki/Oracle_Linux) is a [clone of CentOS/RHEL](https://www.oracle.com/linux/index.html). The Certbot Apache plugin cannot auto-detect the Oracle Linux Apache setup, causing a generic (but incorrect) Apache Linux configuration to be used, which emits this error:

> The apache plugin is not working; there may be problems with your existing configuration.
> The error was: NoInstallationError('Cannot find Apache control command apache2ctl',). Skipping.

On Oracle Linux Server, [the Apache control command](https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-s2-websvc.html) is `apachectl` just like CentOS/RHEL.

The `/etc/os-release` file [on Oracle Linux](https://www.veritas.com/support/en_US/article.000087964) contains `ID="ol"` which does not match any existing override class. My simple one-line PR adds this missing OS override. After this one-line change is applied, then Certbot Apache plugin works as designed on Oracle Linux.

Without this code change, a hack/workaround for Oracle Linux is [to add (_missing_)](https://www.freedesktop.org/software/systemd/man/os-release.html#ID_LIKE=) `ID_LIKE="centos rhel"` to the [`/etc/os-release` file](http://0pointer.de/blog/projects/os-release.html). This forces the Certbot Apache plugin to treat OL like CentOS/RHEL.
