### PR TITLE
Use HTTPS link to semver.org.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Certbot change log
 
-Certbot adheres to [Semantic Versioning](http://semver.org/).
+Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ## 0.31.0 - master
 


### PR DESCRIPTION
I was checking something in the semver docs and noticed that we link to them using HTTP rather than HTTPS. This PR fixes that and I created #6640 to track this problem throughout the codebase.