### PR TITLE
3rd party plugins can be used with and without the pip package name

### DIFF
--- a/certbot/plugins/disco.py
+++ b/certbot/plugins/disco.py
@@ -291,7 +291,7 @@ class PluginsRegistry(collections.Mapping):
     def __str__(self):
         if not self._plugins:
             return "No plugins"
-        cleaned_list = []
+        cleaned_list = [] # type: List[PluginEntryPoint]
         for p_ep in six.itervalues(self._plugins):
             if p_ep not in cleaned_list:
                 cleaned_list.append(p_ep)

--- a/certbot/plugins/disco.py
+++ b/certbot/plugins/disco.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 import zope.interface
 import zope.interface.verify
 
-from acme.magic_typing import Dict  # pylint: disable=unused-import, no-name-in-module
+from acme.magic_typing import Dict, List  # pylint: disable=unused-import, no-name-in-module
 from certbot import constants
 from certbot import errors
 from certbot import interfaces


### PR DESCRIPTION
This is a fix for Issue #4351 
Furthermore the `certbot plugins` command is extended to display for 3rd party plugins the old name as alternative name.