### PR TITLE
Fix up environment variable use in venv creation scripts

### DIFF
--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import re
 
+VENV_NAME_ENV_VAR = 'VENV_NAME'
 VERSION_PATTERN = re.compile(r'^(\d+)\.(\d+).*$')
 
 
@@ -116,6 +117,12 @@ def main(venv_name, venv_args, args):
         else:
             os.remove(path)
 
+    env_venv_name = os.environ.get(VENV_NAME_ENV_VAR)
+    if env_venv_name:
+        print('Creating venv at {0}'
+              ' as specified in {1}'.format(env_venv_name, VENV_NAME_ENV_VAR))
+        venv_name = env_venv_name
+
     if os.path.isdir(venv_name):
         os.rename(venv_name, '{0}.{1}.bak'.format(venv_name, int(time.time())))
 
@@ -150,6 +157,6 @@ def main(venv_name, venv_args, args):
 
 
 if __name__ == '__main__':
-    main(os.environ.get('VENV_NAME', 'venv'),
+    main('venv',
          os.environ.get('VENV_ARGS', ''),
          sys.argv[1:])

--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -158,5 +158,5 @@ def main(venv_name, venv_args, args):
 
 if __name__ == '__main__':
     main('venv',
-         os.environ.get('VENV_ARGS', ''),
+         '',
          sys.argv[1:])

--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python
+"""Aids in creating a developer virtual environment for Certbot.
+
+When this module is run as a script, it takes the arguments that should
+be passed to pip to install the Certbot packages as command line
+arguments. The virtual environment will be created with the name "venv"
+in the current working directory and will use the default version of
+Python for the virtualenv executable in your PATH. You can change the
+name of the virtual environment by setting the environment variable
+VENV_NAME.
+"""
 
 from __future__ import print_function
 
@@ -10,7 +20,6 @@ import subprocess
 import sys
 import re
 
-VENV_NAME_ENV_VAR = 'VENV_NAME'
 VERSION_PATTERN = re.compile(r'^(\d+)\.(\d+).*$')
 
 
@@ -111,16 +120,25 @@ def get_venv_python(venv_path):
 
 
 def main(venv_name, venv_args, args):
+    """Creates a virtual environment and installs packages.
+
+    :param str venv_name: The name or path at where the virtual
+        environment should be created.
+    :param str venv_args: Command line arguments for virtualenv
+    :param str args: Command line arguments that should be given to pip
+        to install packages
+    """
+
     for path in glob.glob('*.egg-info'):
         if os.path.isdir(path):
             shutil.rmtree(path)
         else:
             os.remove(path)
 
-    env_venv_name = os.environ.get(VENV_NAME_ENV_VAR)
+    env_venv_name = os.environ.get('VENV_NAME')
     if env_venv_name:
         print('Creating venv at {0}'
-              ' as specified in {1}'.format(env_venv_name, VENV_NAME_ENV_VAR))
+              ' as specified in VENV_NAME'.format(env_venv_name))
         venv_name = env_venv_name
 
     if os.path.isdir(venv_name):


### PR DESCRIPTION
The reason [docker_dev tests](https://travis-ci.org/certbot/certbot/jobs/454634700) are failing is because the environment variable `VENV_NAME` is no longer being respected when running `tools/venv.py`. The [Dockerfile](https://github.com/certbot/certbot/blob/master/Dockerfile-dev) sets `VENV_NAME` to `../venv` (which is a path rather than a name, however, it was working before), but this variable was no longer being respected by the script causing the path to be reset to `venv`. The change in the location of the virtual environment causes its path to no longer be added to the `PATH` environment variable by the Dockerfile and tests to fail.

This PR fixes that by having the value of `VENV_NAME` override any value set in the `tools/venv*` scripts.

I also removed the use of `VENV_ARGS`. This was used in `_venv_common.sh` as a means of passing arguments for `virtualenv` between the scripts, however, there is no other use of the variable in this repository and passing the arguments through a function call is much more natural in Python.

@adferrand, are you able to review the changes here?