### PR TITLE
Tag to disable random sleep upon a renew task

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1219,10 +1219,7 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
     helpful.add(
         "renew", "--no-random-sleep-on-renew", action="store_false",
         default=flag_default("random_sleep_on_renew"), dest="random_sleep_on_renew",
-        help='By default, renew action called from non interactive shells will be delayed'
-        ' of a random time between 1s to 8min, in order to spread the load to certificate'
-        ' authority servers that would arise from bunch of automated cron tasks at specific'
-        ' times of the day. Setting this flag will disable this delay for the current renew task.')
+        help=argparse.SUPPRESS)
     helpful.add(
         "renew", "--deploy-hook", action=_DeployHookAction,
         help='Command to be run in a shell once for each successfully'

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1213,9 +1213,8 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         " run if an attempt was made to obtain/renew a certificate. If"
         " multiple renewed certificates have identical post-hooks, only"
         " one will be run.")
-    helpful.add(
-        "renew", "--renew-hook",
-        action=_RenewHookAction, help=argparse.SUPPRESS)
+    helpful.add("renew", "--renew-hook",
+                action=_RenewHookAction, help=argparse.SUPPRESS)
     helpful.add(
         "renew", "--no-random-sleep-on-renew", action="store_false",
         default=flag_default("random_sleep_on_renew"), dest="random_sleep_on_renew",

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1215,6 +1215,9 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         " one will be run.")
     helpful.add("renew", "--renew-hook",
                 action=_RenewHookAction, help=argparse.SUPPRESS)
+    helpful.add("renew", "--no-random-sleep-on-renew", action="store_false",
+                default=flag_default("random_sleep_on_renew"), dest="random_sleep_on_renew",
+                help=argparse.SUPPRESS)
     helpful.add(
         "renew", "--deploy-hook", action=_DeployHookAction,
         help='Command to be run in a shell once for each successfully'

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1213,11 +1213,16 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         " run if an attempt was made to obtain/renew a certificate. If"
         " multiple renewed certificates have identical post-hooks, only"
         " one will be run.")
-    helpful.add("renew", "--renew-hook",
-                action=_RenewHookAction, help=argparse.SUPPRESS)
-    helpful.add("renew", "--no-random-sleep-on-renew", action="store_false",
-                default=flag_default("random_sleep_on_renew"), dest="random_sleep_on_renew",
-                help=argparse.SUPPRESS)
+    helpful.add(
+        "renew", "--renew-hook",
+        action=_RenewHookAction, help=argparse.SUPPRESS)
+    helpful.add(
+        "renew", "--no-random-sleep-on-renew", action="store_false",
+        default=flag_default("random_sleep_on_renew"), dest="random_sleep_on_renew",
+        help='By default, renew action called from non interactive shells will be delayed'
+        ' of a random time between 1s to 8min, in order to spread the load to certificate'
+        ' authority servers that would arise from bunch of automated cron tasks at specific'
+        ' times of the day. Setting this flag will disable this delay for the current renew task.')
     helpful.add(
         "renew", "--deploy-hook", action=_DeployHookAction,
         help='Command to be run in a shell once for each successfully'

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -68,6 +68,7 @@ CLI_DEFAULTS = dict(
     directory_hooks=True,
     reuse_key=False,
     disable_renew_updates=False,
+    random_sleep_on_renew=True,
     eab_hmac_key=None,
     eab_kid=None,
 

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -4,9 +4,7 @@ from __future__ import print_function
 import functools
 import logging.handlers
 import os
-import random
 import sys
-import time
 
 import configobj
 import josepy as jose
@@ -67,6 +65,7 @@ def _suggest_donation_if_appropriate(config):
            "Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate\n"
            "Donating to EFF:                    https://eff.org/donate-le\n\n")
     reporter_util.add_message(msg, reporter_util.LOW_PRIORITY)
+
 
 def _report_successful_dry_run(config):
     """Reports on successful dry run
@@ -229,6 +228,7 @@ def _handle_identical_cert_request(config, lineage):
     else:
         assert False, "This is impossible"
 
+
 def _find_lineage_for_domains(config, domains):
     """Determine whether there are duplicated names and how to handle
     them (renew, reinstall, newcert, or raising an error to stop
@@ -267,6 +267,7 @@ def _find_lineage_for_domains(config, domains):
     elif subset_names_cert is not None:
         return _handle_subset_cert_request(config, domains, subset_names_cert)
 
+
 def _find_cert(config, domains, certname):
     """Finds an existing certificate object given domains and/or a certificate name.
 
@@ -289,6 +290,7 @@ def _find_cert(config, domains, certname):
     if action == "reinstall":
         logger.info("Keeping the existing certificate")
     return (action != "reinstall"), lineage
+
 
 def _find_lineage_for_domains_and_certname(config, domains, certname):
     """Find appropriate lineage based on given domains and/or certname.
@@ -331,6 +333,7 @@ def _find_lineage_for_domains_and_certname(config, domains, certname):
                     "Use -d to specify domains, or run certbot certificates to see "
                     "possible certificate names.".format(certname))
 
+
 def _get_added_removed(after, before):
     """Get lists of items removed from `before`
     and a lists of items added to `after`
@@ -340,6 +343,7 @@ def _get_added_removed(after, before):
     added.sort()
     removed.sort()
     return added, removed
+
 
 def _format_list(character, strings):
     """Format list with given character
@@ -352,6 +356,7 @@ def _format_list(character, strings):
         ch=character,
         br=os.linesep
     )
+
 
 def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
     """Ask user to confirm update cert certname to contain new_domains.
@@ -389,6 +394,7 @@ def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
     obj = zope.component.getUtility(interfaces.IDisplay)
     if not obj.yesno(msg, "Update cert", "Cancel", default=True):
         raise errors.ConfigurationError("Specified mismatched cert name and domains.")
+
 
 def _find_domains_or_certname(config, installer, question=None):
     """Retrieve domains and certname from config or user input.
@@ -735,6 +741,7 @@ def update_account(config, unused_plugins):
     eff.handle_subscription(config)
     add_msg("Your e-mail address was updated to {0}.".format(config.email))
 
+
 def _install_cert(config, le_client, domains, lineage=None):
     """Install a cert
 
@@ -760,6 +767,7 @@ def _install_cert(config, le_client, domains, lineage=None):
     le_client.deploy_certificate(domains, path_provider.key_path,
         path_provider.cert_path, path_provider.chain_path, path_provider.fullchain_path)
     le_client.enhance_config(domains, path_provider.chain_path)
+
 
 def install(config, plugins):
     """Install a previously obtained cert in a server.
@@ -818,6 +826,7 @@ def install(config, plugins):
         lineage = cert_manager.lineage_for_certname(config, config.certname)
         enhancements.enable(lineage, domains, installer, config)
 
+
 def _populate_from_certname(config):
     """Helper function for install to populate missing config values from lineage
     defined by --cert-name."""
@@ -835,6 +844,7 @@ def _populate_from_certname(config):
         config.namespace.fullchain_path = lineage.fullchain_path
     return config
 
+
 def _check_certificate_and_key(config):
     if not os.path.isfile(os.path.realpath(config.cert_path)):
         raise errors.ConfigurationError("Error while reading certificate from path "
@@ -842,6 +852,8 @@ def _check_certificate_and_key(config):
     if not os.path.isfile(os.path.realpath(config.key_path)):
         raise errors.ConfigurationError("Error while reading private key from path "
                                        "{0}".format(config.key_path))
+
+
 def plugins_cmd(config, plugins):
     """List server software plugins.
 
@@ -879,6 +891,7 @@ def plugins_cmd(config, plugins):
     available = verified.available()
     logger.debug("Prepared plugins: %s", available)
     notify(str(available))
+
 
 def enhance(config, plugins):
     """Add security enhancements to existing configuration
@@ -970,6 +983,7 @@ def config_changes(config, unused_plugins):
     """
     client.view_config_changes(config, num=config.num)
 
+
 def update_symlinks(config, unused_plugins):
     """Update the certificate file family symlinks
 
@@ -987,6 +1001,7 @@ def update_symlinks(config, unused_plugins):
 
     """
     cert_manager.update_live_symlinks(config)
+
 
 def rename(config, unused_plugins):
     """Rename a certificate
@@ -1006,6 +1021,7 @@ def rename(config, unused_plugins):
     """
     cert_manager.rename_lineage(config)
 
+
 def delete(config, unused_plugins):
     """Delete a certificate
 
@@ -1024,6 +1040,7 @@ def delete(config, unused_plugins):
     """
     cert_manager.delete(config)
 
+
 def certificates(config, unused_plugins):
     """Display information about certs configured with Certbot
 
@@ -1038,6 +1055,7 @@ def certificates(config, unused_plugins):
 
     """
     cert_manager.certificates(config)
+
 
 def revoke(config, unused_plugins):  # TODO: coop with renewal config
     """Revoke a previously obtained certificate.
@@ -1165,6 +1183,7 @@ def _csr_get_and_save_cert(config, le_client):
         os.path.normpath(config.chain_path), os.path.normpath(config.fullchain_path))
     return cert_path, fullchain_path
 
+
 def renew_cert(config, plugins, lineage):
     """Renew & save an existing cert. Do not install it.
 
@@ -1206,6 +1225,7 @@ def renew_cert(config, plugins, lineage):
         installer.restart()
         notify("new certificate deployed with reload of {0} server; fullchain is {1}".format(
                config.installer, lineage.fullchain), pause=False)
+
 
 def certonly(config, plugins):
     """Authenticate & obtain cert, but do not install it.
@@ -1256,6 +1276,7 @@ def certonly(config, plugins):
     _report_new_cert(config, cert_path, fullchain_path, key_path)
     _suggest_donation_if_appropriate(config)
 
+
 def renew(config, unused_plugins):
     """Renew previously-obtained certificates.
 
@@ -1269,16 +1290,6 @@ def renew(config, unused_plugins):
     :rtype: None
 
     """
-    if not sys.stdin.isatty() and config.random_sleep_on_renew:
-        # Noninteractive renewals include a random delay in order to spread
-        # out the load on the certificate authority servers, even if many
-        # users all pick the same time for renewals.  This delay precedes
-        # running any hooks, so that side effects of the hooks (such as
-        # shutting down a web service) aren't prolonged unnecessarily.
-        sleep_time = random.randint(1, 60*8)
-        logger.info("Non-interactive renewal: random delay of %s seconds", sleep_time)
-        time.sleep(sleep_time)
-
     try:
         renewal.handle_renewal_request(config)
     finally:

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -66,7 +66,6 @@ def _suggest_donation_if_appropriate(config):
            "Donating to EFF:                    https://eff.org/donate-le\n\n")
     reporter_util.add_message(msg, reporter_util.LOW_PRIORITY)
 
-
 def _report_successful_dry_run(config):
     """Reports on successful dry run
 
@@ -228,7 +227,6 @@ def _handle_identical_cert_request(config, lineage):
     else:
         assert False, "This is impossible"
 
-
 def _find_lineage_for_domains(config, domains):
     """Determine whether there are duplicated names and how to handle
     them (renew, reinstall, newcert, or raising an error to stop
@@ -267,7 +265,6 @@ def _find_lineage_for_domains(config, domains):
     elif subset_names_cert is not None:
         return _handle_subset_cert_request(config, domains, subset_names_cert)
 
-
 def _find_cert(config, domains, certname):
     """Finds an existing certificate object given domains and/or a certificate name.
 
@@ -290,7 +287,6 @@ def _find_cert(config, domains, certname):
     if action == "reinstall":
         logger.info("Keeping the existing certificate")
     return (action != "reinstall"), lineage
-
 
 def _find_lineage_for_domains_and_certname(config, domains, certname):
     """Find appropriate lineage based on given domains and/or certname.
@@ -333,7 +329,6 @@ def _find_lineage_for_domains_and_certname(config, domains, certname):
                     "Use -d to specify domains, or run certbot certificates to see "
                     "possible certificate names.".format(certname))
 
-
 def _get_added_removed(after, before):
     """Get lists of items removed from `before`
     and a lists of items added to `after`
@@ -343,7 +338,6 @@ def _get_added_removed(after, before):
     added.sort()
     removed.sort()
     return added, removed
-
 
 def _format_list(character, strings):
     """Format list with given character
@@ -356,7 +350,6 @@ def _format_list(character, strings):
         ch=character,
         br=os.linesep
     )
-
 
 def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
     """Ask user to confirm update cert certname to contain new_domains.
@@ -394,7 +387,6 @@ def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
     obj = zope.component.getUtility(interfaces.IDisplay)
     if not obj.yesno(msg, "Update cert", "Cancel", default=True):
         raise errors.ConfigurationError("Specified mismatched cert name and domains.")
-
 
 def _find_domains_or_certname(config, installer, question=None):
     """Retrieve domains and certname from config or user input.
@@ -741,7 +733,6 @@ def update_account(config, unused_plugins):
     eff.handle_subscription(config)
     add_msg("Your e-mail address was updated to {0}.".format(config.email))
 
-
 def _install_cert(config, le_client, domains, lineage=None):
     """Install a cert
 
@@ -767,7 +758,6 @@ def _install_cert(config, le_client, domains, lineage=None):
     le_client.deploy_certificate(domains, path_provider.key_path,
         path_provider.cert_path, path_provider.chain_path, path_provider.fullchain_path)
     le_client.enhance_config(domains, path_provider.chain_path)
-
 
 def install(config, plugins):
     """Install a previously obtained cert in a server.
@@ -826,7 +816,6 @@ def install(config, plugins):
         lineage = cert_manager.lineage_for_certname(config, config.certname)
         enhancements.enable(lineage, domains, installer, config)
 
-
 def _populate_from_certname(config):
     """Helper function for install to populate missing config values from lineage
     defined by --cert-name."""
@@ -844,7 +833,6 @@ def _populate_from_certname(config):
         config.namespace.fullchain_path = lineage.fullchain_path
     return config
 
-
 def _check_certificate_and_key(config):
     if not os.path.isfile(os.path.realpath(config.cert_path)):
         raise errors.ConfigurationError("Error while reading certificate from path "
@@ -852,8 +840,6 @@ def _check_certificate_and_key(config):
     if not os.path.isfile(os.path.realpath(config.key_path)):
         raise errors.ConfigurationError("Error while reading private key from path "
                                        "{0}".format(config.key_path))
-
-
 def plugins_cmd(config, plugins):
     """List server software plugins.
 
@@ -891,7 +877,6 @@ def plugins_cmd(config, plugins):
     available = verified.available()
     logger.debug("Prepared plugins: %s", available)
     notify(str(available))
-
 
 def enhance(config, plugins):
     """Add security enhancements to existing configuration
@@ -983,7 +968,6 @@ def config_changes(config, unused_plugins):
     """
     client.view_config_changes(config, num=config.num)
 
-
 def update_symlinks(config, unused_plugins):
     """Update the certificate file family symlinks
 
@@ -1001,7 +985,6 @@ def update_symlinks(config, unused_plugins):
 
     """
     cert_manager.update_live_symlinks(config)
-
 
 def rename(config, unused_plugins):
     """Rename a certificate
@@ -1021,7 +1004,6 @@ def rename(config, unused_plugins):
     """
     cert_manager.rename_lineage(config)
 
-
 def delete(config, unused_plugins):
     """Delete a certificate
 
@@ -1040,7 +1022,6 @@ def delete(config, unused_plugins):
     """
     cert_manager.delete(config)
 
-
 def certificates(config, unused_plugins):
     """Display information about certs configured with Certbot
 
@@ -1055,7 +1036,6 @@ def certificates(config, unused_plugins):
 
     """
     cert_manager.certificates(config)
-
 
 def revoke(config, unused_plugins):  # TODO: coop with renewal config
     """Revoke a previously obtained certificate.
@@ -1183,7 +1163,6 @@ def _csr_get_and_save_cert(config, le_client):
         os.path.normpath(config.chain_path), os.path.normpath(config.fullchain_path))
     return cert_path, fullchain_path
 
-
 def renew_cert(config, plugins, lineage):
     """Renew & save an existing cert. Do not install it.
 
@@ -1225,7 +1204,6 @@ def renew_cert(config, plugins, lineage):
         installer.restart()
         notify("new certificate deployed with reload of {0} server; fullchain is {1}".format(
                config.installer, lineage.fullchain), pause=False)
-
 
 def certonly(config, plugins):
     """Authenticate & obtain cert, but do not install it.
@@ -1275,7 +1253,6 @@ def certonly(config, plugins):
     key_path = lineage.key_path if lineage else None
     _report_new_cert(config, cert_path, fullchain_path, key_path)
     _suggest_donation_if_appropriate(config)
-
 
 def renew(config, unused_plugins):
     """Renew previously-obtained certificates.

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -1269,7 +1269,7 @@ def renew(config, unused_plugins):
     :rtype: None
 
     """
-    if not sys.stdin.isatty():
+    if not sys.stdin.isatty() and config.random_sleep_on_renew:
         # Noninteractive renewals include a random delay in order to spread
         # out the load on the certificate authority servers, even if many
         # users all pick the same time for renewals.  This delay precedes

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -5,6 +5,9 @@ import itertools
 import logging
 import os
 import traceback
+import sys
+import time
+import random
 
 import six
 import zope.component
@@ -318,9 +321,10 @@ def renew_cert(config, domains, le_client, lineage):
 
 
 def report(msgs, category):
-    "Format a results report for a category of renewal outcomes"
+    """Format a results report for a category of renewal outcomes"""
     lines = ("%s (%s)" % (m, category) for m in msgs)
     return "  " + "\n  ".join(lines)
+
 
 def _renew_describe_results(config, renew_successes, renew_failures,
                             renew_skipped, parse_failures):
@@ -396,6 +400,14 @@ def handle_renewal_request(config):
     renew_failures = []
     renew_skipped = []
     parse_failures = []
+
+    # Noninteractive renewals include a random delay in order to spread
+    # out the load on the certificate authority servers, even if many
+    # users all pick the same time for renewals.  This delay precedes
+    # running any hooks, so that side effects of the hooks (such as
+    # shutting down a web service) aren't prolonged unnecessarily.
+    apply_random_sleep = not sys.stdin.isatty() and config.random_sleep_on_renew
+
     for renewal_file in conf_files:
         disp = zope.component.getUtility(interfaces.IDisplay)
         disp.notification("Processing " + renewal_file, pause=False)
@@ -424,7 +436,15 @@ def handle_renewal_request(config):
                 from certbot import main
                 plugins = plugins_disco.PluginsRegistry.find_all()
                 if should_renew(lineage_config, renewal_candidate):
-                    # domains have been restored into lineage_config by reconstitute
+                    # Apply random sleep upon first renewal if needed
+                    if apply_random_sleep:
+                        sleep_time = random.randint(1, 60 * 8)
+                        logger.info("Non-interactive renewal: random delay of %s seconds", sleep_time)
+                        time.sleep(sleep_time)
+                        # We will sleep only once this day, folks.
+                        apply_random_sleep = True
+
+                    # Domains have been restored into lineage_config by reconstitute
                     # but they're unnecessary anyway because renew_cert here
                     # will just grab them from the certificate
                     # we already know it's time to renew based on should_renew

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -391,10 +391,8 @@ def handle_renewal_request(config):
                            "instead. The renew verb may provide other options "
                            "for selecting certificates to renew in the future.")
 
-    if config.certname:
-        conf_files = [storage.renewal_file_for_certname(config, config.certname)]
-    else:
-        conf_files = storage.renewal_conf_files(config)
+    conf_files = [storage.renewal_file_for_certname(config, config.certname)] if config.certname \
+        else storage.renewal_conf_files(config)
 
     renew_successes = []
     renew_failures = []
@@ -439,7 +437,8 @@ def handle_renewal_request(config):
                     # Apply random sleep upon first renewal if needed
                     if apply_random_sleep:
                         sleep_time = random.randint(1, 60 * 8)
-                        logger.info("Non-interactive renewal: random delay of %s seconds", sleep_time)
+                        logger.info("Non-interactive renewal: random delay of %s seconds",
+                                    sleep_time)
                         time.sleep(sleep_time)
                         # We will sleep only once this day, folks.
                         apply_random_sleep = True
@@ -457,14 +456,12 @@ def handle_renewal_request(config):
                     renew_skipped.append("%s expires on %s" % (renewal_candidate.fullchain,
                                          expiry.strftime("%Y-%m-%d")))
                 # Run updater interface methods
-                updater.run_generic_updaters(lineage_config, renewal_candidate,
-                                             plugins)
+                updater.run_generic_updaters(lineage_config, renewal_candidate, plugins)
 
         except Exception as e:  # pylint: disable=broad-except
             # obtain_cert (presumably) encountered an unanticipated problem.
             logger.warning("Attempting to renew cert (%s) from %s produced an "
-                           "unexpected error: %s. Skipping.", lineagename,
-                               renewal_file, e)
+                           "unexpected error: %s. Skipping.", lineagename, renewal_file, e)
             logger.debug("Traceback was:\n%s", traceback.format_exc())
             renew_failures.append(renewal_candidate.fullchain)
 
@@ -475,5 +472,5 @@ def handle_renewal_request(config):
     if renew_failures or parse_failures:
         raise errors.Error("{0} renew failure(s), {1} parse failure(s)".format(
             len(renew_failures), len(parse_failures)))
-    else:
-        logger.debug("no renewal failures")
+
+    logger.debug("no renewal failures")

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -375,7 +375,7 @@ def _renew_describe_results(config, renew_successes, renew_failures,
     disp.notification("\n".join(out), wrap=False)
 
 
-def handle_renewal_request(config):  # pylint: disable=too-many-locals
+def handle_renewal_request(config):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     """Examine each lineage; renew if due and report results"""
 
     # This is trivially False if config.domains is empty

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -376,7 +376,7 @@ def _renew_describe_results(config, renew_successes, renew_failures,
     disp.notification("\n".join(out), wrap=False)
 
 
-def handle_renewal_request(config):
+def handle_renewal_request(config):  # pylint: disable=too-many-locals
     """Examine each lineage; renew if due and report results"""
 
     # This is trivially False if config.domains is empty


### PR DESCRIPTION
Following #6596, I extracted out my existing solution from #6541.

It adds a flag to the CLI, `--no-random-sleep-on-renew` to disable the random sleep when renew action is called from non interactive shells. The default behavior stays to make the random sleep if the flag is not provided.

The random sleep logic is also moved on layer down, to avoid to trigger it when no renew is going to be executed. Of course, this logic will be executed only once for a set of certificates to be renewed.