### PR TITLE
Update constants.py

### DIFF
--- a/certbot-nginx/certbot_nginx/constants.py
+++ b/certbot-nginx/certbot_nginx/constants.py
@@ -8,7 +8,7 @@ else:
     server_root_tmp = "/etc/nginx"
     
 CLI_DEFAULTS = dict(
-    server_root=server_root_tmp
+    server_root=server_root_tmp,
     ctl="nginx",
 )
 """CLI defaults."""

--- a/certbot-nginx/certbot_nginx/constants.py
+++ b/certbot-nginx/certbot_nginx/constants.py
@@ -1,9 +1,14 @@
 """nginx plugin constants."""
 import pkg_resources
+import platform
 
-
+if(platform.system() == ('FreeBSD' or 'Darwin')):
+    server_root_tmp = "/usr/local/etc/nginx"
+else:
+    server_root_tmp = "/etc/nginx"
+    
 CLI_DEFAULTS = dict(
-    server_root="/etc/nginx",
+    server_root=server_root_tmp
     ctl="nginx",
 )
 """CLI defaults."""


### PR DESCRIPTION
On FreeBSD or MacOS, "certbot --nginx" fails. The reason is, at these op. systems, nginx directory is different than linux.