### PR TITLE
Enable Apache VirtualHost for HTTP challenge validation if not enabled already

### DIFF
--- a/certbot-apache/certbot_apache/http_01.py
+++ b/certbot-apache/certbot_apache/http_01.py
@@ -172,4 +172,10 @@ class ApacheHttp01(common.TLSSNI01):
             self.configurator.parser.add_dir(
                 vhost.path, "Include", self.challenge_conf_post)
 
+            if not vhost.enabled:
+                from certbot_apache.parser import get_aug_path
+                self.configurator.parser.add_dir(
+                    get_aug_path(self.configurator.parser.loc["default"]),
+                    "Include", vhost.filep)
+
             self.moded_vhosts.add(vhost)

--- a/certbot-apache/certbot_apache/http_01.py
+++ b/certbot-apache/certbot_apache/http_01.py
@@ -6,6 +6,7 @@ from acme.magic_typing import Set  # pylint: disable=unused-import, no-name-in-m
 from certbot import errors
 from certbot.plugins import common
 from certbot_apache.obj import VirtualHost  # pylint: disable=unused-import
+from certbot_apache.parser import get_aug_path
 
 logger = logging.getLogger(__name__)
 
@@ -173,7 +174,6 @@ class ApacheHttp01(common.TLSSNI01):
                 vhost.path, "Include", self.challenge_conf_post)
 
             if not vhost.enabled:
-                from certbot_apache.parser import get_aug_path
                 self.configurator.parser.add_dir(
                     get_aug_path(self.configurator.parser.loc["default"]),
                     "Include", vhost.filep)

--- a/certbot-apache/certbot_apache/tests/http_01_test.py
+++ b/certbot-apache/certbot_apache/tests/http_01_test.py
@@ -145,6 +145,10 @@ class ApacheHttp01Test(util.ApacheTest):
                 domain="certbot.demo", account_key=self.account_key)]
         vhosts[0].enabled = False
         self.common_perform_test(achalls, vhosts)
+        matches = self.config.parser.find_dir(
+            "Include", vhosts[0].filep,
+            get_aug_path(self.config.parser.loc["default"]))
+        self.assertEqual(len(matches), 1)
 
     def combinations_perform_test(self, num_achalls, minor_version):
         """Test perform with the given achall count and Apache version."""
@@ -180,11 +184,6 @@ class ApacheHttp01Test(util.ApacheTest):
                 matches = self.config.parser.find_dir("Include",
                                                       self.http.challenge_conf_post,
                                                       vhost.path)
-                self.assertEqual(len(matches), 1)
-            if not vhost.enabled:
-                matches = self.config.parser.find_dir(
-                    "Include", vhost.filep,
-                    get_aug_path(self.config.parser.loc["default"]))
                 self.assertEqual(len(matches), 1)
 
         self.assertTrue(os.path.exists(challenge_dir))


### PR DESCRIPTION
If user provides a custom `--apache-vhost-root` path that's not parsed by Apache per default, Certbot fails the challenge validation. While the `VirtualHost` on custom path is correctly found, and edited, it's still not seen by Apache. This PR adds a temporary `Include` directive to the root Apache configuration when writing the challenge tokens to the `VirtualHost`.