### PR TITLE
Version 2 of ACMEv2 support for Route53 plugin

### DIFF
--- a/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
@@ -178,6 +178,9 @@ class ClientTest(unittest.TestCase):
 
     def test_change_txt_record(self):
         self.client._find_zone_id_for_domain = mock.MagicMock()
+        self.client._get_validation_rrset = mock.MagicMock(
+            return_value=[]
+        )
         self.client.r53.change_resource_record_sets = mock.MagicMock(
             return_value={"ChangeInfo": {"Id": 1}})
 
@@ -185,6 +188,57 @@ class ClientTest(unittest.TestCase):
 
         call_count = self.client.r53.change_resource_record_sets.call_count
         self.assertEqual(call_count, 1)
+
+    def test_change_txt_record_multirecord(self):
+        self.client._find_zone_id_for_domain = mock.MagicMock()
+        self.client._get_validation_rrset = mock.MagicMock()
+        self.client._get_validation_rrset.return_value = [
+            {"Value": "\"pre-existing-value\""},
+            {"Value": "\"pre-existing-value-two\""},
+        ]
+        self.client.r53.change_resource_record_sets = mock.MagicMock(
+            return_value={"ChangeInfo": {"Id": 1}})
+
+        self.client._change_txt_record("DELETE", DOMAIN, "pre-existing-value")
+
+        call_count = self.client.r53.change_resource_record_sets.call_count
+        call_args = self.client.r53.change_resource_record_sets.call_args_list[0][1]
+        call_args_batch = call_args["ChangeBatch"]["Changes"][0]
+        self.assertEqual(call_args_batch["Action"], "UPSERT")
+        self.assertEqual(
+            call_args_batch["ResourceRecordSet"]["ResourceRecords"],
+            [{"Value": "\"pre-existing-value-two\""}])
+
+        self.assertEqual(call_count, 1)
+
+    def test_get_validation_rrset(self):
+        self.client.r53.list_resource_record_sets = mock.MagicMock(
+            return_value={"ResourceRecordSets": [
+                {"Name": "_acme-challenge.example.org.",
+                 "Type": "TXT",
+                 "ResourceRecords": [
+                     {"Value": "\"validation-token\""},
+                     {"Value": "\"another-validation-token\""},
+                 ],
+                },
+                {"Name": "_acme-challenge.example.org.",
+                 "Type": "NS",
+                 "ResourceRecords": [
+                     {"Value": "ns1.example.com"},
+                 ],
+                }
+            ]})
+        rrset = self.client._get_validation_rrset("zoneid",
+            "_acme-challenge.example.org")
+        self.assertEquals(len(rrset), 2)
+        self.assertTrue({"Value": "\"another-validation-token\""} in rrset)
+
+    def test_get_validation_rrset_empty(self):
+        self.client.r53.list_resource_record_sets = mock.MagicMock(
+            return_value={"ResourceRecordSets": []})
+        rrset = self.client._get_validation_rrset("zoneid",
+            "_acme-challenge.example.org")
+        self.assertEquals(rrset, [])
 
     def test_wait_for_change(self):
         self.client.r53.get_change = mock.MagicMock(


### PR DESCRIPTION
Based on #5661 and an alternative to it.

When testing #5661 after carefully following the instructions in the package and from Jacob, I realized that this adds the need for permission `route53:ListResourceRecordSets`. While not at all something I thought about before, I think this is a problem. Suddenly changing the required permissions could break automated renewal for existing users.

We took over this plugin from https://github.com/lifeonmarspt/certbot-route53 who built it for use in their organization and we went through a lot of effort (including making the `authenticator` shim you find in the package and the dummy package on PyPI) not to break anything. Additionally, our DNS plugins in general have been released for many months now, so there are people who are comfortable with Python and/or persistent who are currently using the plugins.

This PR fixes the problem without any change in behavior. That is:

* We don't need any new permissions.
* If you had existing TXT records at the validation domain, they are blown away.
* Attempting to delete a record after another value was set elsewhere is an error.

While #5661 is more technically correct, preserving existing records at `_acme-challenge` domains is unlikely to matter and I think not adding new permissions is worth it.

EDIT: This PR should be merged and not squashed to preserve authorship.