### PR TITLE
Ignore monkey patching errors

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -36,7 +36,10 @@ if sys.version_info < (2, 7, 9):  # pragma: no cover
         requests.packages.urllib3.contrib.pyopenssl.inject_into_urllib3()  # type: ignore
     except AttributeError:
         import urllib3.contrib.pyopenssl  # pylint: disable=import-error
-        urllib3.contrib.pyopenssl.inject_into_urllib3()
+        try:
+            urllib3.contrib.pyopenssl.inject_into_urllib3()
+        except AttributeError:
+            pass
 
 DEFAULT_NETWORK_TIMEOUT = 45
 


### PR DESCRIPTION
Getting the following on CentOS 7:
```
# /usr/bin/certbot renew
Traceback (most recent call last):
  File "/usr/bin/certbot", line 7, in <module>
    from certbot.main import main
  File "/usr/lib/python2.7/site-packages/certbot/main.py", line 21, in <module>
    from certbot import client
  File "/usr/lib/python2.7/site-packages/certbot/client.py", line 16, in <module>
    from acme import client as acme_client
  File "/usr/lib/python2.7/site-packages/acme/client.py", line 39, in <module>
    urllib3.contrib.pyopenssl.inject_into_urllib3()
AttributeError: 'module' object has no attribute 'pyopenssl'
```

I've fixed it by following the suggestion of urllib3 developers:
https://urllib3.readthedocs.io/en/latest/reference/urllib3.contrib.html#module-urllib3.contrib.pyopenssl
which gives the following example code for monkey patching:

```
try:
    import urllib3.contrib.pyopenssl
    urllib3.contrib.pyopenssl.inject_into_urllib3()
except ImportError:
    pass
```

With that change, I could refresh my certs on CentOS 7.