### PR TITLE
Fix oldest nginx integration tests

### DIFF
--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -3,16 +3,15 @@
 root=${root:-$(mktemp -d -t leitXXXX)}
 echo "Root integration tests directory: $root"
 config_dir="$root/conf"
-store_flags="--config-dir $config_dir --work-dir $root/work"
-store_flags="$store_flags --logs-dir $root/logs"
 tls_sni_01_port=5001
 http_01_port=5002
 sources="acme/,$(ls -dm certbot*/ | tr -d ' \n')"
-export root config_dir store_flags tls_sni_01_port http_01_port sources
+export root config_dir tls_sni_01_port http_01_port sources
 certbot_path="$(command -v certbot)"
 # Flags that are added here will be added to Certbot calls within
 # certbot_test_no_force_renew.
-other_flags=""
+other_flags="--config-dir $config_dir --work-dir $root/work"
+other_flags="$other_flags --logs-dir $root/logs"
 
 certbot_test () {
     certbot_test_no_force_renew \
@@ -44,7 +43,7 @@ if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
 fi
 
 if version_at_least 0 30; then
-  other_flags="--no-random-sleep-on-renew"
+  other_flags="$other_flags --no-random-sleep-on-renew"
 fi
 
 certbot_test_no_force_renew () {
@@ -62,13 +61,12 @@ certbot_test_no_force_renew () {
             --tls-sni-01-port $tls_sni_01_port \
             --http-01-port $http_01_port \
             --manual-public-ip-logging-ok \
-            $store_flags \
+            $other_flags \
             --non-interactive \
             --no-redirect \
             --agree-tos \
             --register-unsafely-without-email \
             --debug \
             -vv \
-            "$other_flags" \
             "$@"
 }

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -12,7 +12,7 @@ export root config_dir store_flags tls_sni_01_port http_01_port sources
 certbot_path="$(command -v certbot)"
 # Flags that are added here will be added to Certbot calls within
 # certbot_test_no_force_renew.
-other_flags="-vv"
+other_flags=""
 
 certbot_test () {
     certbot_test_no_force_renew \
@@ -44,7 +44,7 @@ if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
 fi
 
 if version_at_least 0 30; then
-  other_flags="$other_flags --no-random-sleep-on-renew"
+  other_flags="--no-random-sleep-on-renew"
 fi
 
 certbot_test_no_force_renew () {
@@ -68,6 +68,7 @@ certbot_test_no_force_renew () {
             --agree-tos \
             --register-unsafely-without-email \
             --debug \
+            -vv \
             "$other_flags" \
             "$@"
 }

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -12,7 +12,7 @@ export root config_dir store_flags tls_sni_01_port http_01_port sources
 certbot_path="$(command -v certbot)"
 # Flags that are added here will be added to Certbot calls within
 # certbot_test_no_force_renew.
-other_flags=""
+other_flags="-vv"
 
 certbot_test () {
     certbot_test_no_force_renew \
@@ -44,7 +44,7 @@ if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
 fi
 
 if version_at_least 0 30; then
-  other_flags="--no-random-sleep-on-renew"
+  other_flags="$other_flags --no-random-sleep-on-renew"
 fi
 
 certbot_test_no_force_renew () {
@@ -68,7 +68,6 @@ certbot_test_no_force_renew () {
             --agree-tos \
             --register-unsafely-without-email \
             --debug \
-            -vv \
             "$other_flags" \
             "$@"
 }

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -19,10 +19,9 @@ certbot_test () {
         "$@"
 }
 
-# Checks that the Certbot version is at least the given version number. This is
-# useful for making sure Certbot has certain features available. The patch
-# version is currently ignored. You use the exit code of this function to
-# determine the result of the comparison.
+# Succeeds if Certbot version is at least the given version number and fails
+# otherwise. This is useful for making sure Certbot has certain features
+# available. The patch version is currently ignored.
 #
 # Arguments:
 #   First argument is the minimum major version
@@ -42,6 +41,9 @@ if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
     SERVER="http://localhost:4001/directory"
 fi
 
+# --no-random-sleep-on-renew was added in
+# https://github.com/certbot/certbot/pull/6599 and first released in Certbot
+# 0.30.0.
 if version_at_least 0 30; then
   other_flags="$other_flags --no-random-sleep-on-renew"
 fi

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -10,6 +10,9 @@ http_01_port=5002
 sources="acme/,$(ls -dm certbot*/ | tr -d ' \n')"
 export root config_dir store_flags tls_sni_01_port http_01_port sources
 certbot_path="$(command -v certbot)"
+# Flags that are added here will be added to Certbot calls within
+# certbot_test_no_force_renew.
+other_flags=""
 
 certbot_test () {
     certbot_test_no_force_renew \
@@ -40,6 +43,10 @@ if [ "${BOULDER_INTEGRATION:-v1}" = "v2" -a -z "${SERVER:+x}" ]; then
     SERVER="http://localhost:4001/directory"
 fi
 
+if version_at_least 0 30; then
+  other_flags="--no-random-sleep-on-renew"
+fi
+
 certbot_test_no_force_renew () {
     omit_patterns="*/*.egg-info/*,*/dns_common*,*/setup.py,*/test_*,*/tests/*"
     omit_patterns="$omit_patterns,*_test.py,*_test_*,certbot-apache/*"
@@ -62,6 +69,6 @@ certbot_test_no_force_renew () {
             --register-unsafely-without-email \
             --debug \
             -vv \
-            --no-random-sleep-on-renew \
+            "$other_flags" \
             "$@"
 }

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -9,11 +9,30 @@ tls_sni_01_port=5001
 http_01_port=5002
 sources="acme/,$(ls -dm certbot*/ | tr -d ' \n')"
 export root config_dir store_flags tls_sni_01_port http_01_port sources
+certbot_path="$(command -v certbot)"
 
 certbot_test () {
     certbot_test_no_force_renew \
         --renew-by-default \
         "$@"
+}
+
+# Checks that the Certbot version is at least the given version number. This is
+# useful for making sure Certbot has certain features available. The patch
+# version is currently ignored. You use the exit code of this function to
+# determine the result of the comparison.
+#
+# Arguments:
+#   First argument is the minimum major version
+#   Second argument is the minimum minor version
+version_at_least () {
+    # Certbot major and minor version (e.g. 0.30)
+    major_minor=$("$certbot_path" --version 2>&1 | cut -d' ' -f2 | cut -d. -f1,2)
+    major=$(echo "$major_minor" | cut -d. -f1)
+    minor=$(echo "$major_minor" | cut -d. -f2)
+    # Test that either the major version is greater or major version is equal
+    # and minor version is greater than or equal to.
+    [ \( "$major" -gt "$1" \) -o \( "$major" -eq "$1" -a "$minor" -ge "$2" \) ]
 }
 
 # Use local ACMEv2 endpoint if requested and SERVER isn't already set.
@@ -30,7 +49,7 @@ certbot_test_no_force_renew () {
         --append \
         --source $sources \
         --omit $omit_patterns \
-        $(command -v certbot) \
+        "$certbot_path" \
             --server "${SERVER:-http://localhost:4000/directory}" \
             --no-verify-ssl \
             --tls-sni-01-port $tls_sni_01_port \


### PR DESCRIPTION
#6636 broke [test-everything tests](https://travis-ci.org/certbot/certbot/builds/475173804) because `_common.sh` is a common file shared between Certbot and Nginx integration tests and `--no-random-sleep-on-renew` isn't defined for the version of Certbot used in the "oldest" integration tests.

This PR adds code to `_common.sh` to check the Certbot version and if it's new enough, add `--no-random-sleep-on-renew` to the command line. I repurposed `$store_flags` and stopped exporting it because it's not used anywhere outside of this file.

Other approaches I considered and decided against were:

1. Adding this flag in `certbot-boulder-integration.sh`. I decided against it because it's setting us up for the same problem in the future if the oldest version of Certbot is upgraded in the Nginx tests and we call `certbot renew`.
2. Just upgrading the oldest version of Certbot required by Nginx to avoid these issues. While this would work (with perhaps some unnecessary burden for our packagers), I think it's avoiding the real problem here which should now be able to addressed easily with the addition of `$other_flags` and `version_at_least`.

@adferrand or @ohemorange, are one of you able to review this?