### PR TITLE
Fix faulty test on apacheconftest

### DIFF
--- a/certbot-apache/certbot_apache/tests/apache-conf-files/passing/finalize-1243.conf
+++ b/certbot-apache/certbot_apache/tests/apache-conf-files/passing/finalize-1243.conf
@@ -1,7 +1,7 @@
 #LoadModule ssl_module modules/mod_ssl.so
 
-Listen 443
-<VirtualHost *:443>
+Listen 4443
+<VirtualHost *:4443>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
 	# redirection URLs. In the context of virtual hosts, the ServerName


### PR DESCRIPTION
Fixes #6706

On recent versions of Ubuntu, `apacheconftest` is failing when the configuration file `finalize-1243.conf` is parsed. This due to the fact that this configuration file declares `Listen 443`, while this assertion is already done in `/etc/apache2/ports.conf`.

In recent versions, Apache will throw an error about a listener declared two times for the same IP/port.

This PR fixes this test by using the port `4443` instead of `443` in the tested configuration file.
