### PR TITLE
Turn off cancel notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ notifications:
   irc:
     channels:
       - secure: "SGWZl3ownKx9xKVV2VnGt7DqkTmutJ89oJV9tjKhSs84kLijU6EYdPnllqISpfHMTxXflNZuxtGo0wTDYHXBuZL47w1O32W6nzuXdra5zC+i4sYQwYULUsyfOv9gJX8zWAULiK0Z3r0oho45U+FR5ZN6TPCidi8/eGU+EEPwaAw="
+    on_cancel: never
     on_success: never
     on_failure: always
     use_notice: true


### PR DESCRIPTION
By default, Travis cancels builds on branches and PRs if another commit lands in favor of running tests on that. See https://blog.travis-ci.com/2017-09-21-default-auto-cancellation.

I think this behavior is good as it stops us spending resources testing out of date code, but with our current setup, it causes Travis to send us notifications when builds are automatically canceled on master.

This PR changes that by not sending out notifications when a build gets canceled.