### PR TITLE
Add a note about installing certbot DNS plugins

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -185,7 +185,8 @@ Certbot's DNS plugins.
 These plugins are still in the process of being packaged
 by many distributions and cannot currently be installed with ``certbot-auto``.
 If, however, you are comfortable installing the certificates yourself,
-you can run these plugins with :ref:`Docker <docker-user>`.
+you can run these plugins with :ref:`Docker <docker-user>`, or by installing the 
+pip package for your chosen plugin directly (eg. ``pip install certbot-dns-cloudflare``).
 
 Once installed, you can find documentation on how to use each plugin at:
 


### PR DESCRIPTION
Nowhere in the documentation does it explain that plugins are simply pip packages, the implication here was that you must use Docker to use these plugins, but that is not the case.

I actually went through quite a bit of pain trying to get docker up and running on Mac OS, but once I looked at the Dockerfile I realized installing the plugin was trivial and fit my workflow very nicely.