### PR TITLE
Don't error immediately on wildcards

### DIFF
--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -300,8 +300,8 @@ class ChooseNamesTest(unittest.TestCase):
         from certbot.display.ops import get_valid_domains
         all_valid = ["example.com", "second.example.com",
                      "also.example.com", "under_score.example.com",
-                     "justtld"]
-        all_invalid = ["öóòps.net", "*.wildcard.com", "uniçodé.com"]
+                     "justtld", "*.wildcard.com"]
+        all_invalid = ["öóòps.net", "uniçodé.com"]
         two_valid = ["example.com", "úniçøde.com", "also.example.com"]
         self.assertEqual(get_valid_domains(all_valid), all_valid)
         self.assertEqual(get_valid_domains(all_invalid), [])

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 """Tests for certbot.main."""
 # pylint: disable=too-many-lines
 from __future__ import print_function
@@ -939,10 +940,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertRaises(errors.ConfigurationError,
                           self._call,
                           ['-d', (('a' * 50) + '.') * 10])
-        # Wildcard
-        self.assertRaises(errors.ConfigurationError,
-                          self._call,
-                          ['-d', '*.wildcard.tld'])
 
         # Bare IP address (this is actually a different error message now)
         self.assertRaises(errors.ConfigurationError,
@@ -1232,7 +1229,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
 
     def test_renew_with_bad_domain(self):
         renewalparams = {'authenticator': 'webroot'}
-        names = ['*.example.com']
+        names = ['uniçodé.com']
         self._test_renew_common(renewalparams=renewalparams, error_expected=True,
                                 names=names, assert_oc_called=False)
 

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -552,16 +552,6 @@ def enforce_domain_sanity(domain):
     :returns: The domain cast to `str`, with ASCII-only contents
     :rtype: str
     """
-    if isinstance(domain, six.text_type):
-        wildcard_marker = u"*."
-    else:
-        wildcard_marker = b"*."
-
-    # Check if there's a wildcard domain
-    if domain.startswith(wildcard_marker):
-        raise errors.ConfigurationError(
-            "Wildcard domains are not supported: {0}".format(domain))
-
     # Unicode
     try:
         if isinstance(domain, six.binary_type):


### PR DESCRIPTION
Small piece of #5367.

This stops Certbot from immediately erroring out when the user requests a wildcard so devs will be able to issue wildcards for testing. We should still add a check about this client side for ACMEv1, but I'm planning on doing this in a later PR. Just wanted to get this landed so it's not a blocker for devs.