### PR TITLE
Allow josepy to be accessed through acme.jose.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-*
+* The josepy library can now be accessed through acme.jose like it could in
+  previous versions of acme.
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only

--- a/acme/acme/__init__.py
+++ b/acme/acme/__init__.py
@@ -10,3 +10,17 @@ supported version: `draft-ietf-acme-01`_.
   https://github.com/ietf-wg-acme/acme/tree/draft-ietf-acme-acme-01
 
 """
+import sys
+
+# This code exists to keep backwards compatibility with people using acme.jose
+# before it became the standalone josepy package.
+#
+# It is based on
+# https://github.com/requests/requests/blob/1278ecdf71a312dc2268f3bfc0aabfab3c006dcf/requests/packages.py
+
+jose = __import__('josepy')
+for mod in list(sys.modules):
+    # This traversal is apparently necessary such that the identities are
+    # preserved (acme.jose.* is josepy.*)
+    if mod == 'josepy' or mod.startswith('josepy.'):
+        sys.modules['acme.' + mod.replace('josepy', 'jose', 1)] = sys.modules[mod]

--- a/acme/acme/jose_test.py
+++ b/acme/acme/jose_test.py
@@ -1,0 +1,29 @@
+"""Tests for acme.jose shim."""
+import importlib
+import unittest
+
+class JoseTest(unittest.TestCase):
+    """Tests for acme.jose shim."""
+
+    def _test_it(self, submodule, attribute):
+        if submodule:
+            acme_jose_path = 'acme.jose.' + submodule
+            josepy_path = 'josepy.' + submodule
+        else:
+            acme_jose_path = 'acme.jose'
+            josepy_path = 'josepy'
+        acme_jose = importlib.import_module(acme_jose_path)
+        josepy = importlib.import_module(josepy_path)
+
+        self.assertIs(acme_jose, josepy)
+        self.assertIs(getattr(acme_jose, attribute), getattr(josepy, attribute))
+
+    def test_top_level(self):
+        self._test_it('', 'RS512')
+
+    def test_submodule(self):
+        self._test_it('jws', 'JWS')
+
+
+if __name__ == '__main__':
+    unittest.main()  # pragma: no cover


### PR DESCRIPTION
When working on an update to our packages in Ubuntu Xenial, @NCommander noticed that importing code through `acme.jose` no longer works since `josepy` became a separate package and remembers having to fix up some code that was using `acme.jose` himself.

This PR should fix that problem by making all of `josepy` accessible through `acme.jose`. This is primarily beneficial to our OS package maintainers who want to avoid subtle API changes when updating packages in stable repositories. They will likely backport this change, but I figure we might as well add it ourselves to minimize divergences in our OS packages in the future and avoid problems on the off chance someone hasn't upgraded `acme` and was relying on this feature.

@erikrose, are you able to review this? This PR is small and most of the tricky code here I didn't write myself, but I think you probably have the most familiarity with Python's import system.