### PR TITLE
Ensure fullchain_pem in the order is unicode/str

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -795,8 +795,8 @@ class BackwardsCompatibleClientV2(object):
                     'certificate, please rerun the command for a new one.')
 
             cert = OpenSSL.crypto.dump_certificate(
-                    OpenSSL.crypto.FILETYPE_PEM, certr.body.wrapped)
-            chain = crypto_util.dump_pyopenssl_chain(chain)
+                    OpenSSL.crypto.FILETYPE_PEM, certr.body.wrapped).decode()
+            chain = crypto_util.dump_pyopenssl_chain(chain).decode()
 
             return orderr.update(fullchain_pem=(cert + chain))
         else:

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -99,10 +99,10 @@ class BackwardsCompatibleClientV2Test(ClientTestBase):
         self.chain = [wrapped, wrapped]
 
         self.cert_pem = OpenSSL.crypto.dump_certificate(
-            OpenSSL.crypto.FILETYPE_PEM, messages_test.CERT.wrapped)
+            OpenSSL.crypto.FILETYPE_PEM, messages_test.CERT.wrapped).decode()
 
         single_chain = OpenSSL.crypto.dump_certificate(
-            OpenSSL.crypto.FILETYPE_PEM, loaded)
+            OpenSSL.crypto.FILETYPE_PEM, loaded).decode()
         self.chain_pem = single_chain + single_chain
 
         self.fullchain_pem = self.cert_pem + self.chain_pem

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -287,6 +287,9 @@ def dump_pyopenssl_chain(chain, filetype=OpenSSL.crypto.FILETYPE_PEM):
     :param list chain: List of `OpenSSL.crypto.X509` (or wrapped in
         :class:`josepy.util.ComparableX509`).
 
+    :returns: certificate chain bundle
+    :rtype: bytes
+
     """
     # XXX: returns empty string when no chain is available, which
     # shuts up RenewableCert, but might not be the best solution...

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -243,7 +243,7 @@ class Client(object):
             than `authkey`.
         :param acme.messages.OrderResource orderr: contains authzrs
 
-        :returns: certificate and chain as PEM strings
+        :returns: certificate and chain as PEM byte strings
         :rtype: tuple
 
         """
@@ -265,7 +265,8 @@ class Client(object):
 
         deadline = datetime.datetime.now() + datetime.timedelta(seconds=90)
         orderr = self.acme.finalize_order(orderr, deadline)
-        return crypto_util.cert_and_chain_from_fullchain(orderr.fullchain_pem)
+        cert, chain = crypto_util.cert_and_chain_from_fullchain(orderr.fullchain_pem)
+        return cert.encode(), chain.encode()
 
     def obtain_certificate(self, domains):
         """Obtains a certificate from the ACME server.

--- a/certbot/crypto_util.py
+++ b/certbot/crypto_util.py
@@ -441,8 +441,9 @@ def cert_and_chain_from_fullchain(fullchain_pem):
 
     :returns: tuple of string cert_pem and chain_pem
     :rtype: tuple
+
     """
     cert = OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM,
-        OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, fullchain_pem))
+        OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, fullchain_pem)).decode()
     chain = fullchain_pem[len(cert):]
     return (cert, chain)

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -377,8 +377,8 @@ class CertAndChainFromFullchainTest(unittest.TestCase):
     """Tests for certbot.crypto_util.cert_and_chain_from_fullchain"""
 
     def test_cert_and_chain_from_fullchain(self):
-        cert_pem = CERT
-        chain_pem = CERT + SS_CERT
+        cert_pem = CERT.decode()
+        chain_pem = cert_pem + SS_CERT.decode()
         fullchain_pem = cert_pem + chain_pem
         from certbot.crypto_util import cert_and_chain_from_fullchain
         cert_out, chain_out = cert_and_chain_from_fullchain(fullchain_pem)


### PR DESCRIPTION
Fixes #5606.

For context, our concern here was with `acme` having a public API that is used by other projects, we shouldn't change types like this after we ship it. With my understanding of best practices as described in #4516, we should be giving the user `unicode` in Python 2 and a `str` in Python 3, however, much of Certbot's code currently requires `bytes`. The quick fix for this that Erica and I had in mind that allows Certbot to work was to make sure the `acme` API is right, but immediately convert back to `bytes` for Certbot.

I did this after the function in `certbot.crypto_util` because what's part of the public API in Certbot isn't exactly clear and something like `crypto_util` could be used by 3rd party plugins. Our own plugins currently use it. Because of this, I let it take the "proper" types as well and threw the conversion into `certbot.client.`

You can see integration tests passing with this code for every version of Python we support for both ACME versions at https://travis-ci.org/certbot/certbot/builds/348519650. Once this lands, I plan on adding tests like this to the `test-everything` branch.