### PR TITLE
acme: add TLSALPN01Response for initiating tls-alpn-01.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Avoid to process again challenges that are already validated
   when a certificate is issued.
+* Support for initiating (but not solving end-to-end) TLS-ALPN-01 challenges
+  with the `acme` module.
 
 ### Changed
 

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -513,6 +513,27 @@ class TLSSNI01(KeyAuthorizationChallenge):
         return self.response(account_key).gen_cert(key=kwargs.get('cert_key'))
 
 
+@ChallengeResponse.register
+class TLSALPN01Response(KeyAuthorizationChallengeResponse):
+    """ACME TLS-ALPN-01 challenge response.
+
+    This class only allows initiating a TLS-ALPN-01 challenge returned from the
+    CA. Full support for responding to TLS-ALPN-01 challenges by generating and
+    serving the expected response certificate is not currently provided.
+    """
+    typ = "tls-alpn-01"
+
+    def simple_verify(self, chall, domain, account_public_key):
+        """simple_verify for TLS-ALPN-01 challenges passes through to the base
+        KeyAuthorizationChallengeResponse verify implementation.
+        """
+        # pylint: disable=unused-argument
+        verified = self.verify(chall, account_public_key)
+        if not verified:
+            logger.debug("Verification of key authorization in response failed")
+        return verified
+
+
 @Challenge.register  # pylint: disable=too-many-ancestors
 class TLSALPN01(KeyAuthorizationChallenge):
     """ACME tls-alpn-01 challenge.
@@ -522,6 +543,7 @@ class TLSALPN01(KeyAuthorizationChallenge):
 
     """
     typ = "tls-alpn-01"
+    response_cls = TLSALPN01Response
 
     def validation(self, account_key, **kwargs):
         """Generate validation for the challenge."""

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -523,16 +523,6 @@ class TLSALPN01Response(KeyAuthorizationChallengeResponse):
     """
     typ = "tls-alpn-01"
 
-    def simple_verify(self, chall, domain, account_public_key):
-        """simple_verify for TLS-ALPN-01 challenges passes through to the base
-        KeyAuthorizationChallengeResponse verify implementation.
-        """
-        # pylint: disable=unused-argument
-        verified = self.verify(chall, account_public_key)
-        if not verified:
-            logger.debug("Verification of key authorization in response failed")
-        return verified
-
 
 @Challenge.register  # pylint: disable=too-many-ancestors
 class TLSALPN01(KeyAuthorizationChallenge):

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -402,6 +402,43 @@ class TLSSNI01Test(unittest.TestCase):
             KEY, cert_key=mock.sentinel.cert_key))
         mock_gen_cert.assert_called_once_with(key=mock.sentinel.cert_key)
 
+class TLSALPN01ResponseTest(unittest.TestCase):
+    # pylint: disable=too-many-instance-attributes
+
+    def setUp(self):
+        from acme.challenges import TLSALPN01Response
+        self.msg = TLSALPN01Response(key_authorization=u'foo')
+        self.jmsg = {
+            'resource': 'challenge',
+            'type': 'tls-alpn-01',
+            'keyAuthorization': u'foo',
+        }
+
+        from acme.challenges import TLSALPN01
+        self.chall = TLSALPN01(token=(b'x' * 16))
+        self.response = self.chall.response(KEY)
+
+    def test_to_partial_json(self):
+        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+
+    def test_from_json(self):
+        from acme.challenges import TLSALPN01Response
+        self.assertEqual(self.msg, TLSALPN01Response.from_json(self.jmsg))
+
+    def test_from_json_hashable(self):
+        from acme.challenges import TLSALPN01Response
+        hash(TLSALPN01Response.from_json(self.jmsg))
+
+    def test_simple_verify_failure(self):
+        key2 = jose.JWKRSA.load(test_util.load_vector('rsa256_key.pem'))
+        public_key = key2.public_key()
+        verified = self.response.simple_verify(self.chall, "local", public_key)
+        self.assertFalse(verified)
+
+    def test_simple_verify_success(self):
+        public_key = KEY.public_key()
+        verified = self.response.simple_verify(self.chall, "local", public_key)
+        self.assertTrue(verified)
 
 class TLSALPN01Test(unittest.TestCase):
 

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -429,16 +429,6 @@ class TLSALPN01ResponseTest(unittest.TestCase):
         from acme.challenges import TLSALPN01Response
         hash(TLSALPN01Response.from_json(self.jmsg))
 
-    def test_simple_verify_failure(self):
-        key2 = jose.JWKRSA.load(test_util.load_vector('rsa256_key.pem'))
-        public_key = key2.public_key()
-        verified = self.response.simple_verify(self.chall, "local", public_key)
-        self.assertFalse(verified)
-
-    def test_simple_verify_success(self):
-        public_key = KEY.public_key()
-        verified = self.response.simple_verify(self.chall, "local", public_key)
-        self.assertTrue(verified)
 
 class TLSALPN01Test(unittest.TestCase):
 


### PR DESCRIPTION
The existing `acme.TLSALPN01` challenge class did not have a `response_cls`, meaning it was not possible to use a tls-alpn-01 challenge with `client.answer_challenge`.

To support the above a simple `TLSALPN01Response` class is added and used as the `response_cls`. This response class doesn't provide the ability to solve a tls-alpn-01 challenge end to end (e.g. generating and serving the correct response certificate) but it does allow the challenge to be initiated. This is sufficient for users that have set up the challenge response independent of the `acme` module code. I tested this successfully with a hacked up version of Boulder's `chisel2.py` client and a `pebble` instance.

Resolves https://github.com/certbot/certbot/issues/6676
