### PR TITLE
Show both possible Nginx default server root values in docs

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -69,10 +69,7 @@ class NginxConfigurator(common.Installer):
 
     @classmethod
     def add_parser_arguments(cls, add):
-        if os.environ.get("CERTBOT_DOCS") == "1":
-            default_server_root = "%s or %s" % (LINUX_SERVER_ROOT, FREEBSD_DARWIN_SERVER_ROOT)
-        else:
-            default_server_root = constants.CLI_DEFAULTS["server_root"]
+        default_server_root = _determine_default_server_root()
         add("server-root", default=default_server_root,
             help="Nginx server root directory.")
         add("ctl", default=constants.CLI_DEFAULTS["ctl"], help="Path to the "
@@ -1133,3 +1130,11 @@ def install_ssl_options_conf(options_ssl, options_ssl_digest):
     """Copy Certbot's SSL options file into the system's config dir if required."""
     return common.install_version_controlled_file(options_ssl, options_ssl_digest,
         constants.MOD_SSL_CONF_SRC, constants.ALL_SSL_OPTIONS_HASHES)
+
+def _determine_default_server_root():
+    if os.environ.get("CERTBOT_DOCS") == "1":
+        default_server_root = "%s or %s" % (constants.LINUX_SERVER_ROOT,
+            constants.FREEBSD_DARWIN_SERVER_ROOT)
+    else:
+        default_server_root = constants.CLI_DEFAULTS["server_root"]
+    return default_server_root

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -69,7 +69,11 @@ class NginxConfigurator(common.Installer):
 
     @classmethod
     def add_parser_arguments(cls, add):
-        add("server-root", default=constants.CLI_DEFAULTS["server_root"],
+        if os.environ.get("CERTBOT_DOCS") == "1":
+            default_server_root = "%s or %s" % (LINUX_SERVER_ROOT, FREEBSD_DARWIN_SERVER_ROOT)
+        else:
+            default_server_root = constants.CLI_DEFAULTS["server_root"]
+        add("server-root", default=default_server_root,
             help="Nginx server root directory.")
         add("ctl", default=constants.CLI_DEFAULTS["ctl"], help="Path to the "
             "'nginx' binary, used for 'configtest' and retrieving nginx "

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -70,8 +70,8 @@ class NginxConfigurator(common.Installer):
     @classmethod
     def add_parser_arguments(cls, add):
         default_server_root = _determine_default_server_root()
-        add("server-root", default=default_server_root,
-            help="Nginx server root directory.")
+        add("server-root", default=constants.CLI_DEFAULTS["server_root"],
+            help="Nginx server root directory. (default: %s)" % default_server_root)
         add("ctl", default=constants.CLI_DEFAULTS["ctl"], help="Path to the "
             "'nginx' binary, used for 'configtest' and retrieving nginx "
             "version number.")

--- a/certbot-nginx/certbot_nginx/constants.py
+++ b/certbot-nginx/certbot_nginx/constants.py
@@ -2,10 +2,13 @@
 import pkg_resources
 import platform
 
+FREEBSD_DARWIN_SERVER_ROOT = "/usr/local/etc/nginx"
+LINUX_SERVER_ROOT = "/etc/nginx"
+
 if platform.system() in ('FreeBSD', 'Darwin'):
-    server_root_tmp = "/usr/local/etc/nginx"
+    server_root_tmp = FREEBSD_DARWIN_SERVER_ROOT
 else:
-    server_root_tmp = "/etc/nginx"
+    server_root_tmp = LINUX_SERVER_ROOT
 
 CLI_DEFAULTS = dict(
     server_root=server_root_tmp,

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -949,5 +949,30 @@ class InstallSslOptionsConfTest(util.NginxTest):
             " with the sha256 hash of self.config.mod_ssl_conf when it is updated.")
 
 
+class DetermineDefaultServerRootTest(certbot_test_util.ConfigTestCase):
+    """Tests for certbot_nginx.configurator._determine_default_server_root."""
+
+    def _call(self):
+        from certbot_nginx.configurator import _determine_default_server_root
+        return _determine_default_server_root()
+
+    @mock.patch.dict(os.environ, {"CERTBOT_DOCS": "1"})
+    def test_docs_value(self):
+        self._test(expect_both_values=True)
+
+    @mock.patch.dict(os.environ, {})
+    def test_real_values(self):
+        self._test(expect_both_values=False)
+
+    def _test(self, expect_both_values):
+        server_root = self._call()
+
+        if expect_both_values:
+            self.assertIn("/usr/local/etc/nginx", server_root)
+            self.assertIn("/etc/nginx", server_root)
+        else:
+            self.assertTrue("/etc/nginx" in server_root or "/usr/local/etc/nginx" in server_root)
+
+
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -972,6 +972,7 @@ class DetermineDefaultServerRootTest(certbot_test_util.ConfigTestCase):
             self.assertIn("/etc/nginx", server_root)
         else:
             self.assertTrue("/etc/nginx" in server_root or "/usr/local/etc/nginx" in server_root)
+            self.assertFalse("/etc/nginx" in server_root and "/usr/local/etc/nginx" in server_root)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See https://github.com/certbot/website/pull/348#issuecomment-399257703.

```
$ certbot --help all | grep -C 3  nginx-server-root
nginx:
  Nginx Web Server plugin - Alpha

  --nginx-server-root NGINX_SERVER_ROOT
                        Nginx server root directory. (default: /etc/nginx)
  --nginx-ctl NGINX_CTL
                        Path to the 'nginx' binary, used for 'configtest' and
 ```

```
$ CERTBOT_DOCS=1 certbot --help all | grep -C 3  nginx-server-root
nginx:
  Nginx Web Server plugin - Alpha

  --nginx-server-root NGINX_SERVER_ROOT
                        Nginx server root directory. (default: /etc/nginx or
                        /usr/local/etc/nginx)
  --nginx-ctl NGINX_CTL
```