### PR TITLE
Allow py37 testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ pip_install = {toxinidir}/tools/pip_install_editable.sh
 # before the script moves on to the next package. All dependencies are pinned
 # to a specific version for increased stability for developers.
 install_and_test = {toxinidir}/tools/install_and_test.sh
-dns_packages =
-    certbot-dns-cloudflare \
+python37_compatible_dns_packages =
     certbot-dns-cloudxns \
     certbot-dns-digitalocean \
     certbot-dns-dnsimple \
@@ -25,14 +24,22 @@ dns_packages =
     certbot-dns-nsone \
     certbot-dns-rfc2136 \
     certbot-dns-route53
-all_packages =
+dns_packages =
+    certbot-dns-cloudflare \
+    {[base]python37_compatible_dns_packages}
+nondns_packages =
     acme[dev] \
     .[dev] \
     certbot-apache \
-    {[base]dns_packages} \
     certbot-nginx \
     certbot-postfix \
     letshelp-certbot
+python37_compatible_packages =
+    {[base]nondns_packages} \
+    {[base]python37_compatible_dns_packages}
+all_packages =
+    {[base]nondns_packages} \
+    {[base]dns_packages}
 install_packages =
     {toxinidir}/tools/pip_install_editable.sh {[base]all_packages}
 source_paths =

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,13 @@ commands =
 setenv =
     PYTHONHASHSEED = 0
 
+[testenv:py37]
+commands =
+    {[base]install_and_test} {[base]python37_compatible_packages}
+    python tests/lock_test.py
+setenv =
+    {[testenv]setenv}
+
 [testenv:py27-oldest]
 commands =
     {[testenv]commands}


### PR DESCRIPTION
Allows us to test on Python 3.7 until https://github.com/yaml/pyyaml/issues/126 is resolved. Once that issue is resolved, this PR can be reverted.

With the changes here, those in #6169, and changing the macOS tests to use Python 3.7, the tests pass as shown at https://travis-ci.org/certbot/certbot/builds/399337786.