### PR TITLE
Warn when using deprecated acme.challenges.TLSSNI01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 * Removed documentation mentions of `#letsencrypt` IRC on Freenode.
 * Write README to the base of (config-dir)/live directory
 * `--manual` will explicitly warn users that earlier challenges should remain in place when setting up subsequent challenges.
+* Warn when using deprecated acme.challenges.TLSSNI01
 
 ### Fixed
 

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -4,6 +4,7 @@ import functools
 import hashlib
 import logging
 import socket
+import warnings
 
 from cryptography.hazmat.primitives import hashes  # type: ignore
 import josepy as jose
@@ -492,6 +493,11 @@ class TLSSNI01(KeyAuthorizationChallenge):
 
     # boulder#962, ietf-wg-acme#22
     #n = jose.Field("n", encoder=int, decoder=int)
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn("TLS-SNI-01 is deprecated, and will stop working in February 2019.",
+            DeprecationWarning, stacklevel=2)
+        super(TLSSNI01, self).__init__(*args, **kwargs)
 
     def validation(self, account_key, **kwargs):
         """Generate validation.

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -495,7 +495,7 @@ class TLSSNI01(KeyAuthorizationChallenge):
     #n = jose.Field("n", encoder=int, decoder=int)
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("TLS-SNI-01 is deprecated, and will stop working in February 2019.",
+        warnings.warn("TLS-SNI-01 is deprecated, and will stop working soon.",
             DeprecationWarning, stacklevel=2)
         super(TLSSNI01, self).__init__(*args, **kwargs)
 

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -1,5 +1,6 @@
 """Tests for acme.challenges."""
 import unittest
+import warnings
 
 import josepy as jose
 import mock
@@ -360,20 +361,28 @@ class TLSSNI01ResponseTest(unittest.TestCase):
 class TLSSNI01Test(unittest.TestCase):
 
     def setUp(self):
-        from acme.challenges import TLSSNI01
-        self.msg = TLSSNI01(
-            token=jose.b64decode('a82d5ff8ef740d12881f6d3c2277ab2e'))
         self.jmsg = {
             'type': 'tls-sni-01',
             'token': 'a82d5ff8ef740d12881f6d3c2277ab2e',
         }
 
+    def _msg(self):
+        from acme.challenges import TLSSNI01
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            msg = TLSSNI01(
+                token=jose.b64decode('a82d5ff8ef740d12881f6d3c2277ab2e'))
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertTrue('deprecated' in str(w[-1].message))
+        return msg
+
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+        self.assertEqual(self.jmsg, self._msg().to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSSNI01
-        self.assertEqual(self.msg, TLSSNI01.from_json(self.jmsg))
+        self.assertEqual(self._msg(), TLSSNI01.from_json(self.jmsg))
 
     def test_from_json_hashable(self):
         from acme.challenges import TLSSNI01
@@ -388,7 +397,7 @@ class TLSSNI01Test(unittest.TestCase):
     @mock.patch('acme.challenges.TLSSNI01Response.gen_cert')
     def test_validation(self, mock_gen_cert):
         mock_gen_cert.return_value = ('cert', 'key')
-        self.assertEqual(('cert', 'key'), self.msg.validation(
+        self.assertEqual(('cert', 'key'), self._msg().validation(
             KEY, cert_key=mock.sentinel.cert_key))
         mock_gen_cert.assert_called_once_with(key=mock.sentinel.cert_key)
 

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -368,13 +368,14 @@ class TLSSNI01Test(unittest.TestCase):
 
     def _msg(self):
         from acme.challenges import TLSSNI01
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter("always")
             msg = TLSSNI01(
                 token=jose.b64decode('a82d5ff8ef740d12881f6d3c2277ab2e'))
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertTrue('deprecated' in str(w[-1].message))
+            assert warn is not None # using a raw assert for mypy
+            self.assertTrue(len(warn) == 1)
+            self.assertTrue(issubclass(warn[-1].category, DeprecationWarning))
+            self.assertTrue('deprecated' in str(warn[-1].message))
         return msg
 
     def test_to_partial_json(self):


### PR DESCRIPTION
Be sure to edit the `master` section of `CHANGELOG.md` with a line describing this PR before it gets merged.

For #6319.