### PR TITLE
More detailed error logging for nginx plugin

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -136,7 +136,9 @@ class NginxConfigurator(common.Installer):
         """
         # Verify Nginx is installed
         if not util.exe_exists(self.conf('ctl')):
-            raise errors.NoInstallationError
+            raise errors.NoInstallationError(
+                "Could not find a usable 'nginx' binary. Ensure nginx exists, "
+                "the binary is executable, and your PATH is set correctly.")
 
         # Make sure configuration is valid
         self.config_test()

--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -222,7 +222,7 @@ class NginxParser(object):
                 return os.path.join(self.root, name)
 
         raise errors.NoInstallationError(
-            "Could not find configuration root")
+            "Could not find Nginx root configuration file (nginx.conf)")
 
     def filedump(self, ext='tmp', lazy=True):
         """Dumps parsed configurations into files.


### PR DESCRIPTION
This makes errors more useful when Nginx can't be found or when Nginx's
configuration can't be found.  Previously, a generic `NoInstallationError` isn't descriptive enough to explain _what_ wasn't installed or what failed without going digging into the source code.

An error like:
```
 The nginx plugin is not working; there may be problems with your existing configuration.
The error was: NoInstallationError()
```
seems to imply there's a problem with "configuration" which I've previously interpreted as Certbot config problem rather than the Nginx _installation_ or in other common cases the `PATH` isn't right when say run in `cron` (#5920).

This PR just makes the error messages more verbose, helping the user to know what to check:

```
Could not choose appropriate plugin for updaters: The nginx plugin is not working; there may be problems with your existing configuration.
The error was: NoInstallationError("Could not find a usable 'nginx' binary. Ensure nginx exists, the binary is executable, and your PATH is set correctly.",)
```

The error formatting isn't perfect, but that's beyond the scope of this PR; now the user knows what they need to go and check.