### PR TITLE
Don't use pytest.ini during the release.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
+# This file isn't used while testing packages in tools/_release.sh so any
+# settings we want to also change there must be added to the release script
+# directly.
 [pytest]
 addopts = --numprocesses auto --pyargs
 # ResourceWarnings are ignored as errors, since they're raised at close

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -169,7 +169,8 @@ pip freeze | tee $kgs
 pip install pytest
 for module in $subpkgs_modules ; do
     echo testing $module
-    pytest --pyargs $module
+    # use an empty configuration file rather than the one in the repo root
+    pytest -c <(echo '') --pyargs $module
 done
 cd ~-
 


### PR DESCRIPTION
Currently the release script in `master` fails for a few reasons. First, it's trying to use `--numprocesses` which comes from a pytest plugin that we're not installing in the release script. Second, many new warnings are raised when we're not using pinned versions of our dependencies.

I'm not sure I agree, but one could argue that we should fix these issues and use the file during the release. I'm particularly hesitant for us to do this when it comes to warnings. We currently do not pin our dependencies in the release script. Do we really want to stop the release because a new package was released and is warning about something? One could argue we do because these warnings may be visible to the user, but they very rarely are and I think this makes the release process much too painful.

I especially do not think we should block the release on this now as we are not up to date on the warnings raised by the latest versions of our packages so there is a lot to work through.