### PR TITLE
Pin pytest in test_sdists.sh.

### DIFF
--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -12,6 +12,8 @@ export VENV_ARGS="-p $PYTHON"
 # setup venv
 tools/_venv_common.py --requirement letsencrypt-auto-source/pieces/dependency-requirements.txt
 . ./venv/bin/activate
+# pytest is needed to run tests on some of our packages so we install a pinned version here.
+tools/pip_install.py pytest
 
 # build sdists
 for pkg_dir in acme . $PLUGINS; do

--- a/tests/letstest/scripts/test_tests.sh
+++ b/tests/letstest/scripts/test_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -xe
 
-LE_AUTO="letsencrypt/letsencrypt-auto-source/letsencrypt-auto"
+REPO_ROOT="letsencrypt"
+LE_AUTO="$REPO_ROOT/letsencrypt-auto-source/letsencrypt-auto"
 LE_AUTO="$LE_AUTO --debug --no-self-upgrade --non-interactive"
 MODULES="acme certbot certbot_apache certbot_nginx"
 VENV_NAME=venv
@@ -10,9 +11,11 @@ $LE_AUTO --os-packages-only
 LE_AUTO_SUDO="" VENV_PATH="$VENV_NAME" $LE_AUTO --no-bootstrap --version
 . $VENV_NAME/bin/activate
 
+PIP_INSTALL=$("$REPO_ROOT/tools/readlink.py" "$REPO_ROOT/tools/pip_install.py")
+
 # change to an empty directory to ensure CWD doesn't affect tests
 cd $(mktemp -d)
-pip install pytest==3.2.5
+"$PIP_INSTALL" pytest
 
 for module in $MODULES ; do
     echo testing $module

--- a/tests/letstest/scripts/test_tests.sh
+++ b/tests/letstest/scripts/test_tests.sh
@@ -4,18 +4,17 @@ REPO_ROOT="letsencrypt"
 LE_AUTO="$REPO_ROOT/letsencrypt-auto-source/letsencrypt-auto"
 LE_AUTO="$LE_AUTO --debug --no-self-upgrade --non-interactive"
 MODULES="acme certbot certbot_apache certbot_nginx"
+PIP_INSTALL="$REPO_ROOT/tools/pip_install.py"
 VENV_NAME=venv
 
 # *-auto respects VENV_PATH
 $LE_AUTO --os-packages-only
 LE_AUTO_SUDO="" VENV_PATH="$VENV_NAME" $LE_AUTO --no-bootstrap --version
 . $VENV_NAME/bin/activate
-
-PIP_INSTALL=$("$REPO_ROOT/tools/readlink.py" "$REPO_ROOT/tools/pip_install.py")
+"$PIP_INSTALL" pytest
 
 # change to an empty directory to ensure CWD doesn't affect tests
 cd $(mktemp -d)
-"$PIP_INSTALL" pytest
 
 for module in $MODULES ; do
     echo testing $module


### PR DESCRIPTION
Fixes #6763.

By the time this gets reviewed, the immediate problem may have already been fixed by changes to the packages on PyPI, but making this change should make things more resilient going forward.

I tested this on the test farm and all images (that were supposed to) passed.