### PR TITLE
Stop preferring TLS-SNI in the Apache, Nginx, and standalone plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 * Removed documentation mentions of `#letsencrypt` IRC on Freenode.
 * Write README to the base of (config-dir)/live directory
 * `--manual` will explicitly warn users that earlier challenges should remain in place when setting up subsequent challenges.
+* Stop preferring TLS-SNI in the Apache, Nginx, and standalone plugins
 
 ### Fixed
 

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -2253,7 +2253,7 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
     ###########################################################################
     def get_chall_pref(self, unused_domain):  # pylint: disable=no-self-use
         """Return list of challenge preferences."""
-        return [challenges.TLSSNI01, challenges.HTTP01]
+        return [challenges.HTTP01, challenges.TLSSNI01]
 
     def perform(self, achalls):
         """Perform the configuration related challenge.

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -1039,7 +1039,7 @@ class NginxConfigurator(common.Installer):
     ###########################################################################
     def get_chall_pref(self, unused_domain):  # pylint: disable=no-self-use
         """Return list of challenge preferences."""
-        return [challenges.TLSSNI01, challenges.HTTP01]
+        return [challenges.HTTP01, challenges.TLSSNI01]
 
     # Entry point in main.py for performing challenges
     def perform(self, achalls):

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -103,7 +103,7 @@ class NginxConfiguratorTest(util.NginxTest):
             errors.PluginError, self.config.enhance, 'myhost', 'unknown_enhancement')
 
     def test_get_chall_pref(self):
-        self.assertEqual([challenges.TLSSNI01, challenges.HTTP01],
+        self.assertEqual([challenges.HTTP01,challenges.TLSSNI01],
                          self.config.get_chall_pref('myhost'))
 
     def test_save(self):

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -103,7 +103,7 @@ class NginxConfiguratorTest(util.NginxTest):
             errors.PluginError, self.config.enhance, 'myhost', 'unknown_enhancement')
 
     def test_get_chall_pref(self):
-        self.assertEqual([challenges.HTTP01,challenges.TLSSNI01],
+        self.assertEqual([challenges.HTTP01, challenges.TLSSNI01],
                          self.config.get_chall_pref('myhost'))
 
     def test_save(self):

--- a/certbot-nginx/tests/boulder-integration.sh
+++ b/certbot-nginx/tests/boulder-integration.sh
@@ -39,6 +39,8 @@ nginx -v
 reload_nginx
 certbot_test_nginx --domains nginx.wtf run
 test_deployment_and_rollback nginx.wtf
+certbot_test_nginx --domains nginx.wtf run --preferred-challenges tls-sni
+test_deployment_and_rollback nginx.wtf
 certbot_test_nginx --domains nginx2.wtf --preferred-challenges http
 test_deployment_and_rollback nginx2.wtf
 # Overlapping location block and server-block-level return 301

--- a/certbot/plugins/standalone.py
+++ b/certbot/plugins/standalone.py
@@ -114,7 +114,7 @@ class ServerManager(object):
         return self._instances.copy()
 
 
-SUPPORTED_CHALLENGES = [challenges.TLSSNI01, challenges.HTTP01] \
+SUPPORTED_CHALLENGES = [challenges.HTTP01, challenges.TLSSNI01] \
 # type: List[Type[challenges.KeyAuthorizationChallenge]]
 
 


### PR DESCRIPTION
Fixes #6319.