### PR TITLE
Update test farm targets

### DIFF
--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -15,11 +15,15 @@ if ! command -v git ; then
         exit 1
     fi
 fi
-# 0.5.0 is the oldest version of letsencrypt-auto that can be used because it's
-# the first version that pins package versions, properly supports
-# --no-self-upgrade, and works with newer versions of pip.
-git checkout -f v0.5.0 letsencrypt-auto
-if ! ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | grep 0.5.0 ; then
+# 0.17.0 is the oldest version of letsencrypt-auto that has precompiled
+# cryptography and the tagged commit is in master. 0.16.0 was the first version
+# to use precompiled cryptography, but the release PR was squashed losing the
+# commit. We want to use a precompiled version of cryptography for stability.
+# Previous versions that have to compile against OpenSSL on installation
+# started failing on newer distros with newer versions of OpenSSL.
+INITIAL_VERSION="0.17.0"
+git checkout -f "v$INITIAL_VERSION" letsencrypt-auto
+if ! ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | grep "$INITIAL_VERSION" ; then
     echo initial installation appeared to fail
     exit 1
 fi
@@ -71,7 +75,7 @@ if [ $(python -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -eq 26 ];
         exit 1
     fi
     cp letsencrypt-auto cb-auto
-    if ! ./cb-auto -v --debug --version 2>&1 | grep 0.5.0 ; then
+    if ! ./cb-auto -v --debug --version 2>&1 | grep "$INITIAL_VERSION" ; then
         echo "Certbot shouldn't have updated to a new version!"
         exit 1
     fi
@@ -81,7 +85,7 @@ if [ $(python -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -eq 26 ];
     fi
     # Create a 2nd venv at the new path to ensure we properly handle this case
     export VENV_PATH="/opt/eff.org/certbot/venv"
-    if ! sudo -E ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | grep 0.5.0 ; then
+    if ! sudo -E ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | grep "$INITIAL_VERSION" ; then
         echo second installation appeared to fail
         exit 1
     fi

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -11,7 +11,7 @@ targets:
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-70dad51a
+  - ami: ami-09677e0a6b14905b0
     name: ubuntu16.04LTS
     type: ubuntu
     virt: hvm

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -1,6 +1,21 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
+  - ami: ami-064bd2d44a1d6c097
+    name: ubuntu18.10
+    type: ubuntu
+    virt: hvm
+    user: ubuntu
+  - ami: ami-012fd5eb46f56731f
+    name: ubuntu18.04LTS
+    type: ubuntu
+    virt: hvm
+    user: ubuntu
+  - ami: ami-70dad51a
+    name: ubuntu16.04LTS
+    type: ubuntu
+    virt: hvm
+    user: ubuntu
   - ami: ami-7b89cc11
     name: ubuntu14.04LTS
     type: ubuntu
@@ -13,6 +28,11 @@ targets:
     user: ubuntu
   #-----------------------------------------------------------------------------
   # Debian
+  - ami: ami-003f19e0e687de1cd
+    name: debian9
+    type: ubuntu
+    virt: hvm
+    user: admin
   - ami: ami-116d857a
     name: debian8.1
     type: ubuntu


### PR DESCRIPTION
Fixes #6106.

AMIs were taken from https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch and https://cloud-images.ubuntu.com/locator/ec2/.

I didn't update the AMI for Fedora due to #6698.

These new AMIs pass on all test farm tests we run during the release process except Ubuntu 18.04 and 18.10 fail on `test_apache2.sh`. This is tracked at #6706. If this PR lands before this issue is resolved, we should list these systems as expected failures in the release notes.

Adding these AMIs slows down our tests significantly. I didn't measure it, but it feels 50-100% slower at least on my setup. I think it's worth it though.