### PR TITLE
Handle merge conflicts and add Python 3.7 integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,12 @@ matrix:
       services: docker
     - python: "3.7"
       dist: xenial
-      env: TOXENV=py37
+      env: TOXENV=py37 BOULDER_INTEGRATION=v1
+      sudo: required
+      services: docker
+    - python: "3.7"
+      dist: xenial
+      env: TOXENV=py37 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
     - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,11 @@ matrix:
       env: TOXENV=py36 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+    - python: "3.7"
+      dist: xenial
+      env: TOXENV=py37
+      sudo: required
+      services: docker
     - python: "2.7"
       env: TOXENV=nginxroundtrip
     - language: generic
@@ -122,8 +127,6 @@ sudo: false
 
 addons:
   apt:
-    sources:
-    - augeas
     packages:  # Keep in sync with letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh and Boulder.
     - python-dev
     - python-virtualenv
@@ -135,10 +138,6 @@ addons:
     # For certbot-nginx integration testing
     - nginx-light
     - openssl
-    # for apacheconftest
-    - apache2
-    - libapache2-mod-wsgi
-    - libapache2-mod-macro
 
 install: "travis_retry $(command -v pip || command -v pip3) install tox coveralls"
 script:

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -46,6 +46,7 @@ function Cleanup() {
 
 # if our environment asks us to enable modules, do our best!
 if [ "$1" = --debian-modules ] ; then
+    sudo apt-get install -y apache2
     sudo apt-get install -y libapache2-mod-wsgi
     sudo apt-get install -y libapache2-mod-macro
 


### PR DESCRIPTION
This fixes merge conflicts caused by #6179 landing which is causing [test failures](https://travis-ci.org/certbot/certbot/builds/400951407) and adds Python 3.7 integration tests.

**IMPORTANT:** This PR should be merged and not squashed to avoid continued merge conflicts.