### PR TITLE
Fix main logic for windows

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -1348,16 +1348,15 @@ def main(cli_args=sys.argv[1:]):
         compat.raise_for_non_administrative_windows_rights(config.verb)
 
         with log.post_arg_parse_setup(config) as log_error:
-
-            if (log_error
-                    and (not isinstance(log_error, errors.Error) or config.func != plugins_cmd)):
-                # Let plugins_cmd be run as un-privileged user.
+            # Let plugins_cmd be run as un-privileged user (log part)
+            if (log_error and (not isinstance(log_error, errors.Error)
+                               or config.func != plugins_cmd)):
                 raise log_error
 
             try:
                 make_or_verify_needed_dirs(config)
             except errors.Error:
-                # Let plugins_cmd be run as un-privileged user.
+                # Let plugins_cmd be run as un-privileged user (config part)
                 if config.func != plugins_cmd:
                     raise
 

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -64,9 +64,10 @@ class PostArgParseSetupTest(test_util.ConfigTestCase):
     @classmethod
     @contextlib.contextmanager
     def _call(cls, *args, **kwargs):
-        from certbot.log import post_arg_parse_setup
-        with post_arg_parse_setup(*args, **kwargs) as log_error:
-            yield log_error
+        from certbot.log import pre_arg_parse_setup
+        with pre_arg_parse_setup() as post_arg_parse_setup:
+            post_arg_parse_setup(*args, **kwargs)
+            yield
 
     def setUp(self):
         super(PostArgParseSetupTest, self).setUp()

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -100,7 +100,7 @@ class PostArgParseSetupTest(test_util.ConfigTestCase):
                 with mock.patch('certbot.log.sys') as mock_sys:
                     mock_sys.version_info = sys.version_info
                     with self._call(self.config):
-                    
+
                         self.root_logger.removeHandler.assert_called_once_with(
                             self.memory_handler)
                         self.assertTrue(self.root_logger.addHandler.called)

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -599,7 +599,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         args.extend(['--standalone', '-d', 'eg.is'])
         self._cli_missing_flag(args, "register before running")
 
-    #@test_util.broken_on_windows
     @mock.patch('certbot.main._report_new_cert')
     @mock.patch('certbot.main.client.acme_client.Client')
     @mock.patch('certbot.main._determine_account')
@@ -654,7 +653,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             self.assertEqual(call_config.fullchain_path, test_util.temp_join('chain'))
             self.assertEqual(call_config.key_path, test_util.temp_join('privkey'))
 
-    #@test_util.broken_on_windows
     @mock.patch('certbot.main._install_cert')
     @mock.patch('certbot.main.plug_sel.record_chosen_plugins')
     @mock.patch('certbot.main.plug_sel.pick_installer')
@@ -705,7 +703,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue(mock_getcert.called)
         self.assertTrue(mock_inst.called)
 
-    #@test_util.broken_on_windows
     @mock.patch('certbot.main._report_new_cert')
     @mock.patch('certbot.util.exe_exists')
     def test_configurator_selection(self, mock_exe_exists, unused_report):
@@ -745,7 +742,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             self._call(["auth", "--standalone"])
             self.assertEqual(1, mock_certonly.call_count)
 
-    #@test_util.broken_on_windows
     def test_rollback(self):
         _, _, _, client = self._call(['rollback'])
         self.assertEqual(1, client.rollback.call_count)
@@ -773,7 +769,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self._call_no_clientmock(['delete'])
         self.assertEqual(1, mock_cert_manager.call_count)
 
-    #@test_util.broken_on_windows
     def test_plugins(self):
         flags = ['--init', '--prepare', '--authenticators', '--installers']
         for args in itertools.chain(
@@ -1055,7 +1050,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue('fullchain.pem' in cert_msg)
         self.assertTrue('donate' in get_utility().add_message.call_args[0][0])
 
-    #@test_util.broken_on_windows
     @mock.patch('certbot.crypto_util.notAfter')
     def test_certonly_renewal_triggers(self, unused_notafter):
         # --dry-run should force renewal
@@ -1124,7 +1118,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue('No renewals were attempted.' in stdout.getvalue())
         self.assertTrue('The following certs are not due for renewal yet:' in stdout.getvalue())
 
-    #@test_util.broken_on_windows
     def test_quiet_renew(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run"]
@@ -1380,7 +1373,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             self._call(['-c', test_util.vector_path('cli.ini')])
         self.assertTrue(mocked_run.called)
 
-    #@test_util.broken_on_windows
     def test_register(self):
         with mock.patch('certbot.main.client') as mocked_client:
             acc = mock.MagicMock()

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -593,14 +593,13 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             self.assertTrue(message in str(exc))
         self.assertTrue(exc is not None)
 
-    @test_util.broken_on_windows
     def test_noninteractive(self):
         args = ['-n', 'certonly']
         self._cli_missing_flag(args, "specify a plugin")
         args.extend(['--standalone', '-d', 'eg.is'])
         self._cli_missing_flag(args, "register before running")
 
-    @test_util.broken_on_windows
+    #@test_util.broken_on_windows
     @mock.patch('certbot.main._report_new_cert')
     @mock.patch('certbot.main.client.acme_client.Client')
     @mock.patch('certbot.main._determine_account')
@@ -655,7 +654,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             self.assertEqual(call_config.fullchain_path, test_util.temp_join('chain'))
             self.assertEqual(call_config.key_path, test_util.temp_join('privkey'))
 
-    @test_util.broken_on_windows
+    #@test_util.broken_on_windows
     @mock.patch('certbot.main._install_cert')
     @mock.patch('certbot.main.plug_sel.record_chosen_plugins')
     @mock.patch('certbot.main.plug_sel.pick_installer')
@@ -706,7 +705,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue(mock_getcert.called)
         self.assertTrue(mock_inst.called)
 
-    @test_util.broken_on_windows
+    #@test_util.broken_on_windows
     @mock.patch('certbot.main._report_new_cert')
     @mock.patch('certbot.util.exe_exists')
     def test_configurator_selection(self, mock_exe_exists, unused_report):
@@ -746,7 +745,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             self._call(["auth", "--standalone"])
             self.assertEqual(1, mock_certonly.call_count)
 
-    @test_util.broken_on_windows
+    #@test_util.broken_on_windows
     def test_rollback(self):
         _, _, _, client = self._call(['rollback'])
         self.assertEqual(1, client.rollback.call_count)
@@ -774,7 +773,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self._call_no_clientmock(['delete'])
         self.assertEqual(1, mock_cert_manager.call_count)
 
-    @test_util.broken_on_windows
+    #@test_util.broken_on_windows
     def test_plugins(self):
         flags = ['--init', '--prepare', '--authenticators', '--installers']
         for args in itertools.chain(
@@ -1056,7 +1055,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue('fullchain.pem' in cert_msg)
         self.assertTrue('donate' in get_utility().add_message.call_args[0][0])
 
-    @test_util.broken_on_windows
+    #@test_util.broken_on_windows
     @mock.patch('certbot.crypto_util.notAfter')
     def test_certonly_renewal_triggers(self, unused_notafter):
         # --dry-run should force renewal
@@ -1125,7 +1124,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
         self.assertTrue('No renewals were attempted.' in stdout.getvalue())
         self.assertTrue('The following certs are not due for renewal yet:' in stdout.getvalue())
 
-    @test_util.broken_on_windows
+    #@test_util.broken_on_windows
     def test_quiet_renew(self):
         test_util.make_lineage(self.config.config_dir, 'sample-renewal.conf')
         args = ["renew", "--dry-run"]
@@ -1381,7 +1380,7 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
             self._call(['-c', test_util.vector_path('cli.ini')])
         self.assertTrue(mocked_run.called)
 
-    @test_util.broken_on_windows
+    #@test_util.broken_on_windows
     def test_register(self):
         with mock.patch('certbot.main.client') as mocked_client:
             acc = mock.MagicMock()

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -334,10 +334,6 @@ class TempDirTestCase(unittest.TestCase):
         # Certbot, but during tests, atexit will not run registered functions before tearDown is
         # called and instead will run them right before the entire test process exits.
         # It is a problem on Windows, that does not accept to clean resources before closing them.
-        logging.shutdown()
-        # Remove logging handlers that have been closed so they won't be
-        # accidentally used in future tests.
-        logging.getLogger().handlers = []
         util._release_locks()  # pylint: disable=protected-access
 
         def handle_rw_files(_, path, __):


### PR DESCRIPTION
This PR is a part of the effort to remove the last broken unit tests in certbot codebase for Windows, as described in #6850.

This PR proposes a solution to fix the unit tests failing in `certbot.tests.main_test`.

The problem is raised when the `main` method of `certbot.main` is executed not as the entrypoint of the current python process (like when certbot is normally called from the CLI), but multiple times in a particular point of the python process, like it is done during unit tests execution by pytest.

Indeed, the method `main` leaves side-effects after its execution, through `certbot.log`, that are supposed to be cleaned up by the end of the python process, in the assumed design that certbot is called as a main python process, not as a library in another process. Indeed, the `main` function modifies handlers of current logging system, without closing them properly upon exit, and monkeypatch `sys.excepthook` to ensure that a proper formatting is done when some output is written to stderr. In current process, cleaning is made by registering an `atexit` handler, that will be called on the python process finishes.

This is working on Linux even during tests, because it is quite lenient with opened file descriptors, but this is not passing on Windows.

It is the third time that `main` method in `certbot.main` creates problems. First was suprious tests failures on Windows when temporary certbot configs directory are involved, second was for the Letstest execution on the AWS instances.

So I would like to propose a more definitive solution: make `main` cleaning its own context upon exit, allowing both unit tests to call it multiple time without issue on Windows and Linux, and allowing an existing Python process to call it without hidden side affects for the remaining of its execution.

The idea is to use context managers. Context managers are superior to atexit handlers, because they ensure, on the same conditions (current process is not `SIGKILL`ed), to clean a context when leaving it, not when the python process finishes.

So faulty methods in `certbot.log`, `pre_arg_parse_setup` and `post_arg_parse_setup`, becomes context manager, and `main` call them as it (`with` statement), to ensure a proper clean when the function exit. Consequently, existing mitigations in `certbot.tests.util.TempDirTestCase` and `atexit` handlers become useless, and so are removed.

There are two tricky part on which I made a specific effort:
* `post_arg_parse_setup` may fail because of lack of permissions, but can be non-critical if `certbot plugin` is called. This case is handled by yielding from `post_arg_parse_setup` context entering the error reference, if an exception happened, or `None`. Then `main` can decide depending of the command issue to raise the exception, or ignore it.
* specific monkeypatching of `sys.excepthook` are handled, and properly restored upon context exit of `pre_arg_parse_setup` and `post_arg_parse_setup`.