### PR TITLE
Make sure the pluginstorage file gets truncated when writing to it

### DIFF
--- a/certbot/plugins/storage.py
+++ b/certbot/plugins/storage.py
@@ -84,7 +84,8 @@ class PluginStorage(object):
             raise errors.PluginStorageError(errmsg)
         try:
             with os.fdopen(os.open(self._storagepath,
-                                   os.O_WRONLY | os.O_CREAT, 0o600), 'w') as fh:
+                                   os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                                   0o600), 'w') as fh:
                 fh.write(serialized)
         except IOError as e:
             errmsg = "Could not write PluginStorage data to file {0} : {1}".format(


### PR DESCRIPTION
Added `os.O_TRUNC` flag for file open to make sure the file gets truncated when writing to it.