### PR TITLE
Gradually increasing HSTS max-age

### DIFF
--- a/certbot-apache/certbot_apache/apache_util.py
+++ b/certbot-apache/certbot_apache/apache_util.py
@@ -1,4 +1,5 @@
 """ Utility functions for certbot-apache plugin """
+import binascii
 import os
 
 from certbot import util
@@ -98,3 +99,8 @@ def parse_define_file(filepath, varname):
             var_parts = v[2:].partition("=")
             return_vars[var_parts[0]] = var_parts[2]
     return return_vars
+
+
+def unique_id():
+    """ Returns an unique id to be used as a VirtualHost identifier"""
+    return binascii.hexlify(os.urandom(16))

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -1671,7 +1671,11 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         """
         Increase the AutoHSTS values of VirtualHosts
         """
-        managed = self.storage.fetch("autohsts")
+        try:
+            managed = self.storage.fetch("autohsts")
+        except KeyError:
+            # AutoHSTS not enabled
+            return
         curtime = time.time()
         for id_str in managed:
             if managed[id_str]["timestamp"] + constants.AUTOHSTS_FREQ > curtime:
@@ -1686,8 +1690,9 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         """
         Save the current state of AutoHSTS steps with a timestamp
         """
-        managed = self.storage.fetch("autohsts")
-        if not managed:
+        try:
+            managed = self.storage.fetch("autohsts")
+        except KeyError:
             managed = dict()
         managed[id_str] = {"laststep": laststep, "timestamp": time.time()}
         self.storage.put("autohsts", managed)
@@ -1698,7 +1703,11 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         Checks if autohsts vhost has reached maximum auto-increased value
         and changes the HSTS max-age to a high value.
         """
-        managed = self.storage.fetch("autohsts")
+        try:
+            managed = self.storage.fetch("autohsts")
+        except KeyError:
+            # No active AutoHSTS entries
+            return
         vhosts = []
         # Copy, as we are removing from the dict inside the loop
         for id_str in managed.keys()[:]:

--- a/certbot-apache/certbot_apache/constants.py
+++ b/certbot-apache/certbot_apache/constants.py
@@ -48,3 +48,16 @@ UIR_ARGS = ["always", "set", "Content-Security-Policy",
 
 HEADER_ARGS = {"Strict-Transport-Security": HSTS_ARGS,
                "Upgrade-Insecure-Requests": UIR_ARGS}
+
+AUTOHSTS_STEPS = [60, 300, 900, 3600, 21600, 43200, 86400]
+"""AutoHSTS increase steps: 5min, 15min, 1h, 6h, 12h, 24h"""
+
+AUTOHSTS_PERMANENT = 31536000
+"""Value for the last max-age of HSTS"""
+
+AUTOHSTS_FREQ = 36000
+"""Minimum time since last increase to perform a new one"""
+
+MANAGED_COMMENT = "DO NOT REMOVE - Managed by Certbot"
+MANAGED_COMMENT_ID = MANAGED_COMMENT+", VirtualHost id: {0}"
+"""Managed by Certbot comments and the VirtualHost identification template"""

--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -349,6 +349,37 @@ class ApacheParser(object):
         else:
             self.aug.set(first_dir + "/arg", args)
 
+    def add_comment(self, aug_conf_path, comment):
+        """Adds the comment to the augeas path
+
+        :param str aug_conf_path: Augeas configuration path to add directive
+        :param str comment: Comment content
+
+        """
+        self.aug.set(aug_conf_path + "/#comment[last() + 1]", comment)
+
+    def find_comments(self, arg, start=None):
+        """Finds a comment with specified content from the provided DOM path
+
+        :param str arg: Comment content to search
+        :param str start: Beginning Augeas path to begin looking
+
+        :returns: List of augeas paths containing the comment content
+        :rtype: list
+
+        """
+        if not start:
+            start = get_aug_path(self.root)
+
+        comments = self.aug.match("%s//*[label() = '#comment']" % start)
+
+        results = []
+        for comment in comments:
+            c_content = self.aug.get(comment)
+            if c_content and arg in c_content:
+                results.append(comment)
+        return results
+
     def find_dir(self, directive, arg=None, start=None, exclude=True):
         """Finds directive in the configuration.
 

--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class ApacheParser(object):
+    # pylint: disable=too-many-public-methods
     """Class handles the fine details of parsing the Apache Configuration.
 
     .. todo:: Make parsing general... remove sites-available etc...

--- a/certbot-apache/certbot_apache/tests/autohsts_test.py
+++ b/certbot-apache/certbot_apache/tests/autohsts_test.py
@@ -1,0 +1,124 @@
+# pylint: disable=too-many-public-methods,too-many-lines
+"""Test for certbot_apache.configurator AutoHSTS functionality"""
+import re
+import unittest
+import mock
+# six is used in mock.patch()
+import six  # pylint: disable=unused-import
+
+from certbot import errors
+from certbot_apache import constants
+from certbot_apache.tests import util
+
+
+class AutoHSTSTest(util.ApacheTest):
+    """Tests for AutoHSTS feature"""
+    # pylint: disable=protected-access
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super(AutoHSTSTest, self).setUp()
+
+        self.config = util.get_apache_configurator(
+            self.config_path, self.vhost_path, self.config_dir, self.work_dir)
+        self.config.parser.modules.add("headers_module")
+        self.config.parser.modules.add("mod_headers.c")
+        self.config.parser.modules.add("ssl_module")
+        self.config.parser.modules.add("mod_ssl.c")
+
+        self.vh_truth = util.get_vh_truth(
+            self.temp_dir, "debian_apache_2_4/multiple_vhosts")
+
+    def get_autohsts_value(self, vh_path):
+        """ Get value from Strict-Transport-Security header """
+        header_path = self.config.parser.find_dir("Header", None, vh_path)
+        if header_path:
+            pat = '(?:[ "]|^)(strict-transport-security)(?:[ "]|$)'
+            for head in header_path:
+                if re.search(pat, self.config.parser.aug.get(head).lower()):
+                    return self.config.parser.aug.get(head.replace("arg[3]",
+                                                                   "arg[4]"))
+
+    @mock.patch("certbot_apache.configurator.ApacheConfigurator.enable_mod")
+    def test_autohsts_enable_headers_mod(self, mock_enable):
+        self.config.parser.modules.discard("headers_module")
+        self.config.parser.modules.discard("mod_header.c")
+        self.config.enhance("ocspvhost.com", "auto_hsts", None)
+        self.assertTrue(mock_enable.called)
+
+    def test_autohsts_deploy(self):
+        self.config.enhance("ocspvhost.com", "auto_hsts", None)
+
+    @mock.patch("certbot_apache.configurator.logger.warning")
+    def test_autohsts_deploy_already_exists(self, mock_log):
+        self.config.enhance("ocspvhost.com", "auto_hsts", None)
+        self.config.enhance("ocspvhost.com", "auto_hsts", None)
+        self.assertTrue(mock_log.called)
+        self.assertTrue("header is already present" in mock_log.call_args[0][0])
+
+    @mock.patch("certbot_apache.constants.AUTOHSTS_FREQ", 0)
+    def test_autohsts_increase(self):
+        maxage = "\"max-age={0}\""
+        initial_val = maxage.format(constants.AUTOHSTS_STEPS[0])
+        inc_val = maxage.format(constants.AUTOHSTS_STEPS[1])
+
+        self.config.enhance("ocspvhost.com", "auto_hsts", None)
+        # Verify initial value
+        self.assertEquals(self.get_autohsts_value(self.vh_truth[7].path),
+                          initial_val)
+        # Increase
+        self.config.generic_updates("ocspvhost.com")
+        # Verify increased value
+        self.assertEquals(self.get_autohsts_value(self.vh_truth[7].path),
+                          inc_val)
+
+    @mock.patch("certbot_apache.configurator.ApacheConfigurator._autohsts_increase")
+    def test_autohsts_increase_noop(self, mock_increase):
+        maxage = "\"max-age={0}\""
+        initial_val = maxage.format(constants.AUTOHSTS_STEPS[0])
+        self.config.enhance("ocspvhost.com", "auto_hsts", None)
+        # Verify initial value
+        self.assertEquals(self.get_autohsts_value(self.vh_truth[7].path),
+                          initial_val)
+
+        self.config.generic_updates("ocspvhost.com")
+        # Freq not patched, so value shouldn't increase
+        self.assertFalse(mock_increase.called)
+
+
+    @mock.patch("certbot_apache.constants.AUTOHSTS_FREQ", 0)
+    def test_autohsts_increase_no_header(self):
+        self.config.enhance("ocspvhost.com", "auto_hsts", None)
+        # Remove the header
+        dir_locs = self.config.parser.find_dir("Header", None,
+                                              self.vh_truth[7].path)
+        dir_loc = "/".join(dir_locs[0].split("/")[:-1])
+        self.config.parser.aug.remove(dir_loc)
+        self.assertRaises(errors.PluginError,
+                          self.config.generic_updates,
+                          "ocspvhost.com")
+
+    @mock.patch("certbot_apache.constants.AUTOHSTS_FREQ", 0)
+    def test_autohsts_increase_and_make_permanent(self):
+        maxage = "\"max-age={0}\""
+        max_val = maxage.format(constants.AUTOHSTS_PERMANENT)
+        mock_lineage = mock.MagicMock()
+        mock_lineage.key_path = "/etc/apache2/ssl/key-certbot_15.pem"
+        self.config.enhance("ocspvhost.com", "auto_hsts", None)
+        for i in range(len(constants.AUTOHSTS_STEPS)-1):
+            # Ensure that value is not made permanent prematurely
+            self.config.renew_deploy(mock_lineage)
+            self.assertNotEquals(self.get_autohsts_value(self.vh_truth[7].path),
+                                 max_val)
+            self.config.generic_updates("ocspvhost.com")
+            # Value should match pre-permanent increment step
+            cur_val = maxage.format(constants.AUTOHSTS_STEPS[i+1])
+            self.assertEquals(self.get_autohsts_value(self.vh_truth[7].path),
+                              cur_val)
+        # Make permanent
+        self.config.renew_deploy(mock_lineage)
+        self.assertEquals(self.get_autohsts_value(self.vh_truth[7].path),
+                          max_val)
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot-apache/certbot_apache/tests/autohsts_test.py
+++ b/certbot-apache/certbot_apache/tests/autohsts_test.py
@@ -119,6 +119,19 @@ class AutoHSTSTest(util.ApacheTest):
         self.assertEquals(self.get_autohsts_value(self.vh_truth[7].path),
                           max_val)
 
+    def test_autohsts_update_noop(self):
+        with mock.patch("time.time") as mock_time:
+            # Time mock is used to make sure that the execution does not
+            # continue when no autohsts entries exist in pluginstorage
+            self.config._autohsts_update()
+            self.assertFalse(mock_time.called)
+
+    def test_autohsts_make_permanent_noop(self):
+        self.config.storage.put = mock.MagicMock()
+        self.config._autohsts_make_permanent(mock.MagicMock())
+        # Make sure that the execution does not continue when no entries in store
+        self.assertFalse(self.config.storage.put.called)
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -1490,6 +1490,19 @@ class MultipleVhostsTest(util.ApacheTest):
                             "Upgrade-Insecure-Requests")
         self.assertTrue(mock_choose.called)
 
+    def test_add_vhost_id(self):
+        for vh in [self.vh_truth[0], self.vh_truth[1], self.vh_truth[2]]:
+            vh_id = self.config.add_vhost_id(vh)
+            self.assertEqual(vh, self.config.find_vhost_by_id(vh_id))
+
+    def test_find_vhost_by_id_404(self):
+        self.assertEqual(None, self.config.find_vhost_by_id("nonexistent"))
+
+    def test_add_vhost_id_already_exists(self):
+        first_id = self.config.add_vhost_id(self.vh_truth[0])
+        second_id = self.config.add_vhost_id(self.vh_truth[0])
+        self.assertEqual(first_id, second_id)
+
 
 class AugeasVhostsTest(util.ApacheTest):
     """Test vhosts with illegal names dependent on augeas version."""

--- a/certbot-apache/certbot_apache/tests/parser_test.py
+++ b/certbot-apache/certbot_apache/tests/parser_test.py
@@ -299,6 +299,13 @@ class BasicParserTest(util.ParserTest):
             errors.MisconfigurationError,
             self.parser.update_runtime_variables)
 
+    def test_add_comment(self):
+        from certbot_apache.parser import get_aug_path
+        self.parser.add_comment(get_aug_path(self.parser.loc["name"]), "123456")
+        comm = self.parser.find_comments("123456")
+        self.assertEquals(len(comm), 1)
+        self.assertTrue(self.parser.loc["name"] in comm[0])
+
 
 class ParserInitTest(util.ApacheTest):
     def setUp(self):  # pylint: disable=arguments-differ

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1106,6 +1106,12 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
              "authenticated vhost. (default: Ask)")
     helpful.add(
         ["security", "enhance"],
+        "--auto-hsts", action="store_true", dest="auto_hsts",
+        default=flag_default("auto_hsts"),
+        help="Automatically increase Strict-Transport-Security header maxAge "
+             "value over time. Implies --hsts.")
+    helpful.add(
+        ["security", "enhance"],
         "--hsts", action="store_true", dest="hsts", default=flag_default("hsts"),
         help="Add the Strict-Transport-Security header to every HTTP response."
              " Forcing browser to always use SSL for the domain."

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -484,6 +484,7 @@ class Client(object):
 
         enhanced = False
         enhancement_info = (
+            ("auto_hsts", "auto_hsts", None),
             ("hsts", "ensure-http-header", "Strict-Transport-Security"),
             ("redirect", "redirect", None),
             ("staple", "staple-ocsp", chain_path),

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -57,6 +57,7 @@ CLI_DEFAULTS = dict(
     rsa_key_size=2048,
     must_staple=False,
     redirect=None,
+    auto_hsts=False,
     hsts=None,
     uir=None,
     staple=None,

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -875,7 +875,7 @@ def enhance(config, plugins):
     :rtype: None
 
     """
-    supported_enhancements = ["hsts", "redirect", "uir", "staple"]
+    supported_enhancements = ["auto_hsts", "hsts", "redirect", "uir"]
     # Check that at least one enhancement was requested on command line
     if not any([getattr(config, enh) for enh in supported_enhancements]):
         msg = ("Please specify one or more enhancement types to configure. To list "


### PR DESCRIPTION
This PR adds the functionality to enhance Apache configuration to include HTTP Strict Transport Security header with a low initial `max-age` value.

The `max-age` value will get increased on every (scheduled) run of `certbot renew` regardless of the certificate actually getting renewed, if the last increase took place longer than ten hours ago. The increase steps are visible in `constants.AUTOHSTS_STEPS`.

Upon the first actual renewal after reaching the maximum increase step, the `max-age` value will be made "permanent" and will get value of one year.

To achieve accurate `VirtualHost` discovery on subsequent runs, a comment with unique id string will be added to each enhanced `VirtualHost`.