### PR TITLE
Correct Unix paths for Certbot

### DIFF
--- a/certbot/compat.py
+++ b/certbot/compat.py
@@ -180,8 +180,8 @@ WINDOWS_DEFAULT_FOLDERS = {
 }
 LINUX_DEFAULT_FOLDERS = {
     'config': '/etc/letsencrypt',
-    'work': '/var/letsencrypt/lib',
-    'logs': '/var/letsencrypt/log',
+    'work': '/var/lib/letsencrypt',
+    'logs': '/var/log/letsencrypt',
 }
 
 def get_default_folder(folder_type):


### PR DESCRIPTION
PR #6416 introduced a regression on release 0.29.0, by modifying paths for workdir and log on Unix from `/var/lib/letsencrypt` and `/var/log/letsencrypt` to `/var/letsencrypt/lib` and `/var/letsencrypt/log` respectively.

This PR fixes that by reverting to the original paths.

Really sorry for the inconvenience.
