### PR TITLE
travis: container env are bad at reading cpu count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       sudo: required
       services: docker
     - python: "2.7"
-      env: TOXENV=cover FYI="this also tests py27"
+      env: TOXENV=cover NUMPROCESSES=2 FYI="this also tests py27"
     - sudo: required
       env: TOXENV=nginx_compat
       services: docker

--- a/tox.cover.sh
+++ b/tox.cover.sh
@@ -8,6 +8,8 @@
 #
 # -e makes sure we fail fast and don't submit coveralls submit
 
+NUMPROCESSES=${NUMPROCESSES:=auto}
+
 if [ "xxx$1" = "xxx" ]; then
   pkgs="certbot acme certbot_apache certbot_dns_cloudflare certbot_dns_cloudxns certbot_dns_digitalocean certbot_dns_dnsimple certbot_dns_dnsmadeeasy certbot_dns_gehirn certbot_dns_google certbot_dns_linode certbot_dns_luadns certbot_dns_nsone certbot_dns_ovh certbot_dns_rfc2136 certbot_dns_route53 certbot_dns_sakuracloud certbot_nginx certbot_postfix letshelp_certbot"
 else
@@ -61,7 +63,7 @@ cover () {
   fi
 
   pkg_dir=$(echo "$1" | tr _ -)
-  pytest --cov "$pkg_dir" --cov-append --cov-report= --numprocesses auto --pyargs "$1"
+  pytest --cov "$pkg_dir" --cov-append --cov-report= --numprocesses "$NUMPROCESSES" --pyargs "$1"
   coverage report --fail-under="$min" --include="$pkg_dir/*" --show-missing
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -115,6 +115,7 @@ commands =
 
 [testenv:cover]
 basepython = python2.7
+passenv = NUMPROCESSES
 commands =
     {[base]install_packages}
     ./tox.cover.sh


### PR DESCRIPTION
closes #6197 - it guess the issue comes from the container env.

```
+ pytest --cov certbot --cov-append --cov-report= --numprocesses 2 --pyargs certbot
============================= test session starts ==============================
platform linux2 -- Python 2.7.14, pytest-3.2.5, py-1.4.34, pluggy-0.4.0
rootdir: /home/travis/build/certbot/certbot, inifile:
plugins: xdist-1.20.1, forked-0.2, cov-2.5.1
gw0 [874] / gw1 [874]
```