### PR TITLE
Prepare for the 0.33.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.33.1 - master
+
+### Added
+
+*
+
+### Changed
+
+*
+
+### Fixed
+
+* A bug causing certbot-auto to print warnings or crash on some RHEL based
+  systems has been resolved.
+
+Despite us having broken lockstep, we are continuing to release new versions of
+all Certbot components during releases for the time being, however, the only
+package with changes other than its version number was:
+
+*
+
+More details about these changes can be found on our GitHub repo.
+
 ## 0.33.0 - 2019-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ## 0.33.1 - master
 
-### Added
-
-*
-
-### Changed
-
-*
-
 ### Fixed
 
 * A bug causing certbot-auto to print warnings or crash on some RHEL based
@@ -19,9 +11,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only
-package with changes other than its version number was:
-
-*
+changes in this release were to certbot-auto.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -750,7 +750,10 @@ elif [ -f /etc/redhat-release ]; then
   DeterminePythonVersion "NOCRASH"
   # Starting to Fedora 29, python2 is on a deprecation path. Let's move to python3 then.
   RPM_DIST_NAME=`(. /etc/os-release 2> /dev/null && echo $ID) || echo "unknown"`
-  RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) || echo "0"`
+  RPM_DIST_VERSION=0
+  if [ "$RPM_DIST_NAME" = "fedora" ]; then
+    RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) || echo "0"`
+  fi
   if [ "$RPM_DIST_NAME" = "fedora" -a "$RPM_DIST_VERSION" -ge 29 -o "$PYVER" -eq 26 ]; then
     Bootstrap() {
       BootstrapMessage "RedHat-based OSes that will use Python3"

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -325,7 +325,10 @@ elif [ -f /etc/redhat-release ]; then
   DeterminePythonVersion "NOCRASH"
   # Starting to Fedora 29, python2 is on a deprecation path. Let's move to python3 then.
   RPM_DIST_NAME=`(. /etc/os-release 2> /dev/null && echo $ID) || echo "unknown"`
-  RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) || echo "0"`
+  RPM_DIST_VERSION=0
+  if [ "$RPM_DIST_NAME" = "fedora" ]; then
+    RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) || echo "0"`
+  fi
   if [ "$RPM_DIST_NAME" = "fedora" -a "$RPM_DIST_VERSION" -ge 29 -o "$PYVER" -eq 26 ]; then
     Bootstrap() {
       BootstrapMessage "RedHat-based OSes that will use Python3"


### PR DESCRIPTION
The changelog should still say `<version> - master` because it will be fixed up automatically by the release script at https://github.com/certbot/certbot/blob/master/tools/_release.sh#L69.