### PR TITLE
Raise explicitly an error

### DIFF
--- a/certbot/plugins/standalone.py
+++ b/certbot/plugins/standalone.py
@@ -263,4 +263,4 @@ def _handle_perform_error(error):
         if not should_retry:
             raise errors.PluginError(msg)
     else:
-        raise
+        raise error


### PR DESCRIPTION
_Explicit is better than implicit_

When calling `raise` without an argument, Python will raise the last error occured from the caller `except` block. This makes my PyCharm very sad however. So this PR makes the function handling the error raising explicitly the error received as an argument.
