### PR TITLE
Clean stderr in case of /etc/os-release does not exist

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -749,8 +749,8 @@ elif [ -f /etc/redhat-release ]; then
   unset LE_PYTHON
   DeterminePythonVersion "NOCRASH"
   # Starting to Fedora 29, python2 is on a deprecation path. Let's move to python3 then.
-  RPM_DIST_NAME=`(. /etc/os-release && echo $ID) || echo "unknown"`
-  RPM_DIST_VERSION=`(. /etc/os-release && echo $VERSION_ID) || echo "0"`
+  RPM_DIST_NAME=`(. /etc/os-release 2> /dev/null && echo $ID) || echo "unknown"`
+  RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) || echo "0"`
   if [ "$RPM_DIST_NAME" = "fedora" -a "$RPM_DIST_VERSION" -ge 29 -o "$PYVER" -eq 26 ]; then
     Bootstrap() {
       BootstrapMessage "RedHat-based OSes that will use Python3"

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -324,8 +324,8 @@ elif [ -f /etc/redhat-release ]; then
   unset LE_PYTHON
   DeterminePythonVersion "NOCRASH"
   # Starting to Fedora 29, python2 is on a deprecation path. Let's move to python3 then.
-  RPM_DIST_NAME=`(. /etc/os-release && echo $ID) || echo "unknown"`
-  RPM_DIST_VERSION=`(. /etc/os-release && echo $VERSION_ID) || echo "0"`
+  RPM_DIST_NAME=`(. /etc/os-release 2> /dev/null && echo $ID) || echo "unknown"`
+  RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) || echo "0"`
   if [ "$RPM_DIST_NAME" = "fedora" -a "$RPM_DIST_VERSION" -ge 29 -o "$PYVER" -eq 26 ]; then
     Bootstrap() {
       BootstrapMessage "RedHat-based OSes that will use Python3"


### PR DESCRIPTION
With recent changes to make certbot-auto compatible with Fedora 29 (#6812), variables from `/etc/os-release` are loaded to check the exact version during the bootstrap of RPM distributions.

However, centos 6 does not have `/etc/os-release`. This is not critical, since variable `unknown` is set in case of failure, but a message about `/etc/os-release` not existing is printed in the stderr.

This PR removes this inelegant message.