### PR TITLE
Clarify that configurations can be invalid

### DIFF
--- a/certbot/cert_manager.py
+++ b/certbot/cert_manager.py
@@ -353,7 +353,7 @@ def _describe_certs(config, parsed_certs, parse_failures):
             notify("Found the following {0}certs:".format(match))
             notify(_report_human_readable(config, parsed_certs))
         if parse_failures:
-            notify("\nThe following renewal configuration files "
+            notify("\nThe following renewal configurations "
                "were invalid:")
             notify(_report_lines(parse_failures))
 

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -359,7 +359,7 @@ def _renew_describe_results(config, renew_successes, renew_failures,
         notify_error(report(renew_failures, "failure"))
 
     if parse_failures:
-        notify("\nAdditionally, the following renewal configuration files "
+        notify("\nAdditionally, the following renewal configurations "
                "were invalid: ")
         notify(report(parse_failures, "parsefail"))
 


### PR DESCRIPTION
A configuration file will typically point to files...
If those files are supposed to be symbolic links but are not,
then the configuration is invalid.

Any normal person upon being told that a configuration file is
invalid would compare the configuration file to another
configuration file, and not spot anything particularly wrong with it.

The problem in that case is the configuration, which includes the
configuration file and everything it references.
-- NOT the configuration file itself.

#6276

This only addresses half of the problem...
I've looked a little bit into the main part (reporting to the user in the certificates listing), and that appears to require significantly more effort.