### PR TITLE
Travis job to run unit tests against unpinned dependencies on latest Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,9 @@ matrix:
     - language: generic
       env: TOXENV=py3
       os: osx
+    - python: "3.7"
+      dist: xenial
+      env: TOXENV=py37 CERTBOT_NO_PIN=1
 
 
 # Only build pushes to the master branch, PRs, and branches beginning with


### PR DESCRIPTION
Everything is in the title, to respond to #6582, and to reflect the PR #6590 for master branch.

This PR add the relevant travis job to test on the most edge environment.

It will be effective once #6590 is merged on master, and master merged to test-everything.
Then the new job will fail until #6593 is merged on master, and master merged to test-everything.