### PR TITLE
Improve UA default in docs

### DIFF
--- a/certbot/client.py
+++ b/certbot/client.py
@@ -65,9 +65,17 @@ def determine_user_agent(config):
     if config.user_agent is None:
         ua = ("CertbotACMEClient/{0} ({1}; {2}{8}) Authenticator/{3} Installer/{4} "
               "({5}; flags: {6}) Py/{7}")
-        ua = ua.format(certbot.__version__, cli.cli_command, util.get_os_info_ua(),
+        if os.environ.get("CERTBOT_DOCS") == "1":
+            cli_command = "certbot(-auto)"
+            os_info = "OS_NAME OS_VERSION"
+            python_version = "major.minor.patchlevel"
+        else:
+            cli_command = cli.cli_command
+            os_info = util.get_os_info_ua()
+            python_version = platform.python_version()
+        ua = ua.format(certbot.__version__, cli_command, os_info,
                        config.authenticator, config.installer, config.verb,
-                       ua_flags(config), platform.python_version(),
+                       ua_flags(config), python_version,
                        "; " + config.user_agent_comment if config.user_agent_comment else "")
     else:
         ua = config.user_agent

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -153,7 +153,8 @@ kill $!
 cd ~-
 
 # get a snapshot of the CLI help for the docs
-certbot --help all > docs/cli-help.txt
+# We set CERTBOT_DOCS to use dummy values in example user-agent string.
+CERTBOT_DOCS=1 certbot --help all > docs/cli-help.txt
 jws --help > acme/docs/jws-help.txt
 
 cd ..


### PR DESCRIPTION
In [cli-help.txt](https://github.com/certbot/certbot/blob/c9ae365f6678ae64134a9408185601e124cdf296/docs/cli-help.txt#L111) which is used in [our documentation](https://certbot.eff.org/docs/using.html#certbot-command-line-options), the default value of the `--user-agent` flag contains information about the machine that generated the docs. This makes the value shown in the documentation less relevant to other users and leaks information about the developer's setup.

This PR changes this by introducing the environment variable `CERTBOT_DOCS`. When this is set to 1, machine specific values in the user-agent string are replaced with more generic ones. I chose this approach rather than always using generic values so we can still provide more specific information about the values included in the user agent string when a user runs `--certbot --help` on their machine.

This PR sets this environment variable in the release script so `cli-help.txt` will contain these generic values in the future.