### PR TITLE
Use UTF-8 encoding for nginx plugin

### DIFF
--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -2,6 +2,7 @@
 import copy
 import functools
 import glob
+import io
 import logging
 import os
 import pyparsing
@@ -203,12 +204,14 @@ class NginxParser(object):
             if item in self.parsed and not override:
                 continue
             try:
-                with open(item) as _file:
+                with io.open(item, "r", encoding="utf-8") as _file:
                     parsed = nginxparser.load(_file)
                     self.parsed[item] = parsed
                     trees.append(parsed)
             except IOError:
                 logger.warning("Could not open file: %s", item)
+            except UnicodeDecodeError:
+                logger.warning("Could not read file: %s due to invalid character. Only UTF-8 encoding is supported.", item)
             except pyparsing.ParseException as err:
                 logger.debug("Could not parse file: %s due to %s", item, err)
         return trees
@@ -412,10 +415,12 @@ class NginxParser(object):
 def _parse_ssl_options(ssl_options):
     if ssl_options is not None:
         try:
-            with open(ssl_options) as _file:
+            with io.open(ssl_options, "r", encoding="utf-8") as _file:
                 return nginxparser.load(_file)
         except IOError:
             logger.warning("Missing NGINX TLS options file: %s", ssl_options)
+        except UnicodeDecodeError:
+            logger.warn("Could not read file: %s due to invalid character. Only UTF-8 encoding is supported.", ssl_options)
         except pyparsing.ParseBaseException as err:
             logger.debug("Could not parse file: %s due to %s", ssl_options, err)
     return []

--- a/certbot-nginx/certbot_nginx/parser.py
+++ b/certbot-nginx/certbot_nginx/parser.py
@@ -211,7 +211,9 @@ class NginxParser(object):
             except IOError:
                 logger.warning("Could not open file: %s", item)
             except UnicodeDecodeError:
-                logger.warning("Could not read file: %s due to invalid character. Only UTF-8 encoding is supported.", item)
+                logger.warning("Could not read file: %s due to invalid "
+                               "character. Only UTF-8 encoding is "
+                               "supported.", item)
             except pyparsing.ParseException as err:
                 logger.debug("Could not parse file: %s due to %s", item, err)
         return trees
@@ -420,7 +422,8 @@ def _parse_ssl_options(ssl_options):
         except IOError:
             logger.warning("Missing NGINX TLS options file: %s", ssl_options)
         except UnicodeDecodeError:
-            logger.warn("Could not read file: %s due to invalid character. Only UTF-8 encoding is supported.", ssl_options)
+            logger.warn("Could not read file: %s due to invalid character. "
+                        "Only UTF-8 encoding is supported.", ssl_options)
         except pyparsing.ParseBaseException as err:
             logger.debug("Could not parse file: %s due to %s", ssl_options, err)
     return []

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -450,6 +450,19 @@ class NginxParserTest(util.NginxTest): #pylint: disable=too-many-public-methods
         self.assertEqual(len(default.raw), len(new_vhost_parsed.raw))
         self.assertTrue(next(iter(default.addrs)).super_eq(next(iter(new_vhost_parsed.addrs))))
 
+    def test_valid_unicode_characters(self):
+        nparser = parser.NginxParser(self.config_path)
+        # pylint: disable=protected-access
+        parsed = nparser._parse_files(nparser.abs_path('unicode_support/valid_unicode_comments.conf'))
+        self.assertEqual(['server'], parsed[0][2][0])
+        self.assertEqual(['listen', '80'], parsed[0][2][1][3])
+
+    def test_invalid_unicode_characters(self):
+        nparser = parser.NginxParser(self.config_path)
+        # pylint: disable=protected-access
+        parsed = nparser._parse_files(nparser.abs_path('unicode_support/invalid_unicode_comments.conf'))
+        self.assertEqual([], parsed)
+
     def test_duplicate_vhost_remove_ipv6only(self):
         nparser = parser.NginxParser(self.config_path)
 

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -453,14 +453,16 @@ class NginxParserTest(util.NginxTest): #pylint: disable=too-many-public-methods
     def test_valid_unicode_characters(self):
         nparser = parser.NginxParser(self.config_path)
         # pylint: disable=protected-access
-        parsed = nparser._parse_files(nparser.abs_path('unicode_support/valid_unicode_comments.conf'))
+        path = nparser.abs_path('unicode_support/valid_unicode_comments.conf')
+        parsed = nparser._parse_files(path)
         self.assertEqual(['server'], parsed[0][2][0])
         self.assertEqual(['listen', '80'], parsed[0][2][1][3])
 
     def test_invalid_unicode_characters(self):
         nparser = parser.NginxParser(self.config_path)
         # pylint: disable=protected-access
-        parsed = nparser._parse_files(nparser.abs_path('unicode_support/invalid_unicode_comments.conf'))
+        path = nparser.abs_path('unicode_support/invalid_unicode_comments.conf')
+        parsed = nparser._parse_files(path)
         self.assertEqual([], parsed)
 
     def test_duplicate_vhost_remove_ipv6only(self):

--- a/certbot-nginx/certbot_nginx/tests/testdata/etc_nginx/unicode_support/invalid_unicode_comments.conf
+++ b/certbot-nginx/certbot_nginx/tests/testdata/etc_nginx/unicode_support/invalid_unicode_comments.conf
@@ -1,0 +1,7 @@
+# This configuration file is saved with EUC-KR (a.k.a. cp949) encoding,
+# including some Korean alphabets.
+
+server {
+    # 안녕하세요. 80번 포트에서 요청을 기다린다.
+    listen	80;
+}

--- a/certbot-nginx/certbot_nginx/tests/testdata/etc_nginx/unicode_support/valid_unicode_comments.conf
+++ b/certbot-nginx/certbot_nginx/tests/testdata/etc_nginx/unicode_support/valid_unicode_comments.conf
@@ -1,0 +1,9 @@
+# This configuration file is saved with valid UTF-8 encoding,
+# including some CJK alphabets.
+
+server {
+    # 안녕하세요. 80번 포트에서 요청을 기다린다.
+    # こんにちは。８０番ポートからリクエストを待つ。
+    # 你好。等待端口80上的请求。
+    listen	80;
+}


### PR DESCRIPTION
Based on and supersedes #5341.

Fixes #5337.