### PR TITLE
Finalize improvement of Codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,13 +1,14 @@
 coverage:
   status:
     project:
+      default: off
       linux:
         flags: linux
-        target: 98.48
+        target: auto
         threshold: 0.1
         base: auto
       windows:
         flags: windows
-        target: 96.84
+        target: auto
         threshold: 0.1
         base: auto


### PR DESCRIPTION
Following #6934, this PR finalize two things, as explained in #6934:
* disable the default aggregated report
* validate `linux` and `windows` reports against the PR base branch