### PR TITLE
Allow Google DNS plugin to write multiple TXT record values

### DIFF
--- a/certbot-dns-google/certbot_dns_google/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google.py
@@ -223,7 +223,7 @@ class _GoogleClient(object):
         :rtype: `list` of `string`
 
         """
-        rrs_request = self.dns.resourceRecordSets()
+        rrs_request = self.dns.resourceRecordSets()  # pylint: disable=no-member
         request = rrs_request.list(managedZone=zone_id, project=self.project_id)
         response = request.execute()
         # Add dot as the API returns absolute domains

--- a/certbot-dns-google/certbot_dns_google/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google.py
@@ -223,8 +223,8 @@ class _GoogleClient(object):
         :rtype: `list` of `string`
 
         """
-        request = self.dns.resourceRecordSets().list(managedZone=zone_id,
-                                                     project=self.project_id)
+        rrs_request = self.dns.resourceRecordSets()
+        request = rrs_request.list(managedZone=zone_id, project=self.project_id)
         response = request.execute()
         # Add dot as the API returns absolute domains
         record_name += "."


### PR DESCRIPTION
Google API requires all the records in a RRset to be set as a list on a single call. To achieve this, this PR adds automatic check of pre-existing records, deletes the old ones, and adds them to the list with the new one created before making the API call.

Fixes an issue mentioned in comments of #5472