### PR TITLE
logging: log timestamps as local timezone instead of UTC

### DIFF
--- a/certbot/log.py
+++ b/certbot/log.py
@@ -19,7 +19,6 @@ import logging.handlers
 import os
 import sys
 import tempfile
-import time
 import traceback
 
 from acme import messages

--- a/certbot/log.py
+++ b/certbot/log.py
@@ -148,7 +148,6 @@ def setup_log_file_handler(config, logfile, fmt):
     handler.doRollover()  # TODO: creates empty letsencrypt.log.1 file
     handler.setLevel(logging.DEBUG)
     handler_formatter = logging.Formatter(fmt=fmt)
-    handler_formatter.converter = time.gmtime  # don't use localtime
     handler.setFormatter(handler_formatter)
     return handler, log_file_path
 

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -156,7 +156,7 @@ class SetupLogFileHandlerTest(test_util.ConfigTestCase):
         handler.close()
 
         self.assertEqual(handler.level, logging.DEBUG)
-        self.assertEqual(handler.formatter.converter, time.gmtime)
+        self.assertEqual(handler.formatter.converter, time.localtime)
 
         expected_path = os.path.join(self.config.logs_dir, log_file)
         self.assertEqual(log_path, expected_path)


### PR DESCRIPTION
fix for #5604 -- localtime should be used [by default](https://docs.python.org/2/library/logging.html#logging.Formatter.formatTime).