### PR TITLE
Make tox default to any py3 test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 skipsdist = true
-envlist = modification,py{34,35,36},py27-cover,lint
+envlist = modification,py3,py27-cover,lint
 
 [base]
 # pip installs the requested packages in editable mode


### PR DESCRIPTION
[envlist](https://tox.readthedocs.io/en/latest/config.html#conf-envlist) defines the default test environments that should be run if someone runs `tox` without specifying them on the command line or in an environment variable.

When playing with things for #6605, I noticed that we're not testing on Python 3.7 here. We could just also specify `py37` here, however, I personally think it's better to just test with any Python 3 version. My reasons for this are:

* All of our tests in things like Travis do (and I think should) specify which test environment that should be run so this setting isn't used there.
* When devs test locally, most of them do not all have the 4 supported versions of Python 3 installed and instead usually just have 1 so let's just tell `tox` to test with the Python 3 interpreter it can find and test with multiple versions in CI.