### PR TITLE
Dummy AWS credentials for Route53 tests to prevent outbound connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 * Fix ranking of vhosts in Nginx so that all port-matching vhosts come first
 * Correct OVH integration tests on machines without internet access.
 * Stop caching the results of ipv6_info in http01.py
+* Test fix for Route53 plugin to prevent boto3 making outgoing connections.
 
 ## 0.27.1 - 2018-09-06
 

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
@@ -1,5 +1,6 @@
 """Tests for certbot_dns_route53.dns_route53.Authenticator"""
 
+import os
 import unittest
 
 import mock
@@ -19,6 +20,10 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
         super(AuthenticatorTest, self).setUp()
 
         self.config = mock.MagicMock()
+
+        # Set up dummy credentials for testing
+        os.environ["AWS_ACCESS_KEY_ID"] = "dummy_access_key"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "dummy_secret_access_key"
 
         self.auth = Authenticator(self.config, "route53")
 
@@ -116,6 +121,10 @@ class ClientTest(unittest.TestCase):
         super(ClientTest, self).setUp()
 
         self.config = mock.MagicMock()
+
+        # Set up dummy credentials for testing
+        os.environ["AWS_ACCESS_KEY_ID"] = "dummy_access_key"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "dummy_secret_access_key"
 
         self.client = Authenticator(self.config, "route53")
 

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
@@ -27,6 +27,12 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
 
         self.auth = Authenticator(self.config, "route53")
 
+    def tearDown(self):
+        # Remove the dummy credentials from env vars
+        del os.environ["AWS_ACCESS_KEY_ID"]
+        del os.environ["AWS_SECRET_ACCESS_KEY"]
+        super(AuthenticatorTest, self).tearDown()
+
     def test_perform(self):
         self.auth._change_txt_record = mock.MagicMock()
         self.auth._wait_for_change = mock.MagicMock()
@@ -127,6 +133,12 @@ class ClientTest(unittest.TestCase):
         os.environ["AWS_SECRET_ACCESS_KEY"] = "dummy_secret_access_key"
 
         self.client = Authenticator(self.config, "route53")
+
+    def tearDown(self):
+        # Remove the dummy credentials from env vars
+        del os.environ["AWS_ACCESS_KEY_ID"]
+        del os.environ["AWS_SECRET_ACCESS_KEY"]
+        super(ClientTest, self).tearDown()
 
     def test_find_zone_id_for_domain(self):
         self.client.r53.get_paginator = mock.MagicMock()


### PR DESCRIPTION
Boto3 / botocore library has a feature that tries to fetch AWS credentials from IAM if a set of credentials isn't available otherwise. This happens when boto loops through different credential providers in order to find the keys. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=912103

This PR simply adds dummy environmental variables for the tests that will be picked up by the credential provider iterator in order to prevent making outbound connections.
