### PR TITLE
Remove -q/--quiet from pip invocations

### DIFF
--- a/tools/install_and_test.py
+++ b/tools/install_and_test.py
@@ -23,7 +23,7 @@ def call_with_print(command, cwd=None):
 
 def main(args):
     if os.environ.get('CERTBOT_NO_PIN') == '1':
-        command = [sys.executable, '-m', 'pip', '-q', '-e']
+        command = [sys.executable, '-m', 'pip', '-e']
     else:
         script_dir = os.path.dirname(os.path.abspath(__file__))
         command = [sys.executable, os.path.join(script_dir, 'pip_install_editable.py')]
@@ -50,7 +50,7 @@ def main(args):
         shutil.copy2("pytest.ini", temp_cwd)
         try:
             call_with_print(' '.join([
-                sys.executable, '-m', 'pytest', '--quiet', pkg.replace('-', '_')]), cwd=temp_cwd)
+                sys.executable, '-m', 'pytest', pkg.replace('-', '_')]), cwd=temp_cwd)
         finally:
             shutil.rmtree(temp_cwd)
 

--- a/tools/pip_install.py
+++ b/tools/pip_install.py
@@ -83,10 +83,10 @@ def main(args):
 
         merge_requirements(tools_path, test_constraints, all_constraints)
         if requirements:
-            call_with_print('"{0}" -m pip install -q --constraint "{1}" --requirement "{2}"'
+            call_with_print('"{0}" -m pip install --constraint "{1}" --requirement "{2}"'
                             .format(sys.executable, all_constraints, requirements))
 
-        call_with_print('"{0}" -m pip install -q --constraint "{1}" {2}'
+        call_with_print('"{0}" -m pip install --constraint "{1}" {2}'
                         .format(sys.executable, all_constraints, ' '.join(args)))
     finally:
         shutil.rmtree(working_dir)


### PR DESCRIPTION
While reducing noise in test output is valuable, this flag has made a couple aspects of Certbot's development difficult:

1. We test with different sets of dependencies and running pip in quiet mode removes all output about the packages being installed which has made reviewing changes to these tests more difficult.
2. When pip fails, it provides significantly less output about the failure in quiet mode than it does normally. The output is reduced so much that in the two times I've hit this issue in the last month, I was only able to see that installing package X failed rather than what the cause of that failure was which could be seen with `--quiet` removed.

Also, since running pip without `--quiet` is the tox default, I expect Python developers to be familiar with what they see here.

@jsha, this reverts the change you made in 7319cc975a and if you really care, we could reconsider, but landing this PR solves issues that some of the Certbot team and I have been having.