### PR TITLE
Add route53 cname follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 * `revoke` accepts `--cert-name`, and doesn't accept both `--cert-name` and `--cert-path`.
+* certbot-dns-route53 follow CNAME records before attempting auth allowing for users to auth
+  with a different domain as described in https://community.letsencrypt.org/t/renew-using-dns-01-challenge/53498/10
 
 ### Changed
 

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53.py
@@ -2,6 +2,7 @@
 import collections
 import logging
 import time
+import dns.resolver
 
 import boto3
 import zope.interface
@@ -71,6 +72,25 @@ class Authenticator(dns_common.DNSAuthenticator):
         except (NoCredentialsError, ClientError) as e:
             logger.debug('Encountered error during cleanup: %s', e, exc_info=True)
 
+    def _check_for_cname(self, domain):
+        """Check if the record is a CNAME to another domain. This is used sometimes
+        if the user does not have full control over the domain.
+
+        See sansanu comment https://community.letsencrypt.org/t/renew-using-dns-01-challenge/53498/10
+
+        :param domain: domain to generate SSL certificate for
+        :return: CNAME answer if exists otherwise False
+        """
+
+        try:
+            answers = dns.resolver.query(domain, 'CNAME')
+            for answer in answers:
+                logger.info("Following CNAME record to " + str(answer.target))
+                return str(answer.target)
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer) as e:
+            logger.debug(str(e))
+            return False
+
     def _find_zone_id_for_domain(self, domain):
         """Find the zone id responsible a given FQDN.
 
@@ -102,6 +122,10 @@ class Authenticator(dns_common.DNSAuthenticator):
         return zones[0][1]
 
     def _change_txt_record(self, action, validation_domain_name, validation):
+        cname_domain_name = self._check_for_cname(validation_domain_name)
+        if cname_domain_name:
+            validation_domain_name = cname_domain_name
+
         zone_id = self._find_zone_id_for_domain(validation_domain_name)
 
         rrecords = self._resource_records[validation_domain_name]

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     'acme>=0.25.0',
     'certbot>=0.21.1',
     'boto3',
+    'dnspython',
     'mock',
     'setuptools',
     'zope.interface',


### PR DESCRIPTION
This PR allows for the route53 plugin to follow CNAME records for an acme-challenge.  This allows users to auth a domain in a different domain account if they don't have permissions for the original domain account.

This is discussed in the following post:

https://community.letsencrypt.org/t/renew-using-dns-01-challenge/53498/10