### PR TITLE
Add autorenew option to `renew` subcommand

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1192,6 +1192,14 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         default=flag_default("directory_hooks"), dest="directory_hooks",
         help="Disable running executables found in Certbot's hook directories"
         " during renewal. (default: False)")
+    helpful.add(
+        "renew", "--autorenew", action="store_true",
+        dest="autorenew", help="Enable auto renewal of certificates."
+        )
+    helpful.add(
+        "renew", "--no-autorenew", action="store_false",
+        dest="autorenew", help="Disable auto renewal of certificates."
+        )
 
     helpful.add_deprecated_argument("--agree-dev-preview", 0)
     helpful.add_deprecated_argument("--dialog", 0)

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -37,6 +37,7 @@ CLI_DEFAULTS = dict(
     expand=False,
     renew_by_default=False,
     renew_with_new_domains=False,
+    autorenew=True,
     allow_subset_of_names=False,
     tos=False,
     account=None,


### PR DESCRIPTION
Notes:

  - The `autorenew` flag check is done in
    `certbot.renewal.handle_renewal_request`; not sure if this the right
    place to do it.

  - The `webroot_path` and `installer` fields are getting removed from
  renewalparams (in renewal conf file) after the first `certbot renew
  --cert-name ... --no-autorenew` or `certbot renew --cert-name ... --autorenew`.

Addresses issue #4504.