### PR TITLE
Fix pre-existing VirtualHost object paths when adding a new one

### DIFF
--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -729,7 +729,7 @@ class ApacheParser(object):
 
     def _fix_path(self, old, new):
         """Helper function to add index to Augeas path if required"""
-        index_re = "\[\d*\]"
+        index_re = r"\[\d*\]"
         if old == new:
             return old
         if re.search(index_re, old):

--- a/certbot-apache/certbot_apache/tests/parser_test.py
+++ b/certbot-apache/certbot_apache/tests/parser_test.py
@@ -299,6 +299,29 @@ class BasicParserTest(util.ParserTest):
             errors.MisconfigurationError,
             self.parser.update_runtime_variables)
 
+    def test_fix_path_indices_match(self):
+        old_path = new_path = "/augeas/dom/path[1]/match"
+        self.assertEquals(self.parser.fix_path_indices(old_path, new_path),
+                          old_path)
+
+    def test_fix_path_indices_needs_index(self):
+        old_path = "/path/index/needed"
+        new_path = "/path/index[2]/needed"
+        fixed_path = self.parser.fix_path_indices(old_path, new_path)
+        self.assertEquals(fixed_path, "/path/index[1]/needed")
+
+    def test_fix_path_indices_shorter_new(self):
+        old_path = "/path/index/needed"
+        new_path = "/path/index[2]"
+        fixed_path = self.parser.fix_path_indices(old_path, new_path)
+        self.assertEquals(fixed_path, "/path/index[1]/needed")
+
+    def test_fix_path_indices_needs_index_divergence(self):
+        old_path = "/path/index/needed/unique/path"
+        new_path = "/path/index[2]/needed/another/path"
+        fixed_path = self.parser.fix_path_indices(old_path, new_path)
+        self.assertEquals(fixed_path, "/path/index[1]/needed/unique/path")
+
     def test_add_comment(self):
         from certbot_apache.parser import get_aug_path
         self.parser.add_comment(get_aug_path(self.parser.loc["name"]), "123456")

--- a/certbot-apache/certbot_apache/tests/parser_test.py
+++ b/certbot-apache/certbot_apache/tests/parser_test.py
@@ -12,6 +12,7 @@ from certbot_apache.tests import util
 
 
 class BasicParserTest(util.ParserTest):
+    # pylint: disable=too-many-public-methods
     """Apache Parser Test."""
 
     def setUp(self):  # pylint: disable=arguments-differ


### PR DESCRIPTION
When installing certificates for Apache, if there is a need to create multiple `VirtualHosts` to the same file, the first one created gets an Augeas DOM path that has no index, as it's the only one in that path at the very moment. If said VirtualHost has multiple domains, the `deploy_cert` might get called to another domain for that `VirtualHost` later on, after creating another `VirtualHost` to the same file. Augeas then fails to manage path without index, crashing the process.

This PR fixes the pre-existing `VirtualHost` object paths when creating a new one, if needed. It also adds a debug log message to the `deploy_cert` function, logging the processed domain name to help with debugging in the future.