### PR TITLE
Improve style around choosing lineagename

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -337,9 +337,10 @@ class Client(object):
         authenticator and installer, and then create a new renewable lineage
         containing it.
 
-        :param list domains: Domains to request.
-        :param plugins: A PluginsFactory object.
-        :param str certname: Name of new cert
+        :param domains: domains to request a certificate for
+        :type domains: `list` of `str`
+        :param certname: requested name of lineage
+        :type certname: `str` or `None`
 
         :returns: A new :class:`certbot.storage.RenewableCert` instance
             referred to the enrolled cert lineage, False if the cert could not
@@ -354,13 +355,7 @@ class Client(object):
                 "Non-standard path(s), might not work with crontab installed "
                 "by your operating system package manager")
 
-        if certname:
-            new_name = certname
-        elif util.is_wildcard_domain(domains[0]):
-            # Don't make files and directories starting with *.
-            new_name = domains[0][2:]
-        else:
-            new_name = domains[0]
+        new_name = self._choose_lineagename(domains, certname)
 
         if self.config.dry_run:
             logger.debug("Dry run: Skipping creating new lineage for %s",
@@ -371,6 +366,26 @@ class Client(object):
                 new_name, cert,
                 key.pem, chain,
                 self.config)
+
+    def _choose_lineagename(self, domains, certname):
+        """Chooses a name for the new lineage.
+
+        :param domains: domains in certificate request
+        :type domains: `list` of `str`
+        :param certname: requested name of lineage
+        :type certname: `str` or `None`
+
+        :returns: lineage name that should be used
+        :rtype: str
+
+        """
+        if certname:
+            return certname
+        elif util.is_wildcard_domain(domains[0]):
+            # Don't make files and directories starting with *.
+            return domains[0][2:]
+        else:
+            return domains[0]
 
     def save_certificate(self, cert_pem, chain_pem,
                          cert_path, chain_path, fullchain_path):


### PR DESCRIPTION
@pde had some stylistic concerns around #5639 which this PR addresses. I updated the docstring and split some of the code into a separate function. Rather making the code look something like:
```
if certname:
    new_name = certname
else:
    new_name = _strip_wildcard(domains[0])
...
def _strip_wildcard(domain):
    return domain[2:] if util.is_wildcard_domain(domains) else domain
```
I further split up the function moving the logical piece of determining the name for the lineage into its own function. This splits up `obtain_and_enroll_certificate` even more and better documents at a high level what is being done.