### PR TITLE
Add better error handling around release signatures

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -184,7 +184,7 @@ fi
 letsencrypt-auto-source/build.py
 
 # and that it's signed correctly
-tools/offline-sigrequest.sh
+tools/offline-sigrequest.sh || true
 while ! openssl dgst -sha256 -verify $RELEASE_OPENSSL_PUBKEY -signature \
         letsencrypt-auto-source/letsencrypt-auto.sig \
         letsencrypt-auto-source/letsencrypt-auto            ; do
@@ -192,7 +192,7 @@ while ! openssl dgst -sha256 -verify $RELEASE_OPENSSL_PUBKEY -signature \
     read -p "Would you like this script to try and sign it again [Y/n]?" response
     case $response in
       [yY][eE][sS]|[yY]|"")
-        tools/offline-sigrequest.sh;;
+        tools/offline-sigrequest.sh || true;;
       *)
         ;;
     esac

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -15,8 +15,7 @@ RELEASE_BRANCH="candidate-$version"
 if [ "$RELEASE_OPENSSL_PUBKEY" = "" ] ; then
     RELEASE_OPENSSL_PUBKEY="`realpath \`dirname $0\``/eff-pubkey.pem"
 fi
-DEFAULT_GPG_KEY="A2CFB51FA275A7286234E7B24D17C995CD9775F2"
-RELEASE_GPG_KEY=${RELEASE_GPG_KEY:-"$DEFAULT_GPG_KEY"}
+RELEASE_GPG_KEY=${RELEASE_GPG_KEY:-A2CFB51FA275A7286234E7B24D17C995CD9775F2}
 # Needed to fix problems with git signatures and pinentry
 export GPG_TTY=$(tty)
 
@@ -199,15 +198,13 @@ while ! openssl dgst -sha256 -verify $RELEASE_OPENSSL_PUBKEY -signature \
     esac
 done
 
-if [ "$RELEASE_GPG_KEY" = "$DEFAULT_GPG_KEY" ]; then
-    while ! gpg2 --card-status >/dev/null 2>&1; do
-        echo gpg cannot find your OpenPGP card
-        read -p "Please take the card out and put it back in again."
-    done
-fi
-
 # This signature is not quite as strong, but easier for people to verify out of band
-gpg2 -u "$RELEASE_GPG_KEY" --detach-sign --armor --sign --digest-algo sha256 letsencrypt-auto-source/letsencrypt-auto
+while ! gpg2 -u "$RELEASE_GPG_KEY" --detach-sign --armor --sign --digest-algo sha256 letsencrypt-auto-source/letsencrypt-auto; do
+    echo "Unable to sign letsencrypt-auto using $RELEASE_KEY."
+    echo "Make sure your OpenPGP card is in your computer if you are using one."
+    echo "You may need to take the card out and put it back in again."
+    read -p "Press enter to try signing again."
+done
 # We can't rename the openssl letsencrypt-auto.sig for compatibility reasons,
 # but we can use the right name for certbot-auto.asc from day one
 mv letsencrypt-auto-source/letsencrypt-auto.asc letsencrypt-auto-source/certbot-auto.asc

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -215,7 +215,12 @@ cp -p letsencrypt-auto-source/letsencrypt-auto letsencrypt-auto
 
 git add certbot-auto letsencrypt-auto letsencrypt-auto-source docs/cli-help.txt
 git diff --cached
-git commit --gpg-sign="$RELEASE_GPG_KEY" -m "Release $version"
+while ! git commit --gpg-sign="$RELEASE_GPG_KEY" -m "Release $version"; do
+    echo "Unable to sign the release commit using git."
+    echo "You may have to configure git to use gpg2 by running:"
+    echo 'git config --global gpg.program $(command -v gpg2)'
+    read -p "Press enter to try signing again."
+done
 git tag --local-user "$RELEASE_GPG_KEY" --sign --message "Release $version" "$tag"
 
 cd ..


### PR DESCRIPTION
Changes here are:

* Remove `DEFAULT_GPG_KEY` because it's not used anymore.
* Don't treat errors from `tools/offline-sigrequest.sh` as fatal. We're checking the signature in a loop and won't continue until the signature matches.
* Rather than checking the PGP card status after the offline signature, just try using it again and loop if it fails.
* Add error handling around first signature using `git`. In testing this with a throwaway key, I hit an issue where `gpg2` recognized my key, but `git` didn't so I added error handling here too.

While we don't usually do this, after this lands I think we can copy these changes to the 0.27.x branch so we have them in the unlikely event we need to do another point release.

EDIT: I tested this on macOS and Ubuntu 16.04.