### PR TITLE
Add before_install to all tests running on test-everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,113 +21,89 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=cover FYI="this also tests py27"
-      before_install:
     - python: "2.7"
       env: TOXENV=lint
-      before_install:
     - python: "2.7"
       env: TOXENV=py27-nginx-oldest BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      before_install:
     - python: "2.7"
       env: TOXENV=py27-nginx-oldest BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      before_install:
     - python: "2.7"
       env: TOXENV=py27_install BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      before_install:
     - python: "2.7"
       env: TOXENV=py27_install BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      before_install:
     - python: "2.7"
       env: TOXENV='py27-{acme,apache,certbot,dns}-oldest'
-      before_install:
     - sudo: required
       env: TOXENV=apache_compat
       services: docker
-      before_install:
       addons:
     - sudo: required
       env: TOXENV=nginx_compat
       services: docker
-      before_install:
       addons:
     - sudo: required
       env: TOXENV=le_auto_precise
       services: docker
-      before_install:
       addons:
     - sudo: required
       env: TOXENV=le_auto_trusty
       services: docker
-      before_install:
       addons:
     - sudo: required
       env: TOXENV=le_auto_wheezy
       services: docker
-      before_install:
       addons:
     - sudo: required
       env: TOXENV=le_auto_centos6
       services: docker
-      before_install:
       addons:
     - sudo: required
       env: TOXENV=docker_dev
       services: docker
-      before_install:
       addons:
     - python: "2.7"
       env: TOXENV=apacheconftest
       sudo: required
-      before_install:
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      before_install:
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      before_install:
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      before_install:
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      before_install:
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      before_install:
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      before_install:
     - python: "2.7"
       env: TOXENV=nginxroundtrip
-      before_install:
     - language: generic
       env: TOXENV=py27
       os: osx
-      before_install:
     - language: generic
       env: TOXENV=py36
       os: osx
-      before_install:
 
 
 # Only build pushes to the master branch, PRs, and branches beginning with

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,10 @@ matrix:
     - sudo: required
       env: TOXENV=docker_dev
       services: docker
+      addons:
+        apt:
+          packages:  # don't install nginx and apache
+          - libaugeas0
     - python: "2.7"
       env: TOXENV=apacheconftest
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,31 +44,24 @@ matrix:
     - sudo: required
       env: TOXENV=apache_compat
       services: docker
-      addons:
     - sudo: required
       env: TOXENV=nginx_compat
       services: docker
-      addons:
     - sudo: required
       env: TOXENV=le_auto_precise
       services: docker
-      addons:
     - sudo: required
       env: TOXENV=le_auto_trusty
       services: docker
-      addons:
     - sudo: required
       env: TOXENV=le_auto_wheezy
       services: docker
-      addons:
     - sudo: required
       env: TOXENV=le_auto_centos6
       services: docker
-      addons:
     - sudo: required
       env: TOXENV=docker_dev
       services: docker
-      addons:
     - python: "2.7"
       env: TOXENV=apacheconftest
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,26 +21,33 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=cover FYI="this also tests py27"
+      before_install:
     - python: "2.7"
       env: TOXENV=lint
+      before_install:
     - python: "2.7"
       env: TOXENV=py27-nginx-oldest BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      before_install:
     - python: "2.7"
       env: TOXENV=py27-nginx-oldest BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      before_install:
     - python: "2.7"
       env: TOXENV=py27_install BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      before_install:
     - python: "2.7"
       env: TOXENV=py27_install BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      before_install:
     - python: "2.7"
       env: TOXENV='py27-{acme,apache,certbot,dns}-oldest'
+      before_install:
     - sudo: required
       env: TOXENV=apache_compat
       services: docker
@@ -79,38 +86,48 @@ matrix:
     - python: "2.7"
       env: TOXENV=apacheconftest
       sudo: required
+      before_install:
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      before_install:
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      before_install:
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      before_install:
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      before_install:
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      before_install:
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      before_install:
     - python: "2.7"
       env: TOXENV=nginxroundtrip
+      before_install:
     - language: generic
       env: TOXENV=py27
       os: osx
+      before_install:
     - language: generic
       env: TOXENV=py36
       os: osx
+      before_install:
 
 
 # Only build pushes to the master branch, PRs, and branches beginning with


### PR DESCRIPTION
Fixes #5634.

This PR now successfully gets `before_install` running in `test-everything`. Unfortunately, several of these tests that are now running are failing.

We have:
- `py27-nginx-oldest BOULDER_INTEGRATION=v1` and `v2` failing in `test-everything` before this PR
- `le_auto_precise`, `le_auto_wheezy`, and `le_auto_centos6` failing to import `six`
- `docker_dev` failing for a different reason

Questions that I assume other people know the answers to that I'm going to ask in the morning before investigating:
- why is `test-everything` currently failing?
- why are some of the `le_auto`s failing to import `six`? where do we specify that dependency, why is it passing in `trusty`? why isn't it pulling in the dependency from wherever dependencies normally come from?
- what's up with `docker_dev`? what even is `docker_dev`? here is the error:
```
docker_dev runtests: commands[0] | docker-compose run --rm --service-ports development bash -c tox -e lint
WARNING:test command found but not installed in testenv
  cmd: /usr/local/bin/docker-compose
  env: /home/travis/build/certbot/certbot/.tox/docker_dev
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.
ERROR: Cannot start service development: driver failed programming external connectivity on endpoint certbot_development_run_2 (3e43285974a2c4d34e994c035014dc0d0527c3edab2d2e1e9f8ecae1394adbe4): Error starting userland proxy: listen tcp 0.0.0.0:80: bind: address already in use
ERROR: InvocationError: '/usr/local/bin/docker-compose run --rm --service-ports development bash -c tox -e lint'
```