### PR TITLE
Full Python 3.7 support

### DIFF
--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -51,7 +51,7 @@ pytest-forked==0.2
 pytest-xdist==1.20.1
 python-dateutil==2.6.1
 python-digitalocean==1.11
-PyYAML==3.12
+PyYAML==3.13
 repoze.sphinx.autointerface==0.8
 requests-file==1.4.2
 requests-toolbelt==0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ pip_install = {toxinidir}/tools/pip_install_editable.sh
 # before the script moves on to the next package. All dependencies are pinned
 # to a specific version for increased stability for developers.
 install_and_test = {toxinidir}/tools/install_and_test.sh
-python37_compatible_dns_packages =
+dns_packages =
+    certbot-dns-cloudflare \
     certbot-dns-cloudxns \
     certbot-dns-digitalocean \
     certbot-dns-dnsimple \
@@ -24,22 +25,14 @@ python37_compatible_dns_packages =
     certbot-dns-nsone \
     certbot-dns-rfc2136 \
     certbot-dns-route53
-dns_packages =
-    certbot-dns-cloudflare \
-    {[base]python37_compatible_dns_packages}
-nondns_packages =
+all_packages =
     acme[dev] \
     .[dev] \
     certbot-apache \
+    {[base]dns_packages} \
     certbot-nginx \
     certbot-postfix \
     letshelp-certbot
-python37_compatible_packages =
-    {[base]nondns_packages} \
-    {[base]python37_compatible_dns_packages}
-all_packages =
-    {[base]nondns_packages} \
-    {[base]dns_packages}
 install_packages =
     {toxinidir}/tools/pip_install_editable.sh {[base]all_packages}
 source_paths =
@@ -68,13 +61,6 @@ commands =
     python tests/lock_test.py
 setenv =
     PYTHONHASHSEED = 0
-
-[testenv:py37]
-commands =
-    {[base]install_and_test} {[base]python37_compatible_packages}
-    python tests/lock_test.py
-setenv =
-    {[testenv]setenv}
 
 [testenv:py27-oldest]
 commands =


### PR DESCRIPTION
Now that https://github.com/yaml/pyyaml/issues/126 is resolved, #6170 can be ~~deleted~~ reverted by bumping the pinned version of `PyYAML`.

You can see this code passing with full macOS and integration tests at https://travis-ci.org/certbot/certbot/builds/400957729.