### PR TITLE
Separate integration coverage

### DIFF
--- a/certbot-nginx/tests/boulder-integration.sh
+++ b/certbot-nginx/tests/boulder-integration.sh
@@ -62,3 +62,5 @@ test_deployment_and_rollback nginx6.wtf
 # note: not reached if anything above fails, hence "killall" at the
 # top
 nginx -c $nginx_root/nginx.conf -s stop
+
+coverage report --include 'certbot-nginx/*' --show-missing

--- a/certbot-nginx/tests/boulder-integration.sh
+++ b/certbot-nginx/tests/boulder-integration.sh
@@ -63,4 +63,4 @@ test_deployment_and_rollback nginx6.wtf
 # top
 nginx -c $nginx_root/nginx.conf -s stop
 
-coverage report --include 'certbot-nginx/*' --show-missing
+coverage report --fail-under 75 --include 'certbot-nginx/*' --show-missing

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -486,7 +486,7 @@ if [ "${BOULDER_INTEGRATION:-v1}" = "v2" ]; then
         --manual-cleanup-hook ./tests/manual-dns-cleanup.sh
 fi
 
-coverage report --include 'certbot/*' --show-missing
+coverage report --fail-under 65 --include 'certbot/*' --show-missing
 
 # Most CI systems set this variable to true.
 # If the tests are running as part of CI, Nginx should be available.

--- a/tests/boulder-integration.sh
+++ b/tests/boulder-integration.sh
@@ -486,11 +486,11 @@ if [ "${BOULDER_INTEGRATION:-v1}" = "v2" ]; then
         --manual-cleanup-hook ./tests/manual-dns-cleanup.sh
 fi
 
+coverage report --include 'certbot/*' --show-missing
+
 # Most CI systems set this variable to true.
 # If the tests are running as part of CI, Nginx should be available.
 if ${CI:-false} || type nginx;
 then
     . ./certbot-nginx/tests/boulder-integration.sh
 fi
-
-coverage report --fail-under 67 -m


### PR DESCRIPTION
[test-everything tests are failing](https://travis-ci.org/certbot/certbot/builds/391910357) due to not reaching the minimum coverage percentage. This is because during our "oldest" tests, a released version of acme may be used instead of the version in master. In this case, the acme files in our tree get no coverage causing the cover percentage to drop dramatically.

To fix this and make more progress to separating our integration tests, this PR checks coverage separately for certbot and certbot-nginx and only checks coverage on the module we're actually testing. Percentages were taken from https://travis-ci.org/certbot/certbot/builds/391972332.

If we wanted to check coverage on acme in some cases too we could, but we'd need a way to signal to the tests that acme from the tree is being used and use that to conditionally call coverage in a different way. I'm not sure if this is worth it, but we want to do this, I think it should be done in another PR.