### PR TITLE
Fixed Typo

### DIFF
--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -98,7 +98,7 @@ Examples
 
    certbot certonly \\
      --dns-google \\
-     --dns-google-credentials ~/.secrets/certbot/google.ini \\
+     --dns-google-credentials ~/.secrets/certbot/google.json \\
      --dns-google-propagation-seconds 120 \\
      -d example.com
 


### PR DESCRIPTION
Fixed Typo in the examples section since .ini files are not supported.