### PR TITLE
It is safer to pylint on Python 3 than Python 2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -22,7 +22,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=linter_plugin
+load-plugins=
 
 
 [MESSAGES CONTROL]

--- a/linter_plugin.py
+++ b/linter_plugin.py
@@ -9,6 +9,8 @@ from astroid import nodes
 
 def register(unused_linter):
     """Register this module as PyLint plugin."""
+    pass
+
 
 def _transform(cls):
     # fix the "no-member" error on instances of
@@ -17,9 +19,9 @@ def _transform(cls):
 
     # TODO: this is too broad and applies to any tested class...
 
-    if cls.slots() is not None:
-        for slot in cls.slots():
-            cls.locals[slot.value] = [nodes.EmptyNode()]
+    #if cls.slots() is not None:
+    #    for slot in cls.slots():
+    #        cls.locals[slot.value] = [nodes.EmptyNode()]
 
     if cls.name == 'JSONObjectWithFields':
         # _fields is magically introduced by JSONObjectWithFieldsMeta

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import codecs
 import os
 import re
-import sys
 
 from setuptools import setup
 from setuptools import find_packages
@@ -52,14 +51,13 @@ install_requires = [
 ]
 
 dev_extras = [
-    # Pin astroid==1.3.5, pylint==1.4.2 as a workaround for #289
-    'astroid==1.3.5',
+    'astroid',
     'coverage',
     'ipdb',
     'pytest',
     'pytest-cov',
     'pytest-xdist',
-    'pylint==1.4.2',  # upstream #248
+    'pylint>=1.8.4',
     'tox',
     'twine',
     'wheel',

--- a/tox.ini
+++ b/tox.ini
@@ -133,6 +133,7 @@ basepython = python2.7
 # continue, but tox return code will reflect previous error
 commands =
     {[base]install_packages}
+    pip install --upgrade astroid pylint  # required!
     pylint --reports=n --rcfile=.pylintrc {[base]source_paths}
 
 [testenv:mypy]


### PR DESCRIPTION
Syntax Errors will be caught by pylint running on Python 3 but not when running on Python 2:
* print "Hello"
* 0L
* 0755
* except Exception, e
etc...