### PR TITLE
Fix noisy tests

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -626,7 +626,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         toy_stdout = stdout if stdout else six.StringIO()
         with mock.patch('certbot.main.sys.stdout', new=toy_stdout):
             with mock.patch('certbot.main.sys.stderr') as stderr:
-                with mock.patch("certbot.util.atexit_register"):
+                with mock.patch("certbot.util.atexit"):
                     ret = main.main(args[:])  # NOTE: parser can alter its args!
         return ret, toy_stdout, stderr
 


### PR DESCRIPTION
The issue is calls to atexit aren't mocked out. During the tests there are many repeated calls registering functions to be called when the process exits so when the tests finishes, it prints a ton of output from running those registered functions. This suppresses that by mocking out atexit.