### PR TITLE
docs: move warning about distro provided renewal

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -454,6 +454,12 @@ Renewing certificates
    days). Make sure you renew the certificates at least once in 3
    months.
 
+.. seealso:: Many of the certbot clients obtained through a
+   distribution come with automatic renewal out of the box,
+   such as Debian and Ubuntu versions installed through `apt`,
+   CentOS/RHEL 7 through EPEL, etc.  See `Automated Renewals`_
+   for more details.
+
 As of version 0.10.0, Certbot supports a ``renew`` action to check
 all installed certificates for impending expiry and attempt to renew
 them. The simplest form is simply
@@ -559,12 +565,6 @@ are only renewed when they're determined to be near expiry, the command
 can run on a regular basis, like every week or every day). In that case,
 you are likely to want to use the ``-q`` or ``--quiet`` quiet flag to
 silence all output except errors.
-
-.. seealso:: Many of the certbot clients obtained through a
-   distribution come with automatic renewal out of the box,
-   such as Debian and Ubuntu versions installed through `apt`,
-   CentOS/RHEL 7 through EPEL, etc.  See `Automated Renewals`_
-   for more details.
 
 If you are manually renewing all of your certificates, the
 ``--force-renewal`` flag may be helpful; it causes the expiration time of


### PR DESCRIPTION
Currently, you must read ten paragraphs about writing renewal hooks
before you find that most distributions will automatically renew certs
for you.  This is burying the lede in a major way; moving it up to the
header seems a better choice.