### PR TITLE
Remove duplicate route53 options

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -749,11 +749,6 @@ class HelpfulArgumentParser(object):
         :param dict **kwargs: various argparse settings for this argument
 
         """
-
-        # Remove duplicate route53 options from help.
-        if args[0] == '--certbot-route53:auth-propagation-seconds':
-            kwargs["help"] = argparse.SUPPRESS
-
         if isinstance(topics, list):
             # if this flag can be listed in multiple sections, try to pick the one
             # that the user has asked for help about
@@ -840,9 +835,8 @@ class HelpfulArgumentParser(object):
 
         """
         for name, plugin_ep in six.iteritems(plugins):
-            if name != 'certbot-route53:auth':  # Remove duplicate route53 options from help.
-                parser_or_group = self.add_group(name,
-                                                 description=plugin_ep.long_description)
+            parser_or_group = self.add_group(name,
+                                             description=plugin_ep.long_description)
             plugin_ep.plugin_cls.inject_parser_options(parser_or_group, name)
 
     def determine_help_topics(self, chosen_topic):
@@ -861,7 +855,8 @@ class HelpfulArgumentParser(object):
         if chosen_topic == "everything":
             chosen_topic = "run"
         if chosen_topic == "all":
-            return dict([(t, True) for t in self.help_topics])
+            # Addition of condition closes #6209 (removal of duplicate route53 option).
+            return dict([(t, True) if t != 'certbot-route53:auth' else (t, False) for t in self.help_topics])
         elif not chosen_topic:
             return dict([(t, False) for t in self.help_topics])
         else:

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -749,6 +749,7 @@ class HelpfulArgumentParser(object):
         :param dict **kwargs: various argparse settings for this argument
 
         """
+
         if isinstance(topics, list):
             # if this flag can be listed in multiple sections, try to pick the one
             # that the user has asked for help about

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -750,6 +750,9 @@ class HelpfulArgumentParser(object):
 
         """
 
+        if args[0] == '--certbot-route53:auth-propagation-seconds':  # Remove duplicate route53 options from help.
+           kwargs["help"] = argparse.SUPPRESS
+
         if isinstance(topics, list):
             # if this flag can be listed in multiple sections, try to pick the one
             # that the user has asked for help about
@@ -836,8 +839,9 @@ class HelpfulArgumentParser(object):
 
         """
         for name, plugin_ep in six.iteritems(plugins):
-            parser_or_group = self.add_group(name,
-                                             description=plugin_ep.long_description)
+            if name != 'certbot-route53:auth':  # Remove duplicate route53 options from help.
+                parser_or_group = self.add_group(name,
+                                                 description=plugin_ep.long_description)
             plugin_ep.plugin_cls.inject_parser_options(parser_or_group, name)
 
     def determine_help_topics(self, chosen_topic):

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -750,8 +750,9 @@ class HelpfulArgumentParser(object):
 
         """
 
-        if args[0] == '--certbot-route53:auth-propagation-seconds':  # Remove duplicate route53 options from help.
-           kwargs["help"] = argparse.SUPPRESS
+        # Remove duplicate route53 options from help.
+        if args[0] == '--certbot-route53:auth-propagation-seconds':
+            kwargs["help"] = argparse.SUPPRESS
 
         if isinstance(topics, list):
             # if this flag can be listed in multiple sections, try to pick the one

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -856,7 +856,8 @@ class HelpfulArgumentParser(object):
             chosen_topic = "run"
         if chosen_topic == "all":
             # Addition of condition closes #6209 (removal of duplicate route53 option).
-            return dict([(t, True) if t != 'certbot-route53:auth' else (t, False) for t in self.help_topics])
+            return dict([(t, True) if t != 'certbot-route53:auth' else (t, False)
+                         for t in self.help_topics])
         elif not chosen_topic:
             return dict([(t, False) for t in self.help_topics])
         else:

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -429,6 +429,11 @@ class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_allow_subset_with_wildcard(self):
         self.assertRaises(errors.Error, self.parse,
                           "--allow-subset-of-names -d *.example.org".split())
+    
+    def test_route53_no_revert(self):
+        for help_flag in ['-h', '--help']:
+            for topic in ['all', 'plugins', 'dns-route53']:
+                self.assertFalse('certbot-route53:auth' in self._help_output([help_flag, topic]))
 
 
 class DefaultTest(unittest.TestCase):

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -429,7 +429,7 @@ class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_allow_subset_with_wildcard(self):
         self.assertRaises(errors.Error, self.parse,
                           "--allow-subset-of-names -d *.example.org".split())
-    
+
     def test_route53_no_revert(self):
         for help_flag in ['-h', '--help']:
             for topic in ['all', 'plugins', 'dns-route53']:

--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -503,15 +503,6 @@ apache:
                         Full path to Apache control script (default:
                         apache2ctl)
 
-certbot-route53:auth:
-  Obtain certificates using a DNS TXT record (if you are using AWS Route53
-  for DNS).
-
-  --certbot-route53:auth-propagation-seconds CERTBOT_ROUTE53:AUTH_PROPAGATION_SECONDS
-                        The number of seconds to wait for DNS to propagate
-                        before asking the ACME server to verify the DNS
-                        record. (default: 10)
-
 dns-cloudflare:
   Obtain certificates using a DNS TXT record (if you are using Cloudflare
   for DNS).

--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -503,6 +503,14 @@ apache:
                         Full path to Apache control script (default:
                         apache2ctl)
 
+certbot-route53:auth:
+  Obtain certificates using a DNS TXT record (if you are using AWS Route53
+  for DNS).
+  --certbot-route53:auth-propagation-seconds CERTBOT_ROUTE53:AUTH_PROPAGATION_SECONDS
+                        The number of seconds to wait for DNS to propagate
+                        before asking the ACME server to verify the DNS
+                        record. (default: 10)
+
 dns-cloudflare:
   Obtain certificates using a DNS TXT record (if you are using Cloudflare
   for DNS).

--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -506,11 +506,11 @@ apache:
 certbot-route53:auth:
   Obtain certificates using a DNS TXT record (if you are using AWS Route53
   for DNS).
+
   --certbot-route53:auth-propagation-seconds CERTBOT_ROUTE53:AUTH_PROPAGATION_SECONDS
                         The number of seconds to wait for DNS to propagate
                         before asking the ACME server to verify the DNS
                         record. (default: 10)
-
 
 dns-cloudflare:
   Obtain certificates using a DNS TXT record (if you are using Cloudflare

--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -511,6 +511,7 @@ certbot-route53:auth:
                         before asking the ACME server to verify the DNS
                         record. (default: 10)
 
+
 dns-cloudflare:
   Obtain certificates using a DNS TXT record (if you are using Cloudflare
   for DNS).


### PR DESCRIPTION
Duplicate route53 option (certbot-route53:auth) removed.

Fixes https://github.com/certbot/certbot/issues/6209

Not sure if it is worth updating the changelog for such a small change.
