### PR TITLE
Fixes #6085. (#6091)

### DIFF
--- a/acme/MANIFEST.in
+++ b/acme/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE.txt
 include README.rst
+include pytest.ini
 recursive-include docs *
 recursive-include examples *
 recursive-include acme/testdata *

--- a/acme/pytest.ini
+++ b/acme/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = .* build dist CVS _darcs {arch} *.egg


### PR DESCRIPTION
The value of norecusedirs is the default in newer versions of pytest which is
listed at
https://docs.pytest.org/en/3.0.0/customize.html#confval-norecursedirs.

(cherry picked from commit 9f20fa0ef969811803042be4a60f8127f6883e34)