### PR TITLE
Use the ACMEv2 newNonce endpoint when a new nonce is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 * `revoke` accepts `--cert-name`, and doesn't accept both `--cert-name` and `--cert-path`.
+* Use the ACMEv2 newNonce endpoint when a new nonce is needed, and newNonce is available in the directory.
 
 ### Changed
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -978,7 +978,11 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         :raises .ClientError: In case of other networking errors.
 
         """
-        response_ct = response.headers.get('Content-Type')
+        try:
+            response_ct = response.headers.get('Content-Type')
+        except:
+            response_ct = None
+
         try:
             # TODO: response.json() is called twice, once here, and
             # once in _get and _post clients
@@ -1112,11 +1116,11 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         if not self._nonces:
             logger.debug('Requesting fresh nonce')
             if acme_version == 1:
-                new_nonce = self.head(url)
+                response = self.head(url)
             else:
-                # TODO: request a new nonce from the acme newNonce endpoint
-                new_nonce = self.head(new_nonce_url)
-            self._add_nonce(new_nonce)
+                # request a new nonce from the acme newNonce endpoint
+                response = self._check_response(self.head(new_nonce_url))
+            self._add_nonce(response)
         return self._nonces.pop()
 
     def post(self, *args, **kwargs):

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -979,7 +979,6 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
 
         """
         response_ct = response.headers.get('Content-Type')
-
         try:
             # TODO: response.json() is called twice, once here, and
             # once in _get and _post clients

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1116,7 +1116,7 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
                 response = self.head(url)
             else:
                 # request a new nonce from the acme newNonce endpoint
-                response = self._check_response(self.head(self.new_nonce_url))
+                response = self._check_response(self.head(self.new_nonce_url), content_type=None)
             self._add_nonce(response)
         return self._nonces.pop()
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -89,6 +89,8 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
 
         """
         kwargs.setdefault('acme_version', self.acme_version)
+        if hasattr(self.directory, 'newNonce'):
+            kwargs.setdefault('new_nonce_url', getattr(self.directory, 'newNonce'))
         return self.net.post(*args, **kwargs)
 
     def update_registration(self, regr, update=None):
@@ -569,7 +571,6 @@ class ClientV2(ClientBase):
         :param .messages.Directory directory: Directory Resource
         :param .ClientNetwork net: Client network.
         """
-        net.new_nonce_url = getattr(directory, "newNonce")
         super(ClientV2, self).__init__(directory=directory,
             net=net, acme_version=2)
 
@@ -915,7 +916,6 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         self.user_agent = user_agent
         self.session = requests.Session()
         self._default_timeout = timeout
-        self.new_nonce_url = None # set by ClientV2
         adapter = HTTPAdapter()
 
         if source_address is not None:
@@ -1109,14 +1109,16 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         else:
             raise errors.MissingNonce(response)
 
-    def _get_nonce(self, url, acme_version):
+    def _get_nonce(self, url, acme_version, new_nonce_url):
         if not self._nonces:
             logger.debug('Requesting fresh nonce')
             if acme_version == 1:
                 response = self.head(url)
-            else:
+            elif new_nonce_url is not None:
                 # request a new nonce from the acme newNonce endpoint
-                response = self._check_response(self.head(self.new_nonce_url), content_type=None)
+                response = self._check_response(self.head(new_nonce_url), content_type=None)
+            else:
+                raise errors.Error("URL of newNonce endpoint must be set when using ACMEv2.")
             self._add_nonce(response)
         return self._nonces.pop()
 
@@ -1138,7 +1140,9 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
 
     def _post_once(self, url, obj, content_type=JOSE_CONTENT_TYPE,
             acme_version=1, **kwargs):
-        data = self._wrap_in_jws(obj, self._get_nonce(url, acme_version), url, acme_version)
+        new_nonce_url = kwargs.get('new_nonce_url')
+        nonce = self._get_nonce(url, acme_version, new_nonce_url)
+        data = self._wrap_in_jws(obj, nonce, url, acme_version)
         kwargs.setdefault('headers', {'Content-Type': content_type})
         response = self._send_request('POST', url, data=data, **kwargs)
         response = self._check_response(response, content_type=content_type)

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -569,6 +569,7 @@ class ClientV2(ClientBase):
         :param .messages.Directory directory: Directory Resource
         :param .ClientNetwork net: Client network.
         """
+        net.new_nonce_url = getattr(directory, "newNonce")
         super(ClientV2, self).__init__(directory=directory,
             net=net, acme_version=2)
 
@@ -914,6 +915,7 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         self.user_agent = user_agent
         self.session = requests.Session()
         self._default_timeout = timeout
+        self.new_nonce_url = None # set by ClientV2
         adapter = HTTPAdapter()
 
         if source_address is not None:
@@ -1113,7 +1115,7 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
                 new_nonce = self.head(url)
             else:
                 # TODO: request a new nonce from the acme newNonce endpoint
-                new_nonce = self.head(url)
+                new_nonce = self.head(new_nonce_url)
             self._add_nonce(new_nonce)
         return self._nonces.pop()
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -978,10 +978,7 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         :raises .ClientError: In case of other networking errors.
 
         """
-        try:
-            response_ct = response.headers.get('Content-Type')
-        except:
-            response_ct = None
+        response_ct = response.headers.get('Content-Type')
 
         try:
             # TODO: response.json() is called twice, once here, and

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1133,5 +1133,6 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         data = self._wrap_in_jws(obj, self._get_nonce(url), url, acme_version)
         kwargs.setdefault('headers', {'Content-Type': content_type})
         response = self._send_request('POST', url, data=data, **kwargs)
+        response = self._check_response(response, content_type=content_type)
         self._add_nonce(response)
-        return self._check_response(response, content_type=content_type)
+        return response

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1119,7 +1119,7 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
                 response = self.head(url)
             else:
                 # request a new nonce from the acme newNonce endpoint
-                response = self._check_response(self.head(new_nonce_url))
+                response = self._check_response(self.head(self.new_nonce_url))
             self._add_nonce(response)
         return self._nonces.pop()
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1137,7 +1137,10 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
 
     def _post_once(self, url, obj, content_type=JOSE_CONTENT_TYPE,
             acme_version=1, **kwargs):
-        new_nonce_url = kwargs.get('new_nonce_url')
+        try:
+            new_nonce_url = kwargs.pop('new_nonce_url')
+        except KeyError:
+            new_nonce_url = None
         data = self._wrap_in_jws(obj, self._get_nonce(url, new_nonce_url), url, acme_version)
         kwargs.setdefault('headers', {'Content-Type': content_type})
         response = self._send_request('POST', url, data=data, **kwargs)

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -1068,6 +1068,7 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
 
         def send_request(*args, **kwargs):
             # pylint: disable=unused-argument,missing-docstring
+            self.assertFalse("new_nonce_url" in kwargs)
             method = args[0]
             uri = args[1]
             if method == 'HEAD' and uri != "new_nonce_uri":
@@ -1194,6 +1195,11 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
                           self.obj, content_type=self.content_type, acme_version=2,
                           new_nonce_url='new_nonce_uri')
         self.assertEqual(check_response.call_count, 1)
+
+    def test_new_nonce_uri_removed(self):
+        self.content_type = None
+        self.net.post('uri', self.obj, content_type=None,
+            acme_version=2, new_nonce_url='new_nonce_uri')
 
 
 class ClientNetworkSourceAddressBindingTest(unittest.TestCase):

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -805,7 +805,8 @@ class ClientV2Test(ClientTestBase):
     def test_revoke(self):
         self.client.revoke(messages_test.CERT, self.rsn)
         self.net.post.assert_called_once_with(
-            self.directory["revokeCert"], mock.ANY, acme_version=2)
+            self.directory["revokeCert"], mock.ANY, acme_version=2,
+            new_nonce_url=DIRECTORY_V2['newNonce'])
 
     def test_update_registration(self):
         # "Instance of 'Field' has no to_json/update member" bug:
@@ -1186,12 +1187,12 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
         bad_response = mock.MagicMock(ok=False, status_code=http_client.SERVICE_UNAVAILABLE)
         self.net._send_request = mock.MagicMock()
         self.net._send_request.return_value = bad_response
-        self.net.new_nonce_url = 'new_nonce_uri'
         self.content_type = None
         check_response = mock.MagicMock()
         self.net._check_response = check_response
         self.assertRaises(errors.ClientError, self.net.post, 'uri',
-                          self.obj, content_type=self.content_type, acme_version=2)
+                          self.obj, content_type=self.content_type, acme_version=2,
+                          new_nonce_url='new_nonce_uri')
         self.assertEqual(check_response.call_count, 1)
 
 

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -1181,6 +1181,7 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
                           self.net.post, 'uri', obj=self.obj)
 
     def test_post_bad_nonce_head(self):
+        # pylint: disable=protected-access
         # regression test for https://github.com/certbot/certbot/issues/6092
         bad_response = mock.MagicMock(ok=False, status_code=http_client.SERVICE_UNAVAILABLE)
         self.net._send_request = mock.MagicMock()


### PR DESCRIPTION
Also, add checking to the newNonce HEAD request, and check responses in general before attempting to save a nonce, for a better error message.

Fixes #6092.