### PR TITLE
Apache RewriteCond fix Syntax for wildcard domain

### DIFF
--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -1863,7 +1863,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
 
             names = ssl_vhost.get_names()
             for idx, name in enumerate(names):
-                args = ["%{SERVER_NAME}", "={0}".format(name), "[OR]"]
+                args = ["%{SERVER_NAME}", " ^({0})$".format(name), "[OR]"]
                 if idx == len(names) - 1:
                     args.pop()
                 self.parser.add_dir(general_vh.path, "RewriteCond", args)


### PR DESCRIPTION
Fix Apache Mod_rewrite syntax in certbot that cause some error if add another wildcard domain to server.
Example: If I use certbot add abc.com, www.abc.com. And I create another website like api.abc.com( but dont add it to cert bot). The api.abc.com is automatically rediect to https and cert is not trust because I dont add it to cert bot.

The output of mod_rewrite looks like this:
RewriteCond %{SERVER_NAME} ^(abc.com)$ [OR]
RewriteCond %{SERVER_NAME} ^(www.abc.com)$

