### PR TITLE
cd before running tests

### DIFF
--- a/tools/install_and_test.sh
+++ b/tools/install_and_test.sh
@@ -12,12 +12,18 @@ else
   pip_install="$(dirname $0)/pip_install_editable.sh"
 fi
 
+temp_cwd=$(mktemp -d)
+trap "rm -rf $temp_cwd" EXIT
+
 set -x
 for requirement in "$@" ; do
   $pip_install $requirement
   pkg=$(echo $requirement | cut -f1 -d\[)  # remove any extras such as [dev]
+  pkg=$(echo "$pkg" | tr - _ )  # convert package names to Python import names
   if [ $pkg = "." ]; then
     pkg="certbot"
   fi
+  cd "$temp_cwd"
   pytest --numprocesses auto --quiet --pyargs $pkg
+  cd ~-
 done

--- a/tools/install_and_test.sh
+++ b/tools/install_and_test.sh
@@ -25,5 +25,5 @@ for requirement in "$@" ; do
   fi
   cd "$temp_cwd"
   pytest --numprocesses auto --quiet --pyargs $pkg
-  cd ~-
+  cd -
 done


### PR DESCRIPTION
When importing a module, Python first searches the current directory. See
https://docs.python.org/3/tutorial/modules.html#the-module-search-path. This
means that running something like `import certbot` from the root of the Certbot
repo will use the local Certbot files regardless of the version installed on
the system or virtual environment.

Normally this behavior is fine because the local files are what we want to
test, however, during our "oldest" tests, we test against older versions of our
packages to make sure we're keeping compatibility. To make sure our tests use
the correct versions, this commit has our tests cd to an empty temporary
directory before running tests.

We also had to change the package names given to pytest to be the names used in
Python to import the package rather than the name of the files locally to
accommodate this.