### PR TITLE
Add link to pycon issues

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -63,6 +63,10 @@ found in the `virtualenv docs`_.
 Find issues to work on
 ----------------------
 
+.. note:: If you're sprinting on Certbot at PyCon, you can find good issues to
+  work on during the event `here
+  <https://github.com/certbot/certbot/issues?q=is%3Aopen+is%3Aissue+project%3Acertbot%2Fcertbot%2F3>`_.
+
 You can find the open issues in the `github issue tracker`_.  Comparatively
 easy ones are marked `good first issue`_.  If you're starting work on
 something, post a comment to let others know and seek feedback on your plan

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -63,8 +63,8 @@ found in the `virtualenv docs`_.
 Find issues to work on
 ----------------------
 
-.. note:: If you're sprinting on Certbot at PyCon, you can find good issues to
-  work on during the event `here
+.. note:: If you're sprinting on Certbot at PyCon, you can find especially good
+  issues to work on during the event `here
   <https://github.com/certbot/certbot/issues?q=is%3Aopen+is%3Aissue+project%3Acertbot%2Fcertbot%2F3>`_.
 
 You can find the open issues in the `github issue tracker`_.  Comparatively


### PR DESCRIPTION
This adds a link to the issues picked for PyCon to our dev docs.

Initially I was planning on putting this on it's own page, but this is really the only PyCon specific instructions so setting up a separate page for this felt like overkill and scatters the instructions among multiple pages. After the event next week, we can revert this PR.