### PR TITLE
Properly handle None value for installer in updater

### DIFF
--- a/certbot/plugins/selection.py
+++ b/certbot/plugins/selection.py
@@ -263,6 +263,10 @@ def cli_plugin_requests(config):  # pylint: disable=too-many-branches
     :rtype: tuple
     """
     req_inst = req_auth = config.configurator
+    if config.installer == 'None':
+        config.installer = None
+    if config.authenticator == 'None':
+        config.authenticator = None
     req_inst = set_configurator(req_inst, config.installer)
     req_auth = set_configurator(req_auth, config.authenticator)
 

--- a/certbot/plugins/selection_test.py
+++ b/certbot/plugins/selection_test.py
@@ -215,6 +215,14 @@ class GetUnpreparedInstallerTest(test_util.ConfigTestCase):
         self.mock_apache_fail_ep.name = "apache"
         self.assertRaises(errors.PluginSelectionError, self._call)
 
+    def test_return_early_if_none(self):
+        self.config.installer = 'None'
+        # Make sure that the function returns early. PluginsRegistry.filter is
+        # called right after we should return.
+        with mock.patch('certbot.plugins.disco.PluginsRegistry.filter') as mock_f:
+            self._call()
+            self.assertFalse(mock_f.called)
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
Our configuration parser reads all of the configuration values as strings. This causes `installer = None` to become 'None' in the configuration object, and the installer plugin selection fails because of it. This PR adds a simple check to the code determining which installer or authenticator plugin was requested, and returns a proper `None` type in the case described above. This allows us to return early from the updater plugin selection code.