### PR TITLE
Drop minimum integration test coverage to 63

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -437,4 +437,4 @@ then
     . ./certbot-nginx/tests/boulder-integration.sh
 fi
 
-coverage report --fail-under 64 -m
+coverage report --fail-under 63 -m


### PR DESCRIPTION
I think we're on the border between 63 and 64 here and `coverage` doesn't seem totally consistent with the number it reports. To be fair, this may not be a problem in `coverage` and instead be due to things like whether or not we retried connections to boulder and how many times we had to poll something.

For instance, look at #5635. `coverage` specifically only tracks coverage to Python programs and that PR changes only Travis configuration files and shell scripts but initially it passed and then I changed quoting around a string in Bash and it failed.

I'm pretty sure Joona was hitting this problem the other day.