### PR TITLE
Restore parallel waiting to Route53 plugin

### DIFF
--- a/certbot-dns-route53/certbot_dns_route53/authenticator.py
+++ b/certbot-dns-route53/certbot_dns_route53/authenticator.py
@@ -7,7 +7,6 @@ from certbot import interfaces
 from certbot_dns_route53 import dns_route53
 
 
-# pylint: disable=abstract-method
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_route53.Authenticator):

--- a/certbot-dns-route53/certbot_dns_route53/authenticator.py
+++ b/certbot-dns-route53/certbot_dns_route53/authenticator.py
@@ -7,6 +7,7 @@ from certbot import interfaces
 from certbot_dns_route53 import dns_route53
 
 
+# pylint: disable=abstract-method
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_route53.Authenticator):

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -45,15 +45,16 @@ class Authenticator(dns_common.DNSAuthenticator):
     def perform(self, achalls):
         self._attempt_cleanup = True
 
-        change_ids = [
-            self._change_txt_record("UPSERT",
-              achall.validation_domain_name(achall.domain),
-              achall.validation(achall.account_key))
-            for achall in achalls
-        ]
+        try:
+            change_ids = [
+                self._change_txt_record("UPSERT",
+                  achall.validation_domain_name(achall.domain),
+                  achall.validation(achall.account_key))
+                for achall in achalls
+            ]
 
-        for change_id in change_ids:
-            self._wait_for_change(change_id)
+            for change_id in change_ids:
+                self._wait_for_change(change_id)
         except (NoCredentialsError, ClientError) as e:
             logger.debug('Encountered error during perform: %s', e, exc_info=True)
             raise errors.PluginError("\n".join([str(e), INSTRUCTIONS]))

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -42,7 +42,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _setup_credentials(self):
         pass
 
-    def _perform(self, achalls): # pylint: disable=missing-docstring
+    def _perform(self, domain, validation_domain_name, validation): # pylint: disable=missing-docstring
         pass
 
     def perform(self, achalls):

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -18,7 +18,6 @@ INSTRUCTIONS = (
     "https://boto3.readthedocs.io/en/latest/guide/configuration.html#best-practices-for-configuring-credentials "  # pylint: disable=line-too-long
     "and add the necessary permissions for Route53 access.")
 
-# pylint: disable=abstract-method
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
@@ -41,6 +40,9 @@ class Authenticator(dns_common.DNSAuthenticator):
         return "Solve a DNS01 challenge using AWS Route53"
 
     def _setup_credentials(self):
+        pass
+
+    def _perform(self):
         pass
 
     def perform(self, achalls):

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -42,7 +42,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _setup_credentials(self):
         pass
 
-    def perform(self, achalls): # pylint: disable=missing-docstring
+    def _perform(self, achalls): # pylint: disable=missing-docstring
         pass
 
     def perform(self, achalls):

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -42,14 +42,28 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _setup_credentials(self):
         pass
 
-    def _perform(self, domain, validation_domain_name, validation):
-        try:
-            change_id = self._change_txt_record("UPSERT", validation_domain_name, validation)
+    def perform(self, achalls):
+        self._attempt_cleanup = True
 
+        change_ids = [
+            self._change_txt_record("UPSERT",
+              achall.validation_domain_name(achall.domain),
+              achall.validation(achall.account_key))
+            for achall in achalls
+        ]
+
+        for change_id in change_ids:
             self._wait_for_change(change_id)
         except (NoCredentialsError, ClientError) as e:
             logger.debug('Encountered error during perform: %s', e, exc_info=True)
             raise errors.PluginError("\n".join([str(e), INSTRUCTIONS]))
+
+        # Sleep for at least the TTL, to ensure that any records cached by
+        # the ACME server after previous validation attempts are gone. In
+        # most cases we'll need to wait at least this long for the Route53
+        # records to propagate, so this doesn't delay us much.
+        time.sleep(TTL)
+        return [achall.response(achall.account_key) for achall in achalls]
 
     def _cleanup(self, domain, validation_domain_name, validation):
         try:

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -18,6 +18,7 @@ INSTRUCTIONS = (
     "https://boto3.readthedocs.io/en/latest/guide/configuration.html#best-practices-for-configuring-credentials "  # pylint: disable=line-too-long
     "and add the necessary permissions for Route53 access.")
 
+# pylint: disable=abstract-method
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -42,7 +42,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _setup_credentials(self):
         pass
 
-    def _perform(self):
+    def perform(self, achalls): # pylint: disable=missing-docstring
         pass
 
     def perform(self, achalls):

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -58,12 +58,6 @@ class Authenticator(dns_common.DNSAuthenticator):
         except (NoCredentialsError, ClientError) as e:
             logger.debug('Encountered error during perform: %s', e, exc_info=True)
             raise errors.PluginError("\n".join([str(e), INSTRUCTIONS]))
-
-        # Sleep for at least the TTL, to ensure that any records cached by
-        # the ACME server after previous validation attempts are gone. In
-        # most cases we'll need to wait at least this long for the Route53
-        # records to propagate, so this doesn't delay us much.
-        time.sleep(self.ttl)
         return [achall.response(achall.account_key) for achall in achalls]
 
     def _cleanup(self, domain, validation_domain_name, validation):

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -63,7 +63,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         # the ACME server after previous validation attempts are gone. In
         # most cases we'll need to wait at least this long for the Route53
         # records to propagate, so this doesn't delay us much.
-        time.sleep(TTL)
+        time.sleep(self.ttl)
         return [achall.response(achall.account_key) for achall in achalls]
 
     def _cleanup(self, domain, validation_domain_name, validation):


### PR DESCRIPTION
Currently, when you issue for multiple domains using the Route53 plugin, Certbot
waits for each update to propagate before moving onto the next. This change
makes Certbot send all updates, then wait for them all at the same time, which
speeds up issuance for multiple domains dramatically.

Note that this means the Route53 plugin uses slightly less of the dns_common
functionality. In particular, it implements the base Authenticator method `perform`,
rather than the DNSAuthenticator method `_perform` (which performs a single
challenge).

Fixes #5671 