### PR TITLE
Added support for double-quoted file paths in nginx.conf include directives

### DIFF
--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -81,7 +81,7 @@ class NginxParser(object):
 
         """
         if not os.path.isabs(path):
-            return os.path.join(self.root, path).strip('"')
+            return os.path.join(self.root, path).replace('"', '')
         else:
             return path
 

--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -81,7 +81,7 @@ class NginxParser(object):
 
         """
         if not os.path.isabs(path):
-            return os.path.join(self.root, path)
+            return os.path.join(self.root, path).strip('"')
         else:
             return path
 

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -70,6 +70,9 @@ class NginxParserTest(util.NginxTest): #pylint: disable=too-many-public-methods
         self.assertEqual('/etc/nginx/*', nparser.abs_path('/etc/nginx/*'))
         self.assertEqual(os.path.join(self.config_path, 'foo/bar/'),
                          nparser.abs_path('foo/bar/'))
+        self.assertEqual(os.path.join(self.config_path, 'foo/bar/'),
+                         nparser.abs_path('"foo/bar/"'))
+
 
     def test_filedump(self):
         nparser = parser.NginxParser(self.config_path)

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -73,7 +73,6 @@ class NginxParserTest(util.NginxTest): #pylint: disable=too-many-public-methods
         self.assertEqual(os.path.join(self.config_path, 'foo/bar/'),
                          nparser.abs_path('"foo/bar/"'))
 
-
     def test_filedump(self):
         nparser = parser.NginxParser(self.config_path)
         nparser.filedump('test', lazy=False)


### PR DESCRIPTION
## The issue
This is a fix for issues [#5543](https://github.com/certbot/certbot/issues/5543) and [#6325](https://github.com/certbot/certbot/issues/6325).

The issues are related to the fact that Nginx supports using either double quotes or no quotes at all when declaring a path in an `include` directive. Both of the following are syntactically correct in an `nginx.conf` file:

- `include sites-enabled1/*;`
- `include "sites-enabled2/*";`

In the above example, the absolute path of the `sites-enabled1` directory, as returned by the `abs_path` method, will be something like: 
- `/etc/nginx/sites-enabled1/*`

Whereas the absolute path of the `sites-enabled2` directory will be something like:
- `/etc/nginx/"sites-enabled2/*"`

The second path is invalid and will not be considered in any of the scripts subsequent file/directory reading operations.

## Summary of changes
- Removing double quotes `"` from file paths using Pythons `replace()` method at the earliest point relevant. [See code](https://github.com/certbot/certbot/compare/master...Briscoooe:master#diff-b2dab7e6fe39d3a1bf642d561d045633R84)
- Another test case to the `abs_path` test method. [See code](https://github.com/certbot/certbot/compare/master...Briscoooe:master#diff-cf22a62b9f3f06d4c413904d321a4b4bR73)