### PR TITLE
Explicitly add six as a dependency in letsencrypt-auto-source dockerfiles

### DIFF
--- a/letsencrypt-auto-source/Dockerfile.centos6
+++ b/letsencrypt-auto-source/Dockerfile.centos6
@@ -11,7 +11,7 @@ RUN yum install -y python-pip sudo
 COPY ./pieces/pipstrap.py /opt
 RUN /opt/pipstrap.py
 # Pin pytest version for increased stability
-RUN pip install pytest==3.2.5
+RUN pip install pytest==3.2.5 six
 
 # Add an unprivileged user:
 RUN useradd --create-home --home-dir /home/lea --shell /bin/bash --groups wheel --uid 1000 lea

--- a/letsencrypt-auto-source/Dockerfile.centos6
+++ b/letsencrypt-auto-source/Dockerfile.centos6
@@ -11,7 +11,7 @@ RUN yum install -y python-pip sudo
 COPY ./pieces/pipstrap.py /opt
 RUN /opt/pipstrap.py
 # Pin pytest version for increased stability
-RUN pip install pytest==3.2.5 six
+RUN pip install pytest==3.2.5 six==1.10.0
 
 # Add an unprivileged user:
 RUN useradd --create-home --home-dir /home/lea --shell /bin/bash --groups wheel --uid 1000 lea

--- a/letsencrypt-auto-source/Dockerfile.precise
+++ b/letsencrypt-auto-source/Dockerfile.precise
@@ -15,7 +15,7 @@ RUN apt-get update && \
 COPY ./pieces/pipstrap.py /opt
 RUN /opt/pipstrap.py
 # Pin pytest version for increased stability
-RUN pip install pytest==3.2.5 six
+RUN pip install pytest==3.2.5 six==1.10.0
 
 # Let that user sudo:
 RUN sed -i.bkp -e \

--- a/letsencrypt-auto-source/Dockerfile.precise
+++ b/letsencrypt-auto-source/Dockerfile.precise
@@ -15,7 +15,7 @@ RUN apt-get update && \
 COPY ./pieces/pipstrap.py /opt
 RUN /opt/pipstrap.py
 # Pin pytest version for increased stability
-RUN pip install pytest==3.2.5
+RUN pip install pytest==3.2.5 six
 
 # Let that user sudo:
 RUN sed -i.bkp -e \

--- a/letsencrypt-auto-source/Dockerfile.trusty
+++ b/letsencrypt-auto-source/Dockerfile.trusty
@@ -19,7 +19,7 @@ RUN apt-get update && \
 COPY ./pieces/pipstrap.py /opt
 RUN /opt/pipstrap.py
 # Pin pytest version for increased stability
-RUN pip install pytest==3.2.5
+RUN pip install pytest==3.2.5 six
 
 RUN mkdir -p /home/lea/certbot
 

--- a/letsencrypt-auto-source/Dockerfile.trusty
+++ b/letsencrypt-auto-source/Dockerfile.trusty
@@ -19,7 +19,7 @@ RUN apt-get update && \
 COPY ./pieces/pipstrap.py /opt
 RUN /opt/pipstrap.py
 # Pin pytest version for increased stability
-RUN pip install pytest==3.2.5 six
+RUN pip install pytest==3.2.5 six==1.10.0
 
 RUN mkdir -p /home/lea/certbot
 

--- a/letsencrypt-auto-source/Dockerfile.wheezy
+++ b/letsencrypt-auto-source/Dockerfile.wheezy
@@ -14,7 +14,7 @@ RUN apt-get update && \
 COPY ./pieces/pipstrap.py /opt
 RUN /opt/pipstrap.py
 # Pin pytest version for increased stability
-RUN pip install pytest==3.2.5 six
+RUN pip install pytest==3.2.5 six==1.10.0
 
 # Let that user sudo:
 RUN sed -i.bkp -e \

--- a/letsencrypt-auto-source/Dockerfile.wheezy
+++ b/letsencrypt-auto-source/Dockerfile.wheezy
@@ -14,7 +14,7 @@ RUN apt-get update && \
 COPY ./pieces/pipstrap.py /opt
 RUN /opt/pipstrap.py
 # Pin pytest version for increased stability
-RUN pip install pytest==3.2.5
+RUN pip install pytest==3.2.5 six
 
 # Let that user sudo:
 RUN sed -i.bkp -e \

--- a/letsencrypt-auto-source/tests/__init__.py
+++ b/letsencrypt-auto-source/tests/__init__.py
@@ -2,6 +2,6 @@
 
 Run these locally by saying... ::
 
-    ./build.py && docker build -t lea . && docker run --rm -t -i lea
+    ./build.py && docker build -t lea . -f Dockerfile.<distro> && docker run --rm -t -i lea
 
 """


### PR DESCRIPTION
This should have been done in #5590. Needed to get #5806 working. Ran tests locally, they're all passing. They won't run on this branch.