### PR TITLE
Connect AppVeyor to the certbot git repository

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+branches:
+  only:
+    - master
+    - /^\d+\.\d+\.x$/ # version branches like X.X.X
+    - /^test-.*$/
+
+build: off
+
+test_script:
+  - ps: Write-Host "Hello, world!"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+# AppVeyor CI pipeline, executed on Windows Server 2016/2012 R2
 branches:
   only:
     - master
@@ -8,3 +9,4 @@ build: off
 
 test_script:
   - ps: Write-Host "Hello, world!"
+  


### PR DESCRIPTION
Hello !

Since my first PR for cerbot windows compatibility has been merged (see #6296), it is time to industrialize a continuous integration process for windows.

**Principle**

The goal here is to do the same than Travis, but on Windows: to execute all regression tests on various Windows plateform at each push on master, and each push on a PR for master.

This PR and the next are focusing on this:
1) Create a connection to AppVeyor (this PR)
2) Launch as much as possible existing tests on AppVeyor (see adferrand/certbot#8 for a preview).

**About AppVeyor**

First, why AppVeyor ? AppVeyor is really similar to Travis in its approach: it connects to GitHub nicely, configure the build pipeline through a yaml file, allows execution matrix against several environment descriptors (plateform, python version and so on). It is free for GitHub projects, like Travis.

But AppVeyor is built on top of Windows VM clusters, so the build environment is Windows Server 2012 R2, or Windows Server 2016. So to sum up, it is the Travis for Windows.

Furthermore, the VMs offers a complete Visual Studio environment, so it is the royal path to build MSI installers of Certbot on Windows platforms.

**About this PR**

Now, this PR does not a lot of things: it declares a "dummy" `appveyor.yml` at the root of certbot repository: the built declared cannot fail, it just prints "Hello World" before marking the build as succeeded.

What really matters here, is to connect AppVeyor to the certbot github repository, and it is the real work of this PR, that I cannot do obsiously ... 

**The process to connect AppVeyor to GitHub**

The process is really similar to Travis. **It must be done after the current PR is merged to master!** (Otherwise unexpected behavior will occur due to the lack of `appveyor.yml` file on the master branch).

A developper with access to the certbot account need to go to https://www.appveyor.com/, click Sign-In, then select GitHub as the provider to create the account. Once the OAuth authentication is established, AppVeyor will scan for public repositories hold by the certbot GitHub account. From AppVeyor administration page, you will need to go to `Projects`, `New Project`, and select `certbot` in the drop-down list of GitHub category.

Once done, AppVeyor is connected to the certbot project repository. Any PR on master will need by default to pass both Travis CI pipelines and AppVeyor pipelines. As said before, and until my next PR, this will have no impact as the integrated dummy `appveyor.yml` cannot fail.

**Next step**

When this PR is merged and AppVeyor is connected to GitHub, I will create the next PR, that will then toggle the real CI pipeline for Windows that I prepared here: adferrand/certbot#8

**Help**

Of course I am at your disposition for any help needed on this PR and on AppVeyor.

Regards,
Adrien Ferrand