### PR TITLE
Remove keyAuthorization field from the challenge response JWS token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   warnings described at https://github.com/certbot/josepy/issues/13.
 * Apache plugin now respects CERTBOT_DOCS environment variable when adding
   command line defaults.
+* `acme` module avoids to send the `keyAuthorization` in the JWS token while
+  POSTing to a challenge, as it is deprecated on the current ACME specification
+  draft. To ease the migration path for ACME CA servers, Certbot will use a
+  temporary fallback consisting in sending `keyAuthorization` if a `malformed`
+  error is received: this fallback will be removed on Certbot 0.34.0.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   warnings described at https://github.com/certbot/josepy/issues/13.
 * Apache plugin now respects CERTBOT_DOCS environment variable when adding
   command line defaults.
-* `acme` module avoids to send the `keyAuthorization` in the JWS token while
-  POSTing to a challenge, as it is deprecated on the current ACME specification
-  draft. To ease the migration path for ACME CA servers, Certbot will use a
-  temporary fallback consisting in sending `keyAuthorization` if a `malformed`
-  error is received: this fallback will be removed on Certbot 0.34.0.
+* The `acme` module avoids sending the `keyAuthorization` field in the JWS
+  payload when responding to a challenge as the field is not included in the
+  current ACME protocol. To ease the migration path for ACME CA servers,
+  Certbot and its `acme` module will first try the request without the
+  `keyAuthorization` field but will temporarily retry the request with the
+  field included if a `malformed` error is received. This fallback will be
+  removed in version 0.34.0.
 
 ### Fixed
 

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -107,6 +107,7 @@ class KeyAuthorizationChallengeResponse(ChallengeResponse):
     """
     key_authorization = jose.Field("keyAuthorization")
     thumbprint_hash_function = hashes.SHA256
+    authorization_key_config = {'dump': False}
 
     def verify(self, chall, account_public_key):
         """Verify the key authorization.
@@ -139,6 +140,21 @@ class KeyAuthorizationChallengeResponse(ChallengeResponse):
             return False
 
         return True
+
+    def dump_authorization_key(self, dump):
+        # type: (bool) -> None
+        """
+        Set if keyAuthorization is dumped in the JSON representation of this ChallengeResponse.
+        :param bool dump: True to dump the keyAuthorization, False otherwise
+        """
+        self.authorization_key_config['dump'] = dump
+
+    def to_partial_json(self):
+        jobj = super(KeyAuthorizationChallengeResponse, self).to_partial_json()
+        if not self.authorization_key_config.get('dump', False):
+            jobj.pop('keyAuthorization', None)
+
+        return jobj
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -99,13 +99,27 @@ class _TokenChallenge(Challenge):
         return b'..' not in self.token and b'/' not in self.token
 
 
+class _KeyAuthorizationField(jose.Field):
+    """
+    JSON field 'keyAuthorization', that is not displayed in a JSON serialization,
+    as it is deprecated to have this field in the JWS token of a challenge request.
+    See https://github.com/letsencrypt/pebble/issues/192
+    """
+    def __init__(self):
+        super(_KeyAuthorizationField, self).__init__('keyAuthorization')
+
+    def omit(self, value):
+        """Always ignore this field in a JSON serialization"""
+        return True
+
+
 class KeyAuthorizationChallengeResponse(ChallengeResponse):
     """Response to Challenges based on Key Authorization.
 
     :param unicode key_authorization:
 
     """
-    key_authorization = jose.Field("keyAuthorization")
+    key_authorization = _KeyAuthorizationField()
     thumbprint_hash_function = hashes.SHA256
 
     def verify(self, chall, account_public_key):

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -110,7 +110,7 @@ class KeyAuthorizationChallengeResponse(ChallengeResponse):
 
     def __init__(self, *args, **kwargs):
         super(KeyAuthorizationChallengeResponse, self).__init__(*args, **kwargs)
-        object.__setattr__(self, "authorization_key_config", {"dump": False})
+        object.__setattr__(self, "_authorization_key_config", {"dump": False})
 
     def verify(self, chall, account_public_key):
         """Verify the key authorization.
@@ -150,11 +150,11 @@ class KeyAuthorizationChallengeResponse(ChallengeResponse):
         Set if keyAuthorization is dumped in the JSON representation of this ChallengeResponse.
         :param bool dump: True to dump the keyAuthorization, False otherwise
         """
-        self.authorization_key_config['dump'] = dump
+        self._authorization_key_config['dump'] = dump  # pylint: disable=no-member
 
     def to_partial_json(self):
         jobj = super(KeyAuthorizationChallengeResponse, self).to_partial_json()
-        if not self.authorization_key_config.get('dump', False):
+        if not self._authorization_key_config.get('dump', False):  # pylint: disable=no-member
             jobj.pop('keyAuthorization', None)
 
         return jobj

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -110,7 +110,7 @@ class KeyAuthorizationChallengeResponse(ChallengeResponse):
 
     def __init__(self, *args, **kwargs):
         super(KeyAuthorizationChallengeResponse, self).__init__(*args, **kwargs)
-        object.__setattr__(self, "_authorization_key_config", {"dump": False})
+        self._dump_authorization_key(False)
 
     def verify(self, chall, account_public_key):
         """Verify the key authorization.
@@ -144,17 +144,18 @@ class KeyAuthorizationChallengeResponse(ChallengeResponse):
 
         return True
 
-    def dump_authorization_key(self, dump):
+    def _dump_authorization_key(self, dump):
         # type: (bool) -> None
         """
         Set if keyAuthorization is dumped in the JSON representation of this ChallengeResponse.
+        NB: This method is declared as private because it will eventually be removed.
         :param bool dump: True to dump the keyAuthorization, False otherwise
         """
-        self._authorization_key_config['dump'] = dump  # pylint: disable=no-member
+        object.__setattr__(self, '_dump_auth_key', dump)
 
     def to_partial_json(self):
         jobj = super(KeyAuthorizationChallengeResponse, self).to_partial_json()
-        if not self._authorization_key_config.get('dump', False):  # pylint: disable=no-member
+        if not self._dump_auth_key:  # pylint: disable=no-member
             jobj.pop('keyAuthorization', None)
 
         return jobj

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -99,27 +99,13 @@ class _TokenChallenge(Challenge):
         return b'..' not in self.token and b'/' not in self.token
 
 
-class _KeyAuthorizationField(jose.Field):
-    """
-    JSON field 'keyAuthorization', that is not displayed in a JSON serialization,
-    as it is deprecated to have this field in the JWS token of a challenge request.
-    See https://github.com/letsencrypt/pebble/issues/192
-    """
-    def __init__(self):
-        super(_KeyAuthorizationField, self).__init__('keyAuthorization')
-
-    def omit(self, value):
-        """Always ignore this field in a JSON serialization"""
-        return True
-
-
 class KeyAuthorizationChallengeResponse(ChallengeResponse):
     """Response to Challenges based on Key Authorization.
 
     :param unicode key_authorization:
 
     """
-    key_authorization = _KeyAuthorizationField()
+    key_authorization = jose.Field("keyAuthorization")
     thumbprint_hash_function = hashes.SHA256
 
     def verify(self, chall, account_public_key):

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -107,7 +107,10 @@ class KeyAuthorizationChallengeResponse(ChallengeResponse):
     """
     key_authorization = jose.Field("keyAuthorization")
     thumbprint_hash_function = hashes.SHA256
-    authorization_key_config = {'dump': False}
+
+    def __init__(self, *args, **kwargs):
+        super(KeyAuthorizationChallengeResponse, self).__init__(*args, **kwargs)
+        object.__setattr__(self, "authorization_key_config", {"dump": False})
 
     def verify(self, chall, account_public_key):
         """Verify the key authorization.

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -96,9 +96,8 @@ class DNS01ResponseTest(unittest.TestCase):
     def test_to_partial_json(self):
         self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
-        self.msg.dump_authorization_key(True)
+        self.msg._dump_authorization_key(True)  # pylint: disable=protected-access
         self.assertEqual(self.jmsg, self.msg.to_partial_json())
-
 
     def test_from_json(self):
         from acme.challenges import DNS01Response
@@ -171,7 +170,7 @@ class HTTP01ResponseTest(unittest.TestCase):
     def test_to_partial_json(self):
         self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
-        self.msg.dump_authorization_key(True)
+        self.msg._dump_authorization_key(True)  # pylint: disable=protected-access
         self.assertEqual(self.jmsg, self.msg.to_partial_json())
 
     def test_from_json(self):
@@ -294,7 +293,7 @@ class TLSSNI01ResponseTest(unittest.TestCase):
     def test_to_partial_json(self):
         self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.response.to_partial_json())
-        self.response.dump_authorization_key(True)
+        self.response._dump_authorization_key(True)  # pylint: disable=protected-access
         self.assertEqual(self.jmsg, self.response.to_partial_json())
 
     def test_from_json(self):
@@ -431,7 +430,7 @@ class TLSALPN01ResponseTest(unittest.TestCase):
     def test_to_partial_json(self):
         self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
-        self.msg.dump_authorization_key(True)
+        self.msg._dump_authorization_key(True)  # pylint: disable=protected-access
         self.assertEqual(self.jmsg, self.msg.to_partial_json())
 
     def test_from_json(self):

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -94,7 +94,8 @@ class DNS01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
+                         self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import DNS01Response
@@ -165,7 +166,8 @@ class HTTP01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
+                         self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import HTTP01Response
@@ -285,7 +287,8 @@ class TLSSNI01ResponseTest(unittest.TestCase):
         self.assertEqual(self.z_domain, self.response.z_domain)
 
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.response.to_partial_json())
+        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
+                         self.response.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSSNI01Response
@@ -419,7 +422,8 @@ class TLSALPN01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
+                         self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSALPN01Response

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -94,8 +94,7 @@ class DNS01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
-                         self.msg.to_partial_json())
+        self.assertEqual(self.jmsg, self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import DNS01Response
@@ -166,8 +165,7 @@ class HTTP01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
-                         self.msg.to_partial_json())
+        self.assertEqual(self.jmsg, self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import HTTP01Response
@@ -287,8 +285,7 @@ class TLSSNI01ResponseTest(unittest.TestCase):
         self.assertEqual(self.z_domain, self.response.z_domain)
 
     def test_to_partial_json(self):
-        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
-                         self.response.to_partial_json())
+        self.assertEqual(self.jmsg, self.response.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSSNI01Response
@@ -405,7 +402,6 @@ class TLSSNI01Test(unittest.TestCase):
             KEY, cert_key=mock.sentinel.cert_key))
         mock_gen_cert.assert_called_once_with(key=mock.sentinel.cert_key)
 
-
 class TLSALPN01ResponseTest(unittest.TestCase):
     # pylint: disable=too-many-instance-attributes
 
@@ -423,8 +419,7 @@ class TLSALPN01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
-                         self.msg.to_partial_json())
+        self.assertEqual(self.jmsg, self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSALPN01Response

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -96,6 +96,9 @@ class DNS01ResponseTest(unittest.TestCase):
     def test_to_partial_json(self):
         self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
+        self.msg.dump_authorization_key(True)
+        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+
 
     def test_from_json(self):
         from acme.challenges import DNS01Response
@@ -168,6 +171,8 @@ class HTTP01ResponseTest(unittest.TestCase):
     def test_to_partial_json(self):
         self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
+        self.msg.dump_authorization_key(True)
+        self.assertEqual(self.jmsg, self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import HTTP01Response
@@ -289,6 +294,8 @@ class TLSSNI01ResponseTest(unittest.TestCase):
     def test_to_partial_json(self):
         self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.response.to_partial_json())
+        self.response.dump_authorization_key(True)
+        self.assertEqual(self.jmsg, self.response.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSSNI01Response
@@ -424,6 +431,8 @@ class TLSALPN01ResponseTest(unittest.TestCase):
     def test_to_partial_json(self):
         self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
+        self.msg.dump_authorization_key(True)
+        self.assertEqual(self.jmsg, self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSALPN01Response

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -94,7 +94,7 @@ class DNS01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual({k: v for k, v in self.jmsg if k != 'keyAuthorization'},
+        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
 
     def test_from_json(self):
@@ -166,7 +166,7 @@ class HTTP01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual({k: v for k, v in self.jmsg if k != 'keyAuthorization'},
+        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
 
     def test_from_json(self):
@@ -287,7 +287,7 @@ class TLSSNI01ResponseTest(unittest.TestCase):
         self.assertEqual(self.z_domain, self.response.z_domain)
 
     def test_to_partial_json(self):
-        self.assertEqual({k: v for k, v in self.jmsg if k != 'keyAuthorization'},
+        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.response.to_partial_json())
 
     def test_from_json(self):
@@ -423,7 +423,7 @@ class TLSALPN01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual({k: v for k, v in self.jmsg if k != 'keyAuthorization'},
+        self.assertEqual({k: v for k, v in self.jmsg.items() if k != 'keyAuthorization'},
                          self.msg.to_partial_json())
 
     def test_from_json(self):

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -86,6 +86,7 @@ class DNS01ResponseTest(unittest.TestCase):
         self.jmsg = {
             'resource': 'challenge',
             'type': 'dns-01',
+            'keyAuthorization': u'foo',
         }
 
         from acme.challenges import DNS01
@@ -93,7 +94,8 @@ class DNS01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+        self.assertEqual({k: v for k, v in self.jmsg if k != 'keyAuthorization'},
+                         self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import DNS01Response
@@ -156,6 +158,7 @@ class HTTP01ResponseTest(unittest.TestCase):
         self.jmsg = {
             'resource': 'challenge',
             'type': 'http-01',
+            'keyAuthorization': u'foo',
         }
 
         from acme.challenges import HTTP01
@@ -163,7 +166,8 @@ class HTTP01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+        self.assertEqual({k: v for k, v in self.jmsg if k != 'keyAuthorization'},
+                         self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import HTTP01Response
@@ -268,6 +272,7 @@ class TLSSNI01ResponseTest(unittest.TestCase):
         self.jmsg = {
             'resource': 'challenge',
             'type': 'tls-sni-01',
+            'keyAuthorization': self.response.key_authorization,
         }
 
         # pylint: disable=invalid-name
@@ -282,7 +287,8 @@ class TLSSNI01ResponseTest(unittest.TestCase):
         self.assertEqual(self.z_domain, self.response.z_domain)
 
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.response.to_partial_json())
+        self.assertEqual({k: v for k, v in self.jmsg if k != 'keyAuthorization'},
+                         self.response.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSSNI01Response
@@ -399,6 +405,7 @@ class TLSSNI01Test(unittest.TestCase):
             KEY, cert_key=mock.sentinel.cert_key))
         mock_gen_cert.assert_called_once_with(key=mock.sentinel.cert_key)
 
+
 class TLSALPN01ResponseTest(unittest.TestCase):
     # pylint: disable=too-many-instance-attributes
 
@@ -408,6 +415,7 @@ class TLSALPN01ResponseTest(unittest.TestCase):
         self.jmsg = {
             'resource': 'challenge',
             'type': 'tls-alpn-01',
+            'keyAuthorization': u'foo',
         }
 
         from acme.challenges import TLSALPN01
@@ -415,7 +423,8 @@ class TLSALPN01ResponseTest(unittest.TestCase):
         self.response = self.chall.response(KEY)
 
     def test_to_partial_json(self):
-        self.assertEqual(self.jmsg, self.msg.to_partial_json())
+        self.assertEqual({k: v for k, v in self.jmsg if k != 'keyAuthorization'},
+                         self.msg.to_partial_json())
 
     def test_from_json(self):
         from acme.challenges import TLSALPN01Response

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -86,7 +86,6 @@ class DNS01ResponseTest(unittest.TestCase):
         self.jmsg = {
             'resource': 'challenge',
             'type': 'dns-01',
-            'keyAuthorization': u'foo',
         }
 
         from acme.challenges import DNS01
@@ -157,7 +156,6 @@ class HTTP01ResponseTest(unittest.TestCase):
         self.jmsg = {
             'resource': 'challenge',
             'type': 'http-01',
-            'keyAuthorization': u'foo',
         }
 
         from acme.challenges import HTTP01
@@ -270,7 +268,6 @@ class TLSSNI01ResponseTest(unittest.TestCase):
         self.jmsg = {
             'resource': 'challenge',
             'type': 'tls-sni-01',
-            'keyAuthorization': self.response.key_authorization,
         }
 
         # pylint: disable=invalid-name
@@ -411,7 +408,6 @@ class TLSALPN01ResponseTest(unittest.TestCase):
         self.jmsg = {
             'resource': 'challenge',
             'type': 'tls-alpn-01',
-            'keyAuthorization': u'foo',
         }
 
         from acme.challenges import TLSALPN01

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -157,7 +157,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
 
         """
         # Because sending keyAuthorization in a response challenge is deprecated,
-        # we let KeyAuthorizationResponseChallenge not dumping it (default behavior).
+        # it is not included in the KeyAuthorizationResponseChallenge JSON by default.
         # However as a migration path, we temporarily expect a malformed error from the server,
         # and fallback by resending the challenge response with the keyAuthorization field.
         # TODO: Remove this fallback for Certbot 0.34.0

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -157,7 +157,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
 
         """
         # Because sending keyAuthorization in a response challenge has been removed from the ACME
-        # specs, it is not included in the KeyAuthorizationResponseChallenge JSON by default.
+        # spec, it is not included in the KeyAuthorizationResponseChallenge JSON by default.
         # However as a migration path, we temporarily expect a malformed error from the server,
         # and fallback by resending the challenge response with the keyAuthorization field.
         # TODO: Remove this fallback for Certbot 0.34.0

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -156,8 +156,8 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         :raises .UnexpectedUpdate:
 
         """
-        # Because sending keyAuthorization in a response challenge is deprecated,
-        # it is not included in the KeyAuthorizationResponseChallenge JSON by default.
+        # Because sending keyAuthorization in a response challenge has been removed from the ACME
+        # specs, it is not included in the KeyAuthorizationResponseChallenge JSON by default.
         # However as a migration path, we temporarily expect a malformed error from the server,
         # and fallback by resending the challenge response with the keyAuthorization field.
         # TODO: Remove this fallback for Certbot 0.34.0

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -169,7 +169,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
                 logger.debug('Error while responding to a challenge without keyAuthorization '
                              'in the JWS, your ACME CA server may not support it:\n%s', error)
                 logger.debug('Retrying request with keyAuthorization set.')
-                response.dump_authorization_key(True)
+                response._dump_authorization_key(True)  # pylint: disable=protected-access
                 response = self._post(challb.uri, response)
             else:
                 raise

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -171,7 +171,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
                 logger.debug('Retrying request with keyAuthorization set.')
                 response.dump_authorization_key(True)
                 response = self._post(challb.uri, response)
-            else:  # pragma: no cover
+            else:
                 raise
         try:
             authzr_uri = response.links['up']['url']

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -467,7 +467,7 @@ class ClientTest(ClientTestBase):
         self.response.links['up'] = {'url': self.challr.authzr_uri}
         self.response.json.return_value = self.challr.body.to_json()
 
-        def _wrapper_post(url, obj, *args, **kwargs):
+        def _wrapper_post(url, obj, *args, **kwargs):  # pylint: disable=unused-argument
             """
             Simulate an old ACME CA server, that would respond a 'malformed'
             error if keyAuthorization is missing.

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -463,6 +463,34 @@ class ClientTest(ClientTestBase):
             errors.ClientError, self.client.answer_challenge,
             self.challr.body, challenges.DNSResponse(validation=None))
 
+    def test_answer_challenge_key_authorization_fallback(self):
+        self.response.links['up'] = {'url': self.challr.authzr_uri}
+        self.response.json.return_value = self.challr.body.to_json()
+
+        def _wrapper_post(url, obj, *args, **kwargs):
+            """
+            Simulate an old ACME CA server, that would respond a 'malformed'
+            error if keyAuthorization is missing.
+            """
+            jobj = obj.to_partial_json()
+            if 'keyAuthorization' not in jobj:
+                raise messages.Error.with_code('malformed')
+            return self.response
+        self.net.post.side_effect = _wrapper_post
+
+        # This challenge response is of type KeyAuthorizationChallengeResponse, so the fallback
+        # should be triggered, and avoid an exception.
+        http_chall_response = challenges.HTTP01Response(key_authorization='test',
+                                                        resource=mock.MagicMock())
+        self.client.answer_challenge(self.challr.body, http_chall_response)
+
+        # This challenge response is not of type KeyAuthorizationChallengeResponse, so the fallback
+        # should not be triggered, leading to an exception.
+        dns_chall_response = challenges.DNSResponse(validation=None)
+        self.assertRaises(
+            errors.Error, self.client.answer_challenge,
+            self.challr.body, dns_chall_response)
+
     def test_retry_after_date(self):
         self.response.headers['Retry-After'] = 'Fri, 31 Dec 1999 23:59:59 GMT'
         self.assertEqual(


### PR DESCRIPTION
Fixes #6755.

POSTing the `keyAuthorization` in a JWS token when answering an ACME challenge, has been deprecated for some time now. Indeed, this is superfluous as the request is already authentified by the JWS signature.

Boulder still accepts to see this field in the JWS token, and ignore it. Pebble in non strict mode also. But Pebble in strict mode refuses the request, to prepare complete removal of this field in ACME v2.

Certbot still sends the `keyAuthorization` field. This PR removes it, and makes Certbot compliant with current ACME v2 protocol, and so Pebble in strict mode.

The implementation chosen here is done to reduce at most the surface of the API change, to mitigate risk of breakage in third-party applications that rely on `acme`. Indeed, the objects themselves see their API untouched: only the JSON serialization, done to build the JWS token, filter out the `keyAuthorization` field.

See also https://github.com/letsencrypt/pebble/issues/192 for implementation details server side.