### PR TITLE
test(postfix): env for testing on oldest deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     - python: "3.5"
       env: TOXENV=mypy
     - python: "2.7"
-      env: TOXENV='py27-{acme,apache,certbot,dns,nginx}-oldest'
+      env: TOXENV='py27-{acme,apache,certbot,dns,nginx,postfix}-oldest'
       sudo: required
       services: docker
     - python: "3.4"

--- a/certbot-postfix/certbot_postfix/tests/installer_test.py
+++ b/certbot-postfix/certbot_postfix/tests/installer_test.py
@@ -253,7 +253,7 @@ class InstallerTest(certbot_test_util.ConfigTestCase):
                 fake_set.reset_mock()
                 installer.deploy_cert("example.com", "cert_path", "key_path",
                                       "chain_path", "fullchain_path")
-                fake_set.assert_not_called()
+                self.assertFalse(fake_set.called)
 
     @certbot_test_util.patch_get_utility()
     def test_deploy_already_secure(self, mock_util):

--- a/certbot-postfix/local-oldest-requirements.txt
+++ b/certbot-postfix/local-oldest-requirements.txt
@@ -1,2 +1,2 @@
 acme[dev]==0.25.0
-certbot[dev]==0.23.0
+certbot[dev]==0.26.0

--- a/certbot-postfix/setup.py
+++ b/certbot-postfix/setup.py
@@ -6,7 +6,7 @@ version = '0.26.0.dev0'
 
 install_requires = [
     'acme>=0.25.0',
-    'certbot>=0.23.0',
+    'certbot>=0.26.0',
     'setuptools',
     'six',
     'zope.component',

--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,12 @@ commands =
 setenv =
     {[testenv:py27-oldest]setenv}
 
+[testenv:py27-postfix-oldest]
+commands =
+    {[base]install_and_test} certbot-postfix
+setenv =
+    {[testenv:py27-oldest]setenv}
+
 [testenv:py27_install]
 basepython = python2.7
 commands =


### PR DESCRIPTION
Fixes #6124 
Can I bump the `certbot` dependency lower?  Older versions of `certbot` depend on versions of `acme` that are older than `25.0`.