### PR TITLE
 Increase the default propagation time from 1200sec to 1800sec.

### DIFF
--- a/certbot-dns-linode/certbot_dns_linode/__init__.py
+++ b/certbot-dns-linode/certbot_dns_linode/__init__.py
@@ -14,11 +14,10 @@ Named Arguments
                                             DNS to propagate before asking the
                                             ACME server to verify the DNS
                                             record.
-                                            (Default: 1200 because Linode
-                                            updates its first DNS every 15
-                                            minutes and we allow 5 more minutes
-                                            for the update to reach the other 5
-                                            servers)
+                                            (Default: 1800, according to official 
+                                            Linode DNS documentation the 
+                                            recommended time for complete DNS 
+                                            propagation is 30min or 1800seconds.
 ==========================================  ===================================
 
 


### PR DESCRIPTION
According to official Linode DNS documentation the recommended time for complete DNS propagation is 30min or 1800seconds for more info see the official Linode DNS documentation https://www.linode.com/docs/platform/manager/dns-manager/#edit-records)

Be sure to edit the `master` section of `CHANGELOG.md` with a line describing this PR before it gets merged.
