### PR TITLE
Don't search for plugins once for each config item

### DIFF
--- a/certbot/storage.py
+++ b/certbot/storage.py
@@ -238,16 +238,17 @@ def _write_live_readme_to(readme_path, is_base_dir=False):
                                     "certificates.\n".format(prefix=prefix))
 
 
-def _relevant(option):
+def _relevant(namespaces, option):
     """
     Is this option one that could be restored for future renewal purposes?
+
+    :param namespaces: plugin namespaces for configuration options
+    :type namespaces: `list` of `str`
     :param str option: the name of the option
 
     :rtype: bool
     """
     from certbot import renewal
-    plugins = plugins_disco.PluginsRegistry.find_all()
-    namespaces = [plugins_common.dest_namespace(plugin) for plugin in plugins]
 
     return (option in renewal.CONFIG_ITEMS or
             any(option.startswith(namespace) for namespace in namespaces))
@@ -262,10 +263,13 @@ def relevant_values(all_values):
     :rtype dict:
 
     """
+    plugins = plugins_disco.PluginsRegistry.find_all()
+    namespaces = [plugins_common.dest_namespace(plugin) for plugin in plugins]
+
     rv = dict(
         (option, value)
         for option, value in six.iteritems(all_values)
-        if _relevant(option) and cli.option_was_set(option, value))
+        if _relevant(namespaces, option) and cli.option_was_set(option, value))
     # We always save the server value to help with forward compatibility
     # and behavioral consistency when versions of Certbot with different
     # server defaults are used.


### PR DESCRIPTION
I came across #5412 during my triage and after jsha reopened the issue, I couldn't stop myself from taking a quick look. Upon looking at code he linked to, I noticed that Certbot is searching for plugins once for every value in Certbot's configuration. This is completely unnecessary and very slow so I moved searching for plugins outside of the loop.

On a small VPS, I timed Certbot's performance obtaining a new cert with standalone before and after this change and was pretty happy with the results.

Before:
```
real 0m26.625s
user 0m22.228s
sys 0m0.144s
```

After:
```
real 0m7.458s
user 0m1.620s
sys 0m0.156s
```