### PR TITLE
Update Lexicon to correct use of HTTP proxy on OVH provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 * Warn when using deprecated acme.challenges.TLSSNI01
 * Log warning about TLS-SNI deprecation in Certbot
 * Stop preferring TLS-SNI in the Apache, Nginx, and standalone plugins
+* OVH DNS plugin now rely on Lexicon>=2.7.14 to support HTTP proxies
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 * Warn when using deprecated acme.challenges.TLSSNI01
 * Log warning about TLS-SNI deprecation in Certbot
 * Stop preferring TLS-SNI in the Apache, Nginx, and standalone plugins
-* OVH DNS plugin now rely on Lexicon>=2.7.14 to support HTTP proxies
+* OVH DNS plugin now relies on Lexicon>=2.7.14 to support HTTP proxies
 
 ### Fixed
 

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -11,7 +11,7 @@ version = '0.28.0.dev0'
 install_requires = [
     'acme>=0.21.1',
     'certbot>=0.21.1',
-    'dns-lexicon>=2.7.3', # Correct OVH integration tests
+    'dns-lexicon>=2.7.14', # Correct proxy use on OVH provider
     'mock',
     'setuptools',
     'zope.interface',

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -12,7 +12,7 @@ botocore==1.7.41
 cloudflare==1.5.1
 coverage==4.4.2
 decorator==4.1.2
-dns-lexicon==2.7.3
+dns-lexicon==2.7.14
 dnspython==1.15.0
 docutils==0.14
 execnet==1.5.0


### PR DESCRIPTION
This PR update requirement of Lexicon to 2.7.14 on OVH plugin, to allow HTTP proxy to be used correctly when underlying OVH provider is invoked.

See AnalogJ/lexicon#313 and AnalogJ/lexicon#314
