### PR TITLE
Fix server_root default tests on macOS

### DIFF
--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -971,8 +971,7 @@ class DetermineDefaultServerRootTest(certbot_test_util.ConfigTestCase):
             self.assertIn("/usr/local/etc/nginx", server_root)
             self.assertIn("/etc/nginx", server_root)
         else:
-            self.assertTrue("/etc/nginx" in server_root or "/usr/local/etc/nginx" in server_root)
-            self.assertFalse("/etc/nginx" in server_root and "/usr/local/etc/nginx" in server_root)
+            self.assertTrue(server_root == "/etc/nginx" or server_root == "/usr/local/etc/nginx")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tests are failing on macOS. See https://travis-ci.org/certbot/certbot/jobs/397040447#L2510.

This is because if `"/usr/local/etc/nginx" in server_root` is true, `"/etc/nginx" in server_root` is also true so `self.assertFalse("/etc/nginx" in server_root and "/usr/local/etc/nginx" in server_root)` fails.

This fixes that by using `==` rather than `in`.