### PR TITLE
Change build status links to travis-ci.com.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,8 @@ ACME working area in github: https://github.com/ietf-wg-acme/acme
 
 |build-status| |coverage| |docs| |container|
 
-.. |build-status| image:: https://travis-ci.org/certbot/certbot.svg?branch=master
-   :target: https://travis-ci.org/certbot/certbot
+.. |build-status| image:: https://travis-ci.com/certbot/certbot.svg?branch=master
+   :target: https://travis-ci.com/certbot/certbot
    :alt: Travis CI status
 
 .. |coverage| image:: https://codecov.io/gh/certbot/certbot/branch/master/graph/badge.svg


### PR DESCRIPTION
As part of migrating away from the now deprecated support for GitHub services, our Travis config has moved from travis-ci.org to travis-ci.com. This PR updates the links to our build status to use travis-ci.com.

The reference to travis-ci.org at https://github.com/certbot/certbot/blob/651de2dd2fea9c79caae96d039f2570518735bdc/certbot/configuration.py#L98 wasn't updated because build history from travis-ci.org isn't migrated over by Travis yet. Once this has happened, Travis says it will automatically redirect links to travis-ci.org to travis-ci.com. See https://docs.travis-ci.com/user/open-source-repository-migration for more info.