### PR TITLE
Reuse ACMEv1 accounts for ACMEv2 in production

### DIFF
--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -160,6 +160,7 @@ ACCOUNTS_DIR = "accounts"
 """Directory where all accounts are saved."""
 
 LE_REUSE_SERVERS = {
+    'acme-v02.api.letsencrypt.org/directory': 'acme-v01.api.letsencrypt.org/directory',
     'acme-staging-v02.api.letsencrypt.org/directory':
         'acme-staging.api.letsencrypt.org/directory'
 }

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -218,10 +218,16 @@ class AccountFileStorageTest(test_util.ConfigTestCase):
         self._set_server('https://acme-staging.api.letsencrypt.org/directory')
         self.assertEqual([], self.storage.find_all())
 
-    def test_upgrade_version(self):
+    def test_upgrade_version_staging(self):
         self._set_server('https://acme-staging.api.letsencrypt.org/directory')
         self.storage.save(self.acc, self.mock_client)
         self._set_server('https://acme-staging-v02.api.letsencrypt.org/directory')
+        self.assertEqual([self.acc], self.storage.find_all())
+
+    def test_upgrade_version_production(self):
+        self._set_server('https://acme-v01.api.letsencrypt.org/directory')
+        self.storage.save(self.acc, self.mock_client)
+        self._set_server('https://acme-v02.api.letsencrypt.org/directory')
         self.assertEqual([self.acc], self.storage.find_all())
 
     @mock.patch('os.rmdir')


### PR DESCRIPTION
Fixes #6083.

Tested this with the prod server, works!