### PR TITLE
Display (None) instead of a bullet for empty lists

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -340,7 +340,10 @@ def _get_added_removed(after, before):
 def _format_list(character, strings):
     """Format list with given character
     """
-    formatted = "{br}{ch} " + "{br}{ch} ".join(strings)
+    if len(strings) == 0:
+        formatted = "{br}(None)"
+    else:
+        formatted = "{br}{ch} " + "{br}{ch} ".join(strings)
     return formatted.format(
         ch=character,
         br=os.linesep


### PR DESCRIPTION
Include a line break before "(None)" to maintain consistency with output
for lists that are not empty.

Previous result as expected for non-empty lists:

    >>> _format_list('+', ['one', 'two', 'three'])
    '\n+ one\n+ two\n+ three'

Previous unexpected result for empty lists:

    >>> _format_list('+', [])
    '\n+ '

New result as expected (unchanged) for non-empty lists:

    >>> _format_list('+', ['one', 'two', 'three'])
    '\n+ one\n+ two\n+ three'

New behavior more explicit for empty lists:

    >>> _format_list('+', [])
    '\n(None)'

Resolves #5886