### PR TITLE
Add Python 3.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,9 @@ matrix:
       env: TOXENV=py34
       sudo: required
       services: docker
-    - python: "3.6"
-      env: TOXENV=py36
+    - python: "3.7"
+      dist: xenial
+      env: TOXENV=py37
       sudo: required
       services: docker
     - sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
         - $HOME/.cache/pip
 
 before_install:
-  - '([ $TRAVIS_OS_NAME == linux ] && dpkg -s libaugeas0) || (brew update && brew install augeas python3 && brew upgrade python && brew link python)'
+  - 'if [ $TRAVIS_OS_NAME = osx ] ; then brew update && brew install augeas python3 && brew upgrade python && brew link python ; fi'
 
 before_script:
   - 'if [ $TRAVIS_OS_NAME = osx ] ; then ulimit -n 1024 ; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,6 @@ sudo: false
 
 addons:
   apt:
-    sources:
-    - augeas
     packages:  # Keep in sync with letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh and Boulder.
     - python-dev
     - python-virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
         - $HOME/.cache/pip
 
 before_install:
-  - 'if [ $TRAVIS_OS_NAME = osx ] ; then brew update && brew install augeas python3 && brew upgrade python && brew link python ; fi'
+  - '([ $TRAVIS_OS_NAME == linux ] && dpkg -s libaugeas0) || (brew update && brew install augeas python3 && brew upgrade python && brew link python)'
 
 before_script:
   - 'if [ $TRAVIS_OS_NAME = osx ] ; then ulimit -n 1024 ; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,6 @@ addons:
     # For certbot-nginx integration testing
     - nginx-light
     - openssl
-    # for apacheconftest
-    - apache2
-    - libapache2-mod-wsgi
-    - libapache2-mod-macro
 
 install: "travis_retry $(command -v pip || command -v pip3) install tox coveralls"
 script:

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -46,6 +46,7 @@ function Cleanup() {
 
 # if our environment asks us to enable modules, do our best!
 if [ "$1" = --debian-modules ] ; then
+    sudo apt-get install -y apache2
     sudo apt-get install -y libapache2-mod-wsgi
     sudo apt-get install -y libapache2-mod-macro
 


### PR DESCRIPTION
This PR replaces the Python 3.6 tests with Python 3.7 tests to continue testing with the oldest and newest versions of Python 3 in every PR. We'll continue testing with Python 3.6 in the `test-everything` branch and I plan to add more Python 3.7 tests to the `test-everything` branch once this PR is merged.

A number of other changes to were needed to set this up:

* We have to use `dist: xenial` because Python 3.7 requires a newer version of `openssl` than is available in Ubuntu Trusty. See https://github.com/travis-ci/travis-ci/issues/9069.
* We have to remove `sources: augeas` as it's not supported with `dist: xenial`. This is cruft leftover from when we were testing on Ubuntu 12.04 anyway and can be safely removed.
* We have to remove the Apache dependencies. This is because the Apache and Nginx packages starting with Ubuntu 16.04 automatically start the webserver causing Apache and Nginx to conflict if they are installed at the same time. Since the [apacheconftest handles installing packages anyway](https://github.com/certbot/certbot/blob/cb076539ec99423b8e3f8ff7f0bc4fa2b7452766/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test#L49), let's remove them (after adding `apache2` to the package list) which speed up all other builds and avoid the Apache and Nginx conflicts.