### PR TITLE
Add basic ACMEv2 integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,11 @@ before_script:
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=py27_install BOULDER_INTEGRATION=1
+      env: TOXENV=py27_install BOULDER_INTEGRATION=v1
+      sudo: required
+      services: docker
+    - python: "2.7"
+      env: TOXENV=py27_install BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
     - python: "2.7"

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -16,6 +16,13 @@ FAKE_DNS=$(ifconfig docker0 | grep "inet addr:" | cut -d: -f2 | awk '{ print $1}
 [ -z "$FAKE_DNS" ] && FAKE_DNS=$(ip addr show dev docker0 | grep "inet " | xargs | cut -d ' ' -f 2 | cut -d '/' -f 1)
 [ -z "$FAKE_DNS" ] && echo Unable to find the IP for docker0 && exit 1
 sed -i "s/FAKE_DNS: .*/FAKE_DNS: ${FAKE_DNS}/" docker-compose.yml
+
+# If we're testing against ACMEv2, we need to use a newer boulder config for
+# now. See https://github.com/letsencrypt/boulder#quickstart.
+if [ "$BOULDER_INTEGRATION" = "v2" ]; then
+    sed -i 's/BOULDER_CONFIG_DIR: .*/BOULDER_CONFIG_DIR: test\/config-next/' docker-compose.yml
+fi
+
 docker-compose up -d
 
 set +x  # reduce verbosity while waiting for boulder

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -432,7 +432,7 @@ done
 
 # Test ACMEv2-only features
 if [ "${BOULDER_INTEGRATION:-v1}" = "v2" ]; then
-    common -a manual -d *.le4.wtf,le4.wtf --preferred-challenges dns \
+    common -a manual -d '*.le4.wtf,le4.wtf' --preferred-challenges dns \
         --manual-auth-hook ./tests/manual-dns-auth.sh
 fi
 

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -430,6 +430,12 @@ for path in $archive $conf $live; do
     fi
 done
 
+# Test ACMEv2-only features
+if [ "${BOULDER_INTEGRATION:-v1}" = "v2" ]; then
+    common -a manual -d *.le4.wtf,le4.wtf --preferred-challenges dns \
+        --manual-auth-hook ./tests/manual-dns-auth.sh
+fi
+
 # Most CI systems set this variable to true.
 # If the tests are running as part of CI, Nginx should be available.
 if ${CI:-false} || type nginx;

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -17,7 +17,7 @@ certbot_test () {
 }
 
 # Use local ACMEv2 endpoint if requested and SERVER isn't already set.
-if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -n "${SERVER:+x}" ]; then
+if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
     SERVER="http://localhost:4001/directory"
 fi
 

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -17,7 +17,7 @@ certbot_test () {
 }
 
 # Use local ACMEv2 endpoint if requested and SERVER isn't already set.
-if [ "$BOULDER_INTEGRATION" = "v2" -a -z "$SERVER" ]; then
+if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -n "${SERVER:+x}" ]; then
     SERVER="http://localhost:4001/directory"
 fi
 

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -16,6 +16,11 @@ certbot_test () {
         "$@"
 }
 
+# Use local ACMEv2 endpoint if requested and SERVER isn't already set.
+if [ "$BOULDER_INTEGRATION" = "v2" -a -z "$SERVER" ]; then
+    SERVER="http://localhost:4001/directory"
+fi
+
 certbot_test_no_force_renew () {
     omit_patterns="*/*.egg-info/*,*/dns_common*,*/setup.py,*/test_*,*/tests/*"
     omit_patterns="$omit_patterns,*_test.py,*_test_*,"


### PR DESCRIPTION
~~Start of #5584. Rest of it to come once #5620 is merged and we can test wildcard issuance.~~

Fixes #5584.

To provide a little more info since I don't think everyone who works on Certbot knows the horrors of shell scripting, [parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) around `BOULDER_INTEGRATION` and `SERVER` is necessary because [tests/boulder-integration.sh](https://github.com/certbot/certbot/blob/fbace69b5e8fed5ee32cb029478d6b11aea84842/tests/boulder-integration.sh#L11) uses [set -u](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#The-Set-Builtin). This helps prevent bugs, but causes more complicated code to be written sometimes.