### PR TITLE
Suggest DNS authenticator when it's needed

### DIFF
--- a/certbot/auth_handler.py
+++ b/certbot/auth_handler.py
@@ -433,7 +433,7 @@ def _find_smart_path(challbs, preferences, combinations):
         combo_total = 0
 
     if not best_combo:
-        _report_no_chall_path()
+        _report_no_chall_path(challbs)
 
     return best_combo
 
@@ -454,15 +454,23 @@ def _find_dumb_path(challbs, preferences):
         if supported:
             path.append(i)
         else:
-            _report_no_chall_path()
+            _report_no_chall_path(challbs)
 
     return path
 
 
-def _report_no_chall_path():
-    """Logs and raises an error that no satisfiable chall path exists."""
+def _report_no_chall_path(challbs):
+    """Logs and raises an error that no satisfiable chall path exists.
+
+    :param challbs: challenges from the authorization that can't be satisfied
+
+    """
     msg = ("Client with the currently selected authenticator does not support "
            "any combination of challenges that will satisfy the CA.")
+    if len(challbs) == 1 and isinstance(challbs[0].chall, challenges.DNS01):
+        msg += (
+            " You may need to use an authenticator "
+            "plugin that can do challenges over DNS.")
     logger.fatal(msg)
     raise errors.AuthorizationError(msg)
 

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -272,6 +272,12 @@ class HandleAuthorizationsTest(unittest.TestCase):
         self.mock_net.acme_version = 2
         self._test_preferred_challenges_not_supported_common(combos=False)
 
+    def test_dns_only_challenge_not_supported(self):
+        authzrs = [gen_dom_authzr(domain="0", challs=[acme_util.DNS01])]
+        mock_order = mock.MagicMock(authorizations=authzrs)
+        self.assertRaises(
+            errors.AuthorizationError, self.handler.handle_authorizations, mock_order)
+
     def _validate_all(self, unused_1, unused_2):
         for i, aauthzr in enumerate(self.handler.aauthzrs):
             azr = aauthzr.authzr


### PR DESCRIPTION
Fixes the 2nd bullet point of #5367.

For context, Let's Encrypt will currently only issue certificates for wildcard domains if people do their domain validation challenges over DNS. If we're about to error out because we can't satisfy the challenges and the only available challenge is the DNS challenge, suggest that they may need to use a plugin that supports DNS challenges.

The reason I didn't hardcode anything more specific here is that wildcard authorization having to be done over DNS is not a requirement of the ACME spec or the CA Baseline Requirements. Since the CAs Certbot is used with can change (either by using a new CA or a CA changing their policy), I just have a general suggestion about doing the challenge over DNS if it was the only option you were given.