### PR TITLE
Compatibility with more traditional versions of awk

### DIFF
--- a/tests/certbot-boulder-integration.sh
+++ b/tests/certbot-boulder-integration.sh
@@ -174,7 +174,7 @@ CheckRenewHook() {
 TotalAndDistinctLines() {
     total=$1
     distinct=$2
-    awk '{a[$1] = 1}; END {exit(NR !='$total' || length(a) !='$distinct')}'
+    awk '{a[$1] = 1}; END {n = 0; for (i in a) { n++ }; exit(NR !='$total' || n !='$distinct')}'
 }
 
 # Cleanup coverage data


### PR DESCRIPTION
Traditional versions of awk, including versions of mawk prior to 1.3.4, do not support taking the length() of an array, only of a string (see https://stackoverflow.com/questions/16921493/awk-illegal-reference-to-array-a). This function used length() on an array to determine the number of distinct lines in the output, which works fine in gawk and more recent mawks, but not all.

This PR uses a loop to to determine the length of the array, which is compatible with mawk and any other awk implementations that have the same limitation.