### PR TITLE
Update the lexicon version used in tests/Docker.

### DIFF
--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -14,7 +14,7 @@ botocore==1.12.36
 cloudflare==1.5.1
 coverage==4.4.2
 decorator==4.1.2
-dns-lexicon==3.0.8
+dns-lexicon==3.2.1
 dnspython==1.15.0
 docutils==0.12
 execnet==1.5.0


### PR DESCRIPTION
This will resolve problems with certbot-dns-dnsimple in Docker.