### PR TITLE
Revert "Update oldest tests to test against 0.22.0 versions"

### DIFF
--- a/certbot-nginx/local-oldest-requirements.txt
+++ b/certbot-nginx/local-oldest-requirements.txt
@@ -1,2 +1,2 @@
-acme[dev]==0.22.0
-certbot[dev]==0.22.0
+-e acme[dev]
+-e .[dev]

--- a/local-oldest-requirements.txt
+++ b/local-oldest-requirements.txt
@@ -1,1 +1,1 @@
-acme[dev]==0.22.0
+-e acme[dev]


### PR DESCRIPTION
Reverts certbot/certbot#5800 which is causing failures on `test-everything`. I'm going to write up an issue describing what the problem is here and a possible way to work around it and put it in this milestone. I don't want to block other work from being done in the meantime though.