### PR TITLE
Stop caching the results of ipv6_info in http01.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 
 * Match Nginx parser update in allowing variable names to start with `${`.
 * Correct OVH integration tests on machines without internet access.
+* Stop caching the results of ipv6_info in http01.py
 
 ## 0.27.1 - 2018-09-06
 

--- a/certbot-nginx/certbot_nginx/http_01.py
+++ b/certbot-nginx/certbot_nginx/http_01.py
@@ -40,8 +40,6 @@ class NginxHttp01(common.ChallengePerformer):
         super(NginxHttp01, self).__init__(configurator)
         self.challenge_conf = os.path.join(
             configurator.config.config_dir, "le_http_01_cert_challenge.conf")
-        self._ipv6 = None
-        self._ipv6only = None
 
     def perform(self):
         """Perform a challenge on Nginx.
@@ -120,9 +118,7 @@ class NginxHttp01(common.ChallengePerformer):
             self.configurator.config.http01_port)
         port = self.configurator.config.http01_port
 
-        if self._ipv6 is None or self._ipv6only is None:
-            self._ipv6, self._ipv6only = self.configurator.ipv6_info(port)
-        ipv6, ipv6only = self._ipv6, self._ipv6only
+        ipv6, ipv6only = self.configurator.ipv6_info(port)
 
         if ipv6:
             # If IPv6 is active in Nginx configuration

--- a/certbot-nginx/certbot_nginx/tests/http_01_test.py
+++ b/certbot-nginx/certbot_nginx/tests/http_01_test.py
@@ -142,7 +142,6 @@ class HttpPerformTest(util.NginxTest):
         ipv6_info.return_value = (False, False)
         addrs = self.http01._default_listen_addresses()
         http_addr = Addr.fromstring("80")
-        ssl_addr = Addr.fromstring("5001 ssl")
         self.assertEqual(addrs, [http_addr])
 
 if __name__ == "__main__":

--- a/certbot-nginx/certbot_nginx/tests/http_01_test.py
+++ b/certbot-nginx/certbot_nginx/tests/http_01_test.py
@@ -114,9 +114,10 @@ class HttpPerformTest(util.NginxTest):
         # pylint: disable=protected-access
         ipv6_info.return_value = (True, True)
         self.http01._default_listen_addresses()
+        self.assertEqual(ipv6_info.call_count, 1)
         ipv6_info.return_value = (False, False)
         self.http01._default_listen_addresses()
-        self.assertEqual(ipv6_info.call_count, 4)
+        self.assertEqual(ipv6_info.call_count, 2)
 
     @mock.patch("certbot_nginx.configurator.NginxConfigurator.ipv6_info")
     def test_default_listen_addresses_t_t(self, ipv6_info):

--- a/certbot-nginx/certbot_nginx/tls_sni_01.py
+++ b/certbot-nginx/certbot_nginx/tls_sni_01.py
@@ -51,9 +51,6 @@ class NginxTlsSni01(common.TLSSNI01):
         default_addr = "{0} ssl".format(
             self.configurator.config.tls_sni_01_port)
 
-        ipv6, ipv6only = self.configurator.ipv6_info(
-            self.configurator.config.tls_sni_01_port)
-
         for achall in self.achalls:
             vhosts = self.configurator.choose_vhosts(achall.domain, create_if_no_match=True)
 
@@ -61,6 +58,9 @@ class NginxTlsSni01(common.TLSSNI01):
             if vhosts and vhosts[0].addrs:
                 addresses.append(list(vhosts[0].addrs))
             else:
+                # choose_vhosts might have modified vhosts, so put this after
+                ipv6, ipv6only = self.configurator.ipv6_info(
+                    self.configurator.config.tls_sni_01_port)
                 if ipv6:
                     # If IPv6 is active in Nginx configuration
                     ipv6_addr = "[::]:{0} ssl".format(


### PR DESCRIPTION
A single call might change the results of later calls. Add tests for this and `_default_listen_addresses` more broadly.

From the ashes of #6366.