### PR TITLE
Bump certbot's acme depenency to 0.22.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,7 @@ version = meta['version']
 # specified here to avoid masking the more specific request requirements in
 # acme. See https://github.com/pypa/pip/issues/988 for more info.
 install_requires = [
-    # Remember to update local-oldest-requirements.txt when changing the
-    # minimum acme version.
-    'acme>0.21.1',
+    'acme>=0.22.1',
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
     # saying so here causes a runtime error against our temporary fork of 0.9.3
     # in which we added 2.6 support (see #2243), so we relax the requirement.


### PR DESCRIPTION
Fixes #5821. Also removed the comment about `local-oldest-requirements.txt` since it doesn't seem to be relevant anymore.