### PR TITLE
Add missing acme.jose attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,14 @@ Certbot adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-*
+* Fixed accessing josepy contents through acme.jose when the full acme.jose
+  path is used.
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only
 package with changes other than its version number was:
 
-*
+* acme
 
 More details about these changes can be found on our GitHub repo.
 

--- a/acme/acme/__init__.py
+++ b/acme/acme/__init__.py
@@ -12,13 +12,13 @@ supported version: `draft-ietf-acme-01`_.
 """
 import sys
 
-import josepy
-
 # This code exists to keep backwards compatibility with people using acme.jose
 # before it became the standalone josepy package.
 #
 # It is based on
 # https://github.com/requests/requests/blob/1278ecdf71a312dc2268f3bfc0aabfab3c006dcf/requests/packages.py
+
+import josepy as jose
 
 for mod in list(sys.modules):
     # This traversal is apparently necessary such that the identities are

--- a/acme/acme/jose_test.py
+++ b/acme/acme/jose_test.py
@@ -12,11 +12,21 @@ class JoseTest(unittest.TestCase):
         else:
             acme_jose_path = 'acme.jose'
             josepy_path = 'josepy'
-        acme_jose = importlib.import_module(acme_jose_path)
-        josepy = importlib.import_module(josepy_path)
+        acme_jose_mod = importlib.import_module(acme_jose_path)
+        josepy_mod = importlib.import_module(josepy_path)
 
-        self.assertIs(acme_jose, josepy)
-        self.assertIs(getattr(acme_jose, attribute), getattr(josepy, attribute))
+        self.assertIs(acme_jose_mod, josepy_mod)
+        self.assertIs(getattr(acme_jose_mod, attribute), getattr(josepy_mod, attribute))
+
+        # We use the imports below with eval, but pylint doesn't
+        # understand that.
+        # pylint: disable=eval-used,unused-variable
+        import acme
+        import josepy
+        acme_jose_mod = eval(acme_jose_path)
+        josepy_mod = eval(josepy_path)
+        self.assertIs(acme_jose_mod, josepy_mod)
+        self.assertIs(getattr(acme_jose_mod, attribute), getattr(josepy_mod, attribute))
 
     def test_top_level(self):
         self._test_it('', 'RS512')


### PR DESCRIPTION
Fixes the problem at https://github.com/certbot/certbot/pull/6592#discussion_r245106383.

The tests use `eval` which neither myself or `pylint` like very much. I started to change this by splitting the path we wanted to test and repeatedly calling `getattr`, but it didn't seem worth the effort to me.

@erikrose, if you're able to give this a quick review when you get a chance, I'd appreciate it. Our packagers need this ASAP.