### PR TITLE
Apache: list everywhere for challenges (#6046)

### DIFF
--- a/certbot-apache/certbot_apache/tls_sni_01.py
+++ b/certbot-apache/certbot_apache/tls_sni_01.py
@@ -124,8 +124,11 @@ class ApacheTlsSni01(common.TLSSNI01):
             self.configurator.config.tls_sni_01_port)))
 
         try:
-            vhost = self.configurator.choose_vhost(achall.domain,
-                                                   create_if_no_ssl=False)
+            try:
+                vhosts = self.configurator.vhosts
+            except AttributeError:
+                vhost = self.configurator.choose_vhost(achall.domain,
+                                                       create_if_no_ssl=False)
         except (PluginError, MissingCommandlineFlag):
             # We couldn't find the virtualhost for this domain, possibly
             # because it's a new vhost that's not configured yet
@@ -134,13 +137,14 @@ class ApacheTlsSni01(common.TLSSNI01):
             addrs.add(default_addr)
             return addrs
 
-        for addr in vhost.addrs:
-            if "_default_" == addr.get_addr():
-                addrs.add(default_addr)
-            else:
-                addrs.add(
-                    addr.get_sni_addr(
-                        self.configurator.config.tls_sni_01_port))
+        for vhost in vhosts:
+            for addr in vhost.addrs:
+                if "_default_" == addr.get_addr():
+                    addrs.add(default_addr)
+                else:
+                    addrs.add(
+                        addr.get_sni_addr(
+                            self.configurator.config.tls_sni_01_port))
 
         return addrs
 


### PR DESCRIPTION
A site can have multiple hosts sharing a certificate, e.g.:
```
<VirtualHost localhost:443>
ServerName x.example.com
</VirtualHost>
<VirtualHost x.example.com:443>
ServerName x.example.com
</VirtualHost>
<VirtualHost 10.0.0.1:443>
ServerName x.example.com
</VirtualHost>
```

The goal of the SNI challenge is to answer requests for specially defined servernames.
We really do not care how they are delivered to apache, as long as we can get apache to
return our specially crafted certificate.

As such, the simplest approach seems to be to just use *.

There are some potentially bizarre ways for traffic to actually come into localhost
(I actually have done this for other systems), but in general, it is more likely that
it will come in via some other address. That said, there does not appear to be any
harm/risk/reason not to just listen for any possible entrypoint.

It is definitely better to listen to all possible entrypoints than it is to only listen
to localhost, which will on average never be able to answer the request.

---
I'm having trouble figuring out if this works ...