### PR TITLE
Fix for #6085

### DIFF
--- a/acme/MANIFEST.in
+++ b/acme/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE.txt
 include README.rst
+include pytest.ini
 recursive-include docs *
 recursive-include examples *
 recursive-include acme/testdata *

--- a/acme/pytest.ini
+++ b/acme/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = .* build dist CVS _darcs {arch} *.egg


### PR DESCRIPTION
Packagers had to patch this by hand for EPEL and older Ubuntu versions and one of our Ubuntu packagers asked if we could fix this upstream in a future release.

The value of norecusedirs is the default in newer versions of pytest which is listed at https://docs.pytest.org/en/3.0.0/customize.html#confval-norecursedirs.

You can test this by running `tests/letstest/scripts/test_sdists.sh` with the following patch:
```
diff --git a/tests/letstest/scripts/test_sdists.sh b/tests/letstest/scripts/test_sdists.sh
index f18a6406..f34163c2 100755
--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -12,6 +12,7 @@ export VENV_ARGS="-p $PYTHON"
 # setup venv
 tools/_venv_common.sh --requirement letsencrypt-auto-source/pieces/dependency-requirements.txt
 . ./venv/bin/activate
+pip install 'pytest<3'
 
 # build sdists
 for pkg_dir in acme . $PLUGINS; do
```
When I run these tests manually, I do it in Docker. The OS doesn't matter. Check out the repo into a directory named `letsencrypt` and without changing your directory to be inside `letsencrypt`, run `tests/letstest/scripts/test_sdists.sh`. It fails on the master branch but passes on this branch.

I created #6090 to look into writing automated tests for this if we don't change our packaging approach.