### PR TITLE
Added Nginx plugin to Certbot docker image.

### DIFF
--- a/certbot-nginx/Dockerfile
+++ b/certbot-nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM certbot/certbot
+
+COPY . src/certbot-nginx
+
+RUN pip install --no-cache-dir --editable src/certbot-nginx


### PR DESCRIPTION
Added a docker file to implement the nginx plugin on Certbot.

It runs well if you put the nginx folder (/etc/nginx) and letsencrypt folders as a volume on this container. 

This is my docker run command to create it with wildcard certificate:

```
docker run -it --rm --name certbot \
       -v 'letsencrypt:/etc/letsencrypt' \
       -v 'var-letsencrypt:/var/lib/letsencrypt' \
       -v 'nginx-conf:/etc/nginx' \
       certbot/certbot run \
                      --email <email> \
                      --agree-tos \
                      --installer nginx \
                      --redirect \
                      --server https://acme-v02.api.letsencrypt.org/directory \
                      -d *.domain.tld
```