### PR TITLE
Manual delay hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 * Added the `update_account` subcommand for account management commands.
+* Added a --manual-delay-hook argument that can be used to wait for DNS updates.
 
 ### Changed
 


### PR DESCRIPTION
DNS verification with the manual plugin can be painfully slow if multiple domains or hostnames are to be included in the certificate.

I see that various suggestions have been made to improve this, like #4628, #5484 and #5805.

This PR proposes a new hook that can be used to wait for the DNS propagation. The auth hooks can now just trigger the DNS updates in the background and when all updates have been performed, the delay hooks wait for the updates to propagate before the actual verification continues.
