### PR TITLE
removed unused sys imports in setup.py files in various dns directories

### DIFF
--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup
 from setuptools import find_packages
 

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup
 from setuptools import find_packages
 

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup
 from setuptools import find_packages
 

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup
 from setuptools import find_packages
 


### PR DESCRIPTION
Hello, 

We noticed a few unused "sys" library imports in setup.py files in:

certbot-dns-linode
certbot-dns-gehirn
certbot-dns-ovh
certbot-dns-sakuracloud

After removing these imports from these files, the tests "tox -e py27", "tox -e cover", "tox -e lint", and "tox --skip-missing-interpreters" were run and all tests were passed.

Please let us know if any other information/remediation is necessary, thanks! 