### PR TITLE
Correct changelog to mention acme changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only
 package with changes other than its version number was:
 
+* acme
 * certbot
 * certbot-apache
 * certbot-nginx


### PR DESCRIPTION
We forgot to update the changelog when deprecating TLS-SNI-01 code in `acme` which was included in our release today. This fixes up the changelog entry for the last release so at least the information is right going forward.

Maybe it's time we finally automate this step...