### PR TITLE
Support RFC2136 DNS update without TSIG key

### DIFF
--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136_test.py
@@ -69,6 +69,13 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
         self.auth.perform([self.achall])
 
+    def test_no_key_passes(self):
+        config = VALID_CONFIG.copy()
+        del config["rfc2136_name"]
+        del config["rfc2136_secret"]
+        dns_test_common.write(config, self.config.rfc2136_credentials)
+
+        self.auth.perform([self.achall])
 
 class RFC2136ClientTest(unittest.TestCase):
 


### PR DESCRIPTION
* Resolves #5778

Prior to this change, the dns_rfc2136 plugin would error out if no
TSIG key name and secret was provided.