### PR TITLE
Ignore color_scheme warning from IPython.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,8 +9,11 @@ addopts = --numprocesses auto --pyargs
 #   3- ignore warn for importing abstract classes from collections instead of collections.abc,
 #      too much third party dependencies are still relying on this behavior,
 #      but it should be corrected to allow Certbot compatiblity with Python >= 3.8
+#   4- ipdb uses deprecated functionality of IPython. See
+#      https://github.com/gotcha/ipdb/issues/144.
 filterwarnings =
     error
     ignore:decodestring:DeprecationWarning
     ignore:TLS-SNI-01:DeprecationWarning
     ignore:.*collections\.abc:DeprecationWarning
+    ignore:The `color_scheme` argument is deprecated:DeprecationWarning:IPython.*


### PR DESCRIPTION
If you add `import ipdb; ipdb.set_trace()` to a unit test and run `pytest -s /path/to/test/file`, you'll get output like:
```
$ pytest certbot/tests/account_test.py
======================================================================================================================================================================================================== test session starts =========================================================================================================================================================================================================
platform darwin -- Python 2.7.15, pytest-3.2.5, py-1.4.34, pluggy-0.4.0
rootdir: /Users/bmw/Development/certbot/certbot, inifile: pytest.ini
plugins: xdist-1.22.5, forked-0.2, cov-2.5.1
gw0 [34] / gw1 [34] / gw2 [34] / gw3 [34]
scheduling tests via LoadScheduling
.............................F....
============================================================================================================================================================================================================== FAILURES ==============================================================================================================================================================================================================
_______________________________________________________________________________________________________________________________________________________________________________________________________ AccountTest.test_init ________________________________________________________________________________________________________________________________________________________________________________________________________
[gw2] darwin -- Python 2.7.15 /Users/bmw/Development/certbot/certbot/venv/bin/python

self = <certbot.tests.account_test.AccountTest testMethod=test_init>

    def test_init(self):
>       import ipdb; ipdb.set_trace()

certbot/tests/account_test.py:43: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
venv/lib/python2.7/site-packages/ipdb/__main__.py:96: in set_trace
    p = _init_pdb(context).set_trace(frame)
venv/lib/python2.7/site-packages/ipdb/__main__.py:77: in _init_pdb
    p = debugger_cls(def_colors, context=context)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <IPython.core.debugger.Pdb instance at 0x10c862560>, color_scheme = 'Neutral', completekey = None, stdin = None, stdout = None, context = 3

    def __init__(self, color_scheme=None, completekey=None,
                 stdin=None, stdout=None, context=5):
    
        # Parent constructor:
        try:
            self.context = int(context)
            if self.context <= 0:
                raise ValueError("Context must be a positive integer")
        except (TypeError, ValueError):
                raise ValueError("Context must be a positive integer")
    
        OldPdb.__init__(self, completekey, stdin, stdout)
    
        # IPython changes...
        self.shell = get_ipython()
    
        if self.shell is None:
            save_main = sys.modules['__main__']
            # No IPython instance running, we must create one
            from IPython.terminal.interactiveshell import \
                TerminalInteractiveShell
            self.shell = TerminalInteractiveShell.instance()
            # needed by any code which calls __import__("__main__") after
            # the debugger was entered. See also #9941.
            sys.modules['__main__'] = save_main
    
        if color_scheme is not None:
            warnings.warn(
                "The `color_scheme` argument is deprecated since version 5.1",
>               DeprecationWarning)
E           DeprecationWarning: The `color_scheme` argument is deprecated since version 5.1

venv/lib/python2.7/site-packages/IPython/core/debugger.py:243: DeprecationWarning
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

================================================================================================================================================================================================ 1 failed, 33 passed in 2.47 seconds =================================================================================================================================================================================================
```
Erroring on warnings is preventing some people from being able to used their preferred debugger `ipdb` with `pytest`.

This PR in combination with #6713 resolves issues with using `ipdb` with `pytest`.

cc @joohoi 