### PR TITLE
Make python setup.py test use pytest for acme

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
-
+from setuptools.command.test import test as TestCommand
+import sys
 
 version = '0.25.0.dev0'
 
@@ -33,6 +34,19 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+class PyTest(TestCommand):
+    user_options = []
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ''
+
+    def run_tests(self):
+        import shlex
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
 
 setup(
     name='acme',
@@ -65,5 +79,7 @@ setup(
         'dev': dev_extras,
         'docs': docs_extras,
     },
+    tests_require=["pytest"],
     test_suite='acme',
+    cmdclass={"test": PyTest},
 )


### PR DESCRIPTION
Our fake module in `acme.magic_typing` is causing problems with unittest, so let's switch to using `pytest` like we do for [josepy](https://github.com/certbot/josepy/blob/master/setup.py#L109) by following the documentation at https://docs.pytest.org/en/latest/goodpractices.html#manual-integration.

I've confirmed this fixes `test_sdists.sh` which was failing before this change.