### PR TITLE
Fix test farm tests

### DIFF
--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -48,13 +48,13 @@ targets:
   # CentOS
   # These Marketplace AMIs must, irritatingly, have their terms manually
   # agreed to on the AWS marketplace site for any new AWS account using them...
-  - ami: ami-61bbf104
+  - ami: ami-9887c6e7
     name: centos7
     type: centos
     virt: hvm
     user: centos
   # centos6 requires EPEL repo added
-  - ami: ami-57cd8732
+  - ami: ami-1585c46a
     name: centos6
     type: centos
     virt: hvm


### PR DESCRIPTION
The tests had the following assumptions about the AWS account being used which I removed.

* It assumed the previous CentOS AMIs were available while they are not on a new AWS account. I believe the difference is when you agreed to CentOS's TOS through the AWS marketplace. The AMIs we've been using are from 2015 while the oldest one available to new subscribers is from the end of 2017.
* The tests assumed you had a default VPC and subnet which was configured to automatically assign public IP addresses. This may not be the case (and isn't on our new account), so I removed this assumption with a simple check. Perhaps it would be better to automate this setup like we do for security groups, but since we want to rewrite these tests in the long term, I just had it print a message about what needs to be done and exit if a usable subnet isn't available.