### PR TITLE
Speed up AppVeyor execution

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,9 @@
+image: Visual Studio 2015
+
 environment:
   matrix:
-    - FYI: Python 3.4 on Windows Server 2012 R2
-      TOXENV: py34
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    - FYI: Python 3.4 on Windows Server 2016
-      TOXENV: py34
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - FYI: Python 3.5 on Windows Server 2016
-      TOXENV: py35
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - FYI: Python 3.7 on Windows Server 2016 + code coverage
-      TOXENV: py37-cover
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOXENV: py35
+    - TOXENV: py37-cover
 
 branches:
   only:
@@ -23,7 +15,6 @@ install:
   # Use Python 3.7 by default
   - "SET PATH=C:\\Python37;C:\\Python37\\Scripts;%PATH%"
   # Check env
-  - "echo %APPVEYOR_BUILD_WORKER_IMAGE%"
   - "python --version"
   # Upgrade pip to avoid warnings
   - "python -m pip install --upgrade pip"


### PR DESCRIPTION
CI workflow on AppVeyor is slow: there is only one executor at a time, with a heavy warm up. As a consequence, any build currently will take between 20 to 25 mins with four jobs, not to mention time to wait for the executor to be available.

This PR reduce the number of jobs to two, by executing only against the lowest and highest version of Python supported by Certbot on Windows, and by executing everything in Windows Server 2012 R2: if it works on this platform, we can safely rely on the Python stability for the newest Windows versions, to assert that Certbot will work also for them.