### PR TITLE
Hostname length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 * Added the `update_account` subcommand for account management commands.
+* Added the `HostnameTooLong` error type for catching a UnicodeError from `socket.getfqdn()`.
 
 ### Changed
 
@@ -22,6 +23,9 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
   backwards compatibility and support for doing this with new modules in josepy
   will not be added. Users of the acme library should switch to using josepy
   directly if they haven't done so already.
+* Fixed the error displayed by a hostname over 63 characters by adding an exception
+  that would more accurately describe the issue. Which is that the FQDN does not
+  abide by RFC3490.
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only

--- a/certbot/account.py
+++ b/certbot/account.py
@@ -53,11 +53,14 @@ class Account(object):  # pylint: disable=too-few-public-methods
     def __init__(self, regr, key, meta=None):
         self.key = key
         self.regr = regr
-        self.meta = self.Meta(
-            # pyrfc3339 drops microseconds, make sure __eq__ is sane
-            creation_dt=datetime.datetime.now(
-                tz=pytz.UTC).replace(microsecond=0),
-            creation_host=socket.getfqdn()) if meta is None else meta
+        try:
+            self.meta = self.Meta(
+                # pyrfc3339 drops microseconds, make sure __eq__ is sane
+                creation_dt=datetime.datetime.now(
+                    tz=pytz.UTC).replace(microsecond=0),
+                creation_host=socket.getfqdn()) if meta is None else meta
+        except UnicodeError:
+            raise errors.HostnameTooLong("Expected hostname to be <= 63 characters according to RFC3490.")
 
         self.id = hashlib.md5(
             self.key.key.public_key().public_bytes(

--- a/certbot/account.py
+++ b/certbot/account.py
@@ -54,13 +54,14 @@ class Account(object):  # pylint: disable=too-few-public-methods
         self.key = key
         self.regr = regr
         try:
-            self.meta = self.Meta(
-                # pyrfc3339 drops microseconds, make sure __eq__ is sane
-                creation_dt=datetime.datetime.now(
-                    tz=pytz.UTC).replace(microsecond=0),
-                creation_host=socket.getfqdn()) if meta is None else meta
+            creation_hostname = socket.getfqdn()
         except UnicodeError:
             raise errors.HostnameTooLong("Expected hostname to be <= 63 characters according to RFC3490.")
+        else:
+            self.meta = self.Meta(# pyrfc3339 drops microseconds, make sure __eq__ is sane
+                creation_dt=datetime.datetime.now(
+                    tz=pytz.UTC).replace(microsecond=0),
+                creation_host=creation_hostname) if meta is None else meta
 
         self.id = hashlib.md5(
             self.key.key.public_key().public_bytes(

--- a/certbot/errors.py
+++ b/certbot/errors.py
@@ -13,6 +13,10 @@ class AccountNotFound(AccountStorageError):
     """Account not found error."""
 
 
+class HostnameTooLong(Error):
+    """Hostname length too long error"""
+
+
 class ReverterError(Error):
     """Certbot Reverter error."""
 


### PR DESCRIPTION
This added a new error type of `HostnameTooLong` to certbot. It also implemented the catch for `UnicodeError` that is thrown from `socket.getfqdn()` in python 3 when the domain name does not abide by RFC3490 for a max length of 63 characters.

This should create a more accurate error for solving issues:
Fixes #5958
Fixes #5311