### PR TITLE
Require acme>=0.25.0 for nginx (#6099)

### DIFF
--- a/certbot-nginx/local-oldest-requirements.txt
+++ b/certbot-nginx/local-oldest-requirements.txt
@@ -1,2 +1,2 @@
--e acme[dev]
+acme[dev]==0.25.0
 -e .[dev]

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -7,10 +7,7 @@ version = '0.25.0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    # This plugin works with an older version of acme, but Certbot does not.
-    # 0.22.0 is specified here to work around
-    # https://github.com/pypa/pip/issues/988.
-    'acme>0.21.1',
+    'acme>=0.25.0',
     'certbot>0.21.1',
     'mock',
     'PyOpenSSL',


### PR DESCRIPTION
Cherry-picks #6099 onto the 0.25.x release branch.