### PR TITLE
Remove CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,0 @@
-ChangeLog
-=========
-
-To see the changes in a given release, view the issues closed in a given
-release's GitHub milestone:
-
- - `Past releases <https://github.com/certbot/certbot/milestones?state=closed>`_
- - `Upcoming releases <https://github.com/certbot/certbot/milestones>`_

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ EXPOSE 80 443
 VOLUME /etc/letsencrypt /var/lib/letsencrypt
 WORKDIR /opt/certbot
 
-COPY CHANGES.rst README.rst setup.py src/
+COPY CHANGELOG.md README.rst setup.py src/
 COPY acme src/acme
 COPY certbot src/certbot
 

--- a/Dockerfile-old
+++ b/Dockerfile-old
@@ -34,7 +34,7 @@ RUN /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto --os-packages-only
 # Dockerfile we make sure we cache as much as possible
 
 
-COPY setup.py README.rst CHANGES.rst MANIFEST.in letsencrypt-auto-source/pieces/pipstrap.py /opt/certbot/src/
+COPY setup.py README.rst CHANGELOG.md MANIFEST.in letsencrypt-auto-source/pieces/pipstrap.py /opt/certbot/src/
 
 # all above files are necessary for setup.py and venv setup, however,
 # package source code directory has to be copied separately to a

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.rst
-include CHANGES.rst
+include CHANGELOG.md
 include CONTRIBUTING.md
 include LICENSE.txt
 include linter_plugin.py

--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -14,7 +14,7 @@ RUN /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto --os-packages-only
 # the above is not likely to change, so by putting it further up the
 # Dockerfile we make sure we cache as much as possible
 
-COPY setup.py README.rst CHANGES.rst MANIFEST.in linter_plugin.py tox.cover.sh tox.ini .pylintrc /opt/certbot/src/
+COPY setup.py README.rst CHANGELOG.md MANIFEST.in linter_plugin.py tox.cover.sh tox.ini .pylintrc /opt/certbot/src/
 
 # all above files are necessary for setup.py, however, package source
 # code directory has to be copied separately to a subdirectory...

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ init_fn = os.path.join(here, 'certbot', '__init__.py')
 meta = dict(re.findall(r"""__([a-z]+)__ = '([^']+)""", read_file(init_fn)))
 
 readme = read_file(os.path.join(here, 'README.rst'))
-changes = read_file(os.path.join(here, 'CHANGES.rst'))
 version = meta['version']
 
 # This package relies on PyOpenSSL, requests, and six, however, it isn't
@@ -79,7 +78,7 @@ setup(
     name='certbot',
     version=version,
     description="ACME client",
-    long_description=readme,  # later: + '\n\n' + changes
+    long_description=readme,
     url='https://github.com/letsencrypt/letsencrypt',
     author="Certbot Project",
     author_email='client-dev@letsencrypt.org',


### PR DESCRIPTION
The change log is now being tracked in `CHANGELOG.md`, so `CHANGES.rst` is no longer necessary.