### PR TITLE
Gpg2 doc

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -74,20 +74,20 @@ download and run it as follows::
 
 
 	    
-	  user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
-	  user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	  user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	  user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+	    user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
+	    user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	    user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	    user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
 
-	  gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
-	  gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	  gpg: key 4D17C995CD9775F2 marked as ultimately trusted
-	  gpg: checking the trustdb
-	  gpg: marginals needed: 3  completes needed: 1  trust model: pgp
-	  gpg: depth: 0  valid:   2  signed:   2  trust: 0-, 0q, 0n, 0m, 0f, 2u
-	  gpg: depth: 1  valid:   2  signed:   0  trust: 2-, 0q, 0n, 0m, 0f, 0u
-	  gpg: next trustdb check due at 2027-11-22
-	  gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]
+	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
+	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	    gpg: key 4D17C995CD9775F2 marked as ultimately trusted
+	    gpg: checking the trustdb
+	    gpg: marginals needed: 3  completes needed: 1  trust model: pgp
+	    gpg: depth: 0  valid:   2  signed:   2  trust: 0-, 0q, 0n, 0m, 0f, 2u
+	    gpg: depth: 1  valid:   2  signed:   0  trust: 2-, 0q, 0n, 0m, 0f, 0u
+	    gpg: next trustdb check due at 2027-11-22
+	    gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]
 
 
 	    

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,10 +40,15 @@ supports
 <https://github.com/certbot/certbot/blob/master/certbot-apache/certbot_apache/constants.py>`_
 modern OSes based on Debian, Fedora, SUSE, Gentoo and Darwin.
 
+
+To double check the integrity of the ``certbot-auto`` script before running it requires gpg2 installed and
+setting an appropriate key server 
+
 Installing with ``certbot-auto`` requires 512MB of RAM in order to build some
 of the dependencies. Installing from pre-built OS packages avoids this
 requirement. You can also temporarily set a swap file. See "Problems with
 Python virtual environment" below for details.
+
 
 Alternate installation methods
 ================================
@@ -65,11 +70,23 @@ download and run it as follows::
   user@webserver:~$ ./certbot-auto --help
 
 .. hint:: The certbot-auto download is protected by HTTPS, which is pretty good, but if you'd like to
-          double check the integrity of the ``certbot-auto`` script, you can use these steps for verification before running it::
+          double check the integrity of the ``certbot-auto`` script, you can use these steps for verification before running it using gpg2::
 
+   
             user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
+	    user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
             user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
             user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
+	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	    gpg: key 4D17C995CD9775F2 marked as ultimately trusted
+	    gpg: checking the trustdb
+	    gpg: marginals needed: 3  completes needed: 1  trust model: pgp
+	    gpg: depth: 0  valid:   2  signed:   2  trust: 0-, 0q, 0n, 0m, 0f, 2u
+	    gpg: depth: 1  valid:   2  signed:   0  trust: 2-, 0q, 0n, 0m, 0f, 0u
+	    gpg: next trustdb check due at 2027-11-22
+	    gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]
+
 
 The ``certbot-auto`` command updates to the latest client release automatically.
 Since ``certbot-auto`` is a wrapper to ``certbot``, it accepts exactly

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,8 +41,8 @@ supports
 modern OSes based on Debian, Fedora, SUSE, Gentoo and Darwin.
 
 
-To double check the integrity of the ``certbot-auto`` script before running it using gpg2
-install the package gnupg
+To double check the integrity of the ``certbot-auto`` script before running it by gpg2
+requires the package gnupg installed
 
 
 Installing with ``certbot-auto`` requires 512MB of RAM in order to build some

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,13 +70,18 @@ download and run it as follows::
   user@webserver:~$ chmod a+x ./certbot-auto
   user@webserver:~$ ./certbot-auto --help
 
-To check the integrity of the ``certbot-auto`` script,  
+To check the integrity of the ``certbot-auto`` script,
 you can use these steps::
 
-	  
+
 	    user@webserver:~$ wget -N https://dl.eff.org/certbot-auto.asc
 	    user@webserver:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
 	    user@webserver:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+
+
+
+The output of the last command should look something like::
+
 
 	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
 	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
@@ -89,7 +94,7 @@ you can use these steps::
 	    gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]
 
 
-	    
+
 The ``certbot-auto`` command updates to the latest client release automatically.
 Since ``certbot-auto`` is a wrapper to ``certbot``, it accepts exactly
 the same command line flags and arguments. For more information, see

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -74,20 +74,20 @@ download and run it as follows::
 
 
 	    
-            user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
-	    user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+	  user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
+	  user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	  user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	  user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
 
-	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
-	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    gpg: key 4D17C995CD9775F2 marked as ultimately trusted
-	    gpg: checking the trustdb
-	    gpg: marginals needed: 3  completes needed: 1  trust model: pgp
-	    gpg: depth: 0  valid:   2  signed:   2  trust: 0-, 0q, 0n, 0m, 0f, 2u
-	    gpg: depth: 1  valid:   2  signed:   0  trust: 2-, 0q, 0n, 0m, 0f, 0u
-	    gpg: next trustdb check due at 2027-11-22
-	    gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]
+	  gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
+	  gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	  gpg: key 4D17C995CD9775F2 marked as ultimately trusted
+	  gpg: checking the trustdb
+	  gpg: marginals needed: 3  completes needed: 1  trust model: pgp
+	  gpg: depth: 0  valid:   2  signed:   2  trust: 0-, 0q, 0n, 0m, 0f, 2u
+	  gpg: depth: 1  valid:   2  signed:   0  trust: 2-, 0q, 0n, 0m, 0f, 0u
+	  gpg: next trustdb check due at 2027-11-22
+	  gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]
 
 
 	    

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -42,7 +42,7 @@ modern OSes based on Debian, Fedora, SUSE, Gentoo and Darwin.
 
 
 To double check the integrity of the ``certbot-auto`` script before running it using gpg2
-requires the package gnupg installed
+requires the package gnupg or gnupg2 installed
 
 
 Installing with ``certbot-auto`` requires 512MB of RAM in order to build some

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -75,11 +75,13 @@ download and run it as follows::
 
 	    
             user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
+	    
 	    user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	    
             user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	    
             user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
 
-	    
 	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
 	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
 	    gpg: key 4D17C995CD9775F2 marked as ultimately trusted

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,8 +41,8 @@ supports
 modern OSes based on Debian, Fedora, SUSE, Gentoo and Darwin.
 
 
-To double check the integrity of the ``certbot-auto`` script before running it using gpg2
-requires the package gnupg or gnupg2 installed
+Additional integrity verification of certbot-auto script can be done by verifying its digital signature.
+This requires a local installation of gpg2, which comes packaged in many Linux distributions under name gnupg or gnupg2.
 
 
 Installing with ``certbot-auto`` requires 512MB of RAM in order to build some
@@ -70,9 +70,7 @@ download and run it as follows::
   user@webserver:~$ chmod a+x ./certbot-auto
   user@webserver:~$ ./certbot-auto --help
 
-.. hint:: The certbot-auto download is protected by HTTPS, which is pretty good, but if you'd like to
-          double check the integrity of the ``certbot-auto`` script, you can use these steps for verification before running it using gpg2::
-
+.. hint:: To check the integrity of the ``certbot-auto`` script, you can use these steps::
 
 	    
 	    user@webserver:~$ wget -N https://dl.eff.org/certbot-auto.asc

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,7 +41,7 @@ supports
 modern OSes based on Debian, Fedora, SUSE, Gentoo and Darwin.
 
 
-To double check the integrity of the ``certbot-auto`` script before running it by gpg2
+To double check the integrity of the ``certbot-auto`` script before running it using gpg2
 requires the package gnupg installed
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -75,12 +75,9 @@ download and run it as follows::
 
 	    
             user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
-	    
 	    user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    
-            user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    
-            user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+	    user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	    user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
 
 	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
 	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -72,11 +72,14 @@ download and run it as follows::
 .. hint:: The certbot-auto download is protected by HTTPS, which is pretty good, but if you'd like to
           double check the integrity of the ``certbot-auto`` script, you can use these steps for verification before running it using gpg2::
 
-   
+
+	    
             user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
 	    user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
             user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
             user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+
+	    
 	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
 	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
 	    gpg: key 4D17C995CD9775F2 marked as ultimately trusted
@@ -88,6 +91,7 @@ download and run it as follows::
 	    gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]
 
 
+	    
 The ``certbot-auto`` command updates to the latest client release automatically.
 Since ``certbot-auto`` is a wrapper to ``certbot``, it accepts exactly
 the same command line flags and arguments. For more information, see

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,8 +41,9 @@ supports
 modern OSes based on Debian, Fedora, SUSE, Gentoo and Darwin.
 
 
-To double check the integrity of the ``certbot-auto`` script before running it requires gpg2 installed and
-setting an appropriate key server 
+To double check the integrity of the ``certbot-auto`` script before running it using gpg2
+install the package gnupg
+
 
 Installing with ``certbot-auto`` requires 512MB of RAM in order to build some
 of the dependencies. Installing from pre-built OS packages avoids this
@@ -74,10 +75,9 @@ download and run it as follows::
 
 
 	    
-	    user@server:~$ wget -N https://dl.eff.org/certbot-auto.asc
-	    user@server:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    user@server:~$ gpg2 --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    user@server:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
+	    user@webserver:~$ wget -N https://dl.eff.org/certbot-auto.asc
+	    user@webserver:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
+	    user@webserver:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto
 
 	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
 	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,9 +70,10 @@ download and run it as follows::
   user@webserver:~$ chmod a+x ./certbot-auto
   user@webserver:~$ ./certbot-auto --help
 
-.. hint:: To check the integrity of the ``certbot-auto`` script, you can use these steps::
+To check the integrity of the ``certbot-auto`` script,  
+you can use these steps::
 
-	    
+	  
 	    user@webserver:~$ wget -N https://dl.eff.org/certbot-auto.asc
 	    user@webserver:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
 	    user@webserver:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc certbot-auto


### PR DESCRIPTION
Improve documentation about gnupg2 verification of certbot-auto

Added requirement of gpg2  and  instruction for setting an appropriate key server to prevent confusion

[#5718](https://github.com/certbot/certbot/issues/5718)