### PR TITLE
Revert "Disable build for commits pushed on master (#6804)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ branches:
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
 
-# Since master can receive only commits from PR that have already been tested, we avoid with the
-# the following condition to launch again a pipeline when the merge commit is pushed to master.
-# However master still needs to be set in branches section to allow PR for master to be built.
-if: NOT (type = push AND branch = master)
-
 matrix:
   include:
     # These environments are always executed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,6 @@ branches:
     - /^\d+\.\d+\.x$/ # Version branches like X.X.X
     - /^test-.*$/
 
-init:
-  # Since master can receive only commits from PR that have already been tested, we avoid with the
-  # the following condition to launch again a pipeline when the merge commit is pushed to master.
-  # However master still needs to be set in branches section to allow PR for master to be built.
-  - ps: |
-      if (-Not $Env:APPVEYOR_PULL_REQUEST_NUMBER -And $Env:APPVEYOR_REPO_BRANCH -Eq 'master')
-      { $Env:APPVEYOR_SKIP_FINALIZE_ON_EXIT = 'true'; Exit-AppVeyorBuild }
-
 install:
   # Use Python 3.7 by default
   - "SET PATH=C:\\Python37;C:\\Python37\\Scripts;%PATH%"


### PR DESCRIPTION
By removing all the builds on push to master, done in #6804, we also removing the coveralls reports that are necessary to calculate the effect of a PR on code coverage, that is part of the quality gate process.

This PR is reverting #6804, and another implementation preserving the coveralls reports will be done soon.