### PR TITLE
Fallback without dns.resourceRecordSets.list permission

### DIFF
--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -29,6 +29,7 @@ for an account with the following permissions:
 * ``dns.managedZones.list``
 * ``dns.resourceRecordSets.create``
 * ``dns.resourceRecordSets.delete``
+* ``dns.resourceRecordSets.list``
 
 Google provides instructions for `creating a service account <https://developers
 .google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`_ and

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -30,6 +30,7 @@ for an account with the following permissions:
 * ``dns.resourceRecordSets.create``
 * ``dns.resourceRecordSets.delete``
 * ``dns.resourceRecordSets.list``
+* ``dns.resourceRecordSets.update``
 
 Google provides instructions for `creating a service account <https://developers
 .google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`_ and

--- a/certbot-dns-google/certbot_dns_google/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google.py
@@ -108,6 +108,8 @@ class _GoogleClient(object):
         zone_id = self._find_managed_zone_id(domain)
 
         record_contents = self.get_existing_txt_rrset(zone_id, record_name)
+        if record_contents is None:
+            record_contents = []
         add_records = record_contents[:]
 
         if "\""+record_content+"\"" in record_contents:
@@ -176,6 +178,8 @@ class _GoogleClient(object):
             return
 
         record_contents = self.get_existing_txt_rrset(zone_id, record_name)
+        if record_contents is None:
+            record_contents = [record_content]
 
         data = {
             "kind": "dns#change",
@@ -216,11 +220,14 @@ class _GoogleClient(object):
         """
         Get existing TXT records from the RRset for the record name.
 
+        If an error occurs while requesting the record set, it is suppressed
+        and None is returned.
+
         :param str zone_id: The ID of the managed zone.
         :param str record_name: The record name (typically beginning with '_acme-challenge.').
 
-        :returns: List of TXT record values
-        :rtype: `list` of `string`
+        :returns: List of TXT record values or None
+        :rtype: `list` of `string` or `None`
 
         """
         rrs_request = self.dns.resourceRecordSets()  # pylint: disable=no-member
@@ -238,7 +245,7 @@ class _GoogleClient(object):
                 for rr in response["rrsets"]:
                     if rr["name"] == record_name and rr["type"] == "TXT":
                         return rr["rrdatas"]
-        return []
+        return None
 
     def _find_managed_zone_id(self, domain):
         """

--- a/certbot-dns-google/certbot_dns_google/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google.py
@@ -179,7 +179,7 @@ class _GoogleClient(object):
 
         record_contents = self.get_existing_txt_rrset(zone_id, record_name)
         if record_contents is None:
-            record_contents = [record_content]
+            record_contents = ["\"" + record_content + "\""]
 
         data = {
             "kind": "dns#change",

--- a/certbot-dns-google/certbot_dns_google/dns_google_test.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google_test.py
@@ -270,7 +270,7 @@ class GoogleClientTest(unittest.TestCase):
         found = client.get_existing_txt_rrset(self.zone, "_acme-challenge.example.org")
         self.assertEquals(found, ["\"example-txt-contents\""])
         not_found = client.get_existing_txt_rrset(self.zone, "nonexistent.tld")
-        self.assertEquals(not_found, [])
+        self.assertEquals(not_found, None)
 
     @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
     @mock.patch('certbot_dns_google.dns_google.open',

--- a/certbot/plugins/disco.py
+++ b/certbot/plugins/disco.py
@@ -190,6 +190,7 @@ class PluginsRegistry(collections.Mapping):
     def find_all(cls):
         """Find plugins using setuptools entry points."""
         plugins = {}
+        # pylint: disable=not-callable
         entry_points = itertools.chain(
             pkg_resources.iter_entry_points(
                 constants.SETUPTOOLS_PLUGINS_ENTRY_POINT),


### PR DESCRIPTION
Tests may fail until #5677 is merged. Been fighting to make Coveralls report everything passed.

Since `dns.resourceRecordSets.list` is a new permission used by the plugin, we now try to continue without it if the request fails. I had to change things around a bit because if the request fails while trying to add a record, we should just assume there are currently no records and if the request fails when trying to delete a record, we should assume the record we're trying to delete still exists.

Also, I choose not to keep track of records internally like we do for route53 because it's only needed for wildcards so it isn't a regression and doing so adds complexity and is unlikely to matter because Google Cloud only recently started allowing people to set fine grained permissions like this.