### PR TITLE
[Windows] Refactor lock_and_call using queues

### DIFF
--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -362,6 +362,13 @@ class ConfigTestCase(TempDirTestCase):
 
 
 def _handle_lock(event_in, event_out, path):
+    """
+    Acquire a file lock on given path, then wait for release it. This worker is coordinated
+    using events to signal the caller about the locking, and know when to release it.
+    :param multiprocessing.Event event_in: event object to signal when to release the lock
+    :param multiprocessing.Event event_out: event object to signal when the lock is acquired
+    :param path: the path to lock
+    """
     if os.path.isdir(path):
         my_lock = lock.lock_dir(path)
     else:
@@ -374,7 +381,8 @@ def _handle_lock(event_in, event_out, path):
 
 
 def lock_and_call(callback, path_to_lock):
-    """Grab a lock on path_to_lock from a foreign process then execute the callback.
+    """
+    Grab a lock on path_to_lock from a foreign process then execute the callback.
     :param callable callback: object to call after acquiring the lock
     :param str path_to_lock: path to file or directory to lock
     """

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -397,7 +397,7 @@ def lock_and_call(callback, path_to_lock):
     emit_queue.put(None)
 
     # Wait for process termination
-    process.join()
+    process.join(timeout=10)
     assert process.exitcode == 0
 
 

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -363,7 +363,7 @@ class ConfigTestCase(TempDirTestCase):
 
 def _handle_lock(event_in, event_out, path):
     """
-    Acquire a file lock on given path, then wait for release it. This worker is coordinated
+    Acquire a file lock on given path, then wait to release it. This worker is coordinated
     using events to signal the caller about the locking, and know when to release it.
     :param multiprocessing.Event event_in: event object to signal when to release the lock
     :param multiprocessing.Event event_out: event object to signal when the lock is acquired

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -364,7 +364,7 @@ class ConfigTestCase(TempDirTestCase):
 def _handle_lock(event_in, event_out, path):
     """
     Acquire a file lock on given path, then wait to release it. This worker is coordinated
-    using events to signal the caller about the locking, and know when to release it.
+    using events to signal when the lock should be acquired and released.
     :param multiprocessing.Event event_in: event object to signal when to release the lock
     :param multiprocessing.Event event_out: event object to signal when the lock is acquired
     :param path: the path to lock

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -375,7 +375,7 @@ def _handle_lock(event_in, event_out, path):
         my_lock = lock.LockFile(path)
     try:
         event_out.set()
-        event_in.wait(timeout=20)
+        assert event_in.wait(timeout=20), 'Timeout while waiting to release the lock.'
     finally:
         my_lock.release()
 
@@ -395,7 +395,7 @@ def lock_and_call(callback, path_to_lock):
     process.start()
 
     # Wait confirmation that lock is acquired
-    receive_event.wait(timeout=10)
+    assert receive_event.wait(timeout=10), 'Timeout while waiting to acquire the lock.'
     # Execute the callback
     callback()
     # Trigger unlock from foreign process


### PR DESCRIPTION
The PR #6772 created a new implementation that was not broken for Windows, using files to coordinate the parallel processes. However, I observed that sometimes, on AppVeyor for Windows with Python 3.5, lock_and_call is deadlocking, blocking the entire Windows build until the global one hour timeout is reached.

This does not impact Linux on Travis CI however. And I cannot reproduce it in a local development Windows machine.

So I reimplemented lock_and_call with the recommended way: using together multiprocessing.Process, and multiprocessing.Queue to coordinate the parallel processes. This implementation works both on Linux and Windows.

This implementation is also protected against deadlock, throwing exceptions when timeouts are reached.