### PR TITLE
 Increase the default propagation time from 1200sec to 1800sec.

### DIFF
--- a/certbot-dns-linode/certbot_dns_linode/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/dns_linode.py
@@ -29,7 +29,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
     @classmethod
     def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
-        super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=1200)
+        super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=1800)
         add('credentials', help='Linode credentials INI file.')
 
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use


### PR DESCRIPTION
According to official Linode DNS documentation the recommended time for complete DNS propagation is 30min or 1800seconds for more info see the official Linode DNS documentation https://www.linode.com/docs/platform/manager/dns-manager/#edit-records)

Be sure to edit the `master` section of `CHANGELOG.md` with a line describing this PR before it gets merged.
