### PR TITLE
Remove blank line from chain.pem

### DIFF
--- a/certbot/crypto_util.py
+++ b/certbot/crypto_util.py
@@ -445,5 +445,5 @@ def cert_and_chain_from_fullchain(fullchain_pem):
     """
     cert = OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM,
         OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, fullchain_pem)).decode()
-    chain = fullchain_pem[len(cert):]
+    chain = fullchain_pem[len(cert):].lstrip()
     return (cert, chain)

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -380,10 +380,12 @@ class CertAndChainFromFullchainTest(unittest.TestCase):
         cert_pem = CERT.decode()
         chain_pem = cert_pem + SS_CERT.decode()
         fullchain_pem = cert_pem + chain_pem
+        spacey_fullchain_pem = cert_pem + u'\n' + chain_pem
         from certbot.crypto_util import cert_and_chain_from_fullchain
-        cert_out, chain_out = cert_and_chain_from_fullchain(fullchain_pem)
-        self.assertEqual(cert_out, cert_pem)
-        self.assertEqual(chain_out, chain_pem)
+        for fullchain in (fullchain_pem, spacey_fullchain_pem):
+            cert_out, chain_out = cert_and_chain_from_fullchain(fullchain)
+            self.assertEqual(cert_out, cert_pem)
+            self.assertEqual(chain_out, chain_pem)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As reported in #5721, `chain.pem` when used with ACMEv2 has a blank line at the top. Let's remove it.