### PR TITLE
Lexicon v3 compatibility

### DIFF
--- a/certbot-dns-cloudxns/certbot_dns_cloudxns/dns_cloudxns.py
+++ b/certbot-dns-cloudxns/certbot_dns_cloudxns/dns_cloudxns.py
@@ -70,6 +70,7 @@ class _CloudXNSLexiconClient(dns_common_lexicon.LexiconClient):
         super(_CloudXNSLexiconClient, self).__init__()
 
         self.provider = cloudxns.Provider({
+            'provider_name': 'cloudxns',
             'auth_username': api_key,
             'auth_token': secret_key,
             'ttl': ttl,

--- a/certbot-dns-dnsimple/certbot_dns_dnsimple/dns_dnsimple.py
+++ b/certbot-dns-dnsimple/certbot_dns_dnsimple/dns_dnsimple.py
@@ -66,6 +66,7 @@ class _DNSimpleLexiconClient(dns_common_lexicon.LexiconClient):
         super(_DNSimpleLexiconClient, self).__init__()
 
         self.provider = dnsimple.Provider({
+            'provider_name': 'dnssimple',
             'auth_token': token,
             'ttl': ttl,
         })

--- a/certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy/dns_dnsmadeeasy.py
+++ b/certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy/dns_dnsmadeeasy.py
@@ -72,6 +72,7 @@ class _DNSMadeEasyLexiconClient(dns_common_lexicon.LexiconClient):
         super(_DNSMadeEasyLexiconClient, self).__init__()
 
         self.provider = dnsmadeeasy.Provider({
+            'provider_name': 'dnsmadeeasy',
             'auth_username': api_key,
             'auth_token': secret_key,
             'ttl': ttl,

--- a/certbot-dns-gehirn/certbot_dns_gehirn/dns_gehirn.py
+++ b/certbot-dns-gehirn/certbot_dns_gehirn/dns_gehirn.py
@@ -73,6 +73,7 @@ class _GehirnLexiconClient(dns_common_lexicon.LexiconClient):
         super(_GehirnLexiconClient, self).__init__()
 
         self.provider = gehirn.Provider({
+            'provider_name': 'gehirn',
             'auth_token': api_token,
             'auth_secret': api_secret,
             'ttl': ttl,

--- a/certbot-dns-linode/certbot_dns_linode/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/dns_linode.py
@@ -62,6 +62,7 @@ class _LinodeLexiconClient(dns_common_lexicon.LexiconClient):
     def __init__(self, api_key):
         super(_LinodeLexiconClient, self).__init__()
         self.provider = linode.Provider({
+            'provider_name': 'linode',
             'auth_token': api_key
         })
 

--- a/certbot-dns-luadns/certbot_dns_luadns/dns_luadns.py
+++ b/certbot-dns-luadns/certbot_dns_luadns/dns_luadns.py
@@ -69,6 +69,7 @@ class _LuaDNSLexiconClient(dns_common_lexicon.LexiconClient):
         super(_LuaDNSLexiconClient, self).__init__()
 
         self.provider = luadns.Provider({
+            'provider_name': 'luadns',
             'auth_username': email,
             'auth_token': token,
             'ttl': ttl,

--- a/certbot-dns-nsone/certbot_dns_nsone/dns_nsone.py
+++ b/certbot-dns-nsone/certbot_dns_nsone/dns_nsone.py
@@ -66,6 +66,7 @@ class _NS1LexiconClient(dns_common_lexicon.LexiconClient):
         super(_NS1LexiconClient, self).__init__()
 
         self.provider = nsone.Provider({
+            'provider_name': 'nsone',
             'auth_token': api_key,
             'ttl': ttl,
         })

--- a/certbot-dns-ovh/certbot_dns_ovh/dns_ovh.py
+++ b/certbot-dns-ovh/certbot_dns_ovh/dns_ovh.py
@@ -78,6 +78,7 @@ class _OVHLexiconClient(dns_common_lexicon.LexiconClient):
         super(_OVHLexiconClient, self).__init__()
 
         self.provider = ovh.Provider({
+            'provider_name': 'ovh',
             'auth_entrypoint': endpoint,
             'auth_application_key': application_key,
             'auth_application_secret': application_secret,

--- a/certbot-dns-sakuracloud/certbot_dns_sakuracloud/dns_sakuracloud.py
+++ b/certbot-dns-sakuracloud/certbot_dns_sakuracloud/dns_sakuracloud.py
@@ -76,6 +76,7 @@ class _SakuraCloudLexiconClient(dns_common_lexicon.LexiconClient):
         super(_SakuraCloudLexiconClient, self).__init__()
 
         self.provider = sakuracloud.Provider({
+            'provider_name': 'sakuracloud',
             'auth_token': api_token,
             'auth_secret': api_secret,
             'ttl': ttl,

--- a/certbot/plugins/dns_common_lexicon.py
+++ b/certbot/plugins/dns_common_lexicon.py
@@ -68,7 +68,12 @@ class LexiconClient(object):
 
         for domain_name in domain_name_guesses:
             try:
-                self.provider.options['domain'] = domain_name
+                if hasattr(self.provider, 'options'):
+                    # For Lexicon 2.x
+                    self.provider.options['domain'] = domain_name
+                else:
+                    # For Lexicon 3.x
+                    self.provider.domain = domain_name
 
                 self.provider.authenticate()
 


### PR DESCRIPTION
Lexicon will soon move to a new major version after my PR AnalogJ/lexicon#302 is merged. As discussed in #6472, this implies breaking changes that needs to be integrated in dns plugins that are backed by Lexicon.

This PR ensures that theses plugins will work both if Lexicon 2.x and Lexicon 3.x.

Tested on live API with OVH plugin on both Lexicon versions.
