### PR TITLE
Pin all dependency installation in the release script (#6584)

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -166,7 +166,7 @@ fi
 mkdir kgs
 kgs="kgs/$version"
 pip freeze | tee $kgs
-pip install pytest
+python ../tools/pip_install.py pytest
 for module in $subpkgs_modules ; do
     echo testing $module
     # use an empty configuration file rather than the one in the repo root

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -143,7 +143,7 @@ pip install -U pip
 # (or our dependencies) have conditional dependencies implemented with if
 # statements in setup.py and we have cached wheels lying around that would
 # cause those ifs to not be evaluated.
-pip install \
+python ../tools/pip_install.py \
   --no-cache-dir \
   --extra-index-url http://localhost:$PORT \
   $SUBPKGS


### PR DESCRIPTION
Fixes #6584.

`pip freeze` after running the changed line results:

```
acme==0.30.0
asn1crypto==0.22.0
boto3==1.9.36
botocore==1.12.36
certbot==0.30.0
certbot-apache==0.30.0
certbot-dns-cloudflare==0.30.0
certbot-dns-cloudxns==0.30.0
certbot-dns-digitalocean==0.30.0
certbot-dns-dnsimple==0.30.0
certbot-dns-dnsmadeeasy==0.30.0
certbot-dns-gehirn==0.30.0
certbot-dns-google==0.30.0
certbot-dns-linode==0.30.0
certbot-dns-luadns==0.30.0
certbot-dns-nsone==0.30.0
certbot-dns-ovh==0.30.0
certbot-dns-rfc2136==0.30.0
certbot-dns-route53==0.30.0
certbot-dns-sakuracloud==0.30.0
certbot-nginx==0.30.0
certifi==2017.4.17
cffi==1.11.5
chardet==3.0.2
cloudflare==1.5.1
ConfigArgParse==0.12.0
configobj==5.0.6
cryptography==2.2.2
dns-lexicon==2.7.14
dnspython==1.15.0
docutils==0.12
enum34==1.1.2
funcsigs==1.0.2
future==0.16.0
futures==3.1.1
google-api-python-client==1.5.0
httplib2==0.10.3
idna==2.5
ipaddress==1.0.16
jmespath==0.9.3
josepy==1.1.0
logger==1.4
mock==1.3.0
oauth2client==2.0.0
parsedatetime==2.1
pbr==1.8.1
pyasn1==0.1.9
pyasn1-modules==0.0.10
pycparser==2.14
pyOpenSSL==16.2.0
pyparsing==2.1.8
pyRFC3339==1.0
python-augeas==0.5.0
python-dateutil==2.6.1
python-digitalocean==1.11
pytz==2015.7
PyYAML==3.13
requests==2.20.0
requests-file==1.4.2
requests-toolbelt==0.8.0
rsa==3.4.2
s3transfer==0.1.11
simplejson==3.16.0
six==1.10.0
tldextract==2.2.0
uritemplate==0.6
urllib3==1.21.1
zope.component==4.2.2
zope.event==4.1.0
zope.interface==4.1.3
```