### PR TITLE
Doc fixes for certbot-dns-linode

### DIFF
--- a/certbot-dns-linode/certbot_dns_linode/__init__.py
+++ b/certbot-dns-linode/certbot_dns_linode/__init__.py
@@ -23,7 +23,7 @@ Credentials
 
 Use of this plugin requires a configuration file containing Linode API
 credentials, obtained from your Linode account's `Applications & API
-Tokens page <https://cloud.linode.com/settings/api/tokens>`_.
+Tokens page <https://manager.linode.com/profile/api>`_.
 
 .. code-block:: ini
    :name: credentials.ini


### PR DESCRIPTION
1) Add linode docs to `docs/cli-help.txt`.
2) Fix API Keys page url in `certbot-dns-linode/certbot_dns_linode/__init__.py` docs

This should be merged before next release if possible.