### PR TITLE
fix(acme): client._revoke sends default content_type (#5687)

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -227,8 +227,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         response = self._post(url,
                               messages.Revocation(
                                 certificate=cert,
-                                reason=rsn),
-                                content_type=None)
+                                reason=rsn))
         if response.status_code != http_client.OK:
             raise errors.ClientError(
                 'Successful revocation must return HTTP OK status')

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -635,8 +635,7 @@ class ClientTest(ClientTestBase):
     def test_revoke(self):
         self.client.revoke(self.certr.body, self.rsn)
         self.net.post.assert_called_once_with(
-            self.directory[messages.Revocation], mock.ANY, content_type=None,
-            acme_version=1)
+            self.directory[messages.Revocation], mock.ANY, acme_version=1)
 
     def test_revocation_payload(self):
         obj = messages.Revocation(certificate=self.certr.body, reason=self.rsn)
@@ -776,8 +775,7 @@ class ClientV2Test(ClientTestBase):
     def test_revoke(self):
         self.client.revoke(messages_test.CERT, self.rsn)
         self.net.post.assert_called_once_with(
-            self.directory["revokeCert"], mock.ANY, content_type=None,
-            acme_version=2)
+            self.directory["revokeCert"], mock.ANY, acme_version=2)
 
 
 class MockJSONDeSerializable(jose.JSONDeSerializable):


### PR DESCRIPTION
Cherry picked from commit f4bac423fb794c14e426defecc492306ea53cbc4 from #5687. This is needed because Let's Encrypt's going to start erroring on us here starting March 29th. See https://community.letsencrypt.org/t/jws-post-content-type-header-enforcement/55055.