### PR TITLE
Fix comparison to check values for derivative warning in Nginx

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -914,7 +914,7 @@ class NginxConfigurator(common.Installer):
             raise errors.PluginError("Nginx build doesn't support SNI")
 
         product_name, product_version = version_matches[0]
-        if product_name is not 'nginx':
+        if product_name != 'nginx':
             logger.warning("NGINX derivative %s is not officially supported by"
                            " certbot", product_name)
 


### PR DESCRIPTION
Check the value of the variable instead of checking if it points to the same object.

Without this, the check will return inconsistent results depending how interpreter has managed and optimized the instance memory.