### PR TITLE
Set --pyargs directly in the files where it is needed.

### DIFF
--- a/tools/install_and_test.py
+++ b/tools/install_and_test.py
@@ -49,7 +49,7 @@ def main(args):
         shutil.copy2("pytest.ini", temp_cwd)
         try:
             call_with_print(' '.join([
-                sys.executable, '-m', 'pytest', pkg.replace('-', '_')]), cwd=temp_cwd)
+                sys.executable, '-m', 'pytest', '--pyargs', pkg.replace('-', '_')]), cwd=temp_cwd)
         finally:
             shutil.rmtree(temp_cwd)
 

--- a/tox.cover.py
+++ b/tox.cover.py
@@ -48,8 +48,8 @@ def cover(package):
             .format(pkg_dir)))
         return
 
-    subprocess.check_call([
-        sys.executable, '-m', 'pytest', '--cov', pkg_dir, '--cov-append', '--cov-report=', package])
+    subprocess.check_call([sys.executable, '-m', 'pytest', '--pyargs',
+                           '--cov', pkg_dir, '--cov-append', '--cov-report=', package])
     subprocess.check_call([
         sys.executable, '-m', 'coverage', 'report', '--fail-under', str(threshold), '--include',
         '{0}/*'.format(pkg_dir), '--show-missing'])

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands =
     {[base]install_and_test} {[base]all_packages}
     python tests/lock_test.py
 setenv =
-    PYTEST_ADDOPTS = {env:PYTEST_ADDOPTS:--numprocesses auto --pyargs}
+    PYTEST_ADDOPTS = {env:PYTEST_ADDOPTS:--numprocesses auto}
     PYTHONHASHSEED = 0
 
 [testenv:py27-oldest]


### PR DESCRIPTION
It was pointed out to me that you can no longer run `tox.cover.py` directly to run coverage tests on a subset of the packages in this repo.

This happened after we did both of:

1. Factored out `--pyargs` from the different test files and put it in `pytest.ini`.
2. Moved the options we added to `pytest.ini` to `tox.ini` meaning that `--pyargs` is not set unless you run the file through tox.

I think the fact that we factored out `--pyargs` from the files that needed it was a mistake. `--pytest` is needed by `tox.cover.py` and `install_and_test.py` in order to work correctly.

I think CLI options like this which are needed for the file to function should be left in the file directly. Doing anything else in my opinion unnecessarily couples these scripts to other files making them more brittle and harder to maintain.

With that said, I also think CLI options which are not needed (such as `--numprocesses`) can be left to be optionally added through `PYTEST_ADDOPTS`.

@adferrand or @joohoi, are you able to take a look at this?