### PR TITLE
Stop using staging in apacheconftests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ matrix:
       addons:
     - python: "2.7"
       env:
-        - ACME_SERVER_URI="http://localhost:4000/directory"
         - BOULDER_FOR_TOX=1
         - TOXENV=apacheconftest
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,10 @@ matrix:
       before_install:
       addons:
     - python: "2.7"
-      env: TOXENV=apacheconftest
+      env:
+        - ACME_SERVER_URI="http://localhost:4000/directory"
+        - BOULDER_FOR_TOX=1
+        - TOXENV=apacheconftest
       sudo: required
     - python: "2.7"
       env: TOXENV=nginxroundtrip
@@ -92,8 +95,10 @@ addons:
 
 install: "travis_retry $(command -v pip || command -v pip3) install codecov tox"
 script:
+    - '[ -z "${BOULDER_FOR_TOX+x}" ] || travis_retry tests/boulder-fetch.sh'
     - travis_retry tox
-    - '[ -z "${BOULDER_INTEGRATION+x}" ] || (travis_retry tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
+    # If BOULDER_INTEGRATION is set, run integration tests. If BOULDER_FOR_TOX isn't set, we still need to start boulder.
+    - '[ -z "${BOULDER_INTEGRATION+x}" ] || ( ( [ -n "${BOULDER_FOR_TOX+x}" ] || travis_retry tests/boulder-fetch.sh ) && tests/tox-boulder-integration.sh)'
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
       before_install:
       addons:
     - python: "2.7"
-      env: TOXENV=apacheconftest
+      env: TOXENV=apacheconftest-with-pebble
       sudo: required
     - python: "2.7"
       env: TOXENV=nginxroundtrip

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,7 @@ matrix:
       before_install:
       addons:
     - python: "2.7"
-      env:
-        - BOULDER_FOR_TOX=1
-        - TOXENV=apacheconftest
+      env: BOULDER_FOR_TOX=1 TOXENV=apacheconftest
       sudo: required
     - python: "2.7"
       env: TOXENV=nginxroundtrip

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
     - python: "2.7"
       env: TOXENV=apacheconftest-with-pebble
       sudo: required
+      services: docker
     - python: "2.7"
       env: TOXENV=nginxroundtrip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
       before_install:
       addons:
     - python: "2.7"
-      env: BOULDER_FOR_TOX=1 TOXENV=apacheconftest
+      env: TOXENV=apacheconftest
       sudo: required
     - python: "2.7"
       env: TOXENV=nginxroundtrip
@@ -92,10 +92,8 @@ addons:
 
 install: "travis_retry $(command -v pip || command -v pip3) install codecov tox"
 script:
-    - '[ -z "${BOULDER_FOR_TOX+x}" ] || travis_retry tests/boulder-fetch.sh'
     - travis_retry tox
-    # If BOULDER_INTEGRATION is set, run integration tests. If BOULDER_FOR_TOX isn't set, we still need to start boulder.
-    - '[ -z "${BOULDER_INTEGRATION+x}" ] || ( ( [ -n "${BOULDER_FOR_TOX+x}" ] || travis_retry tests/boulder-fetch.sh ) && tests/tox-boulder-integration.sh)'
+    - '[ -z "${BOULDER_INTEGRATION+x}" ] || (travis_retry tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov'
 

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -63,7 +63,7 @@ fi
 
 CERTBOT_CMD="sudo $(command -v certbot) --server $SERVER -vvvv"
 CERTBOT_CMD="$CERTBOT_CMD --debug --apache --register-unsafely-without-email"
-CERTBOT_CMD="$CERTBOT_CMD --agree-tos certonly -t"
+CERTBOT_CMD="$CERTBOT_CMD --agree-tos certonly -t --no-verify-ssl"
 
 FAILS=0
 trap CleanupExit INT

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -3,9 +3,7 @@
 # A hackish script to see if the client is behaving as expected 
 # with each of the "passing" conf files.
 
-SERVER="${SERVER:-http://localhost:4000/directory}"
-if ! python -c "import requests; requests.get('$SERVER')"; then
-    echo "ACME server not found."
+if [ -z "$SERVER" ]; then
     echo "Please set SERVER to the ACME server's directory URL."
     exit 1
 fi

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -4,7 +4,7 @@
 # with each of the "passing" conf files.
 
 SERVER="${SERVER:-http://localhost:4000/directory}"
-if ! curl "$SERVER" >/dev/null 2>&1; then
+if ! python -c "import requests; requests.get('$SERVER')"; then
     echo "ACME server not found."
     echo "Please set SERVER to the ACME server's directory URL."
     exit 1

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -56,13 +56,16 @@ if [ "$1" = --debian-modules ] ; then
     done
 fi
 
+CERTBOT_CMD="sudo $(command -v certbot) --server $ACME_SERVER_URI -vvvv"
+CERTBOT_CMD="$CERTBOT_CMD --debug --apache --register-unsafely-without-email"
+CERTBOT_CMD="$CERTBOT_CMD --agree-tos certonly -t"
 
 FAILS=0
 trap CleanupExit INT
 for f in *.conf ; do 
     echo -n  testing "$f"...
     Setup
-    RESULT=`echo c | sudo $(command -v certbot) -vvvv --debug --staging --apache --register-unsafely-without-email --agree-tos certonly -t 2>&1`
+    RESULT=`echo c | "$CERTBOT_CMD" 2>&1`
     if echo $RESULT | grep -Eq \("Which names would you like"\|"mod_macro is not yet"\) ; then
         echo passed
     else

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -3,8 +3,10 @@
 # A hackish script to see if the client is behaving as expected 
 # with each of the "passing" conf files.
 
-if [ -z "$ACME_SERVER_URI" ]; then
-    echo Please set ACME_SERVER_URI.
+SERVER="${SERVER:-http://localhost:4000/directory}"
+if ! curl "$SERVER" >/dev/null 2>&1; then
+    echo "ACME server not found."
+    echo "Please set SERVER to the ACME server's directory URL."
     exit 1
 fi
 
@@ -61,7 +63,7 @@ if [ "$1" = --debian-modules ] ; then
     done
 fi
 
-CERTBOT_CMD="sudo $(command -v certbot) --server $ACME_SERVER_URI -vvvv"
+CERTBOT_CMD="sudo $(command -v certbot) --server $SERVER -vvvv"
 CERTBOT_CMD="$CERTBOT_CMD --debug --apache --register-unsafely-without-email"
 CERTBOT_CMD="$CERTBOT_CMD --agree-tos certonly -t"
 

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -72,7 +72,7 @@ trap CleanupExit INT
 for f in *.conf ; do 
     echo -n  testing "$f"...
     Setup
-    RESULT=`echo c | "$CERTBOT_CMD" 2>&1`
+    RESULT=`echo c | $CERTBOT_CMD 2>&1`
     if echo $RESULT | grep -Eq \("Which names would you like"\|"mod_macro is not yet"\) ; then
         echo passed
     else

--- a/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test
@@ -3,6 +3,11 @@
 # A hackish script to see if the client is behaving as expected 
 # with each of the "passing" conf files.
 
+if [ -z "$ACME_SERVER_URI" ]; then
+    echo Please set ACME_SERVER_URI.
+    exit 1
+fi
+
 export EA=/etc/apache2/ 
 TESTDIR="`dirname $0`"
 cd $TESTDIR/passing

--- a/tests/letstest/scripts/test_apache2.sh
+++ b/tests/letstest/scripts/test_apache2.sh
@@ -54,7 +54,7 @@ if [ $? -ne 0 ] ; then
 fi
 
 if [ "$OS_TYPE" = "ubuntu" ] ; then
-    export ACME_SERVER_URI="$BOULDER_URL"
+    export SERVER="$BOULDER_URL"
     venv/bin/tox -e apacheconftest
 else
     echo Not running hackish apache tests on $OS_TYPE

--- a/tests/letstest/scripts/test_apache2.sh
+++ b/tests/letstest/scripts/test_apache2.sh
@@ -54,6 +54,7 @@ if [ $? -ne 0 ] ; then
 fi
 
 if [ "$OS_TYPE" = "ubuntu" ] ; then
+    export ACME_SERVER_URI="$BOULDER_URL"
     venv/bin/tox -e apacheconftest
 else
     echo Not running hackish apache tests on $OS_TYPE

--- a/tox.ini
+++ b/tox.ini
@@ -156,7 +156,7 @@ commands =
     {[base]pip_install} acme . certbot-apache certbot-compatibility-test
     {toxinidir}/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test --debian-modules
 passenv =
-    ACME_SERVER_URI
+    SERVER
 
 [testenv:nginxroundtrip]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -162,6 +162,11 @@ passenv =
 commands =
     {toxinidir}/tests/pebble-fetch.sh
     {[testenv:apacheconftest]commands}
+passenv =
+    HOME
+    GOPATH
+    PEBBLEPATH
+    PEBBLE_STRICT
 setenv =
     SERVER=https://localhost:14000/dir
 

--- a/tox.ini
+++ b/tox.ini
@@ -155,6 +155,8 @@ commands =
 commands =
     {[base]pip_install} acme . certbot-apache certbot-compatibility-test
     {toxinidir}/certbot-apache/certbot_apache/tests/apache-conf-files/apache-conf-test --debian-modules
+passenv =
+    ACME_SERVER_URI
 
 [testenv:nginxroundtrip]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -158,6 +158,13 @@ commands =
 passenv =
     SERVER
 
+[testenv:apacheconftest-with-pebble]
+commands =
+    {toxinidir}/tests/pebble-fetch.sh
+    {[testenv:apacheconftest]commands}
+setenv =
+    SERVER=https://localhost:14000/dir
+
 [testenv:nginxroundtrip]
 commands =
     {[base]pip_install} acme . certbot-apache certbot-nginx


### PR DESCRIPTION
Fixes #6585.

I wrote up three suggestions for fixing this at https://github.com/certbot/certbot/issues/6585#issuecomment-448054502. I took the middle approach of requiring the user to provide an ACME server to use. I like this better than the other approaches which were:

> Resolve #5938 instead of this issue.

There is value in these tests as is over the compatibility tests in that they don't use Docker and run on different OSes.

> Spin up a local Python server to return the directory object.

Trying to set up a dummy ACME server seemed hacky and error prone.

Other notes about this PR are:

* ~~I chose to put the Boulder setup for Travis in `.travis.yml` rather than `tox.ini` to keep it all in a single file. (We set up boulder for integration tests in `.travis.yml`.)~~
* I put the Pebble setup in `tox.ini` rather than `.travis.yml` as this seems much cleaner and more natural.
* I created a new `tox` environment called `apacheconftest-with-pebble` that reuses the code from `testenv:apacheconftest` so `apacheconftest` can continue to be used with servers other than Pebble like is done in our test farm tests.
* I chose the environment variable `SERVER` for consistency with our integration tests. I chose to not give this environment variable a default but to fail fast when it is not set.
* ~~I gave the environment variable the default of localhost to simplify things when running Boulder locally (like in Travis). You can still set `SERVER` to staging, however, I didn't make this the default as it kind of defeats the purpose of this PR.~~
* ~~I used Python rather than `curl` to check the value of `SERVER` because `curl` wasn't available on all test farm machines. `requests` is always installed in the virtual environment set up by `tox`.~~
* I ran test farm tests on this PR and they passed.

Finally, after this PR is merged, the `test-everything` branch will have to be updated to resolve changes in `.travis.yml`.