### PR TITLE
Remove amazon linux test farm targets.

### DIFF
--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -44,16 +44,6 @@ targets:
     #     - [ apt-get, install, -y, curl ]
   #-----------------------------------------------------------------------------
   # Other Redhat Distros
-  - ami: ami-60b6c60a
-    name: amazonlinux-2015.09.1
-    type: centos
-    virt: hvm
-    user: ec2-user
-  - ami: ami-0d4cfd66
-    name: amazonlinux-2015.03.1
-    type: centos
-    virt: hvm
-    user: ec2-user
   - ami: ami-a8d369c0
     name: RHEL7
     type: centos


### PR DESCRIPTION
These images are very old and we don't claim to support Amazon Linux. See https://github.com/certbot/certbot/issues/6505, https://github.com/certbot/certbot/issues/6506, and the following output when `certbot-auto` is run on Amazon Linux:
```
FATAL: Amazon Linux support is very experimental at present...
if you would like to work on improving it, please ensure you have backups
and then run this script again with the --debug flag!
Alternatively, you can install OS dependencies yourself and run this script
again with --no-bootstrap.
```
I think we should fix our support for Amazon Linux. They are a major distro and we have a lot of users on the platform. With that said, I don't think it makes sense for us to keep testing with these very old images in the meantime.

After this lands, the release instructions will need to be updated so Amazon Linux failures from our tests aren't expected.