### PR TITLE
Verify permissions of conf root in Apache

### DIFF
--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -224,7 +224,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         else:
             self.vhostroot = os.path.abspath(self.conf("vhost-root"))
 
-	self._check_permissions(self.vhostroot)
+        self._check_permissions(self.vhostroot)
 
         self.parser = self.get_parser()
 
@@ -261,7 +261,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         return matches
 
     def _check_permissions(self, path):
-	"""Verify permissions for root configuration directory."""
+        """Verify permissions for root configuration directory."""
         if not os.access(path, os.W_OK | os.X_OK):
             raise errors.LocalPermissionsError(
                 ("Certbot cannot write to `{}`. Please use `chmod` to ensure "

--- a/certbot/errors.py
+++ b/certbot/errors.py
@@ -38,6 +38,9 @@ class OverlappingMatchFound(Error):
 class LockError(Error):
     """File locking error."""
 
+class LocalPermissionsError(Error):
+    """Necessary access to a directory is denied."""
+
 
 # Auth Handler Errors
 class AuthorizationError(Error):


### PR DESCRIPTION
* Add LocalPermissionsError to errors.py. This may also be used when addressing issues such as #5602.
* Verify permissions of root configuration directory in Apache configurator.
* Edit configurator_test.py to cover changes.