### PR TITLE
Remove leading *. from default cert name.

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -338,7 +338,14 @@ class Client(object):
                 "Non-standard path(s), might not work with crontab installed "
                 "by your operating system package manager")
 
-        new_name = certname if certname else domains[0]
+        if certname:
+            new_name = certname
+        elif util.is_wildcard_domain(domains[0]):
+            # Don't make files and directories starting with *.
+            new_name = domains[0][2:]
+        else:
+            new_name = domains[0]
+
         if self.config.dry_run:
             logger.debug("Dry run: Skipping creating new lineage for %s",
                         new_name)

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -285,7 +285,7 @@ class ClientTest(ClientTestCommon):
     @mock.patch('certbot.storage.RenewableCert.new_lineage')
     def test_obtain_and_enroll_certificate(self,
         mock_storage, mock_obtain_certificate):
-        domains = ["example.com", "www.example.com"]
+        domains = ["*.example.com", "example.com"]
         mock_obtain_certificate.return_value = (mock.MagicMock(),
             mock.MagicMock(), mock.MagicMock(), None)
 
@@ -293,12 +293,14 @@ class ClientTest(ClientTestCommon):
         self.assertTrue(self.client.obtain_and_enroll_certificate(domains, "example_cert"))
 
         self.assertTrue(self.client.obtain_and_enroll_certificate(domains, None))
+        self.assertTrue(self.client.obtain_and_enroll_certificate(domains[1:], None))
 
         self.client.config.dry_run = True
 
         self.assertFalse(self.client.obtain_and_enroll_certificate(domains, None))
 
-        self.assertTrue(mock_storage.call_count == 2)
+        names = [call[0][0] for call in mock_storage.call_args_list]
+        self.assertEqual(names, ["example_cert", "example.com", "example.com"])
 
     @mock.patch("certbot.cli.helpful_parser")
     def test_save_certificate(self, mock_parser):


### PR DESCRIPTION
Part of #5367.

We handle stripping `*.` in `client.py` rather than in `storage` and its utilities so we know whether we're using `domains` or a user provided cert name. If someone runs Certbot with `--cert-name *.example.org`, we should respect their insane wish rather than suddenly changing it on them.