### PR TITLE
Add readthedocs requirements files

### DIFF
--- a/certbot-dns-cloudflare/readthedocs.org.requirements.txt
+++ b/certbot-dns-cloudflare/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-cloudflare[docs]

--- a/certbot-dns-cloudflare/readthedocs.org.requirements.txt
+++ b/certbot-dns-cloudflare/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-cloudflare[docs]

--- a/certbot-dns-cloudxns/readthedocs.org.requirements.txt
+++ b/certbot-dns-cloudxns/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-cloudxns[docs]

--- a/certbot-dns-cloudxns/readthedocs.org.requirements.txt
+++ b/certbot-dns-cloudxns/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-cloudxns[docs]

--- a/certbot-dns-digitalocean/readthedocs.org.requirements.txt
+++ b/certbot-dns-digitalocean/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-digitalocean[docs]

--- a/certbot-dns-digitalocean/readthedocs.org.requirements.txt
+++ b/certbot-dns-digitalocean/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-digitalocean[docs]

--- a/certbot-dns-dnsimple/readthedocs.org.requirements.txt
+++ b/certbot-dns-dnsimple/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-dnsimple[docs]

--- a/certbot-dns-dnsimple/readthedocs.org.requirements.txt
+++ b/certbot-dns-dnsimple/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-dnsimple[docs]

--- a/certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt
+++ b/certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-dnsmadeeasy[docs]

--- a/certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt
+++ b/certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-dnsmadeeasy[docs]

--- a/certbot-dns-google/readthedocs.org.requirements.txt
+++ b/certbot-dns-google/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-google[docs]

--- a/certbot-dns-google/readthedocs.org.requirements.txt
+++ b/certbot-dns-google/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-google[docs]

--- a/certbot-dns-luadns/readthedocs.org.requirements.txt
+++ b/certbot-dns-luadns/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-luadns[docs]

--- a/certbot-dns-luadns/readthedocs.org.requirements.txt
+++ b/certbot-dns-luadns/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-luadns[docs]

--- a/certbot-dns-nsone/readthedocs.org.requirements.txt
+++ b/certbot-dns-nsone/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-nsone[docs]

--- a/certbot-dns-nsone/readthedocs.org.requirements.txt
+++ b/certbot-dns-nsone/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-nsone[docs]

--- a/certbot-dns-rfc2136/readthedocs.org.requirements.txt
+++ b/certbot-dns-rfc2136/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-rfc2136[docs]

--- a/certbot-dns-rfc2136/readthedocs.org.requirements.txt
+++ b/certbot-dns-rfc2136/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-rfc2136[docs]

--- a/certbot-dns-route53/readthedocs.org.requirements.txt
+++ b/certbot-dns-route53/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme[docs]
+-e .[docs]
+-e certbot-dns-route53[docs]

--- a/certbot-dns-route53/readthedocs.org.requirements.txt
+++ b/certbot-dns-route53/readthedocs.org.requirements.txt
@@ -7,6 +7,6 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e .[docs]" must be used instead
 
--e acme[docs]
--e .[docs]
+-e acme
+-e .
 -e certbot-dns-route53[docs]


### PR DESCRIPTION
As part of #5564, I'm setting up Read the Docs for each of our DNS plugins. To do this, we need to tell Read the Docs how to install the plugin so it can build the documentation about it. We have similar files in the root of the repo and the `acme`, `certbot-apache`, `certbot-compatibility-test`, `certbot-nginx`, and `letshelp-certbot` directories.

Despite us having broken lockstep, we should still have each plugin install the latest version of `acme`/`certbot` so the build still works when the version of the plugin in `master` is relying on changes in an unreleased version of `acme`/`certbot`.

While not what we should be doing long term, for the purposes of testing this PR I set up the Cloudflare docs to use this branch. You can see the docs at: https://certbot-dns-cloudflare.readthedocs.io/en/latest/