### PR TITLE
Fix test sdists with atexit handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   warnings described at https://github.com/certbot/josepy/issues/13.
 * Apache plugin now respects CERTBOT_DOCS environment variable when adding
   command line defaults.
+* Tests execution for certbot, certbot-apache and certbot-nginx packages now relies on pytest.
 
 ### Fixed
 
@@ -26,6 +27,7 @@ package with changes other than its version number was:
 * acme
 * certbot
 * certbot-apache
+* certbot-nginx
 
 More details about these changes can be found on our GitHub repo.
 

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -36,6 +36,7 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+
 class PyTest(TestCommand):
     user_options = []
 
@@ -49,6 +50,7 @@ class PyTest(TestCommand):
         import pytest
         errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
+
 
 setup(
     name='acme',
@@ -82,7 +84,7 @@ setup(
         'dev': dev_extras,
         'docs': docs_extras,
     },
-    tests_require=["pytest"],
     test_suite='acme',
+    tests_require=["pytest"],
     cmdclass={"test": PyTest},
 )

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
+from setuptools.command.test import test as TestCommand
+import sys
 
 
 version = '0.32.0.dev0'
@@ -20,6 +22,22 @@ docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags
     'sphinx_rtd_theme',
 ]
+
+
+class PyTest(TestCommand):
+    user_options = []
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ''
+
+    def run_tests(self):
+        import shlex
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
+
 
 setup(
     name='certbot-apache',
@@ -64,4 +82,6 @@ setup(
         ],
     },
     test_suite='certbot_apache',
+    tests_require=["pytest"],
+    cmdclass={"test": PyTest},
 )

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
+from setuptools.command.test import test as TestCommand
+import sys
 
 
 version = '0.32.0.dev0'
@@ -20,6 +22,22 @@ docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags
     'sphinx_rtd_theme',
 ]
+
+
+class PyTest(TestCommand):
+    user_options = []
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ''
+
+    def run_tests(self):
+        import shlex
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
+
 
 setup(
     name='certbot-nginx',
@@ -64,4 +82,6 @@ setup(
         ],
     },
     test_suite='certbot_nginx',
+    tests_require=["pytest"],
+    cmdclass={"test": PyTest},
 )

--- a/certbot/tests/lock_test.py
+++ b/certbot/tests/lock_test.py
@@ -10,7 +10,6 @@ from certbot import errors
 from certbot.tests import util as test_util
 
 
-@test_util.broken_on_windows
 class LockDirTest(test_util.TempDirTestCase):
     """Tests for certbot.lock.lock_dir."""
     @classmethod
@@ -25,7 +24,6 @@ class LockDirTest(test_util.TempDirTestCase):
         test_util.lock_and_call(assert_raises, lock_path)
 
 
-@test_util.broken_on_windows
 class LockFileTest(test_util.TempDirTestCase):
     """Tests for certbot.lock.LockFile."""
     @classmethod
@@ -37,6 +35,7 @@ class LockFileTest(test_util.TempDirTestCase):
         super(LockFileTest, self).setUp()
         self.lock_path = os.path.join(self.tempdir, 'test.lock')
 
+    @test_util.broken_on_windows
     def test_acquire_without_deletion(self):
         # acquire the lock in another process but don't delete the file
         child = multiprocessing.Process(target=self._call,
@@ -54,6 +53,7 @@ class LockFileTest(test_util.TempDirTestCase):
             self.assertRaises, errors.LockError, self._call, self.lock_path)
         test_util.lock_and_call(assert_raises, self.lock_path)
 
+    @test_util.broken_on_windows
     def test_locked_repr(self):
         lock_file = self._call(self.lock_path)
         locked_repr = repr(lock_file)
@@ -71,6 +71,7 @@ class LockFileTest(test_util.TempDirTestCase):
         self.assertTrue(lock_file.__class__.__name__ in lock_repr)
         self.assertTrue(self.lock_path in lock_repr)
 
+    @test_util.broken_on_windows
     def test_race(self):
         should_delete = [True, False]
         stat = os.stat
@@ -86,11 +87,13 @@ class LockFileTest(test_util.TempDirTestCase):
             self._call(self.lock_path)
         self.assertFalse(should_delete)
 
+    @test_util.broken_on_windows
     def test_removed(self):
         lock_file = self._call(self.lock_path)
         lock_file.release()
         self.assertFalse(os.path.exists(self.lock_path))
 
+    @test_util.broken_on_windows
     @mock.patch('certbot.compat.fcntl.lockf')
     def test_unexpected_lockf_err(self, mock_lockf):
         msg = 'hi there'

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -335,6 +335,8 @@ class TempDirTestCase(unittest.TestCase):
         # called and instead will run them right before the entire test process exits.
         # It is a problem on Windows, that does not accept to clean resources before closing them.
         logging.shutdown()
+        # Remove logging handlers that have been closed so they won't be
+        # accidentally used in future tests.
         logging.getLogger().handlers = []
         util._release_locks()  # pylint: disable=protected-access
 

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -334,6 +334,7 @@ class TempDirTestCase(unittest.TestCase):
         # called and instead will run them right before the entire test process exits.
         # It is a problem on Windows, that does not accept to clean resources before closing them.
         logging.shutdown()
+        logging.getLogger().handlers = []
         util._release_locks()  # pylint: disable=protected-access
 
         def handle_rw_files(_, path, __):

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -142,6 +142,7 @@ def _release_locks():
         except:  # pylint: disable=bare-except
             msg = 'Exception occurred releasing lock: {0!r}'.format(dir_lock)
             logger.debug(msg, exc_info=True)
+    _LOCKS.clear()
 
 
 def set_up_core_dir(directory, mode, uid, strict):
@@ -225,9 +226,8 @@ def safe_open(path, mode="w", chmod=None, buffering=None):
     fdopen_args = ()  # type: Union[Tuple[()], Tuple[int]]
     if buffering is not None:
         fdopen_args = (buffering,)
-    return os.fdopen(
-        os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, *open_args),
-        mode, *fdopen_args)
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, *open_args)
+    return os.fdopen(fd, mode, *fdopen_args)
 
 
 def _unique_file(path, filename_pat, count, chmod, mode):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 import codecs
 import os
 import re
+import sys
 
 from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
 
 # Workaround for http://bugs.python.org/issue8876, see
 # http://bugs.python.org/issue8876#msg208792
@@ -77,6 +79,22 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+
+class PyTest(TestCommand):
+    user_options = []
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ''
+
+    def run_tests(self):
+        import shlex
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
+
+
 setup(
     name='certbot',
     version=version,
@@ -123,6 +141,8 @@ setup(
     # to test all packages run "python setup.py test -s
     # {acme,certbot_apache,certbot_nginx}"
     test_suite='certbot',
+    tests_require=["pytest"],
+    cmdclass={"test": PyTest},
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR superseeds #6753.

The failure of `test_sdists.py` with the changes of #6667 is not due to test failures. It is due to the size of the output. Indeed, an execution on my laptop is succeeding, but generates an enormous amount of output about non critical teardown errors, or exceptions generated and checked during the tests. My hypothesis here, as @bmw saw the test not executed and failed, but staled with the necessity to kill it, is that the AWS instance get too much output to handle.

The reason of the size of this output, is that `test_sdists.py` uses `setuptools`, through `python setup.py test`, and this does not capture output, like `pytest` would do.

Hopefully, it is possible to delegate from `setuptools` to `pytest`, and it is already done for `acme`. This PR applies this configuration to `certbot`, `certbot-apache` and `certbot-nginx`.

With this, output is now clean, and should let AWS instances successfully execute `test_sdists.py`.

Of course, this PR reapplies #6667.