### PR TITLE
Add reminder to local-oldest-requirements.txt.

### DIFF
--- a/certbot-apache/local-oldest-requirements.txt
+++ b/certbot-apache/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.25.0
 certbot[dev]==0.26.0

--- a/certbot-dns-cloudflare/local-oldest-requirements.txt
+++ b/certbot-dns-cloudflare/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.21.1
 certbot[dev]==0.21.1

--- a/certbot-dns-cloudxns/local-oldest-requirements.txt
+++ b/certbot-dns-cloudxns/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0

--- a/certbot-dns-digitalocean/local-oldest-requirements.txt
+++ b/certbot-dns-digitalocean/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.21.1
 certbot[dev]==0.21.1

--- a/certbot-dns-dnsimple/local-oldest-requirements.txt
+++ b/certbot-dns-dnsimple/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0

--- a/certbot-dns-dnsmadeeasy/local-oldest-requirements.txt
+++ b/certbot-dns-dnsmadeeasy/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0

--- a/certbot-dns-gehirn/local-oldest-requirements.txt
+++ b/certbot-dns-gehirn/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0

--- a/certbot-dns-google/local-oldest-requirements.txt
+++ b/certbot-dns-google/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.21.1
 certbot[dev]==0.21.1

--- a/certbot-dns-linode/local-oldest-requirements.txt
+++ b/certbot-dns-linode/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0

--- a/certbot-dns-luadns/local-oldest-requirements.txt
+++ b/certbot-dns-luadns/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0

--- a/certbot-dns-nsone/local-oldest-requirements.txt
+++ b/certbot-dns-nsone/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0

--- a/certbot-dns-ovh/local-oldest-requirements.txt
+++ b/certbot-dns-ovh/local-oldest-requirements.txt
@@ -1,3 +1,4 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0
 dns-lexicon==2.7.14

--- a/certbot-dns-rfc2136/local-oldest-requirements.txt
+++ b/certbot-dns-rfc2136/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.21.1
 certbot[dev]==0.21.1

--- a/certbot-dns-route53/local-oldest-requirements.txt
+++ b/certbot-dns-route53/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.25.0
 certbot[dev]==0.21.1

--- a/certbot-dns-sakuracloud/local-oldest-requirements.txt
+++ b/certbot-dns-sakuracloud/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==0.31.0

--- a/certbot-nginx/local-oldest-requirements.txt
+++ b/certbot-nginx/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.29.0
 certbot[dev]==0.33.0

--- a/certbot-postfix/local-oldest-requirements.txt
+++ b/certbot-postfix/local-oldest-requirements.txt
@@ -1,2 +1,3 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.25.0
 certbot[dev]==0.23.0

--- a/local-oldest-requirements.txt
+++ b/local-oldest-requirements.txt
@@ -1,1 +1,2 @@
+# Remember to update setup.py to match the package versions below.
 acme[dev]==0.29.0


### PR DESCRIPTION
We've updated the local-oldest-requirements files a couple times now to get "oldest" tests to pass but forgot to update the corresponding setup.py files. This adds a reminder for us to do that.