### PR TITLE
Use new boulder IP

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -127,7 +127,7 @@ Boulder:
 
 .. code-block:: shell
 
-   export SERVER=http://localhost:4000/directory
+   export SERVER=http://10.77.77.77:4000/directory
    source tests/integration/_common.sh
 
 Run the integration tests using:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -127,7 +127,6 @@ Boulder:
 
 .. code-block:: shell
 
-   export SERVER=http://10.77.77.77:4000/directory
    source tests/integration/_common.sh
 
 Run the integration tests using:

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -24,9 +24,10 @@ if [ "$BOULDER_INTEGRATION" = "v2" ]; then
 fi
 
 docker-compose up -d
+echo 10.77.77.77 boulder | sudo tee -a /etc/hosts
 
 set +x  # reduce verbosity while waiting for boulder
-until curl http://10.77.77.77:4000/directory 2>/dev/null; do
+until curl http://boulder:4000/directory 2>/dev/null; do
   echo waiting for boulder
   sleep 1
 done

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -25,6 +25,7 @@ fi
 
 docker-compose up -d
 echo 10.77.77.77 boulder | sudo tee -a /etc/hosts
+cat /etc/hosts
 
 set +x  # reduce verbosity while waiting for boulder
 for n in `seq 1 60` ; do

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -26,7 +26,7 @@ fi
 docker-compose up -d
 
 set +x  # reduce verbosity while waiting for boulder
-until curl http://localhost:4000/directory 2>/dev/null; do
+until curl http://10.77.77.77:4000/directory 2>/dev/null; do
   echo waiting for boulder
   sleep 1
 done

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -34,4 +34,8 @@ for n in `seq 1 300` ; do
     echo waiting for boulder
     sleep 1
   fi
+  if [[ $n == 300 ]]; then
+    echo timed out waiting for boulder
+    exit 1
+  fi
 done

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -28,7 +28,7 @@ printf "\n10.77.77.77 boulder" | sudo tee -a /etc/hosts
 
 set +x  # reduce verbosity while waiting for boulder
 for n in `seq 1 300` ; do
-  if curl -v http://boulder:4000/directory ; then
+  if curl http://boulder:4000/directory 2>/dev/null ; then
     break
   else
     echo waiting for boulder

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -34,4 +34,7 @@ for n in `seq 1 60` ; do
     echo waiting for boulder
     sleep 1
   fi
+  if [[ $n = 60 ]]; then
+    docker-compose logs boulder
+  fi
 done

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -27,7 +27,7 @@ docker-compose up -d
 printf "\n10.77.77.77 boulder" | sudo tee -a /etc/hosts
 
 set +x  # reduce verbosity while waiting for boulder
-for n in `seq 1 60` ; do
+for n in `seq 1 300` ; do
   if curl -v http://boulder:4000/directory ; then
     break
   else

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -27,7 +27,7 @@ docker-compose up -d
 echo 10.77.77.77 boulder | sudo tee -a /etc/hosts
 
 set +x  # reduce verbosity while waiting for boulder
-until curl http://boulder:4000/directory 2>/dev/null; do
+until curl http://boulder:4000/directory ; do
   echo waiting for boulder
   sleep 1
 done

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -27,7 +27,11 @@ docker-compose up -d
 echo 10.77.77.77 boulder | sudo tee -a /etc/hosts
 
 set +x  # reduce verbosity while waiting for boulder
-until curl http://boulder:4000/directory ; do
-  echo waiting for boulder
-  sleep 1
+for n in `seq 1 60` ; do
+  if curl -v http://boulder:4000/directory ; then
+    break
+  else
+    echo waiting for boulder
+    sleep 1
+  fi
 done

--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -24,8 +24,7 @@ if [ "$BOULDER_INTEGRATION" = "v2" ]; then
 fi
 
 docker-compose up -d
-echo 10.77.77.77 boulder | sudo tee -a /etc/hosts
-cat /etc/hosts
+printf "\n10.77.77.77 boulder" | sudo tee -a /etc/hosts
 
 set +x  # reduce verbosity while waiting for boulder
 for n in `seq 1 60` ; do
@@ -34,8 +33,5 @@ for n in `seq 1 60` ; do
   else
     echo waiting for boulder
     sleep 1
-  fi
-  if [[ $n = 60 ]]; then
-    docker-compose logs boulder
   fi
 done

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -16,7 +16,7 @@ certbot_test () {
         "$@"
 }
 
-export BOULDER_IP=${BOULDER_IP:10.77.77.77}
+export BOULDER_IP=10.77.77.77
 export SERVER=${SERVER:-http://$BOULDER_IP:4000/directory}
 # Use local ACMEv2 endpoint if requested and SERVER isn't already set.
 if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -18,7 +18,7 @@ certbot_test () {
 
 # Use local ACMEv2 endpoint if requested and SERVER isn't already set.
 if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
-    SERVER="http://localhost:4001/directory"
+    SERVER="http://10.77.77.77:4001/directory"
 fi
 
 certbot_test_no_force_renew () {
@@ -30,7 +30,7 @@ certbot_test_no_force_renew () {
         --source $sources \
         --omit $omit_patterns \
         $(command -v certbot) \
-            --server "${SERVER:-http://localhost:4000/directory}" \
+            --server "${SERVER:-http://boulder:4000/directory}" \
             --no-verify-ssl \
             --tls-sni-01-port $tls_sni_01_port \
             --http-01-port $http_01_port \

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -16,11 +16,10 @@ certbot_test () {
         "$@"
 }
 
-export BOULDER_IP=10.77.77.77
-export SERVER=${SERVER:-http://$BOULDER_IP:4000/directory}
+export SERVER=${SERVER:-http://boulder:4000/directory}
 # Use local ACMEv2 endpoint if requested and SERVER isn't already set.
 if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
-    SERVER="http://$BOULDER_IP:4001/directory"
+    SERVER="http://boulder:4001/directory"
 fi
 
 certbot_test_no_force_renew () {

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -30,7 +30,7 @@ certbot_test_no_force_renew () {
         --source $sources \
         --omit $omit_patterns \
         $(command -v certbot) \
-            --server "${SERVER:-http://boulder:4000/directory}" \
+            --server "${SERVER:-http://10.77.77.77:4000/directory}" \
             --no-verify-ssl \
             --tls-sni-01-port $tls_sni_01_port \
             --http-01-port $http_01_port \

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -16,9 +16,11 @@ certbot_test () {
         "$@"
 }
 
+export BOULDER_IP=${BOULDER_IP:10.77.77.77}
+export SERVER=${SERVER:-http://$BOULDER_IP:4000/directory}
 # Use local ACMEv2 endpoint if requested and SERVER isn't already set.
 if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
-    SERVER="http://10.77.77.77:4001/directory"
+    SERVER="http://$BOULDER_IP:4001/directory"
 fi
 
 certbot_test_no_force_renew () {
@@ -30,7 +32,7 @@ certbot_test_no_force_renew () {
         --source $sources \
         --omit $omit_patterns \
         $(command -v certbot) \
-            --server "${SERVER:-http://10.77.77.77:4000/directory}" \
+            --server "${SERVER}" \
             --no-verify-ssl \
             --tls-sni-01-port $tls_sni_01_port \
             --http-01-port $http_01_port \

--- a/tests/manual-dns-auth.sh
+++ b/tests/manual-dns-auth.sh
@@ -2,7 +2,7 @@
 
 # If domain begins with fail, fail the challenge by not completing it.
 if [[ "$CERTBOT_DOMAIN" != fail* ]]; then
-    curl -X POST "http://$BOULDER_IP:8055/set-txt" -d \
+    curl -X POST "http://boulder:8055/set-txt" -d \
         "{\"host\": \"_acme-challenge.$CERTBOT_DOMAIN.\", \
          \"value\": \"$CERTBOT_VALIDATION\"}"
 fi

--- a/tests/manual-dns-auth.sh
+++ b/tests/manual-dns-auth.sh
@@ -2,7 +2,7 @@
 
 # If domain begins with fail, fail the challenge by not completing it.
 if [[ "$CERTBOT_DOMAIN" != fail* ]]; then
-    curl -X POST 'http://$BOULDER_IP:8055/set-txt' -d \
+    curl -X POST "http://$BOULDER_IP:8055/set-txt" -d \
         "{\"host\": \"_acme-challenge.$CERTBOT_DOMAIN.\", \
          \"value\": \"$CERTBOT_VALIDATION\"}"
 fi

--- a/tests/manual-dns-auth.sh
+++ b/tests/manual-dns-auth.sh
@@ -2,7 +2,7 @@
 
 # If domain begins with fail, fail the challenge by not completing it.
 if [[ "$CERTBOT_DOMAIN" != fail* ]]; then
-    curl -X POST 'http://localhost:8055/set-txt' -d \
+    curl -X POST 'http://$BOULDER_IP:8055/set-txt' -d \
         "{\"host\": \"_acme-challenge.$CERTBOT_DOMAIN.\", \
          \"value\": \"$CERTBOT_VALIDATION\"}"
 fi

--- a/tests/manual-dns-cleanup.sh
+++ b/tests/manual-dns-cleanup.sh
@@ -3,6 +3,6 @@
 # If domain begins with fail, we didn't complete the challenge so there is
 # nothing to clean up.
 if [[ "$CERTBOT_DOMAIN" != fail* ]]; then
-    curl -X POST 'http://localhost:8055/clear-txt' -d \
+    curl -X POST 'http://$BOULDER_IP:8055/clear-txt' -d \
         "{\"host\": \"_acme-challenge.$CERTBOT_DOMAIN.\"}"
 fi

--- a/tests/manual-dns-cleanup.sh
+++ b/tests/manual-dns-cleanup.sh
@@ -3,6 +3,6 @@
 # If domain begins with fail, we didn't complete the challenge so there is
 # nothing to clean up.
 if [[ "$CERTBOT_DOMAIN" != fail* ]]; then
-    curl -X POST 'http://$BOULDER_IP:8055/clear-txt' -d \
+    curl -X POST "http://$BOULDER_IP:8055/clear-txt" -d \
         "{\"host\": \"_acme-challenge.$CERTBOT_DOMAIN.\"}"
 fi

--- a/tests/manual-dns-cleanup.sh
+++ b/tests/manual-dns-cleanup.sh
@@ -3,6 +3,6 @@
 # If domain begins with fail, we didn't complete the challenge so there is
 # nothing to clean up.
 if [[ "$CERTBOT_DOMAIN" != fail* ]]; then
-    curl -X POST "http://$BOULDER_IP:8055/clear-txt" -d \
+    curl -X POST "http://boulder:8055/clear-txt" -d \
         "{\"host\": \"_acme-challenge.$CERTBOT_DOMAIN.\"}"
 fi

--- a/tools/deactivate.py
+++ b/tools/deactivate.py
@@ -24,7 +24,7 @@ from acme import client as acme_client
 from acme import errors as acme_errors
 from acme import messages
 
-DIRECTORY = os.getenv('DIRECTORY', 'http://localhost:4000/directory')
+DIRECTORY = os.getenv('DIRECTORY', 'http://10.77.77.77:4000/directory')
 
 if len(sys.argv) != 2:
     print("Usage: python deactivate.py private_key.pem")

--- a/tools/deactivate.py
+++ b/tools/deactivate.py
@@ -24,7 +24,7 @@ from acme import client as acme_client
 from acme import errors as acme_errors
 from acme import messages
 
-DIRECTORY = os.getenv('DIRECTORY', 'http://10.77.77.77:4000/directory')
+DIRECTORY = os.getenv('DIRECTORY', 'http://localhost:4000/directory')
 
 if len(sys.argv) != 2:
     print("Usage: python deactivate.py private_key.pem")


### PR DESCRIPTION
Boulder changed its docker-compose.yml to no longer publish its ports to localhost by default; instead it sets up on 10.77.77.77 on the local Docker network. This updates the Certbot integration tests to work with those changes.