### PR TITLE
Remove visible warnings about missing apachectl

### DIFF
--- a/certbot/plugins/util.py
+++ b/certbot/plugins/util.py
@@ -51,6 +51,6 @@ def path_surgery(cmd):
         return True
     else:
         expanded = " expanded" if any(added) else ""
-        logger.warning("Failed to find executable %s in%s PATH: %s", cmd,
-                       expanded, path)
+        logger.debug("Failed to find executable %s in%s PATH: %s", cmd,
+                     expanded, path)
         return False

--- a/certbot/plugins/util_test.py
+++ b/certbot/plugins/util_test.py
@@ -16,9 +16,8 @@ class GetPrefixTest(unittest.TestCase):
 class PathSurgeryTest(unittest.TestCase):
     """Tests for certbot.plugins.path_surgery."""
 
-    @mock.patch("certbot.plugins.util.logger.warning")
     @mock.patch("certbot.plugins.util.logger.debug")
-    def test_path_surgery(self, mock_debug, mock_warn):
+    def test_path_surgery(self, mock_debug):
         from certbot.plugins.util import path_surgery
         all_path = {"PATH": "/usr/local/bin:/bin/:/usr/sbin/:/usr/local/sbin/"}
         with mock.patch.dict('os.environ', all_path):
@@ -26,14 +25,12 @@ class PathSurgeryTest(unittest.TestCase):
                 mock_exists.return_value = True
                 self.assertEqual(path_surgery("eg"), True)
                 self.assertEqual(mock_debug.call_count, 0)
-                self.assertEqual(mock_warn.call_count, 0)
                 self.assertEqual(os.environ["PATH"], all_path["PATH"])
         no_path = {"PATH": "/tmp/"}
         with mock.patch.dict('os.environ', no_path):
             path_surgery("thingy")
-            self.assertEqual(mock_debug.call_count, 1)
-            self.assertEqual(mock_warn.call_count, 1)
-            self.assertTrue("Failed to find" in mock_warn.call_args[0][0])
+            self.assertEqual(mock_debug.call_count, 2)
+            self.assertTrue("Failed to find" in mock_debug.call_args[0][0])
             self.assertTrue("/usr/local/bin" in os.environ["PATH"])
             self.assertTrue("/tmp" in os.environ["PATH"])
 


### PR DESCRIPTION
Everywhere this function is used, we raise an exception if the executable still isn't found so I think this change is OK. If you want to verify this, see:
```
$ git grep path_surgery\( -- './*' ':(exclude)*_test.py'
certbot-apache/certbot_apache/configurator.py:            if not path_surgery(exe):
certbot-postfix/certbot_postfix/util.py:    if not (certbot_util.exe_exists(exe) or plugins_util.path_surgery(exe)):
certbot/hooks.py:        plug_util.path_surgery(shell_cmd)
certbot/plugins/util.py:def path_surgery(cmd):
```
