### PR TITLE
run Isort on imported packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@ import codecs
 import os
 import re
 
-from setuptools import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 # Workaround for http://bugs.python.org/issue8876, see
 # http://bugs.python.org/issue8876#msg208792


### PR DESCRIPTION
HI fellow
I've just run Isort on `setup.py` because I though that was ugly. why two line when you can make one line?
Thanks