### PR TITLE
Include testdata

### DIFF
--- a/certbot-dns-google/MANIFEST.in
+++ b/certbot-dns-google/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.txt
 include README.rst
 recursive-include docs *
+recursive-include certbot_dns_google/testdata *


### PR DESCRIPTION
In #5791 we added `testdata` to the Google DNS plugin, but we didn't update packaging for that file to be included. This PR fixes that.

If you'd like to test this yourself, you can run the following bash script from the root of the repo on master and on this branch. It should fail on master, but pass when this branch is checked out.

Resolving #985 or #2189 would have caused me to catch this before the release.

```
#!/bin/bash -xe

MY_TMP=$(mktemp -d)
trap 'rm -rf "$MY_TMP"' EXIT
virtualenv -p python2 "$MY_TMP/venv"
. "$MY_TMP/venv/bin/activate"
cd certbot-dns-google
python setup.py clean
rm -rf build dist
python setup.py sdist
mv dist/* "$MY_TMP"

cd "$MY_TMP"
tar -xvf "certbot-dns-google-0.23.0.dev0.tar.gz"
cd certbot-dns-google-0.23.0.dev0
python setup.py build
python setup.py test
python setup.py install
```