### PR TITLE
Remove dead autodeployment code

### DIFF
--- a/certbot/storage.py
+++ b/certbot/storage.py
@@ -879,45 +879,6 @@ class RenewableCert(object):
         with open(target) as f:
             return crypto_util.get_names_from_cert(f.read())
 
-    def autodeployment_is_enabled(self):
-        """Is automatic deployment enabled for this cert?
-
-        If autodeploy is not specified, defaults to True.
-
-        :returns: True if automatic deployment is enabled
-        :rtype: bool
-
-        """
-        return ("autodeploy" not in self.configuration or
-                self.configuration.as_bool("autodeploy"))
-
-    def should_autodeploy(self, interactive=False):
-        """Should this lineage now automatically deploy a newer version?
-
-        This is a policy question and does not only depend on whether
-        there is a newer version of the cert. (This considers whether
-        autodeployment is enabled, whether a relevant newer version
-        exists, and whether the time interval for autodeployment has
-        been reached.)
-
-        :param bool interactive: set to True to examine the question
-            regardless of whether the renewal configuration allows
-            automated deployment (for interactive use). Default False.
-
-        :returns: whether the lineage now ought to autodeploy an
-            existing newer cert version
-        :rtype: bool
-
-        """
-        if interactive or self.autodeployment_is_enabled():
-            if self.has_pending_deployment():
-                interval = self.configuration.get("deploy_before_expiry",
-                                                  "5 days")
-                now = pytz.UTC.fromutc(datetime.datetime.utcnow())
-                if self.target_expiry < add_time_interval(now, interval):
-                    return True
-        return False
-
     def ocsp_revoked(self, version=None):
         # pylint: disable=no-self-use,unused-argument
         """Is the specified cert version revoked according to OCSP?

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -388,8 +388,7 @@ class RenewableCertTests(BaseRenewableCertTest):
     @mock.patch("certbot.storage.cli")
     @mock.patch("certbot.storage.datetime")
     def test_time_interval_judgments(self, mock_datetime, mock_cli):
-        """Test should_autodeploy() and should_autorenew() on the basis
-        of expiry time windows."""
+        """Test should_autorenew() on the basis of expiry time windows."""
         test_cert = test_util.load_vector("cert_512.pem")
 
         self._write_out_ex_kinds()
@@ -430,30 +429,7 @@ class RenewableCertTests(BaseRenewableCertTest):
             mock_datetime.datetime.utcnow.return_value = sometime
             self.test_rc.configuration["deploy_before_expiry"] = interval
             self.test_rc.configuration["renew_before_expiry"] = interval
-            self.assertEqual(self.test_rc.should_autodeploy(), result)
             self.assertEqual(self.test_rc.should_autorenew(), result)
-
-    def test_autodeployment_is_enabled(self):
-        self.assertTrue(self.test_rc.autodeployment_is_enabled())
-        self.test_rc.configuration["autodeploy"] = "1"
-        self.assertTrue(self.test_rc.autodeployment_is_enabled())
-
-        self.test_rc.configuration["autodeploy"] = "0"
-        self.assertFalse(self.test_rc.autodeployment_is_enabled())
-
-    def test_should_autodeploy(self):
-        """Test should_autodeploy() on the basis of reasons other than
-        expiry time window."""
-        # pylint: disable=too-many-statements
-        # Autodeployment turned off
-        self.test_rc.configuration["autodeploy"] = "0"
-        self.assertFalse(self.test_rc.should_autodeploy())
-        self.test_rc.configuration["autodeploy"] = "1"
-        # No pending deployment
-        for ver in six.moves.range(1, 6):
-            for kind in ALL_FOUR:
-                self._write_out_kind(kind, ver)
-        self.assertFalse(self.test_rc.should_autodeploy())
 
     def test_autorenewal_is_enabled(self):
         self.test_rc.configuration["renewalparams"] = {}


### PR DESCRIPTION
Removes deadcode in `autodeployment_is_enabled` and `should_autodeploy` and relevant tests

Fixes #4315 
