### PR TITLE
Remove build path from SSL_DHPARAM_SRC docs

### DIFF
--- a/docs/api/constants.rst
+++ b/docs/api/constants.rst
@@ -3,3 +3,7 @@
 
 .. automodule:: certbot.constants
    :members:
+   :exclude-members: SSL_DHPARAMS_SRC
+
+.. autodata:: SSL_DHPARAMS_SRC
+   :annotation: = '/path/to/certbot/ssl-dhparams.pem'


### PR DESCRIPTION
Fixes #5380.

Docs now look like:
<img width="594" alt="screen shot 2018-03-30 at 3 50 54 pm" src="https://user-images.githubusercontent.com/6504915/38156368-29152b32-3432-11e8-9443-8c9749bd5fab.png">
