### PR TITLE
Fix detect defaults and config serialization in presence of nargs

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -120,7 +120,7 @@ More detailed help:
 
 
 # These argparse parameters should be removed when detecting defaults.
-ARGPARSE_PARAMS_TO_REMOVE = ("const", "nargs", "type",)
+ARGPARSE_PARAMS_TO_REMOVE = ("const", "type",)
 
 
 # These sets are used when to help detect options set by the user.

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -265,6 +265,7 @@ def option_was_set(option, value):
 
 
 def argparse_list(cast, values):
+    """Wrap an argparse type function in a list (default: str)"""
     if cast is None:
         cast = str
     return [cast(value) for value in values]


### PR DESCRIPTION
If a plugin adds a command line argument with the nargs parameter, e.g. nargs='+', this parameter gets filtered from the HelpfulArgumentParser created/used in default detection. As a result, this parser does not parse the command line in the expected way, instead using the default value for nargs.

Leaving nargs in place resolves this issue. See #6164.

Additionally, in `renewal._restore_plugin_configs`, plugin renewal parameters of list type (as generated by nargs='+', among others) were being serialized as strings. A wrapping function has been added to handle list-based parameters.