### PR TITLE
Remove spdy cruft

### DIFF
--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -145,7 +145,7 @@ RENEWER_DEFAULTS = dict(
 """Defaults for renewer script."""
 
 
-ENHANCEMENTS = ["redirect", "ensure-http-header", "ocsp-stapling", "spdy"]
+ENHANCEMENTS = ["redirect", "ensure-http-header", "ocsp-stapling"]
 """List of possible :class:`certbot.interfaces.IInstaller`
 enhancements.
 
@@ -153,7 +153,6 @@ List of expected options parameters:
 - redirect: None
 - ensure-http-header: name of header (i.e. Strict-Transport-Security)
 - ocsp-stapling: certificate chain file path
-- spdy: TODO
 
 """
 


### PR DESCRIPTION
I came across this reference to spdy when explaining the code base to someone and it's cruft. None of our plugins support spdy and the inclusion of `spdy` in this list (and the TODO comment about it) has no effect.