### PR TITLE
Remove tls-sni in compatibility tests

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -330,7 +330,9 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
             logger.info('Domain {0} is forcibly resolved to IP {1}'.format(domain, resolved_ip))
             domain = resolved_ip
 
+        logger.info(domain)
         uri = chall.uri(domain)
+        logger.info(uri)
         logger.debug("Verifying %s at %s...", chall.typ, uri)
         try:
             http_response = requests.get(uri)

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -299,7 +299,7 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
     WHITESPACE_CUTSET = "\n\r\t "
     """Whitespace characters which should be ignored at the end of the body."""
 
-    def simple_verify(self, chall, domain, account_public_key, port=None):
+    def simple_verify(self, chall, domain, account_public_key, port=None, resolved_ip=None):
         """Simple verify.
 
         :param challenges.SimpleHTTP chall: Corresponding challenge.
@@ -307,6 +307,7 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
         :param JWK account_public_key: Public key for the key pair
             being authorized.
         :param int port: Port used in the validation.
+        :param string resolved_ip: If set, domain will be forcibly resolved to this IP.
 
         :returns: ``True`` iff validation with the files currently served by the
             HTTP server is successful.
@@ -324,6 +325,10 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
             logger.warning(
                 "Using non-standard port for http-01 verification: %s", port)
             domain += ":{0}".format(port)
+
+        if resolved_ip:
+            logger.info('Domain {0} is forcibly resolved to IP {1}'.format(domain, resolved_ip))
+            domain = resolved_ip
 
         uri = chall.uri(domain)
         logger.debug("Verifying %s at %s...", chall.typ, uri)

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
@@ -23,7 +23,7 @@ class Proxy(object):
     def __init__(self, args):
         """Initializes the plugin with the given command line args"""
         self._temp_dir = tempfile.mkdtemp()
-        # tempfile.mkdtemp() creates folders with to much restrictive permissions to be accessible
+        # tempfile.mkdtemp() creates folders with too restrictive permissions to be accessible
         # to an Apache worker, leading to HTTP challenge failures. Let's fix that.
         os.chmod(self._temp_dir, 0o755)
         self.le_config = util.create_le_config(self._temp_dir)

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
@@ -23,6 +23,9 @@ class Proxy(object):
     def __init__(self, args):
         """Initializes the plugin with the given command line args"""
         self._temp_dir = tempfile.mkdtemp()
+        # tempfile.mkdtemp() creates folders with to much restrictive permissions to be accessible
+        # to an Apache worker, leading to HTTP challenge failures. Let's fix that.
+        os.chmod(self._temp_dir, 0o755)
         self.le_config = util.create_le_config(self._temp_dir)
         config_dir = util.extract_configs(args.configs, self._temp_dir)
         self._configs = [

--- a/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
@@ -68,7 +68,8 @@ def test_authenticator(plugin, config, temp_dir):
             verified = responses[i].simple_verify(achalls[i].chall,
                                                   achalls[i].domain,
                                                   util.JWK.public_key(),
-                                                  port=plugin.http_port)
+                                                  port=plugin.http_port,
+                                                  resolved_ip='127.0.0.1')
             if verified:
                 logger.info(
                     "http-01 verification for %s succeeded", achalls[i].domain)

--- a/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
@@ -64,18 +64,18 @@ def test_authenticator(plugin, config, temp_dir):
                 "Plugin failed to complete %s for %s in %s",
                 type(achalls[i]), achalls[i].domain, config)
             success = False
-        elif isinstance(responses[i], challenges.TLSSNI01Response):
+        elif isinstance(responses[i], challenges.HTTP01Response):
             verified = responses[i].simple_verify(achalls[i].chall,
                                                   achalls[i].domain,
                                                   util.JWK.public_key(),
                                                   host="127.0.0.1",
-                                                  port=plugin.https_port)
+                                                  port=plugin.http_port)
             if verified:
                 logger.info(
-                    "tls-sni-01 verification for %s succeeded", achalls[i].domain)
+                    "http-01 verification for %s succeeded", achalls[i].domain)
             else:
                 logger.error(
-                    "**** tls-sni-01 verification for %s in %s failed",
+                    "**** http-01 verification for %s in %s failed",
                     achalls[i].domain, config)
                 success = False
 
@@ -102,9 +102,9 @@ def _create_achalls(plugin):
     for domain in names:
         prefs = plugin.get_chall_pref(domain)
         for chall_type in prefs:
-            if chall_type == challenges.TLSSNI01:
-                chall = challenges.TLSSNI01(
-                    token=os.urandom(challenges.TLSSNI01.TOKEN_SIZE))
+            if chall_type == challenges.HTTP01:
+                chall = challenges.HTTP01(
+                    token=os.urandom(challenges.HTTP01.TOKEN_SIZE))
                 challb = acme_util.chall_to_challb(
                     chall, messages.STATUS_PENDING)
                 achall = achallenges.KeyAuthorizationAnnotatedChallenge(

--- a/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
@@ -68,7 +68,6 @@ def test_authenticator(plugin, config, temp_dir):
             verified = responses[i].simple_verify(achalls[i].chall,
                                                   achalls[i].domain,
                                                   util.JWK.public_key(),
-                                                  host="127.0.0.1",
                                                   port=plugin.http_port)
             if verified:
                 logger.info(

--- a/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
@@ -378,7 +378,7 @@ def _fake_dns_resolution(resolved_ip):
     _original_create_connection = connection.create_connection
 
     def _patched_create_connection(address, *args, **kwargs):
-        host, port = address
+        _, port = address
         return _original_create_connection((resolved_ip, port), *args, **kwargs)
 
     try:


### PR DESCRIPTION
This PR is a part of the tls-sni-01 removal plan described in #6849.

It replaces tls-sni-01 challenges use in the compatibility tests for Apache and Nginx by http-01 challenges.