### PR TITLE
Update DNS plugin docs

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -190,10 +190,11 @@ If you'd like to obtain a wildcard certificate from Let's Encrypt or run
 ``certbot`` on a machine other than your target webserver, you can use one of
 Certbot's DNS plugins.
 
-These plugins are still in the process of being packaged
-by many distributions and cannot currently be installed with ``certbot-auto``.
-If, however, you are comfortable installing the certificates yourself,
-you can run these plugins with :ref:`Docker <docker-user>`.
+These plugins are not included in a default Certbot installation and must be
+installed separately. While the DNS plugins cannot currently be used with
+``certbot-auto``, they are available in many OS package managers and as Docker
+images. Visit https://certbot.eff.org to learn the best way to use the DNS
+plugins on your system.
 
 Once installed, you can find documentation on how to use each plugin at:
 


### PR DESCRIPTION
This will be more valuable once https://github.com/certbot/website/issues/353 is resolved, but this makes it clear these plugins aren't installed by default and points people to https://certbot.eff.org to learn the best way to install them. If Docker is the user's best option right now, https://certbot.eff.org will point them to https://certbot.eff.org/docs/install.html#running-with-docker which is the target of the `<docker-user>` link I'm deleting.

@schoen, can you review this?