### PR TITLE
Correct the Content-Type used in the POST-as-GET request to retrieve a cert

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -739,8 +739,7 @@ class ClientV2(ClientBase):
             if body.error is not None:
                 raise errors.IssuanceError(body.error)
             if body.certificate is not None:
-                certificate_response = self._post_as_get(body.certificate,
-                                                    content_type=DER_CONTENT_TYPE).text
+                certificate_response = self._post_as_get(body.certificate).text
                 return orderr.update(body=body, fullchain_pem=certificate_response)
         raise errors.TimeoutError()
 


### PR DESCRIPTION
Fixes #6756

This PR change the `Content-Type` used in the POST-as-GET request used to retrieve a certificate, from the invalid `application/pkix-cert` to the valid `application/jose+json`.

This correct the failed POST-as-GET request and protect Certbot against breakage when using ACME CA servers where the fallback to GET requests is not possible (including future production version for Boulder).