### PR TITLE
No numprocesses in pytest.ini part 2

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,11 @@
 # settings we want to also change there must be added to the release script
 # directly.
 [pytest]
-addopts = --numprocesses auto --pyargs
+# We set values in addopts here that we think should be useful for all pytest
+# invocations. For instance, without --pyargs, pytest becomes dependent on your
+# current working directory and simple commands like `pytest certbot` may fail
+# or not test what you expect.
+addopts = --pyargs
 # In general, all warnings are treated as errors. Here are the exceptions:
 #   1- decodestring: https://github.com/rthalley/dnspython/issues/338
 #   2- ignore our own TLS-SNI-01 warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,11 +2,6 @@
 # settings we want to also change there must be added to the release script
 # directly.
 [pytest]
-# We set values in addopts here that we think should be useful for all pytest
-# invocations. For instance, without --pyargs, pytest becomes dependent on your
-# current working directory and simple commands like `pytest certbot` may fail
-# or not test what you expect.
-addopts = --pyargs
 # In general, all warnings are treated as errors. Here are the exceptions:
 #   1- decodestring: https://github.com/rthalley/dnspython/issues/338
 #   2- ignore our own TLS-SNI-01 warning

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,10 @@ commands =
     {[base]install_and_test} {[base]all_packages}
     python tests/lock_test.py
 setenv =
+    # Values set in PYTEST_ADDOPTS here are ones that we want on by default for
+    # testing, but we want devs to be able to easily override them as
+    # necessary.
+    PYTEST_ADDOPTS = {env:PYTEST_ADDOPTS:--numprocesses auto}
     PYTHONHASHSEED = 0
 
 [testenv:py27-oldest]

--- a/tox.ini
+++ b/tox.ini
@@ -70,10 +70,7 @@ commands =
     {[base]install_and_test} {[base]all_packages}
     python tests/lock_test.py
 setenv =
-    # Values set in PYTEST_ADDOPTS here are ones that we want on by default for
-    # testing, but we want devs to be able to easily override them as
-    # necessary.
-    PYTEST_ADDOPTS = {env:PYTEST_ADDOPTS:--numprocesses auto}
+    PYTEST_ADDOPTS = {env:PYTEST_ADDOPTS:--numprocesses auto --pyargs}
     PYTHONHASHSEED = 0
 
 [testenv:py27-oldest]


### PR DESCRIPTION
This issue supersedes #6713.

Setting --numprocesses doesn't work with `pdb`.

The issue is dated and closed, but here's some documentation for that: https://github.com/pytest-dev/pytest/issues/390.

Removing `--numprocesses` from `pytest.ini` allows devs to invoke `pytest` and use their debugger normally, but you still get the speed improvements for using multiple processes when you invoke `tox`. We could instead only set `--numprocesses` in CI, but I think more devs will appreciate the speed improvements in `tox` than being able to invoke a debugger by default.

Thanks to the suggestion from @adferrand, I'm setting `--numprocesses` in an overrideable environment variable in `tox.ini` to make our test config more flexible for devs so devs can always set `PYTEST_ADDOPTS` if they want to invoke their debugger while running tests with `tox`.

cc @joohoi 