### PR TITLE
Temporarily disable apacheconftest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,6 @@ matrix:
       before_install:
       addons:
     - python: "2.7"
-      env: TOXENV=apacheconftest
-      sudo: required
-    - python: "2.7"
       env: TOXENV=nginxroundtrip
 
 


### PR DESCRIPTION
This allows tests to begin working again while staging is down for maintenance.