### PR TITLE
Upgrade pinned twine version

### DIFF
--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -36,7 +36,7 @@ oauth2client==2.0.0
 pathlib2==2.3.0
 pexpect==4.2.1
 pickleshare==0.7.4
-pkginfo==1.4.1
+pkginfo==1.4.2
 pluggy==0.5.2
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
@@ -66,7 +66,7 @@ tldextract==2.2.0
 tox==2.9.1
 tqdm==4.19.4
 traitlets==4.3.2
-twine==1.9.1
+twine==1.11.0
 typed-ast==1.1.0
 typing==3.6.4
 uritemplate==0.6


### PR DESCRIPTION
For the past couple of releases, twine has errored while trying to upload
packages and this is fixed by upgrading to a newer version of twine. This
commit updates our pinned version installed when using tools/venv.sh to the
latest available version. pkginfo had to be upgraded as well to support the
latest version of twine.

I quickly tried to find the fix for this in `twine`'s changelog but failed. Regardless, upgrading has fixed my problem twice now and upgrading our development environment pinnings shouldn't hurt anything.