### PR TITLE
Revert "disable apacheconftest (#5937)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ matrix:
       before_install:
       addons:
     - python: "2.7"
+      env: TOXENV=apacheconftest
+      sudo: required
+    - python: "2.7"
       env: TOXENV=nginxroundtrip
 
 


### PR DESCRIPTION
This reverts commit 83ea820525d4342ee58baa0d6c6547b6843d8dc6.

This reenables this test now that staging is up again. Once this PR lands, `master` needs to be merged (**NOT SQUASHED**) into `test-everything` to fix the tests.