### PR TITLE
Remove the assumption the domain is unique in the manual plugin

### DIFF
--- a/certbot/plugins/manual.py
+++ b/certbot/plugins/manual.py
@@ -189,7 +189,7 @@ when it receives a TLS ClientHello with the SNI extension set to
         os.environ.update(env)
         _, out = hooks.execute(self.conf('auth-hook'))
         env['CERTBOT_AUTH_OUTPUT'] = out.strip()
-        self.env[achall.domain] = env
+        self.env[achall] = env
 
     def _perform_achall_manually(self, achall):
         validation = achall.validation(achall.account_key)
@@ -215,7 +215,7 @@ when it receives a TLS ClientHello with the SNI extension set to
     def cleanup(self, achalls):  # pylint: disable=missing-docstring
         if self.conf('cleanup-hook'):
             for achall in achalls:
-                env = self.env.pop(achall.domain)
+                env = self.env.pop(achall)
                 if 'CERTBOT_TOKEN' not in env:
                     os.environ.pop('CERTBOT_TOKEN', None)
                 os.environ.update(env)

--- a/certbot/plugins/manual_test.py
+++ b/certbot/plugins/manual_test.py
@@ -93,10 +93,10 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             self.auth.perform(self.achalls),
             [achall.response(achall.account_key) for achall in self.achalls])
         self.assertEqual(
-            self.auth.env[self.dns_achall.domain]['CERTBOT_AUTH_OUTPUT'],
+            self.auth.env[self.dns_achall]['CERTBOT_AUTH_OUTPUT'],
             dns_expected)
         self.assertEqual(
-            self.auth.env[self.http_achall.domain]['CERTBOT_AUTH_OUTPUT'],
+            self.auth.env[self.http_achall]['CERTBOT_AUTH_OUTPUT'],
             http_expected)
         # tls_sni_01 challenge must be perform()ed above before we can
         # get the cert_path and key_path.
@@ -107,7 +107,7 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             self.auth.tls_sni_01.get_z_domain(self.tls_sni_achall),
             'novalidation')
         self.assertEqual(
-            self.auth.env[self.tls_sni_achall.domain]['CERTBOT_AUTH_OUTPUT'],
+            self.auth.env[self.tls_sni_achall]['CERTBOT_AUTH_OUTPUT'],
             tls_sni_expected)
 
     @test_util.patch_get_utility()

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -233,6 +233,7 @@ certname="dns.le.wtf"
 common -a manual -d dns.le.wtf --preferred-challenges dns,tls-sni run \
     --cert-name $certname \
     --manual-auth-hook ./tests/manual-dns-auth.sh \
+    --manual-cleanup-hook ./tests/manual-dns-cleanup.sh \
     --pre-hook 'echo wtf2.pre >> "$HOOK_TEST"' \
     --post-hook 'echo wtf2.post >> "$HOOK_TEST"' \
     --renew-hook 'echo deploy >> "$HOOK_TEST"'
@@ -433,7 +434,8 @@ done
 # Test ACMEv2-only features
 if [ "${BOULDER_INTEGRATION:-v1}" = "v2" ]; then
     common -a manual -d '*.le4.wtf,le4.wtf' --preferred-challenges dns \
-        --manual-auth-hook ./tests/manual-dns-auth.sh
+        --manual-auth-hook ./tests/manual-dns-auth.sh \
+        --manual-cleanup-hook ./tests/manual-dns-cleanup.sh
 fi
 
 # Most CI systems set this variable to true.

--- a/tests/manual-dns-cleanup.sh
+++ b/tests/manual-dns-cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl -X POST 'http://localhost:8055/clear-txt' -d \
+    "{\"host\": \"_acme-challenge.$CERTBOT_DOMAIN.\"}"


### PR DESCRIPTION
Fixes #5659.

Integration test changes are there to prevent regressions.

In addition to the tests working and me just rewriting the code that creates these achalls in #5620, we can be confident the `achalls` aren't going to change on us because from the [documentation for cleanup](https://github.com/certbot/certbot/blob/f51d345d5b33901e54989175a06f2fda1464e636/certbot/interfaces.py#L180):

> achalls: Non-empty (guaranteed) list of :class:`~certbot.achallenges.AnnotatedChallenge` instances, a subset of those previously passed to :func:`perform`

Being immutable objects and a subset of the previous values to `perform` means it shouldn't be a new value for the plugin.