### PR TITLE
Setup cron build with specific jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
 
 matrix:
   include:
+    # These environments are executed on push and cron events
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=all TOXENV=py27_install
       sudo: required
@@ -63,6 +64,113 @@ matrix:
       services: docker
     - python: "2.7"
       env: TOXENV=nginxroundtrip
+
+    # These environments are executed on cron events only
+    - python: "2.7"
+      env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "2.7"
+      env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "2.7"
+      env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "2.7"
+      env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "3.4"
+      env: TOXENV=py34 BOULDER_INTEGRATION=v1
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "3.4"
+      env: TOXENV=py34 BOULDER_INTEGRATION=v2
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "3.5"
+      env: TOXENV=py35 BOULDER_INTEGRATION=v1
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "3.5"
+      env: TOXENV=py35 BOULDER_INTEGRATION=v2
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "3.6"
+      env: TOXENV=py36 BOULDER_INTEGRATION=v1
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "3.6"
+      env: TOXENV=py36 BOULDER_INTEGRATION=v2
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "3.7"
+      dist: xenial
+      env: TOXENV=py37 BOULDER_INTEGRATION=v1
+      sudo: required
+      services: docker
+      if: type = cron
+    - python: "3.7"
+      dist: xenial
+      env: TOXENV=py37 BOULDER_INTEGRATION=v2
+      sudo: required
+      services: docker
+      if: type = cron
+    - sudo: required
+      env: TOXENV=nginx_compat
+      services: docker
+      if: type = cron
+    - sudo: required
+      env: TOXENV=le_auto_precise
+      services: docker
+      if: type = cron
+    - sudo: required
+      env: TOXENV=le_auto_wheezy
+      services: docker
+      if: type = cron
+    - sudo: required
+      env: TOXENV=le_auto_centos6
+      services: docker
+      if: type = cron
+    - sudo: required
+      env: TOXENV=docker_dev
+      services: docker
+      addons:
+        apt:
+          packages:  # don't install nginx and apache
+            - libaugeas0
+      if: type = cron
+    - language: generic
+      env: TOXENV=py27
+      os: osx
+      addons:
+        homebrew:
+          packages:
+            - augeas
+            - python2
+      if: type = cron
+    - language: generic
+      env: TOXENV=py3
+      os: osx
+      addons:
+        homebrew:
+          packages:
+            - augeas
+            - python3
+      if: type = cron
+
 
 
 # Only build pushes to the master branch, PRs, and branches beginning with

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ cache:
     directories:
         - $HOME/.cache/pip
 
-before_install:
-  - '([ $TRAVIS_OS_NAME == linux ] && dpkg -s libaugeas0) || (brew update && brew install augeas python3 && brew upgrade python && brew link python)'
-
 before_script:
   - 'if [ $TRAVIS_OS_NAME = osx ] ; then ulimit -n 1024 ; fi'
   - export TOX_TESTENV_PASSENV=TRAVIS

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,10 +129,6 @@ matrix:
       services: docker
       if: type = cron
     - sudo: required
-      env: TOXENV=nginx_compat
-      services: docker
-      if: type = cron
-    - sudo: required
       env: TOXENV=le_auto_precise
       services: docker
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 
 matrix:
   include:
-    # These environments are executed on push and cron events
+    # These environments are always executed
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=all TOXENV=py27_install
       sudo: required


### PR DESCRIPTION
Fixes #6659 

It appears that the conditional statement `if: cron = type` works as expected:
* on a push event, jobs marked with this statement are completely ignored
* on a cron event, these jobs are executed

This PR takes advantages of it, by integrating the specific environments from `test-everything` branch to be merged into master, and add the conditional statement to execute them only during cron builds.

Once this PR is merged, a cron job can be set to build master at the appropriate time of the day, and `test-everything` will not be needed anymore.

For execution examples from this branch, see:
* during a push event: https://travis-ci.org/adferrand/certbot/builds/480127828
* during a cron event: https://travis-ci.org/adferrand/certbot/builds/480130236

No changelog, as this PR concerns only development stuff.