### PR TITLE
Correct OVH integration tests on machines without internet access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-*
-  
+* Correct OVH integration tests on machines without internet access.
+
 ## 0.27.1 - 2018-09-06
 
 ### Fixed

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -11,7 +11,7 @@ version = '0.28.0.dev0'
 install_requires = [
     'acme>=0.21.1',
     'certbot>=0.21.1',
-    'dns-lexicon>=2.2.1', # Support for >1 TXT record per name
+    'dns-lexicon>=2.7.3', # Correct OVH integration tests
     'mock',
     'setuptools',
     'zope.interface',

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -12,7 +12,7 @@ botocore==1.7.41
 cloudflare==1.5.1
 coverage==4.4.2
 decorator==4.1.2
-dns-lexicon==2.2.1
+dns-lexicon==2.7.3
 dnspython==1.15.0
 docutils==0.14
 execnet==1.5.0


### PR DESCRIPTION
Following #6222, this PR ensures to use Lexicon >= 2.7.3 for OVH plugin, as it corrects IT execution for systems without internet access.
