### PR TITLE
Remove tls-sni challenge in manual plugin

### DIFF
--- a/certbot/plugins/manual.py
+++ b/certbot/plugins/manual.py
@@ -143,9 +143,6 @@ permitted by DNS standards.)
             env['CERTBOT_TOKEN'] = achall.chall.encode('token')
         else:
             os.environ.pop('CERTBOT_TOKEN', None)
-        os.environ.pop('CERTBOT_CERT_PATH', None)
-        os.environ.pop('CERTBOT_KEY_PATH', None)
-        os.environ.pop('CERTBOT_SNI_DOMAIN', None)
         os.environ.update(env)
         _, out = self._execute_hook('auth-hook')
         env['CERTBOT_AUTH_OUTPUT'] = out.strip()
@@ -158,7 +155,8 @@ permitted by DNS standards.)
                 achall=achall, encoded_token=achall.chall.encode('token'),
                 port=self.config.http01_port,
                 uri=achall.chall.uri(achall.domain), validation=validation)
-        else:  # Can be only DNS-01
+        else:
+            assert isinstance(achall.chall, challenges.DNS01)
             msg = self._DNS_INSTRUCTIONS.format(
                 domain=achall.validation_domain_name(achall.domain),
                 validation=validation)

--- a/certbot/plugins/manual.py
+++ b/certbot/plugins/manual.py
@@ -15,34 +15,6 @@ from certbot import reverter
 from certbot.plugins import common
 
 
-class ManualTlsSni01(common.TLSSNI01):
-    """TLS-SNI-01 authenticator for the Manual plugin
-
-    :ivar configurator: Authenticator object
-    :type configurator: :class:`~certbot.plugins.manual.Authenticator`
-
-    :ivar list achalls: Annotated
-        class:`~certbot.achallenges.KeyAuthorizationAnnotatedChallenge`
-        challenges
-
-    :param list indices: Meant to hold indices of challenges in a
-        larger array. NginxTlsSni01 is capable of solving many challenges
-        at once which causes an indexing issue within NginxConfigurator
-        who must return all responses in order.  Imagine NginxConfigurator
-        maintaining state about where all of the http-01 Challenges,
-        TLS-SNI-01 Challenges belong in the response array.  This is an
-        optional utility.
-
-    :param str challenge_conf: location of the challenge config file
-    """
-
-    def perform(self):
-        """Create the SSL certificates and private keys"""
-
-        for achall in self.achalls:
-            self._setup_challenge_cert(achall)
-
-
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(common.Plugin):
@@ -63,14 +35,9 @@ class Authenticator(common.Plugin):
         'type of challenge. $CERTBOT_DOMAIN will always contain the domain '
         'being authenticated. For HTTP-01 and DNS-01, $CERTBOT_VALIDATION '
         'is the validation string, and $CERTBOT_TOKEN is the filename of the '
-        'resource requested when performing an HTTP-01 challenge. When '
-        'performing a TLS-SNI-01 challenge, $CERTBOT_SNI_DOMAIN will contain '
-        'the SNI name for which the ACME server expects to be presented with '
-        'the self-signed certificate located at $CERTBOT_CERT_PATH. The '
-        'secret key needed to complete the TLS handshake is located at '
-        '$CERTBOT_KEY_PATH. An additional cleanup script can also be '
-        'provided and can use the additional variable $CERTBOT_AUTH_OUTPUT '
-        'which contains the stdout output from the auth script.')
+        'resource requested when performing an HTTP-01 challenge. An additional '
+        'cleanup script can also be provided and can use the additional variable '
+        '$CERTBOT_AUTH_OUTPUT which contains the stdout output from the auth script.')
     _DNS_INSTRUCTIONS = """\
 Please deploy a DNS TXT record under the name
 {domain} with the following value:
@@ -86,14 +53,6 @@ Create a file containing just this data:
 And make it available on your web server at this URL:
 
 {uri}
-"""
-    _TLSSNI_INSTRUCTIONS = """\
-Configure the service listening on port {port} to present the certificate
-{cert}
-using the secret key
-{key}
-when it receives a TLS ClientHello with the SNI extension set to
-{sni_domain}
 """
     _SUBSEQUENT_CHALLENGE_INSTRUCTIONS = """
 (This must be set up in addition to the previous challenges; do not remove,
@@ -112,7 +71,6 @@ permitted by DNS standards.)
         self.reverter.recovery_routine()
         self.env = dict() \
         # type: Dict[achallenges.KeyAuthorizationAnnotatedChallenge, Dict[str, str]]
-        self.tls_sni_01 = None
         self.subsequent_dns_challenge = False
         self.subsequent_any_challenge = False
 
@@ -149,7 +107,7 @@ permitted by DNS standards.)
 
     def get_chall_pref(self, domain):
         # pylint: disable=missing-docstring,no-self-use,unused-argument
-        return [challenges.HTTP01, challenges.DNS01, challenges.TLSSNI01]
+        return [challenges.HTTP01, challenges.DNS01]
 
     def perform(self, achalls):  # pylint: disable=missing-docstring
         self._verify_ip_logging_ok()
@@ -160,12 +118,6 @@ permitted by DNS standards.)
 
         responses = []
         for achall in achalls:
-            if isinstance(achall.chall, challenges.TLSSNI01):
-                # Make a new ManualTlsSni01 instance for each challenge
-                # because the manual plugin deals with one challenge at a time.
-                self.tls_sni_01 = ManualTlsSni01(self)
-                self.tls_sni_01.add_chall(achall)
-                self.tls_sni_01.perform()
             perform_achall(achall)
             responses.append(achall.response(achall.account_key))
         return responses
@@ -191,16 +143,9 @@ permitted by DNS standards.)
             env['CERTBOT_TOKEN'] = achall.chall.encode('token')
         else:
             os.environ.pop('CERTBOT_TOKEN', None)
-        if isinstance(achall.chall, challenges.TLSSNI01):
-            env['CERTBOT_CERT_PATH'] = self.tls_sni_01.get_cert_path(achall)
-            env['CERTBOT_KEY_PATH'] = self.tls_sni_01.get_key_path(achall)
-            env['CERTBOT_SNI_DOMAIN'] = self.tls_sni_01.get_z_domain(achall)
-            os.environ.pop('CERTBOT_VALIDATION', None)
-            env.pop('CERTBOT_VALIDATION')
-        else:
-            os.environ.pop('CERTBOT_CERT_PATH', None)
-            os.environ.pop('CERTBOT_KEY_PATH', None)
-            os.environ.pop('CERTBOT_SNI_DOMAIN', None)
+        os.environ.pop('CERTBOT_CERT_PATH', None)
+        os.environ.pop('CERTBOT_KEY_PATH', None)
+        os.environ.pop('CERTBOT_SNI_DOMAIN', None)
         os.environ.update(env)
         _, out = self._execute_hook('auth-hook')
         env['CERTBOT_AUTH_OUTPUT'] = out.strip()
@@ -213,17 +158,10 @@ permitted by DNS standards.)
                 achall=achall, encoded_token=achall.chall.encode('token'),
                 port=self.config.http01_port,
                 uri=achall.chall.uri(achall.domain), validation=validation)
-        elif isinstance(achall.chall, challenges.DNS01):
+        else:  # Can be only DNS-01
             msg = self._DNS_INSTRUCTIONS.format(
                 domain=achall.validation_domain_name(achall.domain),
                 validation=validation)
-        else:
-            assert isinstance(achall.chall, challenges.TLSSNI01)
-            msg = self._TLSSNI_INSTRUCTIONS.format(
-                cert=self.tls_sni_01.get_cert_path(achall),
-                key=self.tls_sni_01.get_key_path(achall),
-                port=self.config.tls_sni_01_port,
-                sni_domain=self.tls_sni_01.get_z_domain(achall))
         if isinstance(achall.chall, challenges.DNS01):
             if self.subsequent_dns_challenge:
                 # 2nd or later dns-01 challenge

--- a/certbot/plugins/manual_test.py
+++ b/certbot/plugins/manual_test.py
@@ -75,16 +75,13 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             '{0} -c "from __future__ import print_function;'
             'import os;  print(os.environ.get(\'CERTBOT_DOMAIN\'));'
             'print(os.environ.get(\'CERTBOT_TOKEN\', \'notoken\'));'
-            'print(os.environ.get(\'CERTBOT_CERT_PATH\', \'nocert\'));'
-            'print(os.environ.get(\'CERTBOT_KEY_PATH\', \'nokey\'));'
             'print(os.environ.get(\'CERTBOT_VALIDATION\', \'novalidation\'));"'
             .format(sys.executable))
-        dns_expected = '{0}\n{1}\n{2}\n{3}\n{4}'.format(
-            self.dns_achall.domain, 'notoken', 'nocert', 'nokey',
+        dns_expected = '{0}\n{1}\n{2}'.format(
+            self.dns_achall.domain, 'notoken',
             self.dns_achall.validation(self.dns_achall.account_key))
-        http_expected = '{0}\n{1}\n{2}\n{3}\n{4}'.format(
+        http_expected = '{0}\n{1}\n{2}'.format(
             self.http_achall.domain, self.http_achall.chall.encode('token'),
-            'nocert', 'nokey',
             self.http_achall.validation(self.http_achall.account_key))
 
         self.assertEqual(

--- a/certbot/plugins/manual_test.py
+++ b/certbot/plugins/manual_test.py
@@ -22,8 +22,7 @@ class AuthenticatorTest(test_util.TempDirTestCase):
         self.http_achall = acme_util.HTTP01_A
         self.dns_achall = acme_util.DNS01_A
         self.dns_achall_2 = acme_util.DNS01_A_2
-        self.tls_sni_achall = acme_util.TLSSNI01_A
-        self.achalls = [self.http_achall, self.dns_achall, self.tls_sni_achall, self.dns_achall_2]
+        self.achalls = [self.http_achall, self.dns_achall, self.dns_achall_2]
         for d in ["config_dir", "work_dir", "in_progress"]:
             os.mkdir(os.path.join(self.tempdir, d))
             # "backup_dir" and "temp_checkpoint_dir" get created in
@@ -38,8 +37,7 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             backup_dir=os.path.join(self.tempdir, "backup_dir"),
             temp_checkpoint_dir=os.path.join(
                                         self.tempdir, "temp_checkpoint_dir"),
-            in_progress_dir=os.path.join(self.tempdir, "in_progess"),
-            tls_sni_01_port=5001)
+            in_progress_dir=os.path.join(self.tempdir, "in_progess"))
 
         from certbot.plugins.manual import Authenticator
         self.auth = Authenticator(self.config, name='manual')
@@ -58,9 +56,7 @@ class AuthenticatorTest(test_util.TempDirTestCase):
 
     def test_get_chall_pref(self):
         self.assertEqual(self.auth.get_chall_pref('example.org'),
-                         [challenges.HTTP01,
-                          challenges.DNS01,
-                          challenges.TLSSNI01])
+                         [challenges.HTTP01, challenges.DNS01])
 
     @test_util.patch_get_utility()
     def test_ip_logging_not_ok(self, mock_get_utility):
@@ -81,16 +77,14 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             'print(os.environ.get(\'CERTBOT_TOKEN\', \'notoken\'));'
             'print(os.environ.get(\'CERTBOT_CERT_PATH\', \'nocert\'));'
             'print(os.environ.get(\'CERTBOT_KEY_PATH\', \'nokey\'));'
-            'print(os.environ.get(\'CERTBOT_SNI_DOMAIN\', \'nosnidomain\'));'
             'print(os.environ.get(\'CERTBOT_VALIDATION\', \'novalidation\'));"'
             .format(sys.executable))
-        dns_expected = '{0}\n{1}\n{2}\n{3}\n{4}\n{5}'.format(
-            self.dns_achall.domain, 'notoken',
-            'nocert', 'nokey', 'nosnidomain',
+        dns_expected = '{0}\n{1}\n{2}\n{3}\n{4}'.format(
+            self.dns_achall.domain, 'notoken', 'nocert', 'nokey',
             self.dns_achall.validation(self.dns_achall.account_key))
-        http_expected = '{0}\n{1}\n{2}\n{3}\n{4}\n{5}'.format(
+        http_expected = '{0}\n{1}\n{2}\n{3}\n{4}'.format(
             self.http_achall.domain, self.http_achall.chall.encode('token'),
-            'nocert', 'nokey', 'nosnidomain',
+            'nocert', 'nokey',
             self.http_achall.validation(self.http_achall.account_key))
 
         self.assertEqual(
@@ -102,17 +96,6 @@ class AuthenticatorTest(test_util.TempDirTestCase):
         self.assertEqual(
             self.auth.env[self.http_achall]['CERTBOT_AUTH_OUTPUT'],
             http_expected)
-        # tls_sni_01 challenge must be perform()ed above before we can
-        # get the cert_path and key_path.
-        tls_sni_expected = '{0}\n{1}\n{2}\n{3}\n{4}\n{5}'.format(
-            self.tls_sni_achall.domain, 'notoken',
-            self.auth.tls_sni_01.get_cert_path(self.tls_sni_achall),
-            self.auth.tls_sni_01.get_key_path(self.tls_sni_achall),
-            self.auth.tls_sni_01.get_z_domain(self.tls_sni_achall),
-            'novalidation')
-        self.assertEqual(
-            self.auth.env[self.tls_sni_achall]['CERTBOT_AUTH_OUTPUT'],
-            tls_sni_expected)
 
     @test_util.patch_get_utility()
     def test_manual_perform(self, mock_get_utility):
@@ -122,13 +105,8 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             [achall.response(achall.account_key) for achall in self.achalls])
         for i, (args, kwargs) in enumerate(mock_get_utility().notification.call_args_list):
             achall = self.achalls[i]
-            if isinstance(achall.chall, challenges.TLSSNI01):
-                self.assertTrue(
-                        self.auth.tls_sni_01.get_cert_path(
-                            self.tls_sni_achall) in args[0])
-            else:
-                self.assertTrue(
-                        achall.validation(achall.account_key) in args[0])
+            self.assertTrue(
+                achall.validation(achall.account_key) in args[0])
             self.assertFalse(kwargs['wrap'])
 
     @test_util.broken_on_windows
@@ -153,18 +131,6 @@ class AuthenticatorTest(test_util.TempDirTestCase):
                     achall.chall.encode('token'))
             else:
                 self.assertFalse('CERTBOT_TOKEN' in os.environ)
-            if isinstance(achall.chall, challenges.TLSSNI01):
-                self.assertEqual(
-                    os.environ['CERTBOT_CERT_PATH'],
-                    self.auth.tls_sni_01.get_cert_path(achall))
-                self.assertEqual(
-                    os.environ['CERTBOT_KEY_PATH'],
-                    self.auth.tls_sni_01.get_key_path(achall))
-                self.assertFalse(
-                    os.path.exists(os.environ['CERTBOT_CERT_PATH']))
-                self.assertFalse(
-                    os.path.exists(os.environ['CERTBOT_KEY_PATH']))
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is a part of the tls-sni-01 removal plan described in #6849.

It removes the capability to make tls-sni-01 challenges in the manual plugin.