### PR TITLE
Simplify a branch that is not totally covered

### DIFF
--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -93,12 +93,7 @@ class ApacheParser(object):
             # Add new path to parser paths
             new_dir = os.path.dirname(inc_path)
             new_file = os.path.basename(inc_path)
-            if new_dir in self.existing_paths.keys():
-                # Add to existing path
-                self.existing_paths[new_dir].append(new_file)
-            else:
-                # Create a new path
-                self.existing_paths[new_dir] = [new_file]
+            self.existing_paths.setdefault(new_dir, []).append(new_file)
 
     def add_mod(self, mod_name):
         """Shortcut for updating parser modules."""


### PR DESCRIPTION
To fix one of the two uncovered lines in `certbot-apache`, given in #6880. Instead of adding a test to just increase the coverage, this fixes the uncovered line using a `setdefault` on the dict.