### PR TITLE
Do not run the full CI pipeline on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,141 +18,163 @@ branches:
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
 
-stages:
-  # Normal stage always executed (including PR) except pushes on master
-  - name: test
-    if: NOT (type = push AND branch = master)
-  # Restricted stage executed only for pushes on master
-  - name: test-master
-    if: type = push AND branch = master
-  # Extended stage executed on cron jobs an push on non-master branches
-  - name: test-extended
-    if: type = cron OR (type = push AND branch != master)
+# Normal job always executed (including PR) except pushes on master
+not-on-master: &not-on-master
+  if: NOT (type = push AND branch = master)
+
+# Extended job executed on cron jobs and pushes on non-master branches
+extended-pipeline: &extended-pipeline
+  if: type = cron OR (type = push AND branch != master)
 
 matrix:
   include:
-    # Jobs attached to the test stage
-    - stage: test
-      python: "2.7"
+    # Main pipeline
+    - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=all TOXENV=py27_install
       sudo: required
       services: docker
+      <<: *not-on-master
     - python: "2.7"
       env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=all TOXENV=py27_install
       sudo: required
       services: docker
+      <<: *not-on-master
+
+    # This job is always executed, including on master
     - python: "2.7"
       env: TOXENV=py27-cover FYI="py27 tests + code coverage"
+
     - sudo: required
       env: TOXENV=nginx_compat
       services: docker
       before_install:
       addons:
+      <<: *not-on-master
     - python: "2.7"
       env: TOXENV=lint
+      <<: *not-on-master
     - python: "3.4"
       env: TOXENV=mypy
+      <<: *not-on-master
     - python: "3.5"
       env: TOXENV=mypy
+      <<: *not-on-master
     - python: "2.7"
       env: TOXENV='py27-{acme,apache,certbot,dns,nginx,postfix}-oldest'
       sudo: required
       services: docker
+      <<: *not-on-master
     - python: "3.4"
       env: TOXENV=py34
       sudo: required
       services: docker
+      <<: *not-on-master
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37
       sudo: required
       services: docker
+      <<: *not-on-master
     - sudo: required
       env: TOXENV=apache_compat
       services: docker
       before_install:
       addons:
+      <<: *not-on-master
     - sudo: required
       env: TOXENV=le_auto_trusty
       services: docker
       before_install:
       addons:
+      <<: *not-on-master
     - python: "2.7"
       env: TOXENV=apacheconftest-with-pebble
       sudo: required
       services: docker
+      <<: *not-on-master
     - python: "2.7"
       env: TOXENV=nginxroundtrip
+      <<: *not-on-master
 
-    # Jobs attached to the test-master stage
-    - stage: test-master
-      python: "2.7"
-      env: TOXENV=py27-cover FYI="py27 tests + code coverage"
-
-    # Jobs attached to the test-extended stage
-    - stage: test-extended
-      python: "3.7"
+    # Extended pipeline on cron jobs and push to test-* branches
+    - python: "3.7"
       dist: xenial
       env: TOXENV=py37 CERTBOT_NO_PIN=1
+      <<: *extended-pipeline
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "2.7"
       env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "2.7"
       env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
+      <<: *extended-pipeline
     - sudo: required
       env: TOXENV=le_auto_xenial
       services: docker
+      <<: *extended-pipeline
     - sudo: required
       env: TOXENV=le_auto_jessie
       services: docker
+      <<: *extended-pipeline
     - sudo: required
       env: TOXENV=le_auto_centos6
       services: docker
+      <<: *extended-pipeline
     - sudo: required
       env: TOXENV=docker_dev
       services: docker
@@ -160,6 +182,7 @@ matrix:
         apt:
           packages:  # don't install nginx and apache
             - libaugeas0
+      <<: *extended-pipeline
     - language: generic
       env: TOXENV=py27
       os: osx
@@ -168,6 +191,7 @@ matrix:
           packages:
             - augeas
             - python2
+      <<: *extended-pipeline
     - language: generic
       env: TOXENV=py3
       os: osx
@@ -176,6 +200,7 @@ matrix:
           packages:
             - augeas
             - python3
+      <<: *extended-pipeline
 
 # container-based infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,22 @@ branches:
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
 
+stages:
+  # Normal stage always executed (including PR) except pushes on master
+  - name: test
+    if: NOT (type = push AND branch = master)
+  # Restricted stage executed only for pushes on master
+  - name: test-master
+    if: type = push AND branch = master
+  # Extended stage executed on cron jobs an push on non-master branches
+  - name: test-extended
+    if: type = cron OR (type = push AND branch != master)
+
 matrix:
   include:
-    # These environments are always executed
-    - python: "2.7"
+    # Jobs attached to the test stage
+    - stage: test
+      python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=all TOXENV=py27_install
       sudo: required
       services: docker
@@ -72,87 +84,75 @@ matrix:
     - python: "2.7"
       env: TOXENV=nginxroundtrip
 
-    # These environments are executed on cron events and commits to tested
-    # branches other than master. Which branches are tested is controlled by
-    # the "branches" section earlier in this file.
-    - python: "3.7"
+    # Jobs attached to the test-master stage
+    - stage: test-master
+      python: "2.7"
+      env: TOXENV=py27-cover FYI="py27 tests + code coverage"
+
+    # Jobs attached to the test-extended stage
+    - stage: test-extended
+      python: "3.7"
       dist: xenial
       env: TOXENV=py37 CERTBOT_NO_PIN=1
-      if: type = cron OR (type = push AND branch != master)
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "2.7"
       env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "2.7"
       env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - sudo: required
       env: TOXENV=le_auto_xenial
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - sudo: required
       env: TOXENV=le_auto_jessie
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - sudo: required
       env: TOXENV=le_auto_centos6
       services: docker
-      if: type = cron OR (type = push AND branch != master)
     - sudo: required
       env: TOXENV=docker_dev
       services: docker
@@ -160,7 +160,6 @@ matrix:
         apt:
           packages:  # don't install nginx and apache
             - libaugeas0
-      if: type = cron OR (type = push AND branch != master)
     - language: generic
       env: TOXENV=py27
       os: osx
@@ -169,7 +168,6 @@ matrix:
           packages:
             - augeas
             - python2
-      if: type = cron OR (type = push AND branch != master)
     - language: generic
       env: TOXENV=py3
       os: osx
@@ -178,7 +176,6 @@ matrix:
           packages:
             - augeas
             - python3
-      if: type = cron OR (type = push AND branch != master)
 
 # container-based infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
 
-# Job for main test suite, always executed (including PR) except for pushes on master.
+# Jobs for the main test suite are always executed (including on PRs) except for pushes on master.
 not-on-master: &not-on-master
   if: NOT (type = push AND branch = master)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,17 @@ branches:
     - /^\d+\.\d+\.x$/
     - /^test-.*$/
 
-# Normal job always executed (including PR) except pushes on master
+# Job for main test suite, always executed (including PR) except for pushes on master.
 not-on-master: &not-on-master
   if: NOT (type = push AND branch = master)
 
-# Extended job executed on cron jobs and pushes on non-master branches
-extended-pipeline: &extended-pipeline
+# Job for extended test suite, executed for cron jobs and pushes on non-master branches.
+extended-test-suite: &extended-test-suite
   if: type = cron OR (type = push AND branch != master)
 
 matrix:
   include:
-    # Main pipeline
+    # Main test suite
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=all TOXENV=py27_install
       sudo: required
@@ -96,85 +96,85 @@ matrix:
       env: TOXENV=nginxroundtrip
       <<: *not-on-master
 
-    # Extended pipeline on cron jobs and push to test-* branches
+    # Extended test suite on cron jobs and pushes to tested branches other than master
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37 CERTBOT_NO_PIN=1
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "2.7"
       env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=certbot TOXENV=py27-certbot-oldest
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "2.7"
       env: BOULDER_INTEGRATION=v1 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "2.7"
       env: BOULDER_INTEGRATION=v2 INTEGRATION_TEST=nginx TOXENV=py27-nginx-oldest
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "3.4"
       env: TOXENV=py34 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "3.5"
       env: TOXENV=py35 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "3.6"
       env: TOXENV=py36 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37 BOULDER_INTEGRATION=v1
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37 BOULDER_INTEGRATION=v2
       sudo: required
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - sudo: required
       env: TOXENV=le_auto_xenial
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - sudo: required
       env: TOXENV=le_auto_jessie
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - sudo: required
       env: TOXENV=le_auto_centos6
       services: docker
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - sudo: required
       env: TOXENV=docker_dev
       services: docker
@@ -182,7 +182,7 @@ matrix:
         apt:
           packages:  # don't install nginx and apache
             - libaugeas0
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - language: generic
       env: TOXENV=py27
       os: osx
@@ -191,7 +191,7 @@ matrix:
           packages:
             - augeas
             - python2
-      <<: *extended-pipeline
+      <<: *extended-test-suite
     - language: generic
       env: TOXENV=py3
       os: osx
@@ -200,7 +200,7 @@ matrix:
           packages:
             - augeas
             - python3
-      <<: *extended-pipeline
+      <<: *extended-test-suite
 
 # container-based infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ branches:
 not-on-master: &not-on-master
   if: NOT (type = push AND branch = master)
 
-# Job for extended test suite, executed for cron jobs and pushes on non-master branches.
+# Jobs for the extended test suite are executed for cron jobs and pushes on non-master branches.
 extended-test-suite: &extended-test-suite
   if: type = cron OR (type = push AND branch != master)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,14 @@ branches:
     - /^\d+\.\d+\.x$/ # Version branches like X.X.X
     - /^test-.*$/
 
+init:
+  # Since master can receive only commits from PR that have already been tested, following
+  # condition avoid to launch all jobs except the coverage one for commits pushed to master.
+  - ps: |
+      if (-Not $Env:APPVEYOR_PULL_REQUEST_NUMBER -And $Env:APPVEYOR_REPO_BRANCH -Eq 'master' `
+          -And -Not ($Env:TOXENV -Like '*-cover'))
+      { $Env:APPVEYOR_SKIP_FINALIZE_ON_EXIT = 'true'; Exit-AppVeyorBuild }
+
 install:
   # Use Python 3.7 by default
   - "SET PATH=C:\\Python37;C:\\Python37\\Scripts;%PATH%"


### PR DESCRIPTION
This PR proposes a better implementation of #6804. This idea is to save the CI working capacity by avoiding to run the CI pipeline on commits to master. Indeed, any commit to this branch comes from a pull request that has already been processed by the CI pipeline. 

First implementation was disabling totally Travis and AppVeyor jobs for pushes to master. However, this approach was breaking the quality gate executed on a PR through Coveralls, because Coveralls needs a report generated on the latest master commit on which a given PR may be merged. And obviously, this report is generated by the pipeline executed on pushes to master... 

On this PR, I leverage available logic on Travis and AppVeyor in order to run the complete pipeline on PRs and pushes to non-master branches, and only the job with coverage on pushes to master:
* on Travis, this is done with conditional stages each of them having the relevant jobs from the matrix execution be declared
* on AppVeyor, the command `Exit-AppVeyorBuild` that exits immediately and successfully a job, is launched on pushes to master branch if the job is not about coverage.

I took also this occasion to classify all jobs that are run only on cron execution to a specific stage. This allows to group the execution condition on the stage level. 