### PR TITLE
Preserve other-read bit on private keys too

### DIFF
--- a/certbot/storage.py
+++ b/certbot/storage.py
@@ -1144,7 +1144,8 @@ class RenewableCert(object):
             # If the previous privkey in this lineage has an existing gid or group mode > 0,
             # let's keep those.
             group_mode = stat.S_IMODE(os.stat(old_privkey).st_mode) & \
-                (stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP)
+                (stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | \
+                 stat.S_IROTH)
             mode = BASE_PRIVKEY_MODE | group_mode
             os.chown(target["privkey"], -1, os.stat(old_privkey).st_gid)
             os.chmod(target["privkey"], mode)

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -565,12 +565,12 @@ class RenewableCertTests(BaseRenewableCertTest):
         # If new key, permissions should be rest to 600 + preserved group
         self.test_rc.save_successor(2, b"newcert", b"new_privkey", b"new chain", self.config)
         self.assertTrue(compat.compare_file_modes(
-            os.stat(self.test_rc.version("privkey", 3)).st_mode, 0o640))
+            os.stat(self.test_rc.version("privkey", 3)).st_mode, 0o644))
         # If permissions reverted, next renewal will also revert permissions of new key
         os.chmod(self.test_rc.version("privkey", 3), 0o404)
         self.test_rc.save_successor(3, b"newcert", b"new_privkey", b"new chain", self.config)
         self.assertTrue(compat.compare_file_modes(
-            os.stat(self.test_rc.version("privkey", 4)).st_mode, 0o600))
+            os.stat(self.test_rc.version("privkey", 4)).st_mode, 0o604))
 
     @test_util.broken_on_windows
     @mock.patch("certbot.storage.relevant_values")

--- a/tests/certbot-boulder-integration.sh
+++ b/tests/certbot-boulder-integration.sh
@@ -281,7 +281,7 @@ CheckCertCount() {
 }
 
 CheckGroup() {
-    group_mode() { echo $((0`stat -c %a $1` & 070)); }
+    group_mode() { echo $((0`stat -c %a $1` & 074)); }
     group_owner() { echo `stat -c %G $1`; }
     if [ `group_mode $1` -ne `group_mode $2` ] ; then
         echo "Expected group permission `group_mode $1`, got `group_mode $2` on file $2"


### PR DESCRIPTION
Be sure to edit the `master` section of `CHANGELOG.md` with a line describing this PR before it gets merged.

Additional fix for #1473 to prevent breakages.

Not updating the guidelines in `using.rst`-- I don't want to encourage people to use this. now that Certbot preserves gid, the better way to set permissions is to change the group permisisons!