### PR TITLE
Fix typo in changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ More details about these changes can be found on our GitHub repo.
 
 * Fedora 29+ is now supported by certbot-auto. Since Python 2.x is on a deprecation
   path in Fedora, certbot-auto will install and use Python 3.x on Fedora 29+.
-* CLI flag `--http-port` has been added for Nginx plugin exclusively, and replaces
+* CLI flag `--https-port` has been added for Nginx plugin exclusively, and replaces
   `--tls-sni-01-port`. It defines the HTTPS port the Nginx plugin will use while
   setting up a new SSL vhost. By default the HTTPS port is 443.
 


### PR DESCRIPTION
Fixes a typo in the changelog pointed out at https://community.letsencrypt.org/t/certbot-0-33-0-release/90298/4 so it's correct going forward.