### PR TITLE
Read in bytes to fix --reuse-key on Python 3

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -299,7 +299,7 @@ class Client(object):
             # We've been asked to reuse a specific existing private key.
             # Therefore, we'll read it now and not generate a new one in
             # either case below.
-            with open(old_keypath, "r") as f:
+            with open(old_keypath, "rb") as f:
                 keypath = old_keypath
                 keypem = f.read()
             key = util.Key(file=keypath, pem=keypem) # type: Optional[util.Key]

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -299,6 +299,9 @@ class Client(object):
             # We've been asked to reuse a specific existing private key.
             # Therefore, we'll read it now and not generate a new one in
             # either case below.
+            #
+            # We read in bytes here because the type of `key.pem`
+            # created below is also bytes.
             with open(old_keypath, "rb") as f:
                 keypath = old_keypath
                 keypem = f.read()


### PR DESCRIPTION
You can see tests passing with this commit at https://travis-ci.org/certbot/certbot/builds/387933452.