### PR TITLE
Whitelist docker-compose in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -241,5 +241,5 @@ passenv = DOCKER_*
 commands =
     docker-compose run --rm --service-ports development bash -c 'tox -e lint'
 whitelist_externals =
-    docker
+    docker-compose
 passenv = DOCKER_*


### PR DESCRIPTION
When the `docker_dev` test runs, it [prints a warning](https://travis-ci.org/certbot/certbot/jobs/452082456#L614) because it's running a command not found in the test's virtual environment.

This removes that warning by whitelisting `docker-compose`. `docker` does not need to be whitelisted because it is never called.