### PR TITLE
Replace deprecated Gandi plugin link

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -277,7 +277,7 @@ Plugin      Auth Inst Notes
 plesk_      Y    Y    Integration with the Plesk web hosting tool
 haproxy_    Y    Y    Integration with the HAProxy load balancer
 s3front_    Y    Y    Integration with Amazon CloudFront distribution of S3 buckets
-gandi_      Y    Y    Integration with Gandi's hosting products and API
+gandi_      Y    Y    Integration with Gandi LiveDNS API
 varnish_    Y    N    Obtain certificates via a Varnish server
 external_   Y    N    A plugin for convenient scripting (See also ticket 2782_)
 icecast_    N    Y    Deploy certificates to Icecast 2 streaming media servers
@@ -290,7 +290,7 @@ heroku_     Y    Y    Integration with Heroku SSL
 .. _plesk: https://github.com/plesk/letsencrypt-plesk
 .. _haproxy: https://github.com/greenhost/certbot-haproxy
 .. _s3front: https://github.com/dlapiduz/letsencrypt-s3front
-.. _gandi: https://github.com/Gandi/letsencrypt-gandi
+.. _gandi: https://github.com/obynio/certbot-plugin-gandi
 .. _icecast: https://github.com/e00E/lets-encrypt-icecast
 .. _varnish: http://git.sesse.net/?p=letsencrypt-varnish-plugin
 .. _2782: https://github.com/certbot/certbot/issues/2782


### PR DESCRIPTION
The [previous certbot plugin for Gandi](https://github.com/Gandi/letsencrypt-gandi) is deprecated and not maintained anymore. I updated the documentation [with a new plugin](https://github.com/obynio/certbot-plugin-gandi) that support the new Gandi LiveDNS v5 API.