### PR TITLE
Add user friendly wildcard error for ACMEv1

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -318,8 +318,8 @@ class Client(ClientBase):
 
         if identifier.value.startswith("*"):
             raise errors.WildcardUnsupportedError(
-                "Requesting an authorization for a wildcard"
-                " name is forbidden by the ACME protocol.")
+                "Requesting an authorization for a wildcard name is"
+                " forbidden by this version of the ACME protocol.")
 
         new_authz = messages.NewAuthorization(identifier=identifier)
         response = self._post(self.directory.new_authz, new_authz)

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -310,9 +310,17 @@ class Client(ClientBase):
         :returns: Authorization Resource.
         :rtype: `.AuthorizationResource`
 
+        :raises errors.WildcardUnsupportedError: if a wildcard is requested
+
         """
         if new_authzr_uri is not None:
             logger.debug("request_challenges with new_authzr_uri deprecated.")
+
+        if identifier.value.startswith("*"):
+            raise errors.WildcardUnsupportedError(
+                "Requesting an authorization for a wildcard"
+                " name is forbidden by the ACME protocol.")
+
         new_authz = messages.NewAuthorization(identifier=identifier)
         response = self._post(self.directory.new_authz, new_authz)
         # TODO: handle errors
@@ -332,6 +340,8 @@ class Client(ClientBase):
 
         :returns: Authorization Resource.
         :rtype: `.AuthorizationResource`
+
+        :raises errors.WildcardUnsupportedError: if a wildcard is requested
 
         """
         return self.request_challenges(messages.Identifier(
@@ -752,6 +762,10 @@ class BackwardsCompatibleClientV2(object):
 
         :returns: The newly created order.
         :rtype: OrderResource
+
+        :raises errors.WildcardUnsupportedError: if a wildcard domain is
+            requested but unsupported by the ACME version
+
         """
         if self.acme_version == 1:
             csr = OpenSSL.crypto.load_certificate_request(OpenSSL.crypto.FILETYPE_PEM, csr_pem)

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -376,6 +376,13 @@ class ClientTest(ClientTestBase):
             errors.UnexpectedUpdate, self.client.request_challenges,
             self.identifier)
 
+    def test_request_challenges_wildcard(self):
+        wildcard_identifier = messages.Identifier(
+            typ=messages.IDENTIFIER_FQDN, value='*.example.org')
+        self.assertRaises(
+            errors.WildcardUnsupportedError, self.client.request_challenges,
+            wildcard_identifier)
+
     def test_request_domain_challenges(self):
         self.client.request_challenges = mock.MagicMock()
         self.assertEqual(

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -115,3 +115,6 @@ class ConflictError(ClientError):
         self.location = location
         super(ConflictError, self).__init__()
 
+
+class WildcardUnsupportedError(Error):
+    """Error for when a wildcard is requested but is unsupported by ACME CA."""

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -311,11 +311,11 @@ class Client(object):
             return cert, chain, key, csr
 
     def _get_order_and_authorizations(self, csr_pem, best_effort):
-        """Request an new order and complete its authorizations.
+        """Request a new order and complete its authorizations.
 
         :param str csr_pem: A CSR in PEM format.
         :param bool best_effort: True if failing to complete all
-            authorizations should raise an exception
+            authorizations should not raise an exception
 
         :returns: order resource containing its completed authorizations
         :rtype: acme.messages.OrderResource

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -184,7 +184,7 @@ class ClientTest(ClientTestCommon):
             self.client.obtain_certificate_from_csr(
                 test_csr,
                 orderr=None))
-        auth_handler.handle_authorizations.assert_called_with(self.eg_order)
+        auth_handler.handle_authorizations.assert_called_with(self.eg_order, False)
 
         # Test for no auth_handler
         self.client.auth_handler = None


### PR DESCRIPTION
Part of #5367.

Checking for wildcards in ACME doesn't have to worry about bytes, because the relevant documentation says the value must be unicode/str and none of Certbot's code paths violates this. (`acme.crypto_util._pyopenssl_cert_or_req_all_names` which is used in `BackwardsCompatibleClientV2` before calling this function returns unicode/str in Python 2/3 respectively.) 