### PR TITLE
Stop multitester.py from eating errors.

### DIFF
--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -32,7 +32,7 @@ see:
 from __future__ import print_function
 from __future__ import with_statement
 
-import sys, os, time, argparse, socket
+import sys, os, time, argparse, socket, traceback
 import multiprocessing as mp
 from multiprocessing import Manager
 import urllib2
@@ -363,6 +363,7 @@ def test_client_process(inqueue, outqueue):
         except:
             outqueue.put((ii, target, 'fail'))
             print("%s - %s FAIL"%(target['ami'], target['name']))
+            traceback.print_exc(file=sys.stdout)
             pass
 
         # append server certbot.log to each per-machine output log
@@ -371,6 +372,7 @@ def test_client_process(inqueue, outqueue):
             execute(grab_certbot_log)
         except:
             print("log fail\n")
+            traceback.print_exc(file=sys.stdout)
             pass
 
 
@@ -426,6 +428,7 @@ try:
         execute(local_git_clone, cl_args.repo)
 except FabricException:
     print("FAIL: trouble with git repo")
+    traceback.print_exc()
     exit()
 
 


### PR DESCRIPTION
While working on #6700, tests were failing and I had no idea why. It turns out I had forgotten to add a parameter to the `targets.yaml` file which caused a `KeyError` exception to occur inside of `multitester.py` when it tried to retrieve that option. Unfortunately, multitester.py quietly was suppressing this error so I had no idea. This PR modifies the file to always make sure the exception is output to help with debugging.

If you're curious why I'm having the traceback printed to stdout, notice https://github.com/certbot/certbot/compare/multitester-ate-my-errors?expand=1#diff-821c98fdcbcf065345fc89980bc6609eL351. In each test process, `sys.stdout` is overwritten with the relevant logfile. While it's not pretty, this is how these tests currently work so using `sys.stdout`  causes tracebacks to also be written to the correct logfile.