### PR TITLE
Correct boulder integration tests using the latest challtestsrv version

### DIFF
--- a/tests/boulder-fetch.sh
+++ b/tests/boulder-fetch.sh
@@ -11,7 +11,6 @@ if [ ! -d ${BOULDERPATH} ]; then
 fi
 
 cd ${BOULDERPATH}
-sed -i "s/FAKE_DNS: .*/FAKE_DNS: 10.77.77.1/" docker-compose.yml
 
 docker-compose up -d boulder
 
@@ -28,3 +27,6 @@ if ! curl http://localhost:4000/directory 2>/dev/null; then
   echo "timed out waiting for boulder to start"
   exit 1
 fi
+
+# Setup the DNS resolution used by boulder instance to docker host
+curl -X POST -d '{"ip":"10.77.77.1"}' http://localhost:8055/set-default-ipv4


### PR DESCRIPTION
Urgent PR, to be merged as soon as possible to repair the CI.

Latest version of boulder test stack uses the latest challtestsrv instance built from pebble project. In this new version, the default IP to respond for any A record DNS request is not set anymore with the `FAKE_DNS` environment variable, but using a specific POST request against the running challtestsrv instance.

Currently all CI processes will be broken on integratino tests until fix, because the boulder instance will not be able to resolve the docker host, where certbot set the HTTP/HTTPS server to validate a given TLS/HTTP challenge.

This PR add required logic to `boulder-fetch.sh` to let integration tests be executed correctly.