### PR TITLE
Remove tls-sni-01 challenges in integration tests

### DIFF
--- a/certbot-nginx/tests/boulder-integration.sh
+++ b/certbot-nginx/tests/boulder-integration.sh
@@ -39,8 +39,6 @@ nginx -v
 reload_nginx
 certbot_test_nginx --domains nginx.wtf run
 test_deployment_and_rollback nginx.wtf
-certbot_test_nginx --domains nginx-tls.wtf run --preferred-challenges tls-sni
-test_deployment_and_rollback nginx-tls.wtf
 certbot_test_nginx --domains nginx2.wtf --preferred-challenges http
 test_deployment_and_rollback nginx2.wtf
 # Overlapping location block and server-block-level return 301

--- a/certbot-nginx/tests/boulder-integration.sh
+++ b/certbot-nginx/tests/boulder-integration.sh
@@ -64,4 +64,4 @@ test_deployment_and_rollback nginx6.wtf
 # top
 nginx -c $nginx_root/nginx.conf -s stop
 
-coverage report --fail-under 75 --include 'certbot-nginx/*' --show-missing
+coverage report --fail-under 72 --include 'certbot-nginx/*' --show-missing

--- a/tests/certbot-boulder-integration.sh
+++ b/tests/certbot-boulder-integration.sh
@@ -221,19 +221,7 @@ common plugins --init --prepare | grep webroot
 
 # We start a server listening on the port for the
 # unrequested challenge to prevent regressions in #3601.
-python ./tests/run_http_server.py $http_01_port &
-python_server_pid=$!
-
-certname="le1.wtf"
-common --domains le1.wtf --preferred-challenges tls-sni-01 auth \
-       --cert-name $certname \
-       --pre-hook 'echo wtf.pre >> "$HOOK_TEST"' \
-       --post-hook 'echo wtf.post >> "$HOOK_TEST"'\
-       --deploy-hook 'echo deploy >> "$HOOK_TEST"'
-kill $python_server_pid
-CheckDeployHook $certname
-
-python ./tests/run_http_server.py $tls_sni_01_port &
+python ./tests/run_http_server.py $tls_alpn_01_port &
 python_server_pid=$!
 certname="le2.wtf"
 common --domains le2.wtf --preferred-challenges http-01 run \
@@ -254,7 +242,7 @@ common certonly -a manual -d le.wtf --rsa-key-size 4096 --cert-name $certname \
 CheckRenewHook $certname
 
 certname="dns.le.wtf"
-common -a manual -d dns.le.wtf --preferred-challenges dns,tls-sni run \
+common -a manual -d dns.le.wtf --preferred-challenges dns run \
     --cert-name $certname \
     --manual-auth-hook ./tests/manual-dns-auth.sh \
     --manual-cleanup-hook ./tests/manual-dns-cleanup.sh \
@@ -396,7 +384,7 @@ CheckDirHooks 1
 # with fail.
 common -a manual -d dns1.le.wtf,fail.dns1.le.wtf \
     --allow-subset-of-names \
-    --preferred-challenges dns,tls-sni \
+    --preferred-challenges dns \
     --manual-auth-hook ./tests/manual-dns-auth.sh \
     --manual-cleanup-hook ./tests/manual-dns-cleanup.sh
 

--- a/tests/certbot-boulder-integration.sh
+++ b/tests/certbot-boulder-integration.sh
@@ -231,9 +231,9 @@ common --domains le1.wtf --preferred-challenges http-01 auth \
        --deploy-hook 'echo deploy >> "$HOOK_TEST"'
 CheckDeployHook $certname
 
-# Previous test used to be a tls-sni-01 challenge that has now not supported anymore.
-# Now it is a http-01 challenge, that is making it a duplicate of the following test.
-# But removing it would break many tests here, that are strongly coupled.
+# Previous test used to be a tls-sni-01 challenge that is not supported anymore.
+# Now it is a http-01 challenge and this makes it a duplicate of the following test.
+# But removing it would break many tests here, as they are strongly coupled.
 # See https://github.com/certbot/certbot/pull/6679
 certname="le2.wtf"
 common --domains le2.wtf --preferred-challenges http-01 run \

--- a/tests/certbot-boulder-integration.sh
+++ b/tests/certbot-boulder-integration.sh
@@ -223,6 +223,18 @@ common plugins --init --prepare | grep webroot
 # unrequested challenge to prevent regressions in #3601.
 python ./tests/run_http_server.py $tls_alpn_01_port &
 python_server_pid=$!
+certname="le1.wtf"
+common --domains le1.wtf --preferred-challenges http-01 auth \
+       --cert-name $certname \
+       --pre-hook 'echo wtf.pre >> "$HOOK_TEST"' \
+       --post-hook 'echo wtf.post >> "$HOOK_TEST"'\
+       --deploy-hook 'echo deploy >> "$HOOK_TEST"'
+CheckDeployHook $certname
+
+# Previous test used to be a tls-sni-01 challenge that has now not supported anymore.
+# Now it is a http-01 challenge, that is making it a duplicate of the following test.
+# But removing it would break many tests here, that are strongly coupled.
+# See https://github.com/certbot/certbot/pull/6679
 certname="le2.wtf"
 common --domains le2.wtf --preferred-challenges http-01 run \
        --cert-name $certname \

--- a/tests/integration/_common.sh
+++ b/tests/integration/_common.sh
@@ -3,10 +3,10 @@
 root=${root:-$(mktemp -d -t leitXXXX)}
 echo "Root integration tests directory: $root"
 config_dir="$root/conf"
-tls_sni_01_port=5001
+tls_alpn_01_port=5001
 http_01_port=5002
 sources="acme/,$(ls -dm certbot*/ | tr -d ' \n')"
-export root config_dir tls_sni_01_port http_01_port sources
+export root config_dir tls_alpn_01_port http_01_port sources
 certbot_path="$(command -v certbot)"
 # Flags that are added here will be added to Certbot calls within
 # certbot_test_no_force_renew.
@@ -60,7 +60,7 @@ certbot_test_no_force_renew () {
         "$certbot_path" \
             --server "${SERVER:-http://localhost:4000/directory}" \
             --no-verify-ssl \
-            --tls-sni-01-port $tls_sni_01_port \
+            --tls-sni-01-port $tls_alpn_01_port \
             --http-01-port $http_01_port \
             --manual-public-ip-logging-ok \
             $other_flags \


### PR DESCRIPTION
Since https://github.com/letsencrypt/boulder/commit/92e8e1708a725e9d08a5da2f4a7132320ed2158b, Boulder does not propose anymore tls-sni-01 challenges. This makes fail the Certbot integration tests that require to fulfill a tls-sni-01 challenge.

This PR removes all operations relevant to this deprecated and soon extincted challenge.