### PR TITLE
Fix typo in comment ("upstreqm")

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -534,7 +534,7 @@ BootstrapSuseCommon() {
     # Since Leap 15.0 (and associated Tumbleweed version), python-virtualenv
     # is a source package, and python2-virtualenv must be used instead.
     # Also currently python2-setuptools is not a dependency of python2-virtualenv,
-    # while it should be. Installing it explicitly until upstreqm fix.
+    # while it should be. Installing it explicitly until upstream fix.
     OPENSUSE_VIRTUALENV_PACKAGES="python2-virtualenv python2-setuptools"
   fi
 

--- a/letsencrypt-auto-source/pieces/bootstrappers/suse_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/suse_common.sh
@@ -20,7 +20,7 @@ BootstrapSuseCommon() {
     # Since Leap 15.0 (and associated Tumbleweed version), python-virtualenv
     # is a source package, and python2-virtualenv must be used instead.
     # Also currently python2-setuptools is not a dependency of python2-virtualenv,
-    # while it should be. Installing it explicitly until upstreqm fix.
+    # while it should be. Installing it explicitly until upstream fix.
     OPENSUSE_VIRTUALENV_PACKAGES="python2-virtualenv python2-setuptools"
   fi
 


### PR DESCRIPTION
Spell "upstream" correctly.


Since this is a minor fix, I wasn't sure if a CHANGELOG.md entry was needed, and I also skipped the build.py step (but I did avoid touching the top-level certbot-auto and letsencrypt-auto files, per the instructions).