### PR TITLE
Don't report coverage on Apache during integration tests

### DIFF
--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -443,4 +443,4 @@ then
     . ./certbot-nginx/tests/boulder-integration.sh
 fi
 
-coverage report --fail-under 68 -m
+coverage report --fail-under 67 -m

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -443,4 +443,4 @@ then
     . ./certbot-nginx/tests/boulder-integration.sh
 fi
 
-coverage report --fail-under 63 -m
+coverage report --fail-under 68 -m

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -23,7 +23,7 @@ fi
 
 certbot_test_no_force_renew () {
     omit_patterns="*/*.egg-info/*,*/dns_common*,*/setup.py,*/test_*,*/tests/*"
-    omit_patterns="$omit_patterns,*_test.py,*_test_*,"
+    omit_patterns="$omit_patterns,*_test.py,*_test_*,certbot-apache/*"
     omit_patterns="$omit_patterns,certbot-compatibility-test/*,certbot-dns*/"
     coverage run \
         --append \


### PR DESCRIPTION
The integration tests don't actually test any Apache functionality and trying to test this for our "oldest" tests without Apache installed caused failures. See #5668.

EDIT: I used 67% as the minimum as I sometimes got [68% during testing](https://travis-ci.org/certbot/certbot/jobs/349535456) and I'd like to avoid issues like those in #5641.