### PR TITLE
Add note to developer guide docs about installing docs extras. (#4946)

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -376,6 +376,9 @@ commands:
 This should generate documentation in the ``docs/_build/html``
 directory.
 
+.. note:: If you skipped the "Getting Started" instructions above,
+  run ``pip install -e .[docs]`` to install Certbot's docs extras modules.
+
 
 .. _docker-dev:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -377,7 +377,7 @@ This should generate documentation in the ``docs/_build/html``
 directory.
 
 .. note:: If you skipped the "Getting Started" instructions above,
-  run ``pip install -e .[docs]`` to install Certbot's docs extras modules.
+  run ``pip install -e ".[docs]"`` to install Certbot's docs extras modules.
 
 
 .. _docker-dev:


### PR DESCRIPTION
This PR updates the Developer Guide docs with a brief note about how to install the docs extras in case a contributor skips the Getting Started setup.

This should be helpful for those that want to contribute to docs without installing all of the dev requirements through `./tools/venv.sh`.