### PR TITLE
Automate EBS cleanup

### DIFF
--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -168,14 +168,6 @@ def _get_block_device_mappings(ami_id):
             for mapping in EC2.Image(ami_id).block_device_mappings
             if not mapping.get('Ebs', {}).get('DeleteOnTermination', True)]
 
-def terminate_and_clean(instances):
-    """
-    Some AMIs specify EBS stores that won't delete on instance termination.
-    These must be manually deleted after shutdown.
-    """
-    for instance in instances:
-        instance.terminate()
-
 
 # Helper Routines
 #-------------------------------------------------------------------------------
@@ -362,10 +354,11 @@ def test_client_process(inqueue, outqueue):
 def cleanup(cl_args, instances, targetlist):
     print('Logs in ', LOGDIR)
     if not cl_args.saveinstances:
-        print('Terminating EC2 Instances and Cleaning Dangling EBS Volumes')
+        print('Terminating EC2 Instances')
         if cl_args.killboulder:
             boulder_server.terminate()
-        terminate_and_clean(instances)
+        for instance in instances:
+            instance.terminate()
     else:
         # print login information for the boxes for debugging
         for ii, target in enumerate(targetlist):


### PR DESCRIPTION
Part of #6056.

I have another piece to this locally which makes us terminating the instances more reliable, but I thought I'd split up the PR and first submit this which causes Amazon to automatically handle deleting EBS volumes when instances are shutdown.

The general approach here is described at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/RootDeviceStorage.html#Using_RootDeviceStorage. Doing something like this significantly speeds up cleanup and ensures we always cleanup storage because [EC2 only supports EBS and instance volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html#block-device-mapping-def) and [instance volumes cannot outlive the associated instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-lifetime).

Probably the easiest way to tests this is to run a test with `--killboulder` on the command line and wait for the test to finish or hit ctrl+c after you see "Waiting on Boulder Server". If you do that and wait a few minutes, you can then run `aws ec2 --profile <profile> describe-volumes` and if no one else is running tests on our account, the output should be empty.