### PR TITLE
docs: remove mentions of #letsencrypt on Freenode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-*
+* Removed documentation mentions of `#letsencrypt` IRC on Freenode.
 
 ### Fixed
 

--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,6 @@ ACME working area in github: https://github.com/ietf-wg-acme/acme
 
 |build-status| |coverage| |docs| |container|
 
-.. _Freenode: https://webchat.freenode.net?channels=%23letsencrypt
-
 .. |build-status| image:: https://travis-ci.org/certbot/certbot.svg?branch=master
    :target: https://travis-ci.org/certbot/certbot
    :alt: Travis CI status

--- a/README.rst
+++ b/README.rst
@@ -91,8 +91,6 @@ Main Website: https://certbot.eff.org
 
 Let's Encrypt Website: https://letsencrypt.org
 
-IRC Channel: #letsencrypt on `Freenode`_
-
 Community: https://community.letsencrypt.org
 
 ACME spec: http://ietf-wg-acme.github.io/acme/

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -988,9 +988,6 @@ Getting help
 If you're having problems, we recommend posting on the Let's Encrypt
 `Community Forum <https://community.letsencrypt.org>`_.
 
-You can also chat with us on IRC: `(#letsencrypt @
-freenode) <https://webchat.freenode.net?channels=%23letsencrypt>`_
-
 If you find a bug in the software, please do report it in our `issue
 tracker <https://github.com/certbot/certbot/issues>`_. Remember to
 give us as much information as possible:


### PR DESCRIPTION
This PR removes two mentions of the `#letsencrypt` IRC channel on Freenode. This channel is being deprecated with the intention to consolidate on the community forum.