### PR TITLE
Don't require festival during signing

### DIFF
--- a/tools/offline-sigrequest.sh
+++ b/tools/offline-sigrequest.sh
@@ -2,17 +2,17 @@
 
 set -o errexit
 
-if ! `which festival > /dev/null` ; then
-    echo Please install \'festival\'!
-    exit 1
-fi
-
 function sayhash { # $1 <-- HASH ; $2 <---SIGFILEBALL
   while read -p "Press Enter to read the hash aloud or type 'done':  " INP && [ "$INP" = "" ] ; do
-    cat $1 | (echo "(Parameter.set 'Duration_Stretch 1.8)"; \
-                echo -n '(SayText "'; \
-                sha256sum | cut -c1-64 | fold -1 | sed 's/^a$/alpha/; s/^b$/bravo/; s/^c$/charlie/; s/^d$/delta/; s/^e$/echo/; s/^f$/foxtrot/'; \
-                echo '")' ) | festival
+    if ! `which festival > /dev/null` ; then
+      echo \`festival\` is not installed!
+      echo Please install it to read the hash aloud
+    else
+      cat $1 | (echo "(Parameter.set 'Duration_Stretch 1.8)"; \
+                  echo -n '(SayText "'; \
+                  sha256sum | cut -c1-64 | fold -1 | sed 's/^a$/alpha/; s/^b$/bravo/; s/^c$/charlie/; s/^d$/delta/; s/^e$/echo/; s/^f$/foxtrot/'; \
+                  echo '")' ) | festival
+    fi
   done
 
   echo 'Paste in the data from the QR code, then type Ctrl-D:'


### PR DESCRIPTION
Festival isn't available via Homebrew and is only needed to read the hash
aloud, so let's not make it a strict requirement that it's installed. You can
simply read the hash from the terminal instead.

I've been commenting out the check for festival I deleted during every release since January and it'd be cool if I could stop doing that.