### PR TITLE
Disable rerun feature of Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -200,7 +200,7 @@ addons:
 install: "travis_retry $(command -v pip || command -v pip3) install codecov tox"
 script:
     - tox
-    - '[ -z "${BOULDER_INTEGRATION+x}" ] || (tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
+    - '[ -z "${BOULDER_INTEGRATION+x}" ] || (travis_retry tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,10 +197,10 @@ addons:
     - nginx-light
     - openssl
 
-install: "travis_retry $(command -v pip || command -v pip3) install codecov tox"
+install: "$(command -v pip || command -v pip3) install codecov tox"
 script:
     - tox
-    - '[ -z "${BOULDER_INTEGRATION+x}" ] || (travis_retry tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
+    - '[ -z "${BOULDER_INTEGRATION+x}" ] || (tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,7 +199,6 @@ addons:
 
 install: "travis_retry $(command -v pip || command -v pip3) install codecov tox"
 script:
-script:
     - tox
     - '[ -z "${BOULDER_INTEGRATION+x}" ] || (tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,8 +199,9 @@ addons:
 
 install: "travis_retry $(command -v pip || command -v pip3) install codecov tox"
 script:
-    - travis_retry tox
-    - '[ -z "${BOULDER_INTEGRATION+x}" ] || (travis_retry tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
+script:
+    - tox
+    - '[ -z "${BOULDER_INTEGRATION+x}" ] || (tests/boulder-fetch.sh && tests/tox-boulder-integration.sh)'
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov'
 

--- a/tools/pip_install.py
+++ b/tools/pip_install.py
@@ -16,7 +16,6 @@ import sys
 import re
 import shutil
 import tempfile
-import time
 
 import merge_requirements as merge_module
 import readlink
@@ -71,18 +70,9 @@ def merge_requirements(tools_path, requirements, test_constraints, all_constrain
         fd.write(merged_requirements)
 
 
-def call_with_print(command, cwd=None, retries=2):
-    raise_error = None
-    for i in range(retries + 1):
-        print('(retry {0}/{1}): '.format(i, retries) if i else '' + command)
-        try:
-            subprocess.check_call(command, shell=True, cwd=cwd or os.getcwd())
-            return
-        except subprocess.CalledProcessError as error:
-            raise_error = error
-            time.sleep(1)
-
-    raise raise_error
+def call_with_print(command, cwd=None):
+    print(command)
+    subprocess.check_call(command, shell=True, cwd=cwd or os.getcwd())
 
 
 def main(args):

--- a/tools/pip_install.py
+++ b/tools/pip_install.py
@@ -16,6 +16,7 @@ import sys
 import re
 import shutil
 import tempfile
+import time
 
 import merge_requirements as merge_module
 import readlink
@@ -70,9 +71,18 @@ def merge_requirements(tools_path, requirements, test_constraints, all_constrain
         fd.write(merged_requirements)
 
 
-def call_with_print(command, cwd=None):
-    print(command)
-    subprocess.check_call(command, shell=True, cwd=cwd or os.getcwd())
+def call_with_print(command, cwd=None, retries=2):
+    raise_error = None
+    for i in range(retries + 1):
+        print('(retry {0}/{1}): '.format(i, retries) if i else '' + command)
+        try:
+            subprocess.check_call(command, shell=True, cwd=cwd or os.getcwd())
+            return
+        except subprocess.CalledProcessError as error:
+            raise_error = error
+            time.sleep(1)
+
+    raise raise_error
 
 
 def main(args):


### PR DESCRIPTION
The rerun capability in a test campaign can be a nice feature. It can also a bad design.

It is right that with high level tests, like performance or end-to-end tests, a given test runtime can depend on an external component, outside the scope of the developers, that would spuriously fail. In theses situations, having the capacity to rerun several time a test can be a great benefit. Indeed, as these tests are inherently flaky, the rerun greatly reduces their failure because of external reasons, reducing also the `Pierre et le  Loup` effect (from a well-known french book for children): because tests constantly fail for no reason, you stop to listen to them and to not see when they fail for a real reason.

However this not apply to unit tests, or operations about code quality. For theses executions, the flakiness should not exist: a unit test is supposed to have no external dependency. A rerun approach would just hide a situation that is not desirable for this kind of tests

Also effectively I see that our tests are usually not flaky: so the only effect of the rerun is to give the failure state about a test three times slower. If a test becomes flaky, this should be fixed, and so be visible immediately in our CI.

For these reasons, I remove the `travis_retry` in the  `script` section of `.travis-ci.yml`, to call directly `tox` and let the pipeline fails on the first error.

Instead, I set a travis_retry in the install step, as this could theorically solve temporary network failures while executing pip. Arguably it could be removed also, as I do not think that 3 executions within a minute will be sufficient for a network failure, that is most likely be a really critical error with complex solving from the pip ecosystem maintainers.