### PR TITLE
Put API link at the bottom of DNS plugin docs

### DIFF
--- a/certbot-dns-cloudflare/docs/index.rst
+++ b/certbot-dns-cloudflare/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-cloudflare's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_cloudflare
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_cloudflare
-   :members:
 
 
 Indices and tables

--- a/certbot-dns-cloudxns/docs/index.rst
+++ b/certbot-dns-cloudxns/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-cloudxns's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_cloudxns
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_cloudxns
-   :members:
 
 
 

--- a/certbot-dns-digitalocean/docs/index.rst
+++ b/certbot-dns-digitalocean/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-digitalocean's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_digitalocean
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_digitalocean
-   :members:
 
 
 

--- a/certbot-dns-dnsimple/docs/index.rst
+++ b/certbot-dns-dnsimple/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-dnsimple's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_dnsimple
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_dnsimple
-   :members:
 
 
 

--- a/certbot-dns-dnsmadeeasy/docs/index.rst
+++ b/certbot-dns-dnsmadeeasy/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-dnsmadeeasy's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_dnsmadeeasy
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_dnsmadeeasy
-   :members:
 
 
 

--- a/certbot-dns-google/docs/index.rst
+++ b/certbot-dns-google/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-google's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_google
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_google
-   :members:
 
 
 

--- a/certbot-dns-luadns/docs/index.rst
+++ b/certbot-dns-luadns/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-luadns's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_luadns
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_luadns
-   :members:
 
 
 

--- a/certbot-dns-nsone/docs/index.rst
+++ b/certbot-dns-nsone/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-nsone's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_nsone
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_nsone
-   :members:
 
 
 

--- a/certbot-dns-rfc2136/docs/index.rst
+++ b/certbot-dns-rfc2136/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-rfc2136's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_rfc2136
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_rfc2136
-   :members:
 
 
 

--- a/certbot-dns-route53/docs/index.rst
+++ b/certbot-dns-route53/docs/index.rst
@@ -10,13 +10,13 @@ Welcome to certbot-dns-route53's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+.. automodule:: certbot_dns_route53
+   :members:
+
 .. toctree::
    :maxdepth: 1
 
    api
-
-.. automodule:: certbot_dns_route53
-   :members:
 
 
 

--- a/tools/sphinx-quickstart.sh
+++ b/tools/sphinx-quickstart.sh
@@ -25,7 +25,7 @@ API Documentation
    :glob:
 
    api/**" > api.rst
-sed -i -e "s|   :caption: Contents:|   :caption: Contents:\n\n.. toctree::\n   :maxdepth: 1\n\n   api\n\n.. automodule:: ${PROJECT//-/_}\n   :members:|" index.rst
+sed -i -e "s|   :caption: Contents:|   :caption: Contents:\n\n.. automodule:: ${PROJECT//-/_}\n   :members:\n\n.. toctree::\n   :maxdepth: 1\n\n   api|" index.rst
 
 echo "Suggested next steps:
 * Add API docs to: $PROJECT/docs/api/


### PR DESCRIPTION
Part of #5564.

Currently these docs look like https://certbot-dns-cloudflare.readthedocs.io/en/latest/ with the link to the API documentation at the very top. This link is only useful for people work on the plugin which is way fewer people than those just wanting to use it. Let's move this link to the bottom to get the more relevant information at the top.

To see what the docs look like with this change, check out this branch, [(create and) activate the virtual environment](https://certbot.eff.org/docs/contributing.html#running-a-local-copy-of-the-client) and run a command like `make -C certbot-dns-cloudflare/docs clean html`. Afterwards, the generated HTML can be found at `certbot-dns-cloudflare/docs/_build/html/index.html`.