### PR TITLE
closes #6384: Handle dot-style wildcard domains like star-style domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Handle dot-style wildcard domains like star-style domains
 
 ### Changed
 

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -169,7 +169,7 @@ class MultipleVhostsTest(util.ApacheTest):
         self.assertEqual(names, set(
             ["certbot.demo", "ocspvhost.com", "encryption-example.demo",
              "nonsym.link", "vhost.in.rootconf", "www.certbot.demo",
-             "duplicate.example.com"]
+             "duplicate.example.com", "*.blue.purple.com"]
         ))
 
     @certbot_util.patch_get_utility()
@@ -188,7 +188,7 @@ class MultipleVhostsTest(util.ApacheTest):
         self.config.vhosts.append(vhost)
 
         names = self.config.get_all_names()
-        self.assertEqual(len(names), 9)
+        self.assertEqual(len(names), 10)
         self.assertTrue("zombo.com" in names)
         self.assertTrue("google.com" in names)
         self.assertTrue("certbot.demo" in names)

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -555,7 +555,12 @@ class NginxConfigurator(common.Installer):
         all_names = set()  # type: Set[str]
 
         for vhost in self.parser.get_vhosts():
-            all_names.update(vhost.names)
+            for server_name in vhost.names:
+                if util.is_wildcard_dot_domain(server_name):
+                    # expand .example.com into *.example.com and example.com
+                    all_names.update(('*' + server_name, server_name[1:]))
+                else:
+                    all_names.add(server_name)
 
             for addr in vhost.addrs:
                 host = addr.get_addr()

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -83,11 +83,25 @@ class NginxConfiguratorTest(util.NginxTest):
     def test_get_all_names(self, mock_gethostbyaddr):
         mock_gethostbyaddr.return_value = ('155.225.50.69.nephoscale.net', [], [])
         names = self.config.get_all_names()
-        self.assertEqual(names, {
-            "155.225.50.69.nephoscale.net", "www.example.org", "another.alias",
-             "migration.com", "summer.com", "geese.com", "sslon.com",
-             "globalssl.com", "globalsslsetssl.com", "ipv6.com", "ipv6ssl.com",
-             "headers.com"})
+        self.assertEqual({
+            '*.example.com',
+            '*.www.example.com',
+            '*.www.foo.com',
+            '155.225.50.69.nephoscale.net',
+            'www.example.org',
+            'another.alias',
+            'example.com',
+            'migration.com',
+            'summer.com',
+            'geese.com',
+            'sslon.com',
+            'globalssl.com',
+            'globalsslsetssl.com',
+            'ipv6.com',
+            'ipv6ssl.com',
+            'headers.com'
+        },
+        names)
 
     def test_supported_enhancements(self):
         self.assertEqual(['redirect', 'ensure-http-header', 'staple-ocsp'],

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -497,12 +497,21 @@ class EnforceDomainSanityTest(unittest.TestCase):
         # that it's _not_ an error (at the initial sanity check stage)
         self._call('this.is.xn--ls8h.tld')
 
+    def test_wildcard_star_domain(self):
+        """ star-style domain should pass through unchanged """
+        self.assertEqual(self._call('*.example.com'), '*.example.com')
+
+    def test_wildcard_dot_domain(self):
+        """ dot-style domain should get mutated into a star-style wildcard domain """
+        self.assertEqual(self._call('.example.com'), '*.example.com')
+
 
 class IsWildcardDomainTest(unittest.TestCase):
     """Tests for is_wildcard_domain."""
 
     def setUp(self):
-        self.wildcard = u"*.example.org"
+        self.star_wildcard = u"*.example.org"
+        self.dot_wildcard = u".example.org"
         self.no_wildcard = u"example.org"
 
     def _call(self, domain):
@@ -513,9 +522,13 @@ class IsWildcardDomainTest(unittest.TestCase):
         self.assertFalse(self._call(self.no_wildcard))
         self.assertFalse(self._call(self.no_wildcard.encode()))
 
-    def test_wildcard(self):
-        self.assertTrue(self._call(self.wildcard))
-        self.assertTrue(self._call(self.wildcard.encode()))
+    def test_star_wildcard(self):
+        self.assertTrue(self._call(self.star_wildcard))
+        self.assertTrue(self._call(self.star_wildcard.encode()))
+
+    def test_dot_wildcard(self):
+        self.assertTrue(self._call(self.dot_wildcard))
+        self.assertTrue(self._call(self.dot_wildcard.encode()))
 
 
 class OsInfoTest(unittest.TestCase):


### PR DESCRIPTION
* e.g. mutate .example.com into *.example.com as early as possible

Not sure if this is the correct approach, but seems reasonable 

closes #6384