### PR TITLE
Remove .dev0 from version numbers during releases.

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -87,6 +87,14 @@ if [ "$RELEASE_BRANCH" != "candidate-$version" ] ; then
 fi
 git checkout "$RELEASE_BRANCH"
 
+for pkg_dir in $SUBPKGS_NO_CERTBOT certbot-compatibility-test .
+do
+  sed -i 's/\.dev0//' "$pkg_dir/setup.py"
+done
+# We only add Certbot's setup.py here because the other files are added in the
+# call to SetVersion below.
+git add -p setup.py
+
 SetVersion() {
     ver="$1"
     # bumping Certbot's version number is done differently


### PR DESCRIPTION
Partial fix for #6098. Changing existing requirements to `>=` rather than `>` is coming in another PR.

@erikrose, do you feel comfortable and able to review this?

This allows us to depend on packages like acme>=0.26.0.dev0 during development and automatically change it to acme>=0.26.0 during the release. We use `git add -p` to be safe, but if .dev0 is used at all in our released setup.py files, we're probably doing something wrong.