### PR TITLE
Use Python3 to run tools/venv3.py.

### DIFF
--- a/tools/venv3.py
+++ b/tools/venv3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Developer virtualenv setup for Certbot client
 import _venv_common
 


### PR DESCRIPTION
I hit some issues trying to set up a development environment on CentOS 6 for testing.

The first issue I hit is that `/usr/bin/env python` refers to Python 2.6 which is no longer supported by the Python community, Certbot, or these venv creation tools. This means that simply running these scripts directly with specifying the Python interpreter like `python3 tools/venv3.py` results in the error output:
```
Incompatible python version for Certbot found: 2.6.6
Traceback (most recent call last):
  File "tools/venv3.py", line 36, in <module>
    main()
  File "tools/venv3.py", line 31, in main
    venv_args = '--python "{0}"'.format(_venv_common.find_python_executable(3))
  File "/root/certbot/tools/_venv_common.py", line 58, in find_python_executable
    output = subprocess.check_output([one_python, '--version'],
AttributeError: 'module' object has no attribute 'check_output'
```
This simple change makes the `tools/venv3.py` script use `python3` to run itself by default. I think this change is safe to make because if you try to run `tools/venv3.py` without Python 3 installed, the script will fail later anyway.

Every UNIX system I'm aware of (ignoring Windows because these shebang lines don't work on Windows) that offers Python 3 includes an executable named `python3` in the user's path, even if `python` also refers to to Python 3.