### PR TITLE
Double max_rounds in auth_handler

### DIFF
--- a/certbot/auth_handler.py
+++ b/certbot/auth_handler.py
@@ -189,7 +189,7 @@ class AuthHandler(object):
         return active_achalls
 
     def _poll_challenges(self, aauthzrs, chall_update,
-                         best_effort, min_sleep=3, max_rounds=15):
+                         best_effort, min_sleep=3, max_rounds=30):
         """Wait for all challenge results to be determined."""
         indices_to_check = set(chall_update.keys())
         comp_indices = set()


### PR DESCRIPTION
Increase the maximum number of times we'll poll the authorization in Certbot. I increased `max_rounds` instead of `min_sleep` to keep sleep time low when the server is able to respond quickly.