### PR TITLE
Get mypy tox env running in the current setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ tests/letstest/venv/
 
 # pytest cache
 .cache
+.mypy_cache/
 
 # docker files
 .docker

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,10 @@ dev_extras = [
     'wheel',
 ]
 
+dev3_extras = [
+    'mypy',
+]
+
 docs_extras = [
     'repoze.sphinx.autointerface',
     # autodoc_member_order = 'bysource', autodoc_default_flags, and #4686
@@ -110,6 +114,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'dev': dev_extras,
+        'dev3': dev3_extras,
         'docs': docs_extras,
     },
 

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -30,6 +30,7 @@ josepy==1.0.1
 logger==1.4
 logilab-common==1.4.1
 MarkupSafe==1.0
+mypy==0.580
 ndg-httpsclient==0.3.2
 oauth2client==2.0.0
 pathlib2==2.3.0

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -67,6 +67,8 @@ tox==2.9.1
 tqdm==4.19.4
 traitlets==4.3.2
 twine==1.9.1
+typed-ast==1.1.0
+typing==3.6.4
 uritemplate==0.6
 virtualenv==15.1.0
 wcwidth==0.1.7

--- a/tox.ini
+++ b/tox.ini
@@ -136,9 +136,9 @@ commands =
     pylint --reports=n --rcfile=.pylintrc {[base]source_paths}
 
 [testenv:mypy]
-basepython = python3.4
+basepython = python3.5
 commands =
-    {[base]pip_install} mypy
+    {[base]pip_install} .[dev3]
     {[base]install_packages}
     mypy --py2 --ignore-missing-imports {[base]source_paths}
 

--- a/tox.ini
+++ b/tox.ini
@@ -136,7 +136,7 @@ commands =
     pylint --reports=n --rcfile=.pylintrc {[base]source_paths}
 
 [testenv:mypy]
-basepython = python3.5
+basepython = python3
 commands =
     {[base]pip_install} .[dev3]
     {[base]install_packages}


### PR DESCRIPTION
Fixes #5848.

This doesn't run it in tests, just gets `mypy` literally able to be run at all. `mypy` only runs under python3.