### PR TITLE
[Windows|Unix] Reimplement reverter logic to make it cross-platform compatible

### DIFF
--- a/certbot/tests/reverter_test.py
+++ b/certbot/tests/reverter_test.py
@@ -49,7 +49,6 @@ class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
             x = f.read()
         self.assertTrue("No changes" in x)
 
-    @test_util.broken_on_windows
     def test_basic_add_to_temp_checkpoint(self):
         # These shouldn't conflict even though they are both named config.txt
         self.reverter.add_to_temp_checkpoint(self.sets[0], "save1")
@@ -91,7 +90,6 @@ class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
         self.assertRaises(errors.ReverterError, self.reverter.add_to_checkpoint,
                           set([config3]), "invalid save")
 
-    @test_util.broken_on_windows
     def test_multiple_saves_and_temp_revert(self):
         self.reverter.add_to_temp_checkpoint(self.sets[0], "save1")
         update_file(self.config1, "updated-directive")
@@ -121,7 +119,6 @@ class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
         self.assertFalse(os.path.isfile(config3))
         self.assertFalse(os.path.isfile(config4))
 
-    @test_util.broken_on_windows
     def test_multiple_registration_same_file(self):
         self.reverter.register_file_creation(True, self.config1)
         self.reverter.register_file_creation(True, self.config1)
@@ -146,7 +143,6 @@ class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
             errors.ReverterError, self.reverter.register_file_creation,
             "filepath")
 
-    @test_util.broken_on_windows
     def test_register_undo_command(self):
         coms = [
             ["a2dismod", "ssl"],
@@ -169,7 +165,6 @@ class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
                 errors.ReverterError, self.reverter.register_undo_command,
                 True, ["command"])
 
-    @test_util.broken_on_windows
     @mock.patch("certbot.util.run_script")
     def test_run_undo_commands(self, mock_run):
         mock_run.side_effect = ["", errors.SubprocessError]
@@ -233,7 +228,6 @@ class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
             self.assertRaises(
                 errors.ReverterError, self.reverter.revert_temporary_config)
 
-    @test_util.broken_on_windows
     @mock.patch("certbot.reverter.logger.warning")
     def test_recover_checkpoint_missing_new_files(self, mock_warn):
         self.reverter.register_file_creation(
@@ -248,7 +242,6 @@ class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
         self.assertRaises(
             errors.ReverterError, self.reverter.revert_temporary_config)
 
-    @test_util.broken_on_windows
     def test_recovery_routine_temp_and_perm(self):
         # Register a new perm checkpoint file
         config3 = os.path.join(self.dir1, "config3.txt")
@@ -312,7 +305,6 @@ class TestFullCheckpointsReverter(test_util.ConfigTestCase):
         self.assertRaises(
             errors.ReverterError, self.reverter.rollback_checkpoints, "one")
 
-    @test_util.broken_on_windows
     def test_rollback_finalize_checkpoint_valid_inputs(self):
 
         config3 = self._setup_three_checkpoints()
@@ -364,7 +356,6 @@ class TestFullCheckpointsReverter(test_util.ConfigTestCase):
         self.assertRaises(
             errors.ReverterError, self.reverter.finalize_checkpoint, "Title")
 
-    @test_util.broken_on_windows
     @mock.patch("certbot.reverter.logger")
     def test_rollback_too_many(self, mock_logger):
         # Test no exist warning...
@@ -377,7 +368,6 @@ class TestFullCheckpointsReverter(test_util.ConfigTestCase):
         self.reverter.rollback_checkpoints(4)
         self.assertEqual(mock_logger.warning.call_count, 1)
 
-    @test_util.broken_on_windows
     def test_multi_rollback(self):
         config3 = self._setup_three_checkpoints()
         self.reverter.rollback_checkpoints(3)


### PR DESCRIPTION
This PR is a part of the effort to remove the last broken unit tests in certbot codebase for Windows, as described in #6850.

This PR fixes the logic of `certbot.reverter` module to make it runnable on Windows. This critical module is used to revert modifications done by Certbot on a system when something goes wrong during a certificate deployment.

To do so, several piece of informations are stored on the filesystem, and will be used by `certbot.reverter` to know what need to be reverted at any point during a process. In particular, modified files and new files are stored this way. The form of the storage is a file, where each line represents a path:
```
/path/to/affected_file_1
/path/to/affected_file_2
```

Two problems arises on Windows:
* end of lines in Windows are CRLF, while the current logic of `certbot.reverter` expects LF end lines (Linux style)
* on Windows, `certbot.reverter` generates superfluous empty lines when writing, making the revert process failing when the persisted file is loaded, because each line is expected to contain a valid path.

So the format for theses files is a weak formatting, a separation of statements based on LF end of lines. It seems that it is not the first time that this is a problem, because another file (the shell commands issued by certbot), is using a CSV format. However, the `csv` module behavior is not consistent across Python 2.x/3.x, making necessary some specific mitigations in `certbot.reverter` code.

So I am proposing a new solution here, in order to correct `certbot.reverter` for Windows, while taking advantage of a less brittle and platform independant format for relevant files, and making a consistent implementation accross the various files use during a revert process.

The idea is to use the module `json`. Instead of writing/reading new paths lines by lines, or use the `csv` module, `certbot.revert` will write the list of paths using `json.dumps` in the file, and read the list of files using `json.loads` when needed. Here are the advantages:
* the format used in the files is JSON, which is a strong format, in particular not dependant to LF/CRLF end of lines
* `json` module is working consistently accross Python 2.x/3.x without specific code
* no parallel read/write, or writing line by line: files are read as a whole at one point, then written as a whole later

As a consequence, relevant unit tests in `certbot.tests.reverter_test` are reactivated.