### PR TITLE
Calculate timedelta with thisUpdate/nextUpdate in UTC

### DIFF
--- a/certbot/ocsp.py
+++ b/certbot/ocsp.py
@@ -200,7 +200,7 @@ def _check_ocsp_response(response_ocsp, request_ocsp, issuer_cert):
     #      for OpenSSL, so we do not do it here.
     # See OpenSSL implementation as a reference:
     # https://github.com/openssl/openssl/blob/ef45aa14c5af024fcb8bef1c9007f3d1c115bd85/crypto/ocsp/ocsp_cl.c#L338-L391
-    now = datetime.now()
+    now = datetime.utcnow()  # thisUpdate/nextUpdate are expressed in UTC/GMT time zone
     if not response_ocsp.this_update:
         raise AssertionError('param thisUpdate is not set.')
     if response_ocsp.this_update > now + timedelta(minutes=5):


### PR DESCRIPTION
Fixes #6836.

OCSP responses contains a `thisUpdate` and `nextUpdate` that allow to calculate its validity. Certbot currently uses `datetime.now()` to get the current time when OCSP check is done through `cryptography`. But `datetime.now()` expresses the date in the machine local time, and comparison operators on datetime do not take into account the offset between two datetime objects expressed in difference timezones.

As a consequence, a given `thisUpdate` may be seen as a future date depending on the local time, failing the OCSP check process.

The error is not critical for certbot, as it will just make some valid OCSP responses giving an `EXPIRED` status been ignored.

This PR fixes this comparison by taking the current time in UTC using `datetime.utctime()`.