### PR TITLE
Route53 assume role

### DIFF
--- a/certbot-dns-route53/certbot_dns_route53/__init__.py
+++ b/certbot-dns-route53/certbot_dns_route53/__init__.py
@@ -12,6 +12,10 @@ Named Arguments
                                           to propagate before asking the ACME
                                           server to verify the DNS record.
                                           (Default: 10)
+
+``--dns-route53-assume-role``             Assume a role in a different AWS
+                                          account. Specify the account ID
+                                          and role separated with a colon.
 ========================================  =====================================
 
 
@@ -116,5 +120,14 @@ Examples
    certbot certonly \\
      --dns-route53 \\
      --dns-route53-propagation-seconds 30 \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To aquire a certificate for ``example.com``, assuming a role in
+             a different account
+
+   certbot certonly \\
+     --dns-route53 \\
+     --dns-route53-assume-role 123456:dns-role \\
      -d example.com
 """

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -4,7 +4,6 @@ import logging
 import time
 
 import boto3
-import botocore
 import zope.interface
 from botocore.exceptions import NoCredentialsError, ClientError
 

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -44,7 +44,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     @classmethod
     def add_parser_arguments(cls, add): # pylint: disable=arguments-differ
         super(Authenticator, cls).add_parser_arguments(add)
-        add("assume-role", help="Assume a role in a different account.")
+        add("assume-role", default=None, help="Assume a role in a different account.")
 
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
         return "Solve a DNS01 challenge using AWS Route53"

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -174,6 +174,6 @@ class Authenticator(dns_common.DNSAuthenticator):
                                     aws_secret_access_key=credentials["SecretAccessKey"],
                                     aws_session_token=credentials["SessionToken"])
             return session.client("route53")
-        except botocore.exceptions.NoCredentialsError as e:
-            logger.error('Could not find AWS credentials: %s', e)
-            raise errors.PluginError('Error obtaining AWS credentials: {0}'.format(e))
+        except (NoCredentialsError, ClientError) as e:
+            logger.debug('Encountered error during _get_session: %s', e, exc_info=True)
+            raise errors.PluginError("\n".join([str(e), INSTRUCTIONS]))

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -161,12 +161,16 @@ class Authenticator(dns_common.DNSAuthenticator):
 
     def _get_session(self, accountrole):
         """Assume a role in a different account"""
+        if ':' not in accountrole:
+            raise errors.PluginError(
+                "The account role should be formatted as AWS account ID and role separated with a ':' "
+                "(1234567:my_role)")
         account_id, role = accountrole.split(":")
         sts = boto3.client("sts")
         try:
             response = sts.assume_role(
                 RoleArn="arn:aws:iam::%s:role/%s" % (account_id, role),
-                RoleSessionName="TODO-session-name",
+                RoleSessionName="role-session-name-%s" % int(time.time()),
                 DurationSeconds=900
             )
             credentials = response["Credentials"]

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -163,7 +163,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         account_id, role = accountrole.split(":")
         sts = boto3.client("sts")
         response = sts.assume_role(
-            RoleArn="arn:aws:iam::%s:role/%s" % *(account_id, role),
+            RoleArn="arn:aws:iam::%s:role/%s" % (account_id, role),
             RoleSessionName="TODO-session-name",
             DurationSeconds=900
         )

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
@@ -18,7 +18,7 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
 
         super(AuthenticatorTest, self).setUp()
 
-        self.config = mock.MagicMock()
+        self.config = mock.MagicMock(route53_assume_role=None)
 
         self.auth = Authenticator(self.config, "route53")
 
@@ -115,7 +115,7 @@ class ClientTest(unittest.TestCase):
 
         super(ClientTest, self).setUp()
 
-        self.config = mock.MagicMock()
+        self.config = mock.MagicMock(route53_assume_role=None)
 
         self.client = Authenticator(self.config, "route53")
 


### PR DESCRIPTION
Add a `--dns-route53-assume-role` command line option to assume a role in a different account before performing DNS validation.

I'd appreciate some advice on how to add tests for this please.