### PR TITLE
Add failure message if test farm tests do not run the correct number of tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Test farm tests print failure message if they do not run the correct number of tests.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-* Test farm tests print failure message if they do not run the correct number of tests.
+*
 
 ### Changed
 

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -564,6 +564,11 @@ try:
         ii, target, status = outq
         print('%d %s %s'%(ii, target['name'], status))
         results_file.write('%d %s %s\n'%(ii, target['name'], status))
+    if len(outputs) != num_processes:
+        failure_message = 'FAILURE: Some target machines failed to run and were not tested. ' +
+            'Tests should be rerun.'
+        print(failure_message)
+        results_file.write(failure_message + '\n')
     results_file.close()
 
 finally:

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -565,7 +565,7 @@ try:
         print('%d %s %s'%(ii, target['name'], status))
         results_file.write('%d %s %s\n'%(ii, target['name'], status))
     if len(outputs) != num_processes:
-        failure_message = 'FAILURE: Some target machines failed to run and were not tested. ' +
+        failure_message = 'FAILURE: Some target machines failed to run and were not tested. ' +\
             'Tests should be rerun.'
         print(failure_message)
         results_file.write(failure_message + '\n')


### PR DESCRIPTION
Fixes #6748.

Here's what results look like when it fails (created by adding +1 to the numerical comparison):
```
0 ubuntu18.10 pass
1 ubuntu18.04LTS pass
2 ubuntu16.04LTS pass
3 ubuntu14.04LTS pass
4 ubuntu14.04LTS_32bit pass
5 debian9 pass
6 debian8.1 pass
7 amazonlinux-2015.09.1 pass
8 amazonlinux-2015.03.1 pass
9 RHEL7 pass
10 fedora23 pass
11 centos7 pass
12 centos6 pass
FAILURE: Some target machines failed to run and were not tested. Tests should be rerun.
Logs in  letest-1550274238
Terminating EC2 Instances
```

Adding a `raise` at [line 358](https://github.com/certbot/certbot/blob/master/tests/letstest/multitester.py#L358) produces the expected behavior: no information about individual tests printed, failure message printed instead and written out to `results`.

Also confirmed that the error message doesn't print on normal behavior.