### PR TITLE
Add mypy to envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 skipsdist = true
-envlist = modification,py{34,35,36},py27-cover,lint
+envlist = modification,py{34,35,36},py27-cover,lint,mypy
 
 [base]
 # pip installs the requested packages in editable mode


### PR DESCRIPTION
[envlist](https://tox.readthedocs.io/en/latest/config.html#conf-envlist) defines the default test environments that should be run if someone runs `tox` without specifying them on the command line or in an environment variable.

I think `mypy` should be run here as it is fairly quick and I think it's not uncommon for it to find problems if you're working on a significant code change.