### PR TITLE
Factor out location_directive_for_achall

### DIFF
--- a/certbot-nginx/certbot_nginx/http_01.py
+++ b/certbot-nginx/certbot_nginx/http_01.py
@@ -159,16 +159,22 @@ class NginxHttp01(common.ChallengePerformer):
         document_root = os.path.join(
             self.configurator.config.work_dir, "http_01_nonexistent")
 
+        block.extend([['server_name', ' ', achall.domain],
+                      ['root', ' ', document_root],
+                      self._location_directive_for_achall(achall)
+                      ])
+        # TODO: do we want to return something else if they otherwise access this block?
+        return [['server'], block]
+
+    def _location_directive_for_achall(self, achall):
         validation = achall.validation(achall.account_key)
         validation_path = self._get_validation_path(achall)
 
-        block.extend([['server_name', ' ', achall.domain],
-                      ['root', ' ', document_root],
-                      [['location', ' ', '=', ' ', validation_path],
-                        [['default_type', ' ', 'text/plain'],
-                         ['return', ' ', '200', ' ', validation]]]])
-        # TODO: do we want to return something else if they otherwise access this block?
-        return [['server'], block]
+        location_directive = [['location', ' ', '=', ' ', validation_path],
+                              [['default_type', ' ', 'text/plain'],
+                               ['return', ' ', '200', ' ', validation]]]
+        return location_directive
+
 
     def _make_or_mod_server_block(self, achall):
         """Modifies a server block to respond to a challenge.
@@ -191,12 +197,7 @@ class NginxHttp01(common.ChallengePerformer):
         vhost = vhosts[0]
 
         # Modify existing server block
-        validation = achall.validation(achall.account_key)
-        validation_path = self._get_validation_path(achall)
-
-        location_directive = [[['location', ' ', '=', ' ', validation_path],
-                               [['default_type', ' ', 'text/plain'],
-                                ['return', ' ', '200', ' ', validation]]]]
+        location_directive = [self._location_directive_for_achall(achall)]
 
         self.configurator.parser.add_server_directives(vhost,
             location_directive)


### PR DESCRIPTION
Part of #5438: "code could use deduping internally to `certbot-nginx/certbot_nginx/http_01.py` -- for example, `rewrite_directive` is defined identically twice"

Turns out the code actually wasn't that internally duplicative.
