### PR TITLE
Add DNS Dockerfiles

### DIFF
--- a/certbot-dns-cloudflare/Dockerfile
+++ b/certbot-dns-cloudflare/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-cloudflare
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-cloudflare

--- a/certbot-dns-cloudxns/Dockerfile
+++ b/certbot-dns-cloudxns/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-cloudxns
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-cloudxns

--- a/certbot-dns-digitalocean/Dockerfile
+++ b/certbot-dns-digitalocean/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-digitalocean
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-digitalocean

--- a/certbot-dns-dnsimple/Dockerfile
+++ b/certbot-dns-dnsimple/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-dnsimple
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-dnsimple

--- a/certbot-dns-dnsmadeeasy/Dockerfile
+++ b/certbot-dns-dnsmadeeasy/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-dnsmadeeasy
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-dnsmadeeasy

--- a/certbot-dns-google/Dockerfile
+++ b/certbot-dns-google/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-google
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-google

--- a/certbot-dns-luadns/Dockerfile
+++ b/certbot-dns-luadns/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-luadns
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-luadns

--- a/certbot-dns-nsone/Dockerfile
+++ b/certbot-dns-nsone/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-nsone
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-nsone

--- a/certbot-dns-rfc2136/Dockerfile
+++ b/certbot-dns-rfc2136/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-rfc2136
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-rfc2136

--- a/certbot-dns-route53/Dockerfile
+++ b/certbot-dns-route53/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-dns-route53
+
+RUN pip install --no-cache-dir --editable src/certbot-dns-route53


### PR DESCRIPTION
Fixes the pieces of #5328 we need to do before the release. Landing this before the release makes sure these Dockerfiles are in our next release tag which we can use on Docker Hub.

Currently, building these yourself is pretty awkward. With the version in `setup.py` in `master` pinned to 0.22.0.dev0 and Certbot on Docker Hub being 0.21.1, these files won't work without some help. You either need to modify `setup.py` or put these files on the 0.21.1 git tag.

This will get better over time though with #5490 and the suggestions [here](https://github.com/certbot/certbot/issues/5328#issuecomment-366896636) about how to build a rolling release.