### PR TITLE
Remove reference to latest ACME draft implemented.

### DIFF
--- a/acme/acme/__init__.py
+++ b/acme/acme/__init__.py
@@ -1,13 +1,8 @@
 """ACME protocol implementation.
 
-This module is an implementation of the `ACME protocol`_. Latest
-supported version: `draft-ietf-acme-01`_.
-
+This module is an implementation of the `ACME protocol`_.
 
 .. _`ACME protocol`: https://ietf-wg-acme.github.io/acme
-
-.. _`draft-ietf-acme-01`:
-  https://github.com/ietf-wg-acme/acme/tree/draft-ietf-acme-acme-01
 
 """
 import sys


### PR DESCRIPTION
We have implemented far past the original ACME draft and I don't think it's worth trying to keep the text here up to date so I removed it entirely.