### PR TITLE
Clarify behavior for deleting certs as part of revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Fixed accessing josepy contents through acme.jose when the full acme.jose
   path is used.
+* Clarify behavior for deleting certs as part of revocation.
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only
@@ -47,7 +48,7 @@ More details about these changes can be found on our GitHub repo.
 
 * Copied account management functionality from the `register` subcommand
   to the `update_account` subcommand.
-* Marked usage `register --update-registration` for deprecation and 
+* Marked usage `register --update-registration` for deprecation and
   removal in a future release.
 
 ### Fixed

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1311,7 +1311,8 @@ def _create_subparsers(helpful):
     helpful.add("revoke",
                 "--delete-after-revoke", action="store_true",
                 default=flag_default("delete_after_revoke"),
-                help="Delete certificates after revoking them.")
+                help="Delete certificates after revoking them, along with all previous and later "
+                "versions of those certificates.")
     helpful.add("revoke",
                 "--no-delete-after-revoke", action="store_false",
                 dest="delete_after_revoke",

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -548,7 +548,8 @@ def _delete_if_appropriate(config): # pylint: disable=too-many-locals,too-many-b
 
     attempt_deletion = config.delete_after_revoke
     if attempt_deletion is None:
-        msg = ("Would you like to delete the cert(s) you just revoked?")
+        msg = ("Would you like to delete the cert(s) you just revoked, along with all earlier and "
+            "later versions of the cert?")
         attempt_deletion = display.yesno(msg, yes_label="Yes (recommended)", no_label="No",
                 force_interactive=True, default=True)
 


### PR DESCRIPTION
Fixes #5499.

Be sure to edit the `master` section of `CHANGELOG.md`. This includes a
description of the change and ensuring the modified package(s) are listed as
having been changed.
