### PR TITLE
DER_CONTENT_TYPE in accept instead content-type

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -740,7 +740,7 @@ class ClientV2(ClientBase):
                 raise errors.IssuanceError(body.error)
             if body.certificate is not None:
                 certificate_response = self._post_as_get(body.certificate,
-                                                    content_type=DER_CONTENT_TYPE).text
+                                                    accept=DER_CONTENT_TYPE).text
                 return orderr.update(body=body, fullchain_pem=certificate_response)
         raise errors.TimeoutError()
 


### PR DESCRIPTION
Noticed that DER_CONTENT_TYPE is used in content_type header.

Should that be perhaps Accept header?

Be sure to edit the `master` section of `CHANGELOG.md` with a line describing this PR before it gets merged.
