### PR TITLE
Fix atexit handlers

### DIFF
--- a/certbot/tests/lock_test.py
+++ b/certbot/tests/lock_test.py
@@ -10,7 +10,6 @@ from certbot import errors
 from certbot.tests import util as test_util
 
 
-@test_util.broken_on_windows
 class LockDirTest(test_util.TempDirTestCase):
     """Tests for certbot.lock.lock_dir."""
     @classmethod
@@ -25,7 +24,6 @@ class LockDirTest(test_util.TempDirTestCase):
         test_util.lock_and_call(assert_raises, lock_path)
 
 
-@test_util.broken_on_windows
 class LockFileTest(test_util.TempDirTestCase):
     """Tests for certbot.lock.LockFile."""
     @classmethod
@@ -37,6 +35,7 @@ class LockFileTest(test_util.TempDirTestCase):
         super(LockFileTest, self).setUp()
         self.lock_path = os.path.join(self.tempdir, 'test.lock')
 
+    @test_util.broken_on_windows
     def test_acquire_without_deletion(self):
         # acquire the lock in another process but don't delete the file
         child = multiprocessing.Process(target=self._call,
@@ -54,6 +53,7 @@ class LockFileTest(test_util.TempDirTestCase):
             self.assertRaises, errors.LockError, self._call, self.lock_path)
         test_util.lock_and_call(assert_raises, self.lock_path)
 
+    @test_util.broken_on_windows
     def test_locked_repr(self):
         lock_file = self._call(self.lock_path)
         locked_repr = repr(lock_file)
@@ -71,6 +71,7 @@ class LockFileTest(test_util.TempDirTestCase):
         self.assertTrue(lock_file.__class__.__name__ in lock_repr)
         self.assertTrue(self.lock_path in lock_repr)
 
+    @test_util.broken_on_windows
     def test_race(self):
         should_delete = [True, False]
         stat = os.stat
@@ -86,11 +87,13 @@ class LockFileTest(test_util.TempDirTestCase):
             self._call(self.lock_path)
         self.assertFalse(should_delete)
 
+    @test_util.broken_on_windows
     def test_removed(self):
         lock_file = self._call(self.lock_path)
         lock_file.release()
         self.assertFalse(os.path.exists(self.lock_path))
 
+    @test_util.broken_on_windows
     @mock.patch('certbot.compat.fcntl.lockf')
     def test_unexpected_lockf_err(self, mock_lockf):
         msg = 'hi there'

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -329,18 +329,19 @@ class TempDirTestCase(unittest.TestCase):
 
     def tearDown(self):
         """Execute after test"""
-        # Cleanup opened resources after a test. This is usually done through atexit handlers in
-        # Certbot, but during tests, atexit will not run registered functions before tearDown is
-        # called and instead will run them right before the entire test process exits.
-        # It is a problem on Windows, that does not accept to clean resources before closing them.
-        logging.shutdown()
-        util._release_locks()  # pylint: disable=protected-access
+        if os.name == 'nt':
+            # Cleanup opened resources after a test. This is usually done through atexit handlers in
+            # Certbot, but during tests, atexit will not run registered functions before tearDown is
+            # called and instead will run them right before the entire test process exits.
+            # It is a problem on Windows, that does not accept to clean resources before closing them.
+            logging.shutdown()
+            util._release_locks()  # pylint: disable=protected-access
 
-        def handle_rw_files(_, path, __):
-            """Handle read-only files, that will fail to be removed on Windows."""
-            os.chmod(path, stat.S_IWRITE)
-            os.remove(path)
-        shutil.rmtree(self.tempdir, onerror=handle_rw_files)
+            def handle_rw_files(_, path, __):
+                """Handle read-only files, that will fail to be removed on Windows."""
+                os.chmod(path, stat.S_IWRITE)
+                os.remove(path)
+            shutil.rmtree(self.tempdir, onerror=handle_rw_files)
 
 
 class ConfigTestCase(TempDirTestCase):

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -333,7 +333,7 @@ class TempDirTestCase(unittest.TestCase):
             # Cleanup opened resources after a test. This is usually done through atexit handlers in
             # Certbot, but during tests, atexit will not run registered functions before tearDown is
             # called and instead will run them right before the entire test process exits.
-            # It is a problem on Windows, that does not accept to clean resources before closing them.
+            # It is a problem on Windows, where closing resources must be done before cleaning.
             logging.shutdown()
             util._release_locks()  # pylint: disable=protected-access
 

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -142,6 +142,7 @@ def _release_locks():
         except:  # pylint: disable=bare-except
             msg = 'Exception occurred releasing lock: {0!r}'.format(dir_lock)
             logger.debug(msg, exc_info=True)
+    _LOCKS.clear()
 
 
 def set_up_core_dir(directory, mode, uid, strict):
@@ -225,9 +226,8 @@ def safe_open(path, mode="w", chmod=None, buffering=None):
     fdopen_args = ()  # type: Union[Tuple[()], Tuple[int]]
     if buffering is not None:
         fdopen_args = (buffering,)
-    return os.fdopen(
-        os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, *open_args),
-        mode, *fdopen_args)
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, *open_args)
+    return os.fdopen(fd, mode, *fdopen_args)
 
 
 def _unique_file(path, filename_pat, count, chmod, mode):


### PR DESCRIPTION
This PR fixes problems that have occured after #6667 integration on farm tests, and required the revert #6752.

This fix is simply to trigger the tearDown logic only for Windows: