### PR TITLE
Wrap TLS-ALPN extension with ASN.1

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -546,7 +546,9 @@ class TLSALPN01Response(KeyAuthorizationChallengeResponse):
             key.generate_key(crypto.TYPE_RSA, bits)
 
 
-        der_value = b"DER:" + codecs.encode(self.h, 'hex')
+        # Instead of using a ASN.1 encoding library just append the OCTET STRING tag (0x04)
+        # and the length of the SHA256 hash (0x20) since both of these should never change
+        der_value = b"DER:0420" + codecs.encode(self.h, 'hex')
         acme_extension = crypto.X509Extension(self.ID_PE_ACME_IDENTIFIER_V1,
                 critical=True, value=der_value)
 

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -594,7 +594,8 @@ class TLSALPN01Response(KeyAuthorizationChallengeResponse):
             # way to get full OID of an unknown extension from pyopenssl.
             if ext.get_short_name() == b'UNDEF':
                 data = ext.get_data()
-                return data == self.h
+                # Add the ASN.1 tag/length prefix to the hash before comparison
+                return data == b'\x04\x20' + self.h
 
         return False
 


### PR DESCRIPTION
Instead of just using the raw value of the hash. Since the tag and OCTET STRING length will never change just prepend the tag and length bytes instead of using an ASN.1 library to do this work.