### PR TITLE
#4242 Support multi emails register

### DIFF
--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -285,7 +285,7 @@ class Registration(ResourceBody):
         if phone is not None:
             details.append(cls.phone_prefix + phone)
         if email is not None:
-            details.append(cls.email_prefix + email)
+            details.extend([cls.email_prefix + mail for mail in email.split(',')])
         kwargs['contact'] = tuple(details)
         return cls(**kwargs)
 

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -381,7 +381,7 @@ VERB_HELP = [
     ("register", {
         "short": "Register for account with Let's Encrypt / other ACME server",
         "opts": ("Options for account registration & modification"
-                 ". To register multi email, separate by comma,"
+                 ". To register multi emails, separate by comma,"
                  " ex: u1@example.com,u2@example.com"),
         "usage": "\n\n  certbot register --email user@example.com [options]\n\n"
     }),

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -380,9 +380,7 @@ VERB_HELP = [
     }),
     ("register", {
         "short": "Register for account with Let's Encrypt / other ACME server",
-        "opts": ("Options for account registration & modification"
-                 ". To register multi emails, separate by comma,"
-                 " ex: u1@example.com,u2@example.com"),
+        "opts": "Options for account registration & modification",
         "usage": "\n\n  certbot register --email user@example.com [options]\n\n"
     }),
     ("unregister", {

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -380,7 +380,9 @@ VERB_HELP = [
     }),
     ("register", {
         "short": "Register for account with Let's Encrypt / other ACME server",
-        "opts": "Options for account registration & modification",
+        "opts": ("Options for account registration & modification"
+                 ". To register multi email, separate by comma,"
+                 " ex: u1@example.com,u2@example.com"),
         "usage": "\n\n  certbot register --email user@example.com [options]\n\n"
     }),
     ("unregister", {
@@ -418,7 +420,7 @@ VERB_HELP = [
     }),
     ("enhance", {
         "short": "Add security enhancements to your existing configuration",
-        "opts": ("Helps to harden the TLS configration by adding security enhancements "
+        "opts": ("Helps to harden the TLS configuration by adding security enhancements "
                  "to already existing configuration."),
         "usage": "\n\n  certbot enhance [options]\n\n"
     }),

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -179,8 +179,9 @@ def perform_registration(acme, config, tos_cb):
     Actually register new account, trying repeatedly if there are email
     problems
 
-    :param .IConfig config: Client configuration.
     :param acme.client.Client client: ACME client object.
+    :param .IConfig config: Client configuration.
+    :param Callable tos_cb: a callback to handle Term of Service agreement.
 
     :returns: Registration Resource.
     :rtype: `acme.messages.RegistrationResource`

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -201,7 +201,9 @@ class IConfig(zope.interface.Interface):
     """
     server = zope.interface.Attribute("ACME Directory Resource URI.")
     email = zope.interface.Attribute(
-        "Email used for registration and recovery contact. (default: Ask)")
+        "Email used for registration and recovery contact. (default: Ask). "
+        "Use comma to register multiple emails, "
+        "ex: u1@example.com,u2@example.com")
     rsa_key_size = zope.interface.Attribute("Size of the RSA key.")
     must_staple = zope.interface.Attribute(
         "Adds the OCSP Must Staple extension to the certificate. "

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -201,9 +201,9 @@ class IConfig(zope.interface.Interface):
     """
     server = zope.interface.Attribute("ACME Directory Resource URI.")
     email = zope.interface.Attribute(
-        "Email used for registration and recovery contact. (default: Ask). "
-        "Use comma to register multiple emails, "
-        "ex: u1@example.com,u2@example.com")
+        "Email used for registration and recovery contact. Use comma to "
+        "register multiple emails, ex: u1@example.com,u2@example.com. "
+        "(default: Ask).")
     rsa_key_size = zope.interface.Attribute("Size of the RSA key.")
     must_staple = zope.interface.Attribute(
         "Adds the OCSP Must Staple extension to the certificate. "

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -732,9 +732,8 @@ def register(config, unused_plugins):
     cb_client = client.Client(config, acc, None, None, acme=acme)
     # We rely on an exception to interrupt this process if it didn't work.
     acc_contacts = ['mailto:' + email for email in config.email.split(',')]
-    # TODO see if the below code can be simplified
-    acc.regr = cb_client.acme.update_registration(acc.regr.update(
-        body=acc.regr.body.update(contact=acc_contacts)))
+    acc.regr.body.update(contact=acc_contacts)
+    acc.regr = cb_client.acme.update_registration(acc.regr)
     account_storage.save_regr(acc, cb_client.acme)
     eff.handle_subscription(config)
     add_msg("Your e-mail address was updated to {0}.".format(config.email))

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -726,13 +726,15 @@ def register(config, unused_plugins):
             return ("--register-unsafely-without-email provided, however, a "
                     "new e-mail address must\ncurrently be provided when "
                     "updating a registration.")
-        config.email = display_ops.get_email(optional=False)
+        config.email = display_ops.get_email(optional=False)  # TODO: check return type
 
     acc, acme = _determine_account(config)
     cb_client = client.Client(config, acc, None, None, acme=acme)
     # We rely on an exception to interrupt this process if it didn't work.
+    acc_contacts = ['mailto:' + email for email in config.email.split(',')]
+    # TODO see if the below code can be simplified
     acc.regr = cb_client.acme.update_registration(acc.regr.update(
-        body=acc.regr.body.update(contact=('mailto:' + config.email,))))
+        body=acc.regr.body.update(contact=acc_contacts)))
     account_storage.save_regr(acc, cb_client.acme)
     eff.handle_subscription(config)
     add_msg("Your e-mail address was updated to {0}.".format(config.email))

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -732,8 +732,8 @@ def register(config, unused_plugins):
     cb_client = client.Client(config, acc, None, None, acme=acme)
     # We rely on an exception to interrupt this process if it didn't work.
     acc_contacts = ['mailto:' + email for email in config.email.split(',')]
-    acc.regr.body.update(contact=acc_contacts)
-    acc.regr = cb_client.acme.update_registration(acc.regr)
+    acc.regr = cb_client.acme.update_registration(acc.regr.update(
+        body=acc.regr.body.update(contact=acc_contacts)))
     account_storage.save_regr(acc, cb_client.acme)
     eff.handle_subscription(config)
     add_msg("Your e-mail address was updated to {0}.".format(config.email))

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1433,7 +1433,9 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                         mocked_storage = mock.MagicMock()
                         mocked_account.AccountFileStorage.return_value = mocked_storage
                         mocked_storage.find_all.return_value = ["an account"]
-                        mocked_det.return_value = (mock.MagicMock(), "foo")
+                        mock_acc = mock.MagicMock()
+                        mock_regr = mock_acc.regr
+                        mocked_det.return_value = (mock_acc, "foo")
                         cb_client = mock.MagicMock()
                         mocked_client.Client.return_value = cb_client
                         x = self._call_no_clientmock(
@@ -1443,8 +1445,10 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                         self.assertTrue(x[0] is None)
                         # and we got supposedly did update the registration from
                         # the server
-                        self.assertTrue(
-                            cb_client.acme.update_registration.called)
+                        reg_arg = cb_client.acme.update_registration.call_args[0][0]
+                        # Test the return value of .update() was used because
+                        # the regr is immutable.
+                        self.assertEqual(reg_arg, mock_regr.update())
                         # and we saved the updated registration on disk
                         self.assertTrue(mocked_storage.save_regr.called)
                         self.assertTrue(

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -191,6 +191,11 @@ for dir in $renewal_hooks_dirs; do
         exit 1
     fi
 done
+
+common register --email ex1@domain.org,ex2@domain.org
+
+common register --update-registration --email ex1@domain.org
+
 common register --update-registration --email ex1@domain.org,ex2@domain.org
 
 common plugins --init --prepare | grep webroot

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -192,6 +192,8 @@ for dir in $renewal_hooks_dirs; do
     fi
 done
 
+common unregister
+
 common register --email ex1@domain.org,ex2@domain.org
 
 common register --update-registration --email ex1@domain.org

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -191,7 +191,7 @@ for dir in $renewal_hooks_dirs; do
         exit 1
     fi
 done
-common register --update-registration --email example@example.org
+common register --update-registration --email ex1@domain.org,ex2@domain.org
 
 common plugins --init --prepare | grep webroot
 


### PR DESCRIPTION
This change will allow registering/updating account with multi emails. 
Detail is enclosed in #4242 