### PR TITLE
Move the OCSP change to the right section.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* If possible, Certbot uses built-in support for OCSP from recent cryptography
+  versions instead of the OpenSSL binary: as a consequence Certbot does not need
+  the OpenSSL binary to be installed anymore if cryptography>=2.5 is installed.
 
 ### Changed
 
@@ -49,9 +51,6 @@ More details about these changes can be found on our GitHub repo.
 
 * Avoid reprocessing challenges that are already validated
   when a certificate is issued.
-* If possible, Certbot uses built-in support for OCSP from recent cryptography
-  versions instead of the OpenSSL binary: as a consequence Certbot does not need
-  the OpenSSL binary to be installed anymore if cryptography>=2.5 is installed.
 * Support for initiating (but not solving end-to-end) TLS-ALPN-01 challenges
   with the `acme` module.
 


### PR DESCRIPTION
Looks like this got added to our changelog for the released 0.31.0 instead of the upcoming release. We want this change for the release tomorrow.