### PR TITLE
Fix tox environment `le_auto_jessie`

### DIFF
--- a/letsencrypt-auto-source/Dockerfile.jessie
+++ b/letsencrypt-auto-source/Dockerfile.jessie
@@ -7,7 +7,9 @@ FROM debian:jessie
 RUN useradd --create-home --home-dir /home/lea --shell /bin/bash --groups sudo --uid 1000 lea
 
 # Install pip, sudo, and openssl:
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian/ jessie main" > /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
+    apt-get update && \
     apt-get -q -y install python-pip sudo openssl && \
     apt-get clean
 # Use pipstrap to update to a stable and tested version of pip


### PR DESCRIPTION
Currently, `tox -e le_auto_jessie` job fails. It breaks in particular the cron pipeline that test everything each night.

The failure occurs while setting up the Jessie Docker container to run the tests for certbot-auto, when `apt-get update` is invoked, with this error:
```
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found
```

Indeed, if there are `stretch-updates`, `buster-updates` and so on in the repository, there is no `jessie-updates`. I do not know exactly the logic of Debian here, but as `*-updates` folders store stable updates, a distribution moving to LTS support like Jessie has no stable updates anymore. I suppose `jessie-updates have been decommissioned recently, and the official Docker has not been updated yet to use the LTS configuration for repositories.

This PR does that live in the Dockerfile, using official instructions from https://wiki.debian.org/LTS/Using, and fixes this specific job.