### PR TITLE
 Get mypy running with clean output

### DIFF
--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/dns_digitalocean_test.py
@@ -50,7 +50,8 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
 
 class DigitalOceanClientTest(unittest.TestCase):
-    id = 1
+
+    id_num = 1
     record_prefix = "_acme-challenge"
     record_name = record_prefix + "." + DOMAIN
     record_content = "bar"
@@ -70,7 +71,7 @@ class DigitalOceanClientTest(unittest.TestCase):
 
         domain_mock = mock.MagicMock()
         domain_mock.name = DOMAIN
-        domain_mock.create_new_domain_record.return_value = {'domain_record': {'id': self.id}}
+        domain_mock.create_new_domain_record.return_value = {'domain_record': {'id': self.id_num}}
 
         self.manager.get_all_domains.return_value = [wrong_domain_mock, domain_mock]
 

--- a/certbot/crypto_util.py
+++ b/certbot/crypto_util.py
@@ -13,7 +13,7 @@ import pyrfc3339
 import six
 import zope.component
 from cryptography.hazmat.backends import default_backend
-from cryptography import x509
+from cryptography import x509 # type: ignore
 
 from acme import crypto_util as acme_crypto_util
 

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -216,11 +216,12 @@ class CertificatesTest(BaseCertManagerTest):
         cert.is_test_cert = False
         parsed_certs = [cert]
 
+        mock_config = mock.MagicMock(certname=None, lineagename=None)
+        # pylint: disable=protected-access
+
         # pylint: disable=protected-access
         get_report = lambda: cert_manager._report_human_readable(mock_config, parsed_certs)
 
-        mock_config = mock.MagicMock(certname=None, lineagename=None)
-        # pylint: disable=protected-access
         out = get_report()
         self.assertTrue("INVALID: EXPIRED" in out)
 

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -54,7 +54,7 @@ _INITIAL_PID = os.getpid()
 # the dict are attempted to be cleaned up at program exit. If the
 # program exits before the lock is cleaned up, it is automatically
 # released, but the file isn't deleted.
-_LOCKS = OrderedDict()
+_LOCKS = OrderedDict() # type: OrderedDict[str, lock.LockFile]
 
 
 def run_script(params, log=logger.error):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 2.7
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ basepython = python3
 commands =
     {[base]pip_install} .[dev3]
     {[base]install_packages}
-    mypy --py2 --ignore-missing-imports {[base]source_paths}
+    mypy {[base]source_paths}
 
 [testenv:apacheconftest]
 #basepython = python2.7


### PR DESCRIPTION
Fixes #5849.

~mypy will run with clean output once #5863 is merged.~