### PR TITLE
Fix Docker link

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,7 +24,7 @@ running:
 
 If you're on macOS, we recommend you skip the rest of this section and instead
 run Certbot in Docker. You can find instructions for how to do this :ref:`here
-<docker>`. If you're running on Linux, you can run the following commands to
+<docker-dev>`. If you're running on Linux, you can run the following commands to
 install dependencies and set up a virtual environment where you can run
 Certbot. You will need to repeat this when Certbot's dependencies change or when
 a new plugin is introduced.
@@ -377,7 +377,7 @@ This should generate documentation in the ``docs/_build/html``
 directory.
 
 
-.. _docker:
+.. _docker-dev:
 
 Running the client with Docker
 ==============================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -94,6 +94,8 @@ Disable and remove the swapfile once the virtual environment is constructed::
   user@webserver:~$ sudo swapoff /tmp/swapfile
   user@webserver:~$ sudo rm /tmp/swapfile
 
+.. _docker-user:
+
 Running with Docker
 -------------------
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -185,7 +185,7 @@ Certbot's DNS plugins.
 These plugins are still in the process of being packaged
 by many distributions and cannot currently be installed with ``certbot-auto``.
 If, however, you are comfortable installing the certificates yourself,
-you can run these plugins with :ref:`Docker <docker>`.
+you can run these plugins with :ref:`Docker <docker-user>`.
 
 Once installed, you can find documentation on how to use each plugin at:
 


### PR DESCRIPTION
As pointed out at https://github.com/certbot/certbot/issues/5731#issuecomment-373689215, our Docker link in the DNS plugin section actually links to info about the dev Docker setup! This fixes the link and adds slightly more descriptive names for the links in Sphinx.