### PR TITLE
deps: bump pytest-xdist to 1.22.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       sudo: required
       services: docker
     - python: "2.7"
-      env: TOXENV=cover NUMPROCESSES=2 FYI="this also tests py27"
+      env: TOXENV=cover FYI="this also tests py27"
     - sudo: required
       env: TOXENV=nginx_compat
       services: docker

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -48,7 +48,7 @@ pylint==1.4.2
 pytest==3.2.5
 pytest-cov==2.5.1
 pytest-forked==0.2
-pytest-xdist==1.20.1
+pytest-xdist==1.22.5
 python-dateutil==2.6.1
 python-digitalocean==1.11
 PyYAML==3.13

--- a/tox.cover.sh
+++ b/tox.cover.sh
@@ -8,8 +8,6 @@
 #
 # -e makes sure we fail fast and don't submit coveralls submit
 
-NUMPROCESSES=${NUMPROCESSES:=auto}
-
 if [ "xxx$1" = "xxx" ]; then
   pkgs="certbot acme certbot_apache certbot_dns_cloudflare certbot_dns_cloudxns certbot_dns_digitalocean certbot_dns_dnsimple certbot_dns_dnsmadeeasy certbot_dns_gehirn certbot_dns_google certbot_dns_linode certbot_dns_luadns certbot_dns_nsone certbot_dns_ovh certbot_dns_rfc2136 certbot_dns_route53 certbot_dns_sakuracloud certbot_nginx certbot_postfix letshelp_certbot"
 else
@@ -63,7 +61,7 @@ cover () {
   fi
 
   pkg_dir=$(echo "$1" | tr _ -)
-  pytest --cov "$pkg_dir" --cov-append --cov-report= --numprocesses "$NUMPROCESSES" --pyargs "$1"
+  pytest --cov "$pkg_dir" --cov-append --cov-report= --numprocesses "auto" --pyargs "$1"
   coverage report --fail-under="$min" --include="$pkg_dir/*" --show-missing
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ source_paths =
     tests/lock_test.py
 
 [testenv]
+passenv = TRAVIS
 commands =
     {[base]install_and_test} {[base]all_packages}
     python tests/lock_test.py
@@ -121,7 +122,6 @@ commands =
 
 [testenv:cover]
 basepython = python2.7
-passenv = NUMPROCESSES
 commands =
     {[base]install_packages}
     ./tox.cover.sh
@@ -166,7 +166,9 @@ commands =
     docker run --rm -it apache-compat -c apache.tar.gz -vvvv
 whitelist_externals =
     docker
-passenv = DOCKER_*
+passenv =
+    DOCKER_*
+    TRAVIS
 
 [testenv:nginx_compat]
 commands =
@@ -175,7 +177,9 @@ commands =
     docker run --rm -it nginx-compat -c nginx.tar.gz -vv -aie
 whitelist_externals =
     docker
-passenv = DOCKER_*
+passenv =
+    DOCKER_*
+    TRAVIS
 
 [testenv:le_auto_precise]
 # At the moment, this tests under Python 2.7 only, as only that version is
@@ -185,7 +189,9 @@ commands =
     docker run --rm -t -i lea
 whitelist_externals =
     docker
-passenv = DOCKER_*
+passenv =
+    DOCKER_*
+    TRAVIS
 
 [testenv:le_auto_trusty]
 # At the moment, this tests under Python 2.7 only, as only that version is
@@ -198,6 +204,7 @@ whitelist_externals =
     docker
 passenv =
     DOCKER_*
+    TRAVIS
     TRAVIS_BRANCH
 
 [testenv:le_auto_wheezy]


### PR DESCRIPTION
Latest pytest-xdist knows how to properly read the number of processes given by Travis.

cf #6236, reverts #6211 