### PR TITLE
Remove PYTHONPATH from setenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,6 @@ commands =
     {[base]install_and_test} {[base]all_packages}
     python tests/lock_test.py
 setenv =
-    PYTHONPATH = {toxinidir}
     PYTHONHASHSEED = 0
 
 [testenv:py27-oldest]


### PR DESCRIPTION
This was added in #233. [The commit](https://github.com/certbot/certbot/pull/233/commits/74c02363e7afb30f0c6a24fb7c7e41b770a0ec2c) comment says it was added so `pylint` finds our `linter_plugin.py`, but this isn't needed anymore. Setting this value is also breaking some of our tests (see #6005), because it causes Python to find the version of Certbot in `master` for our oldest tests. See https://travis-ci.org/certbot/certbot/jobs/379873219#L783 for an example of this.