### PR TITLE
Fix spurious test_relevant_values* failures

### DIFF
--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -340,6 +340,8 @@ class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         config_dir_option = 'config_dir'
         self.assertFalse(cli.option_was_set(
             config_dir_option, cli.flag_default(config_dir_option)))
+        self.assertFalse(cli.option_was_set(
+            'authenticator', cli.flag_default('authenticator')))
 
     def test_encode_revocation_reason(self):
         for reason, code in constants.REVOCATION_REASONS.items():

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -563,7 +563,7 @@ class RenewableCertTests(BaseRenewableCertTest):
         self.test_rc.save_successor(2, b"newcert", b"new_privkey", b"new chain", self.config)
         self.assertTrue(mock_chown.called)
 
-    def _test_relevant_values_common(self, values):
+    def _test_relevant_values_common(self, values, set_by_cli=False):
         defaults = dict((option, cli.flag_default(option))
                         for option in ("authenticator", "installer",
                                        "rsa_key_size", "server",))
@@ -576,8 +576,9 @@ class RenewableCertTests(BaseRenewableCertTest):
         expected_server = values["server"]
 
         from certbot.storage import relevant_values
-        with mock.patch("certbot.cli.helpful_parser", mock_parser):
-            rv = relevant_values(values)
+        with mock.patch("certbot.cli.set_by_cli", return_value=set_by_cli):
+            with mock.patch("certbot.cli.helpful_parser", mock_parser):
+                rv = relevant_values(values)
         self.assertIn("server", rv)
         self.assertEqual(rv.pop("server"), expected_server)
         return rv
@@ -614,14 +615,12 @@ class RenewableCertTests(BaseRenewableCertTest):
             self._test_relevant_values_common(
                 {"authenticator": None, "installer": None}), {})
 
-    @mock.patch("certbot.cli.set_by_cli")
     @mock.patch("certbot.plugins.disco.PluginsRegistry.find_all")
-    def test_relevant_values_namespace(self, mock_find_all, mock_set_by_cli):
-        mock_set_by_cli.return_value = True
+    def test_relevant_values_namespace(self, mock_find_all):
         mock_find_all.return_value = ["certbot-foo:bar"]
         values = {"certbot_foo:bar_baz": 42}
         self.assertEqual(
-            self._test_relevant_values_common(values), values)
+            self._test_relevant_values_common(values, set_by_cli=True), values)
 
     def test_relevant_values_server(self):
         self.assertEqual(

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -12,7 +12,6 @@ import pytz
 import six
 
 import certbot
-from certbot import cli
 from certbot import compat
 from certbot import errors
 from certbot.storage import ALL_FOUR
@@ -35,6 +34,48 @@ def fill_with_sample_data(rc_object):
     for kind in ALL_FOUR:
         with open(getattr(rc_object, kind), "w") as f:
             f.write(kind)
+
+
+class RelevantValuesTest(unittest.TestCase):
+    """Tests for certbot.storage.relevant_values."""
+
+    def setUp(self):
+        self.values = {"server": "example.org"}
+
+    def _call(self, *args, **kwargs):
+        from certbot.storage import relevant_values
+        return relevant_values(*args, **kwargs)
+
+    @mock.patch("certbot.cli.option_was_set")
+    @mock.patch("certbot.plugins.disco.PluginsRegistry.find_all")
+    def test_namespace(self, mock_find_all, mock_option_was_set):
+        mock_find_all.return_value = ["certbot-foo:bar"]
+        mock_option_was_set.return_value = True
+
+        self.values["certbot_foo:bar_baz"] = 42
+        self.assertEqual(
+            self._call(self.values.copy()), self.values)
+
+    @mock.patch("certbot.cli.option_was_set")
+    def test_option_set(self, mock_option_was_set):
+        mock_option_was_set.return_value = True
+
+        self.values["allow_subset_of_names"] = True
+        self.values["authenticator"] = "apache"
+        self.values["rsa_key_size"] = 1337
+        expected_relevant_values = self.values.copy()
+        self.values["hello"] = "there"
+
+        self.assertEqual(self._call(self.values), expected_relevant_values)
+
+    @mock.patch("certbot.cli.option_was_set")
+    def test_option_unset(self, mock_option_was_set):
+        mock_option_was_set.return_value = False
+
+        expected_relevant_values = self.values.copy()
+        self.values["rsa_key_size"] = 2048
+
+        self.assertEqual(self._call(self.values), expected_relevant_values)
 
 
 class BaseRenewableCertTest(test_util.ConfigTestCase):
@@ -562,72 +603,6 @@ class RenewableCertTests(BaseRenewableCertTest):
         self.assertFalse(mock_chown.called)
         self.test_rc.save_successor(2, b"newcert", b"new_privkey", b"new chain", self.config)
         self.assertTrue(mock_chown.called)
-
-    def _test_relevant_values_common(self, values):
-        defaults = dict((option, cli.flag_default(option))
-                        for option in ("authenticator", "installer",
-                                       "rsa_key_size", "server",))
-        mock_parser = mock.Mock(args=[], verb="plugins",
-                                defaults=defaults)
-
-        # make a copy to ensure values isn't modified
-        values = values.copy()
-        values.setdefault("server", defaults["server"])
-        expected_server = values["server"]
-
-        from certbot.storage import relevant_values
-        with mock.patch("certbot.cli.helpful_parser", mock_parser):
-            rv = relevant_values(values)
-        self.assertIn("server", rv)
-        self.assertEqual(rv.pop("server"), expected_server)
-        return rv
-
-    def test_relevant_values(self):
-        """Test that relevant_values() can reject an irrelevant value."""
-        self.assertEqual(
-            self._test_relevant_values_common({"hello": "there"}), {})
-
-    def test_relevant_values_default(self):
-        """Test that relevant_values() can reject a default value."""
-        option = "rsa_key_size"
-        values = {option: cli.flag_default(option)}
-        self.assertEqual(self._test_relevant_values_common(values), {})
-
-    def test_relevant_values_nondefault(self):
-        """Test that relevant_values() can retain a non-default value."""
-        values = {"rsa_key_size": 12}
-        self.assertEqual(
-            self._test_relevant_values_common(values), values)
-
-    def test_relevant_values_bool(self):
-        values = {"allow_subset_of_names": True}
-        self.assertEqual(
-            self._test_relevant_values_common(values), values)
-
-    def test_relevant_values_str(self):
-        values = {"authenticator": "apache"}
-        self.assertEqual(
-            self._test_relevant_values_common(values), values)
-
-    def test_relevant_values_plugins_none(self):
-        self.assertEqual(
-            self._test_relevant_values_common(
-                {"authenticator": None, "installer": None}), {})
-
-    @mock.patch("certbot.cli.set_by_cli")
-    @mock.patch("certbot.plugins.disco.PluginsRegistry.find_all")
-    def test_relevant_values_namespace(self, mock_find_all, mock_set_by_cli):
-        mock_set_by_cli.return_value = True
-        mock_find_all.return_value = ["certbot-foo:bar"]
-        values = {"certbot_foo:bar_baz": 42}
-        self.assertEqual(
-            self._test_relevant_values_common(values), values)
-
-    def test_relevant_values_server(self):
-        self.assertEqual(
-            # _test_relevant_values_common handles testing the server
-            # value and removes it
-            self._test_relevant_values_common({"server": "example.org"}), {})
 
     @mock.patch("certbot.storage.relevant_values")
     def test_new_lineage(self, mock_rv):

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -11,10 +11,13 @@ import mock
 import pytz
 import six
 
+from six.moves import reload_module  # pylint: disable=import-error
+
 import certbot
 from certbot import cli
 from certbot import compat
 from certbot import errors
+from certbot.plugins import disco as plugins_disco
 from certbot.storage import ALL_FOUR
 
 import certbot.tests.util as test_util
@@ -564,6 +567,9 @@ class RenewableCertTests(BaseRenewableCertTest):
         self.assertTrue(mock_chown.called)
 
     def _test_relevant_values_common(self, values):
+        # Reload certbot.cli to clean global state
+        reload_module(cli)
+
         defaults = dict((option, cli.flag_default(option))
                         for option in ("authenticator", "installer",
                                        "rsa_key_size", "server",))
@@ -614,14 +620,29 @@ class RenewableCertTests(BaseRenewableCertTest):
             self._test_relevant_values_common(
                 {"authenticator": None, "installer": None}), {})
 
-    @mock.patch("certbot.cli.set_by_cli")
-    @mock.patch("certbot.plugins.disco.PluginsRegistry.find_all")
-    def test_relevant_values_namespace(self, mock_find_all, mock_set_by_cli):
-        mock_set_by_cli.return_value = True
-        mock_find_all.return_value = ["certbot-foo:bar"]
-        values = {"certbot_foo:bar_baz": 42}
-        self.assertEqual(
-            self._test_relevant_values_common(values), values)
+    def test_relevant_values_namespace(self):
+        # Create a dummy plugin object to test that third party plugins
+        # values are handled properly.
+        plugin_name = "certboot-foo:bar"
+        plugin_arg = "baz"
+        plugin_dest = "{0}_{1}".format(plugin_name.replace("-", "_"), plugin_arg)
+
+        def inject_parser_options(parser, name):
+            """Add a simple argument to the parser for the plugin."""
+            parser.add_argument('--{0}-{1}'.format(name, plugin_arg))
+
+        foo_plugin_ep = mock.MagicMock()
+        foo_plugin_ep.plugin_cls.inject_parser_options.side_effect = inject_parser_options
+
+        plugins = dict(plugins_disco.PluginsRegistry.find_all())
+        plugins[plugin_name] = foo_plugin_ep
+        find_all_rv = plugins_disco.PluginsRegistry(plugins)
+
+        values = {plugin_dest: 42}
+
+        with mock.patch("certbot.plugins.disco.PluginsRegistry.find_all", return_value=find_all_rv):
+            self.assertEqual(
+                self._test_relevant_values_common(values), values)
 
     def test_relevant_values_server(self):
         self.assertEqual(

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -17,6 +17,7 @@ import certbot
 from certbot import cli
 from certbot import compat
 from certbot import errors
+from certbot.plugins import common as plugins_common
 from certbot.plugins import disco as plugins_disco
 from certbot.storage import ALL_FOUR
 
@@ -625,7 +626,7 @@ class RenewableCertTests(BaseRenewableCertTest):
         # values are handled properly.
         plugin_name = "certboot-foo:bar"
         plugin_arg = "baz"
-        plugin_dest = "{0}_{1}".format(plugin_name.replace("-", "_"), plugin_arg)
+        plugin_dest = plugins_common.dest_namespace(plugin_name) + plugin_arg
 
         def inject_parser_options(parser, name):
             """Add a simple argument to the parser for the plugin."""


### PR DESCRIPTION
Tests were failing on #6766. I believe this was due to the global state used in `cli.py`.

We could try to fix up this global state for each test, but `storage_test.py` seems like the wrong place to have tests that are strongly coupled to `cli.py`. I think such tests should be in `cli_test.py`. In fact, we already have tests for the problematic function at https://github.com/certbot/certbot/blob/11e0fa52d0f2e7d8780465f5b2202e0cb717e065/certbot/tests/cli_test.py#L470

Instead, I just mocked out the function in `cli.py` using the problematic global state allowing us to focus on testing pieces specific to `storage.py`.

I tested the failing environments in #6766 with this PR merged on top of it at https://travis-ci.com/certbot/certbot/builds/102590400 and tests passed.