### PR TITLE
Fix detect defaults when nargs present

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -120,7 +120,7 @@ More detailed help:
 
 
 # These argparse parameters should be removed when detecting defaults.
-ARGPARSE_PARAMS_TO_REMOVE = ("const", "nargs", "type",)
+ARGPARSE_PARAMS_TO_REMOVE = ("const", "type",)
 
 
 # These sets are used when to help detect options set by the user.


### PR DESCRIPTION
If a plugin adds a command line argument with the `nargs` parameter, e.g. `nargs='+'`, this parameter gets filtered from the `HelpfulArgumentParser` created/used in default detection. As a result, this parser does not parse the command line in the expected way, instead using the default value for `nargs`.

Leaving `nargs` in place resolves this issue. See #6164.