### PR TITLE
correct error message: text now prompts user to run $certbot certificates

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -324,7 +324,7 @@ def _find_lineage_for_domains_and_certname(config, domains, certname):
                 return "newcert", None
             else:
                 raise errors.ConfigurationError("No certificate with name {0} found. "
-                    "Use -d to specify domains, or run certbot --certificates to see "
+                    "Use -d to specify domains, or run certbot certificates to see "
                     "possible certificate names.".format(certname))
 
 def _get_added_removed(after, before):


### PR DESCRIPTION
Error message now correctly promts the user to run `certbot certificates` instead of `certbot --certificates`.

I ran `python certbot/tests/main_test.py` and all tests ran; except I had an unrelated error:

No handlers could be found for logger "certbot.main"

running `tox -e lint` completed successfully.