### PR TITLE
Revert "use older boulder version (#5852)"

### DIFF
--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -7,11 +7,10 @@ set -xe
 export GOPATH=${GOPATH:-$HOME/gopath}
 BOULDERPATH=${BOULDERPATH:-$GOPATH/src/github.com/letsencrypt/boulder}
 if [ ! -d ${BOULDERPATH} ]; then
-  git clone https://github.com/letsencrypt/boulder ${BOULDERPATH}
+  git clone --depth=1 https://github.com/letsencrypt/boulder ${BOULDERPATH}
 fi
 
 cd ${BOULDERPATH}
-git checkout fa5c9176655d9fa8dfca188de08bd5373aca422f
 FAKE_DNS=$(ifconfig docker0 | grep "inet addr:" | cut -d: -f2 | awk '{ print $1}')
 [ -z "$FAKE_DNS" ] && FAKE_DNS=$(ifconfig docker0 | grep "inet " | xargs | cut -d ' ' -f 2)
 [ -z "$FAKE_DNS" ] && FAKE_DNS=$(ip addr show dev docker0 | grep "inet " | xargs | cut -d ' ' -f 2 | cut -d '/' -f 1)


### PR DESCRIPTION
This reverts commit 6b29d159a2f221c3437770bdb43924ee6f953c4b now that https://github.com/letsencrypt/boulder/pull/3643 has landed.