### PR TITLE
Fix crash when email submission endpoint unavailable

### DIFF
--- a/certbot/eff.py
+++ b/certbot/eff.py
@@ -71,11 +71,17 @@ def _check_response(response):
 
     """
     logger.debug('Received response:\n%s', response.content)
-    if response.ok:
-        if not response.json()['status']:
-            _report_failure('your e-mail address appears to be invalid')
-    else:
+    try:
+        response.raise_for_status()
+        assert response.json()['status'] == True
+    except requests.exceptions.HTTPError:
         _report_failure()
+    except ValueError:
+        _report_failure('there was a problem with the server response')
+    except KeyError:
+        _report_failure('the server response was missing some information')
+    except AssertionError:
+        _report_failure('your e-mail address appears to be invalid')
 
 
 def _report_failure(reason=None):

--- a/certbot/eff.py
+++ b/certbot/eff.py
@@ -73,15 +73,12 @@ def _check_response(response):
     logger.debug('Received response:\n%s', response.content)
     try:
         response.raise_for_status()
-        assert response.json()['status'] == True
+        if response.json()['status'] == False:
+            _report_failure('your e-mail address appears to be invalid')
     except requests.exceptions.HTTPError:
         _report_failure()
-    except ValueError:
+    except (ValueError, KeyError):
         _report_failure('there was a problem with the server response')
-    except KeyError:
-        _report_failure('the server response was missing some information')
-    except AssertionError:
-        _report_failure('your e-mail address appears to be invalid')
 
 
 def _report_failure(reason=None):

--- a/certbot/tests/eff_test.py
+++ b/certbot/tests/eff_test.py
@@ -117,11 +117,30 @@ class SubscribeTest(unittest.TestCase):
 
     @test_util.patch_get_utility()
     def test_not_ok(self, mock_get_utility):
+        from certbot.eff import requests
         self.response.ok = False
+        self.response.raise_for_status.side_effect = requests.exceptions.HTTPError
         self._call()  # pylint: disable=no-value-for-parameter
         actual = self._get_reported_message(mock_get_utility)
         unexpected_part = 'because'
         self.assertFalse(unexpected_part in actual)
+
+    @test_util.patch_get_utility()
+    def test_response_not_json(self, mock_get_utility):
+        self.response.json.side_effect = ValueError()
+        self._call()  # pylint: disable=no-value-for-parameter
+        actual = self._get_reported_message(mock_get_utility)
+        expected_part = 'problem'
+        self.assertTrue(expected_part in actual)
+
+    @test_util.patch_get_utility()
+    def test_response_json_missing_status_element(self, mock_get_utility):
+        self.json = {}
+        self.response.json.return_value = self.json
+        self._call()  # pylint: disable=no-value-for-parameter
+        actual = self._get_reported_message(mock_get_utility)
+        expected_part = 'missing'
+        self.assertTrue(expected_part in actual)
 
     def _get_reported_message(self, mock_get_utility):
         self.assertTrue(mock_get_utility().add_message.called)

--- a/certbot/tests/eff_test.py
+++ b/certbot/tests/eff_test.py
@@ -1,4 +1,5 @@
 """Tests for certbot.eff."""
+import requests
 import unittest
 
 import mock
@@ -117,7 +118,6 @@ class SubscribeTest(unittest.TestCase):
 
     @test_util.patch_get_utility()
     def test_not_ok(self, mock_get_utility):
-        from certbot.eff import requests
         self.response.ok = False
         self.response.raise_for_status.side_effect = requests.exceptions.HTTPError
         self._call()  # pylint: disable=no-value-for-parameter
@@ -135,11 +135,10 @@ class SubscribeTest(unittest.TestCase):
 
     @test_util.patch_get_utility()
     def test_response_json_missing_status_element(self, mock_get_utility):
-        self.json = {}
-        self.response.json.return_value = self.json
+        self.json.clear()
         self._call()  # pylint: disable=no-value-for-parameter
         actual = self._get_reported_message(mock_get_utility)
-        expected_part = 'missing'
+        expected_part = 'problem'
         self.assertTrue(expected_part in actual)
 
     def _get_reported_message(self, mock_get_utility):


### PR DESCRIPTION
Handle KeyError and ValueError so that if the email submission endpoint
goes down, Certbot can still run.

Add tests to eff_test.py:
 - simulate non-JSON response as described in issue #5858
 - simulate JSON response without 'status' element

Non-JSON response throws an uncaught ValueError when attempting to
decode as JSON. A JSON response missing the 'status' element throws an
uncaught KeyError when checking whether status is True or False.

Teach _check_response to handle ValueError and KeyError and report an
issue to the user.

Rewrite if statement as assertion with try-except block to make error
handling consistent within the function. Update test_not_ok to make
mocked raise_for_status function raise a requests.exceptions.HTTPError.

Resolves #5858