### PR TITLE
Add debugging info for Nginx tls-sni and http integration tests purposes

### DIFF
--- a/certbot-nginx/certbot_nginx/http_01.py
+++ b/certbot-nginx/certbot_nginx/http_01.py
@@ -102,6 +102,7 @@ class NginxHttp01(common.ChallengePerformer):
         config = [self._make_or_mod_server_block(achall) for achall in self.achalls]
         config = [x for x in config if x is not None]
         config = nginxparser.UnspacedList(config)
+        logger.debug("Generated server block:\n%s", str(config))
 
         self.configurator.reverter.register_file_creation(
             True, self.challenge_conf)

--- a/certbot-nginx/certbot_nginx/tls_sni_01.py
+++ b/certbot-nginx/certbot_nginx/tls_sni_01.py
@@ -141,6 +141,8 @@ class NginxTlsSni01(common.TLSSNI01):
         with open(self.challenge_conf, "w") as new_conf:
             nginxparser.dump(config, new_conf)
 
+        logger.debug("Generated server block:\n%s", str(config))
+
     def _make_server_block(self, achall, addrs):
         """Creates a server block for a challenge.
 

--- a/certbot-nginx/tests/boulder-integration.sh
+++ b/certbot-nginx/tests/boulder-integration.sh
@@ -35,6 +35,7 @@ test_deployment_and_rollback() {
 }
 
 export default_server="default_server"
+nginx -v
 reload_nginx
 certbot_test_nginx --domains nginx.wtf run
 test_deployment_and_rollback nginx.wtf


### PR DESCRIPTION
Be sure to edit the `master` section of `CHANGELOG.md` with a line describing this PR before it gets merged.

From the ashes of #6366.