### PR TITLE
Don't mention _venv_common.sh in certbot-auto.

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -593,8 +593,7 @@ BootstrapArchCommon() {
   #   - ArchLinux (x86_64)
   #
   # "python-virtualenv" is Python3, but "python2-virtualenv" provides
-  # only "virtualenv2" binary, not "virtualenv" necessary in
-  # ./tools/_venv_common.py
+  # only "virtualenv2" binary, not "virtualenv".
 
   deps="
     python2

--- a/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/arch_common.sh
@@ -7,8 +7,7 @@ BootstrapArchCommon() {
   #   - ArchLinux (x86_64)
   #
   # "python-virtualenv" is Python3, but "python2-virtualenv" provides
-  # only "virtualenv2" binary, not "virtualenv" necessary in
-  # ./tools/_venv_common.py
+  # only "virtualenv2" binary, not "virtualenv".
 
   deps="
     python2


### PR DESCRIPTION
This wasn't always the case, but nowadays, _venv_common is a developer tool and
has nothing to do with certbot-auto.