### PR TITLE
 Support quoted server names in Nginx

### DIFF
--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -743,7 +743,7 @@ def _parse_server_raw(server):
                 if addr.ssl:
                     parsed_server['ssl'] = True
         elif directive[0] == 'server_name':
-            parsed_server['names'].update(directive[1:])
+            parsed_server['names'].update(x.strip('"\'') for x in directive[1:])
         elif _is_ssl_on_directive(directive):
             parsed_server['ssl'] = True
             apply_ssl_to_all_addrs = True

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -639,7 +639,7 @@ class NginxConfiguratorTest(util.NginxTest):
         self.assertEqual([[['server'],
                            [['listen', 'myhost', 'default_server'],
                             ['listen', 'otherhost', 'default_server'],
-                            ['server_name', 'www.example.org'],
+                            ['server_name', '"www.example.org"'],
                             [['location', '/'],
                              [['root', 'html'],
                               ['index', 'index.html', 'index.htm']]]]],

--- a/certbot-nginx/certbot_nginx/tests/testdata/etc_nginx/sites-enabled/default
+++ b/certbot-nginx/certbot_nginx/tests/testdata/etc_nginx/sites-enabled/default
@@ -1,7 +1,7 @@
 server {
     listen       myhost default_server;
     listen       otherhost default_server;
-    server_name www.example.org;
+    server_name "www.example.org";
 
     location / {
         root   html;


### PR DESCRIPTION
Fixes #5543.

Here's the thing. This is a perfectly fine way to solve this problem.

A slightly more complete solution would go and check that we're removing quotes everywhere else they might be. This is clearly the wrong choice, we can wait until we get complaints about other places to go fix those.

A more complete way to solve this problem is to revamp the Nginx parsing infrastructure, so we can do all the things you're supposed to do at parse time like removing quotes and whitespace. Then we can kill unspaced list! And then we'd need a different solution for writing things back out that handles detecting formatting and where to put things. There's multiple perfectly good ways to handle that, which I'm not writing out here because they're pretty obvious. This would also solve at least one other open parsing-related ticket regarding strings and quotes.

The _best_ way to solve this tiny problem is by rewriting and packaging certbot as just a cert-management library that a plugin to the Nginx server could pull in. This is because the authoritative parsing is what Nginx does, and also because it's so much better of a UX.

In the meantime, here's a 27-character fix.