### PR TITLE
No numprocesses in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,10 @@
 # settings we want to also change there must be added to the release script
 # directly.
 [pytest]
-addopts = --numprocesses auto --pyargs
+# We don't set --numprocesses here so devs invoking pytest directly can still
+# use debuggers like (i)pdb which do not work when tests are split across
+# multiple processes.
+addopts = --pyargs
 # In general, all warnings are treated as errors. Here are the exceptions:
 #   1- decodestring: https://github.com/rthalley/dnspython/issues/338
 #   2- ignore our own TLS-SNI-01 warning

--- a/tools/install_and_test.py
+++ b/tools/install_and_test.py
@@ -48,8 +48,9 @@ def main(args):
         temp_cwd = tempfile.mkdtemp()
         shutil.copy2("pytest.ini", temp_cwd)
         try:
-            call_with_print(' '.join([
-                sys.executable, '-m', 'pytest', pkg.replace('-', '_')]), cwd=temp_cwd)
+            call_with_print(' '.join([sys.executable, '-m', 'pytest',
+                                     '--numprocesses', 'auto', pkg.replace('-', '_')]),
+                            cwd=temp_cwd)
         finally:
             shutil.rmtree(temp_cwd)
 

--- a/tox.cover.py
+++ b/tox.cover.py
@@ -49,7 +49,8 @@ def cover(package):
         return
 
     subprocess.check_call([
-        sys.executable, '-m', 'pytest', '--cov', pkg_dir, '--cov-append', '--cov-report=', package])
+        sys.executable, '-m', 'pytest', '--numprocesses', 'auto',
+        '--cov', pkg_dir, '--cov-append', '--cov-report=', package])
     subprocess.check_call([
         sys.executable, '-m', 'coverage', 'report', '--fail-under', str(threshold), '--include',
         '{0}/*'.format(pkg_dir), '--show-missing'])


### PR DESCRIPTION
Setting --numprocesses doesn't work with `pdb`.

The issue is dated and closed, but here's some documentation for that: https://github.com/pytest-dev/pytest/issues/390.

Removing `--numprocesses` from `pytest.ini` allows devs to invoke `pytest` and use their debugger normally, but you still get the speed improvements for using multiple processes when you invoke `tox`. We could instead only set `--numprocesses` in CI, but I think more devs will appreciate the speed improvements in `tox` than being able to invoke a debugger.

cc @joohoi 