### PR TITLE
[Unix] Create a framework for certbot integration tests: PART 3a

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/assertions.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/assertions.py
@@ -15,13 +15,14 @@ def assert_hook_execution(probe_path, probe_content):
     assert '{0}{1}'.format(probe_content, os.linesep) in lines
 
 
-def assert_save_renew_hook(config_dir, lineage):
+def assert_saved_renew_hook(config_dir, lineage):
     """
     Assert that the renew hook configuration of a lineage has been saved.
     :param config_dir: location of the certbot configuration
     :param lineage: lineage domain name
     """
-    assert os.path.isfile(os.path.join(config_dir, 'renewal/{0}.conf'.format(lineage)))
+    with open(os.path.join(config_dir, 'renewal', '{0}.conf'.format(lineage))) as file_h:
+        assert 'renew_hook' in file_h.read()
 
 
 def assert_cert_count_for_lineage(config_dir, lineage, count):

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -128,23 +128,6 @@ def test_manual_dns_auth(context):
     assert_save_renew_hook(context.config_dir, certname)
 
 
-def test_invalid_domain_with_dns_challenge(context):
-    """Test certificate issuance failure with DNS-01 challenge."""
-    # Manual dns auth hooks from misc are designed to fail if the domain contains 'fail-*'.
-    certs = ','.join([context.get_domain('dns1'), context.get_domain('fail-dns1')])
-    context.certbot([
-        '-a', 'manual', '-d', certs,
-        '--allow-subset-of-names',
-        '--preferred-challenges', 'dns',
-        '--manual-auth-hook', context.manual_dns_auth_hook,
-        '--manual-cleanup-hook', context.manual_dns_cleanup_hook
-    ])
-
-    output = context.certbot(['certificates'])
-
-    assert context.get_domain('fail-dns1') not in output
-
-
 def test_renew_files_permissions(context):
     """Test proper certificate file permissions upon renewal"""
     certname = context.get_domain('renew')

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -8,7 +8,7 @@ from os.path import join
 import pytest
 from certbot_integration_tests.certbot_tests import context as certbot_context
 from certbot_integration_tests.certbot_tests.assertions import (
-    assert_hook_execution, assert_save_renew_hook, assert_cert_count_for_lineage,
+    assert_hook_execution, assert_saved_renew_hook, assert_cert_count_for_lineage,
     assert_world_permissions, assert_equals_group_owner, assert_equals_permissions,
 )
 from certbot_integration_tests.utils import misc
@@ -87,7 +87,7 @@ def test_http_01(context):
         ])
 
     assert_hook_execution(context.hook_probe, 'deploy')
-    assert_save_renew_hook(context.config_dir, certname)
+    assert_saved_renew_hook(context.config_dir, certname)
 
 
 def test_manual_http_auth(context):
@@ -103,11 +103,12 @@ def test_manual_http_auth(context):
             '--manual-cleanup-hook', scripts[1],
             '--pre-hook', 'echo wtf.pre >> "{0}"'.format(context.hook_probe),
             '--post-hook', 'echo wtf.post >> "{0}"'.format(context.hook_probe),
-            '--deploy-hook', 'echo deploy >> "{0}"'.format(context.hook_probe)
+            '--renew-hook', 'echo renew >> "{0}"'.format(context.hook_probe)
         ])
 
-    assert_hook_execution(context.hook_probe, 'deploy')
-    assert_save_renew_hook(context.config_dir, certname)
+    with pytest.raises(AssertionError):
+        assert_hook_execution(context.hook_probe, 'renew')
+    assert_saved_renew_hook(context.config_dir, certname)
 
 
 def test_manual_dns_auth(context):
@@ -120,12 +121,12 @@ def test_manual_dns_auth(context):
         '--manual-cleanup-hook', context.manual_dns_cleanup_hook,
         '--pre-hook', 'echo wtf.pre >> "{0}"'.format(context.hook_probe),
         '--post-hook', 'echo wtf.post >> "{0}"'.format(context.hook_probe),
-        '--renew-hook', 'echo renew >> "{0}"'.format(context.hook_probe)
+        '--renew-hook', 'echo deploy >> "{0}"'.format(context.hook_probe)
     ])
 
     with pytest.raises(AssertionError):
         assert_hook_execution(context.hook_probe, 'renew')
-    assert_save_renew_hook(context.config_dir, certname)
+    assert_saved_renew_hook(context.config_dir, certname)
 
 
 def test_renew_files_permissions(context):

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -128,6 +128,23 @@ def test_manual_dns_auth(context):
     assert_save_renew_hook(context.config_dir, certname)
 
 
+def test_invalid_domain_with_dns_challenge(context):
+    """Test certificate issuance failure with DNS-01 challenge."""
+    # Manual dns auth hooks from misc are designed to fail if the domain contains 'fail-*'.
+    certs = ','.join([context.get_domain('dns1'), context.get_domain('fail-dns1')])
+    context.certbot([
+        '-a', 'manual', '-d', certs,
+        '--allow-subset-of-names',
+        '--preferred-challenges', 'dns',
+        '--manual-auth-hook', context.manual_dns_auth_hook,
+        '--manual-cleanup-hook', context.manual_dns_cleanup_hook
+    ])
+
+    output = context.certbot(['certificates'])
+
+    assert context.get_domain('fail-dns1') not in output
+
+
 def test_renew_files_permissions(context):
     """Test proper certificate file permissions upon renewal"""
     certname = context.get_domain('renew')

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -121,7 +121,7 @@ def test_manual_dns_auth(context):
         '--manual-cleanup-hook', context.manual_dns_cleanup_hook,
         '--pre-hook', 'echo wtf.pre >> "{0}"'.format(context.hook_probe),
         '--post-hook', 'echo wtf.post >> "{0}"'.format(context.hook_probe),
-        '--renew-hook', 'echo deploy >> "{0}"'.format(context.hook_probe)
+        '--renew-hook', 'echo renew >> "{0}"'.format(context.hook_probe)
     ])
 
     with pytest.raises(AssertionError):


### PR DESCRIPTION
Following #6821, this PR continues to convert certbot integration tests into certbot-ci.

This PR add tests covering on L185-222 in `tests/certbot-boulder-integration.sh`.