### PR TITLE
Remove IValidator

### DIFF
--- a/certbot-compatibility-test/certbot_compatibility_test/validator.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/validator.py
@@ -2,20 +2,17 @@
 import logging
 import socket
 import requests
-import zope.interface
 
 import six
 from six.moves import xrange  # pylint: disable=import-error,redefined-builtin
 
 from acme import crypto_util
 from acme import errors as acme_errors
-from certbot import interfaces
 
 
 logger = logging.getLogger(__name__)
 
 
-@zope.interface.implementer(interfaces.IValidator)
 class Validator(object):
     # pylint: disable=no-self-use
     """Collection of functions to test a live webserver's configuration"""

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -522,56 +522,6 @@ class IDisplay(zope.interface.Interface):
         """
 
 
-class IValidator(zope.interface.Interface):
-    """Configuration validator."""
-
-    def certificate(cert, name, alt_host=None, port=443):
-        """Verifies the certificate presented at name is cert
-
-        :param OpenSSL.crypto.X509 cert: Expected certificate
-        :param str name: Server's domain name
-        :param bytes alt_host: Host to connect to instead of the IP
-            address of host
-        :param int port: Port to connect to
-
-        :returns: True if the certificate was verified successfully
-        :rtype: bool
-
-        """
-
-    def redirect(name, port=80, headers=None):
-        """Verify redirect to HTTPS
-
-        :param str name: Server's domain name
-        :param int port: Port to connect to
-        :param dict headers: HTTP headers to include in request
-
-        :returns: True if redirect is successfully enabled
-        :rtype: bool
-
-        """
-
-    def hsts(name):
-        """Verify HSTS header is enabled
-
-        :param str name: Server's domain name
-
-        :returns: True if HSTS header is successfully enabled
-        :rtype: bool
-
-        """
-
-    def ocsp_stapling(name):
-        """Verify ocsp stapling for domain
-
-        :param str name: Server's domain name
-
-        :returns: True if ocsp stapling is successfully enabled
-        :rtype: bool
-
-        """
-
-
 class IReporter(zope.interface.Interface):
     """Interface to collect and display information to the user."""
 


### PR DESCRIPTION
I came across `IValidator` when explaining the code base to someone and it's completely unnecessary. The validator code in `certbot-compatibility-test` was in the `certbot` package once upon a time, but that was long ago so the otherwise unused `zope.interface` definition seems entirely unnecessary.