### PR TITLE
Fix acme race condition

### DIFF
--- a/acme/acme/standalone_test.py
+++ b/acme/acme/standalone_test.py
@@ -281,6 +281,9 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
         if self.process.is_alive():
             self.process.terminate()
             self.process.join(timeout=5)
+            # Check that we didn't timeout waiting for the process to
+            # terminate.
+            self.assertNotEqual(self.process.exitcode, None)
         shutil.rmtree(self.test_cwd)
 
     @mock.patch('acme.standalone.TLSSNI01Server.handle_request')

--- a/acme/acme/standalone_test.py
+++ b/acme/acme/standalone_test.py
@@ -280,6 +280,7 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
         os.chdir(self.old_cwd)
         if self.process.is_alive():
             self.process.terminate()
+            self.process.join(timeout=5)
         shutil.rmtree(self.test_cwd)
 
     @mock.patch('acme.standalone.TLSSNI01Server.handle_request')


### PR DESCRIPTION
We've started seeing spurious failures in our `acme` unit tests such as https://ci.appveyor.com/project/certbot/certbot/builds/23398251/job/c8o8fmrh3b0g08g0. The error that occurs is `shutil.rmtree` fails because the process is still running.

While the [multiprocessing documentation](https://docs.python.org/3/library/multiprocessing.html) isn't very clear on this, they have an example that implies that `terminate()` does not block on the process actually terminating. The example from their documentation as of writing this is:
```
>>> import multiprocessing, time, signal
>>> p = multiprocessing.Process(target=time.sleep, args=(1000,))
>>> print(p, p.is_alive())
<Process(Process-1, initial)> False
>>> p.start()
>>> print(p, p.is_alive())
<Process(Process-1, started)> True
>>> p.terminate()
>>> time.sleep(0.1)
>>> print(p, p.is_alive())
<Process(Process-1, stopped[SIGTERM])> False
```
Notice their use of `time.sleep()` after calling `p.terminate()` and before calling `p.is_alive()`.

To fix this, I'm adding a call to `join` to block continuing on the process actually terminating.

This shouldn't be an issue, but to avoid the tests hanging forever if something goes horribly wrong, I added a 5 second timeout. Unfortunately, [join](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.join) doesn't give you a way to tell the call timed out or the process has exited, so I added an assertion that the process actually exited before continuing.