### PR TITLE
Move fixing oldest reqs to avoid merge conflicts.

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -75,8 +75,15 @@ for pkg_dir in $SUBPKGS_NO_CERTBOT certbot-compatibility-test .
 do
   sed -i 's/\.dev0//' "$pkg_dir/setup.py"
   git add "$pkg_dir/setup.py"
-done
 
+  if [ -f "$pkg_dir/local-oldest-requirements.txt" ]; then
+    sed -i "s/-e acme\[dev\]/acme[dev]==$version/" "$pkg_dir/local-oldest-requirements.txt"
+    sed -i "s/-e acme/acme[dev]==$version/" "$pkg_dir/local-oldest-requirements.txt"
+    sed -i "s/-e \.\[dev\]/certbot[dev]==$version/" "$pkg_dir/local-oldest-requirements.txt"
+    sed -i "s/-e \./certbot[dev]==$version/" "$pkg_dir/local-oldest-requirements.txt"
+    git add "$pkg_dir/local-oldest-requirements.txt"
+  fi
+done
 
 SetVersion() {
     ver="$1"
@@ -265,16 +272,6 @@ if [ "$RELEASE_BRANCH" = candidate-"$version" ] ; then
     SetVersion "$nextversion".dev0
     letsencrypt-auto-source/build.py
     git add letsencrypt-auto-source/letsencrypt-auto
-    for pkg_dir in $SUBPKGS_NO_CERTBOT .
-    do
-      if [ -f "$pkg_dir/local-oldest-requirements.txt" ]; then
-        sed -i "s/-e acme\[dev\]/acme[dev]==$version/" "$pkg_dir/local-oldest-requirements.txt"
-        sed -i "s/-e acme/acme[dev]==$version/" "$pkg_dir/local-oldest-requirements.txt"
-        sed -i "s/-e \.\[dev\]/certbot[dev]==$version/" "$pkg_dir/local-oldest-requirements.txt"
-        sed -i "s/-e \./certbot[dev]==$version/" "$pkg_dir/local-oldest-requirements.txt"
-        git add "$pkg_dir/local-oldest-requirements.txt"
-      fi
-    done
     git diff
     git commit -m "Bump version to $nextversion"
 fi


### PR DESCRIPTION
When releasing 0.33.1 and resolving merge conflicts between the candidate-0.33.1 branch and master, I had merge conflicts in the local-oldest-requirements.txt files. This is because the point release branch does not contain modifications to these files that landed in master because it happens later in the release script in the commit bumping version numbers which is not included in the point release branch.

I think having to resolve these merge conflicts is unnecessary and even a slight problem because it means that the "oldest" tests on the point release branch may still be using the latest version of certain components when they actually should be using an older version.

I fixed this by moving this code earlier in the script so the local-oldest-requirements.txt files are updated at the same time as the setup.py files.