### PR TITLE
Update tools/venv3.py to support py launcher on Windows

### DIFF
--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -59,7 +59,7 @@ def main(venv_name, venv_args, args):
         # Windows specific
         print('---------------------------------------------------------------------------')
         print('Please run one of the following commands to activate developer environment:')
-        print('{0}\\bin\\activate.bat (for Batch)'.format(venv_name))
+        print('{0}\\Scripts\\activate.bat (for Batch)'.format(venv_name))
         print('.\\{0}\\Scripts\\Activate.ps1 (for Powershell)'.format(venv_name))
         print('---------------------------------------------------------------------------')
     else:

--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -30,7 +30,7 @@ def find_python_executable(python_major):
     :param int python_major: the Python major version to target (2 or 3)
     :rtype: str
     :return: the relevant python executable path
-    :raise: RuntimeError if no relevant python executable path could be found
+    :raise RuntimeError: if no relevant python executable path could be found
     """
     python_executable_path = None
 
@@ -43,22 +43,25 @@ def find_python_executable(python_major):
     versions_to_test = ['2.7', '2', ''] if python_major == 2 else ['3', '']
     for one_version in versions_to_test:
         try:
-            output = subprocess.check_output('python{0} --version'.format(one_version),
-                                             universal_newlines=True, shell=True,
-                                             stderr=subprocess.STDOUT)
+            one_python = 'python{0}'.format(one_version)
+            output = subprocess.check_output([one_python, '--version'],
+                                             universal_newlines=True, stderr=subprocess.STDOUT)
             if _check_version(output.strip().split()[1], python_major):
-                return 'python{0}'.format(python_major)
+                return subprocess.check_output([one_python, '-c',
+                                                'import sys; sys.stdout.write(sys.executable);'],
+                                               universal_newlines=True)
         except (subprocess.CalledProcessError, OSError):
             pass
 
     # Last try, with Windows Python launcher
     try:
-        output_version = subprocess.check_output('py -{0} --version'.format(python_major),
-                                                 universal_newlines=True, shell=True,
-                                                 stderr=subprocess.STDOUT)
+        env_arg = '-{0}'.format(python_major)
+        output_version = subprocess.check_output(['py', env_arg],
+                                                 universal_newlines=True, stderr=subprocess.STDOUT)
         if _check_version(output_version.strip().split()[1], python_major):
-            command = 'py -{0} -c "import sys; sys.stdout.write(sys.executable);"'.format(python_major)
-            return subprocess.check_output(command, universal_newlines=True, shell=True)
+            return subprocess.check_output(['py', env_arg, '-c',
+                                            'import sys; sys.stdout.write(sys.executable);'],
+                                           universal_newlines=True)
     except (subprocess.CalledProcessError, OSError):
         pass
 

--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -56,7 +56,7 @@ def find_python_executable(python_major):
     # Last try, with Windows Python launcher
     try:
         env_arg = '-{0}'.format(python_major)
-        output_version = subprocess.check_output(['py', env_arg],
+        output_version = subprocess.check_output(['py', env_arg, '--version'],
                                                  universal_newlines=True, stderr=subprocess.STDOUT)
         if _check_version(output_version.strip().split()[1], python_major):
             return subprocess.check_output(['py', env_arg, '-c',

--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -35,8 +35,9 @@ def find_python_executable(python_major):
     python_executable_path = None
 
     # First try, current python executable
-    # if _check_version('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]), python_major):
-    #     return sys.executable
+    if _check_version('{0}.{1}.{2}'.format(
+            sys.version_info[0], sys.version_info[1], sys.version_info[2]), python_major):
+        return sys.executable
 
     # Second try, with python executables in path
     versions_to_test = ['2.7', '2', ''] if python_major == 2 else ['3', '']
@@ -80,7 +81,11 @@ def _check_version(version_str, major_version):
     elif major_version == 3:
         minimal_version_supported = (3, 4)
 
-    return version >= minimal_version_supported
+    if version >= minimal_version_supported:
+        return True
+
+    print('Incompatible python version for Certbot found: {0}'.format(version_str))
+    return False
 
 
 def subprocess_with_print(command):

--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -37,9 +37,9 @@ def main(venv_name, venv_args, args):
 
     exit_code = 0
 
-    exit_code = subprocess_with_print(' '.join([
-        sys.executable, '-m', 'virtualenv', '--no-site-packages', '--setuptools',
-        venv_name, venv_args])) or exit_code
+    command = ('"{0}" -m virtualenv --no-site-packages --setuptools {1} {2}'
+               .format(sys.executable, venv_name, venv_args))
+    exit_code = subprocess_with_print(command) or exit_code
 
     python_executable = get_venv_python(venv_name)
 

--- a/tools/pip_install.py
+++ b/tools/pip_install.py
@@ -20,8 +20,10 @@ import tempfile
 import merge_requirements as merge_module
 import readlink
 
+
 def find_tools_path():
     return os.path.dirname(readlink.main(__file__))
+
 
 def certbot_oldest_processing(tools_path, args, test_constraints):
     if args[0] != '-e' or len(args) != 2:
@@ -37,6 +39,7 @@ def certbot_oldest_processing(tools_path, args, test_constraints):
 
     return requirements
 
+
 def certbot_normal_processing(tools_path, test_constraints):
     repo_path = os.path.dirname(tools_path)
     certbot_requirements = os.path.normpath(os.path.join(
@@ -49,6 +52,7 @@ def certbot_normal_processing(tools_path, test_constraints):
             if search:
                 fd.write('{0}{1}'.format(search.group(1), os.linesep))
 
+
 def merge_requirements(tools_path, test_constraints, all_constraints):
     merged_requirements = merge_module.main(
         os.path.join(tools_path, 'dev_constraints.txt'),
@@ -57,9 +61,11 @@ def merge_requirements(tools_path, test_constraints, all_constraints):
     with open(all_constraints, 'w') as fd:
         fd.write(merged_requirements)
 
+
 def call_with_print(command, cwd=None):
     print(command)
     subprocess.check_call(command, shell=True, cwd=cwd or os.getcwd())
+
 
 def main(args):
     tools_path = find_tools_path()
@@ -77,15 +83,14 @@ def main(args):
 
         merge_requirements(tools_path, test_constraints, all_constraints)
         if requirements:
-            call_with_print(' '.join([
-                sys.executable, '-m', 'pip', 'install', '-q', '--constraint', all_constraints,
-                '--requirement', requirements]))
+            call_with_print('"{0}" -m pip install -q --constraint "{1}" --requirement "{2}"'
+                            .format(sys.executable, all_constraints, requirements))
 
-        command = [sys.executable, '-m', 'pip', 'install', '-q', '--constraint', all_constraints]
-        command.extend(args)
-        call_with_print(' '.join(command))
+        call_with_print('"{0}" -m pip install -q --constraint "{1}" {2}'
+                        .format(sys.executable, all_constraints, ' '.join(args)))
     finally:
         shutil.rmtree(working_dir)
+
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/tools/venv.py
+++ b/tools/venv.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # Developer virtualenv setup for Certbot client
-
-from __future__ import absolute_import
-
 import os
-import subprocess
-import sys
 
 import _venv_common
 
@@ -33,27 +28,14 @@ REQUIREMENTS = [
     '-e certbot-compatibility-test',
 ]
 
-def get_venv_args():
-    with open(os.devnull, 'w') as fnull:
-        command_python2_st_code = subprocess.call(
-            'command -v python2', shell=True, stdout=fnull, stderr=fnull)
-        if not command_python2_st_code:
-            return '--python python2'
-
-        command_python27_st_code = subprocess.call(
-            'command -v python2.7', shell=True, stdout=fnull, stderr=fnull)
-        if not command_python27_st_code:
-            return '--python python2.7'
-
-    raise ValueError('Couldn\'t find python2 or python2.7 in {0}'.format(os.environ.get('PATH')))
 
 def main():
     if os.name == 'nt':
         raise ValueError('Certbot for Windows is not supported on Python 2.x.')
 
-    venv_args = get_venv_args()
-
+    venv_args = '--python "{0}"'.format(_venv_common.find_python_executable(2))
     _venv_common.main('venv', venv_args, REQUIREMENTS)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/venv3.py
+++ b/tools/venv3.py
@@ -43,6 +43,16 @@ def get_venv_args():
     if not where_python3_st_code or not command_python3_st_code:
         return '--python python3'
 
+    # On Windows, default installation procedure will not put python executable in PATH
+    # but the Python launcher instead: we get the python 3 executable path from it.
+    try:
+        python3_path = subprocess.check_output('py -3 -c "import sys; print(sys.executable);"', 
+                                               universal_newlines=True).strip()
+    except subprocess.CalledProcessError:
+        python3_path = None
+    if python3_path:
+        return '--python "{0}"'.format(python3_path)
+
     raise ValueError('Couldn\'t find python3 in {0}'.format(os.environ.get('PATH')))
 
 def main():

--- a/tools/venv3.py
+++ b/tools/venv3.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python
 # Developer virtualenv setup for Certbot client
-
-from __future__ import absolute_import
-
-import os
-import subprocess
-import sys
-
 import _venv_common
 
 REQUIREMENTS = [
@@ -33,32 +26,11 @@ REQUIREMENTS = [
     '-e certbot-compatibility-test',
 ]
 
-def get_venv_args():
-    with open(os.devnull, 'w') as fnull:
-        where_python3_st_code = subprocess.call(
-            'where python3', shell=True, stdout=fnull, stderr=fnull)
-        command_python3_st_code = subprocess.call(
-            'command -v python3', shell=True, stdout=fnull, stderr=fnull)
-
-    if not where_python3_st_code or not command_python3_st_code:
-        return '--python python3'
-
-    # On Windows, default installation procedure will not put python executable in PATH
-    # but the Python launcher instead: we get the python 3 executable path from it.
-    try:
-        python3_path = subprocess.check_output('py -3 -c "import sys; print(sys.executable);"', 
-                                               universal_newlines=True).strip()
-    except subprocess.CalledProcessError:
-        python3_path = None
-    if python3_path:
-        return '--python "{0}"'.format(python3_path)
-
-    raise ValueError('Couldn\'t find python3 in {0}'.format(os.environ.get('PATH')))
 
 def main():
-    venv_args = get_venv_args()
-
+    venv_args = '--python "{0}"'.format(_venv_common.find_python_executable(3))
     _venv_common.main('venv3', venv_args, REQUIREMENTS)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I put the old PR description below, for information purpose, because I rewrote entirely the PR in the last commits, on this old description is not relevant anymore.

Following some inconsistencies occurred during by developments, and in the light of #6508, it decided to wrote a PR that will take fully advantage of the conversion from bash to python to the development setup tools.

This PR adresses several issues when trying to use the development setup tools (`tools/venv.py` and `tools/venv3.py`:
* on Windows, `python` executable is not always in PATH (default behavior)
* even if the option is checked, the `python` executable is not associated to the usually symlink `python3` on Windows
* on Windows again, really powerful introspection of the available Python environments can be done with `py`, the Windows Python launcher
* in general for all systems, `tools/venv.py` and `tools/venv3.py` ensures that the respective Python major version will be used to setup the virtual environment if available. However, no check is done do the compatible supported minor version. For instance, Python 2.6 or Python 3.3 will not raise any exception during the setup, even if the virtual environment is effectively not compatible and not supported by Certbot
* finally, the best and first candidate to test should be the Python executable used to launch the `tools/venv*.py` script. It was not relevant before because it was shell scripts, but do it is.

The logic is shared in `_venv_common.py`, and will be called appropriately for both scripts. In priority decreasing order, python executable will be search and tested:
* from the current Python executable, as exposed by `sys.executable`
* from any python or pythonX (X as a python version like 2, 3 or 2.7 or 3.4) executable available in PATH
* from the Windows Python launched `py` if available

> On Windows, standard installation procedure is to not put python executable in `PATH` (either `python` or `python3`), but the Python launcher instead (`py`).
> 
> This PR modifies `tools/venv3.py` to test also presence of the Python launcher in `PATH`, then get the actual Python 3.x executable path to use it as a parameter in `virtualenv`.
> 
> I did not put any logic for `tools\venv.py` because Python 2.x is not supported for Certbot on Windows. However, the code is designed in the way that even if `py` is launched with Python 2.x as default, calling `tools/venv3.py` ensures that it is Python 3.x (if exists) that will be used to generate the virtual environment.
> 
> This PR allows also python paths that contain spaces (Linux/Windows, py2x/py3x).