### PR TITLE
Adjust QUIET_LOGGING_LEVEL to ERROR, matching --help output.

### DIFF
--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -122,7 +122,7 @@ REVOCATION_REASONS = {
 
 """Defaults for CLI flags and `.IConfig` attributes."""
 
-QUIET_LOGGING_LEVEL = logging.WARNING
+QUIET_LOGGING_LEVEL = logging.ERROR
 """Logging level to use in quiet mode."""
 
 RENEWER_DEFAULTS = dict(


### PR DESCRIPTION
This will squelch the WARNING-level message about Non-standard paths.

issue #2552