### PR TITLE
Used packaged acme in oldest tests

### DIFF
--- a/certbot-apache/local-oldest-requirements.txt
+++ b/certbot-apache/local-oldest-requirements.txt
@@ -1,2 +1,2 @@
--e acme[dev]
+acme[dev]==0.25.0
 certbot[dev]==0.21.1

--- a/certbot-dns-route53/local-oldest-requirements.txt
+++ b/certbot-dns-route53/local-oldest-requirements.txt
@@ -1,2 +1,2 @@
--e acme[dev]
+acme[dev]==0.25.0
 certbot[dev]==0.21.1

--- a/local-oldest-requirements.txt
+++ b/local-oldest-requirements.txt
@@ -1,1 +1,1 @@
--e acme[dev]
+acme[dev]==0.25.0


### PR DESCRIPTION
Now that 0.25.0 is out, we don't need to use `acme` from `master` anymore for the oldest tests.

We unfortunately still need to use Certbot from master for the Nginx oldest tests until #5810 is resolved.