### PR TITLE
Add VIRTUALENV_NO_DOWNLOAD=1 to all calls to virtualenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Fixed accessing josepy contents through acme.jose when the full acme.jose
   path is used.
 * Clarify behavior for deleting certs as part of revocation.
+* Add --no-download to all calls to virtualenv to address breakages from venv downloading the latest pip
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Fixed accessing josepy contents through acme.jose when the full acme.jose
   path is used.
 * Clarify behavior for deleting certs as part of revocation.
-* Add --no-download to all calls to virtualenv to address breakages from venv downloading the latest pip
+* Add VIRTUALENV_NO_DOWNLOAD=1 to all calls to virtualenv to address breakages
+  from venv downloading the latest pip
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only

--- a/Dockerfile-old
+++ b/Dockerfile-old
@@ -51,7 +51,7 @@ COPY certbot-apache /opt/certbot/src/certbot-apache/
 COPY certbot-nginx /opt/certbot/src/certbot-nginx/
 
 
-RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv
+RUN VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages -p python2 /opt/certbot/venv
 
 # PATH is set now so pipstrap upgrades the correct (v)env
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/Dockerfile-old
+++ b/Dockerfile-old
@@ -51,7 +51,7 @@ COPY certbot-apache /opt/certbot/src/certbot-apache/
 COPY certbot-nginx /opt/certbot/src/certbot-nginx/
 
 
-RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv
+RUN virtualenv --no-site-packages --no-download -p python2 /opt/certbot/venv
 
 # PATH is set now so pipstrap upgrades the correct (v)env
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/Dockerfile-old
+++ b/Dockerfile-old
@@ -51,7 +51,7 @@ COPY certbot-apache /opt/certbot/src/certbot-apache/
 COPY certbot-nginx /opt/certbot/src/certbot-nginx/
 
 
-RUN virtualenv --no-site-packages --no-download -p python2 /opt/certbot/venv
+RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv
 
 # PATH is set now so pipstrap upgrades the correct (v)env
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -31,7 +31,7 @@ COPY certbot-nginx /opt/certbot/src/certbot-nginx/
 COPY certbot-compatibility-test /opt/certbot/src/certbot-compatibility-test/
 COPY tools /opt/certbot/src/tools
 
-RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
+RUN VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
     /opt/certbot/venv/bin/pip install -U setuptools && \
     /opt/certbot/venv/bin/pip install -U pip
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -31,7 +31,7 @@ COPY certbot-nginx /opt/certbot/src/certbot-nginx/
 COPY certbot-compatibility-test /opt/certbot/src/certbot-compatibility-test/
 COPY tools /opt/certbot/src/tools
 
-RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
+RUN virtualenv --no-site-packages --no-download -p python2 /opt/certbot/venv && \
     /opt/certbot/venv/bin/pip install -U setuptools && \
     /opt/certbot/venv/bin/pip install -U pip
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -31,7 +31,7 @@ COPY certbot-nginx /opt/certbot/src/certbot-nginx/
 COPY certbot-compatibility-test /opt/certbot/src/certbot-compatibility-test/
 COPY tools /opt/certbot/src/tools
 
-RUN virtualenv --no-site-packages --no-download -p python2 /opt/certbot/venv && \
+RUN virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
     /opt/certbot/venv/bin/pip install -U setuptools && \
     /opt/certbot/venv/bin/pip install -U pip
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -946,9 +946,9 @@ if [ "$1" = "--le-auto-phase2" ]; then
     rm -rf "$VENV_PATH"
     if [ "$PYVER" -le 27 ]; then
       if [ "$VERBOSE" = 1 ]; then
-        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
+        virtualenv --no-site-packages --no-download --python "$LE_PYTHON" "$VENV_PATH"
       else
-        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
+        virtualenv --no-site-packages --no-download --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
       fi
     else
       if [ "$VERBOSE" = 1 ]; then

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -946,9 +946,9 @@ if [ "$1" = "--le-auto-phase2" ]; then
     rm -rf "$VENV_PATH"
     if [ "$PYVER" -le 27 ]; then
       if [ "$VERBOSE" = 1 ]; then
-        virtualenv --no-site-packages --no-download --python "$LE_PYTHON" "$VENV_PATH"
+        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
       else
-        virtualenv --no-site-packages --no-download --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
+        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
       fi
     else
       if [ "$VERBOSE" = 1 ]; then

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -945,10 +945,12 @@ if [ "$1" = "--le-auto-phase2" ]; then
     DeterminePythonVersion
     rm -rf "$VENV_PATH"
     if [ "$PYVER" -le 27 ]; then
+      # Use an environment variable instead of a flag for compatibility with old versions
       if [ "$VERBOSE" = 1 ]; then
-        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
+        VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
       else
-        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
+        VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH" \
+          > /dev/null
       fi
     else
       if [ "$VERBOSE" = 1 ]; then

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -537,10 +537,12 @@ if [ "$1" = "--le-auto-phase2" ]; then
     DeterminePythonVersion
     rm -rf "$VENV_PATH"
     if [ "$PYVER" -le 27 ]; then
+      # Use an environment variable instead of a flag for compatibility with old versions
       if [ "$VERBOSE" = 1 ]; then
-        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
+        VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
       else
-        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
+        VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH" \
+          > /dev/null
       fi
     else
       if [ "$VERBOSE" = 1 ]; then

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -538,9 +538,9 @@ if [ "$1" = "--le-auto-phase2" ]; then
     rm -rf "$VENV_PATH"
     if [ "$PYVER" -le 27 ]; then
       if [ "$VERBOSE" = 1 ]; then
-        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
+        virtualenv --no-site-packages --no-download --python "$LE_PYTHON" "$VENV_PATH"
       else
-        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
+        virtualenv --no-site-packages --no-download --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
       fi
     else
       if [ "$VERBOSE" = 1 ]; then

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -538,9 +538,9 @@ if [ "$1" = "--le-auto-phase2" ]; then
     rm -rf "$VENV_PATH"
     if [ "$PYVER" -le 27 ]; then
       if [ "$VERBOSE" = 1 ]; then
-        virtualenv --no-site-packages --no-download --python "$LE_PYTHON" "$VENV_PATH"
+        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH"
       else
-        virtualenv --no-site-packages --no-download --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
+        virtualenv --no-site-packages --python "$LE_PYTHON" "$VENV_PATH" > /dev/null
       fi
     else
       if [ "$VERBOSE" = 1 ]; then

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -42,7 +42,7 @@ mv "dist.$version" "dist.$version.$(date +%s).bak" || true
 git tag --delete "$tag" || true
 
 tmpvenv=$(mktemp -d)
-virtualenv --no-site-packages -p python2 $tmpvenv
+VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages -p python2 $tmpvenv
 . $tmpvenv/bin/activate
 # update setuptools/pip just like in other places in the repo
 pip install -U setuptools
@@ -135,7 +135,7 @@ cd "dist.$version"
 python -m SimpleHTTPServer $PORT &
 # cd .. is NOT done on purpose: we make sure that all subpackages are
 # installed from local PyPI rather than current directory (repo root)
-virtualenv --no-site-packages ../venv
+VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages ../venv
 . ../venv/bin/activate
 pip install -U setuptools
 pip install -U pip

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -42,7 +42,7 @@ mv "dist.$version" "dist.$version.$(date +%s).bak" || true
 git tag --delete "$tag" || true
 
 tmpvenv=$(mktemp -d)
-virtualenv --no-site-packages -p python2 $tmpvenv
+virtualenv --no-site-packages --no-download -p python2 $tmpvenv
 . $tmpvenv/bin/activate
 # update setuptools/pip just like in other places in the repo
 pip install -U setuptools
@@ -135,7 +135,7 @@ cd "dist.$version"
 python -m SimpleHTTPServer $PORT &
 # cd .. is NOT done on purpose: we make sure that all subpackages are
 # installed from local PyPI rather than current directory (repo root)
-virtualenv --no-site-packages ../venv
+virtualenv --no-site-packages --no-download ../venv
 . ../venv/bin/activate
 pip install -U setuptools
 pip install -U pip

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -42,7 +42,7 @@ mv "dist.$version" "dist.$version.$(date +%s).bak" || true
 git tag --delete "$tag" || true
 
 tmpvenv=$(mktemp -d)
-virtualenv --no-site-packages --no-download -p python2 $tmpvenv
+virtualenv --no-site-packages -p python2 $tmpvenv
 . $tmpvenv/bin/activate
 # update setuptools/pip just like in other places in the repo
 pip install -U setuptools
@@ -135,7 +135,7 @@ cd "dist.$version"
 python -m SimpleHTTPServer $PORT &
 # cd .. is NOT done on purpose: we make sure that all subpackages are
 # installed from local PyPI rather than current directory (repo root)
-virtualenv --no-site-packages --no-download ../venv
+virtualenv --no-site-packages ../venv
 . ../venv/bin/activate
 pip install -U setuptools
 pip install -U pip


### PR DESCRIPTION
This will immediately address the breakage reported in #6682 and tracked at #6685. Virtualenv downloads the latest pip, which causes issues, so tell virtualenv to not download the latest pip.

I added the flag preemptively to other files as well, they're in separate commits so it will be easy to revert any spots we don't want.

I've confirmed that this fixes the issue on a machine that fails with the version of certbot-auto currently in master: recent version of virtualenv, python 2.7.