### PR TITLE
Revert "Configure jessie repos in LTS mode during Docker build (#6887)"

### DIFF
--- a/letsencrypt-auto-source/Dockerfile.jessie
+++ b/letsencrypt-auto-source/Dockerfile.jessie
@@ -7,9 +7,7 @@ FROM debian:jessie
 RUN useradd --create-home --home-dir /home/lea --shell /bin/bash --groups sudo --uid 1000 lea
 
 # Install pip, sudo, and openssl:
-RUN echo "deb http://deb.debian.org/debian/ jessie main" > /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get -q -y install python-pip sudo openssl && \
     apt-get clean
 # Use pipstrap to update to a stable and tested version of pip


### PR DESCRIPTION
This reverts commit a27bd28b39e5312ef77d5767a989fc4661e179fb since https://github.com/debuerreotype/docker-debian-artifacts/issues/66 has been resolved.

I ran tests locally with this change (after running `docker pull debian:jessie`) and they passed.