### PR TITLE
[Docker] Update to Python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Certbot's official Docker images are now based on Python 3.6 rather than 2.7.
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2-alpine3.9
+FROM python:3.6-alpine3.10
 
 ENTRYPOINT [ "certbot" ]
 EXPOSE 80 443


### PR DESCRIPTION
Not every module seems to be 3.7 compatible, but I think 3.6 is fine?
https://github.com/certbot/certbot/blob/7b7f7b25fb25414156c9e80d4829531faa78a05e/certbot-dns-ovh/setup.py#L37-L45