### PR TITLE
[Unix] Create a framework for certbot integration tests: PART 3b

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -61,6 +61,38 @@ def test_manual_dns_auth(context):
     assert_save_renew_hook(context.config_dir, certname)
 
 
+def test_certonly(context):
+    """Test the certonly verb on certbot."""
+    context.certbot(['certonly', '--cert-name', 'newname', '-d', context.get_domain('newname')])
+
+
+def test_auth_and_install_with_csr(context):
+    """Test certificate issuance and install using an existing CSR."""
+    certname = context.get_domain('le3')
+    key_path = join(context.workspace, 'key.pem')
+    csr_path = join(context.workspace, 'csr.der')
+
+    misc.generate_csr([certname], key_path, csr_path)
+
+    cert_path = join(context.workspace, 'csr/cert.pem')
+    chain_path = join(context.workspace, 'csr/chain.pem')
+
+    context.certbot([
+        'auth', '--csr', csr_path,
+        '--cert-path', cert_path,
+        '--chain-path', chain_path
+    ])
+
+    print(misc.read_certificate(cert_path))
+    print(misc.read_certificate(chain_path))
+
+    context.certbot([
+        '--domains', certname, 'install',
+        '--cert-path', cert_path,
+        '--key-path', key_path
+    ])
+
+
 def test_renew_files_permissions(context):
     """Test certificate file permissions upon renewal"""
     certname = context.get_domain('renew')

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -74,8 +74,8 @@ def test_auth_and_install_with_csr(context):
 
     misc.generate_csr([certname], key_path, csr_path)
 
-    cert_path = join(context.workspace, 'csr/cert.pem')
-    chain_path = join(context.workspace, 'csr/chain.pem')
+    cert_path = join(context.workspace, 'csr', 'cert.pem')
+    chain_path = join(context.workspace, 'csr', 'chain.pem')
 
     context.certbot([
         'auth', '--csr', csr_path,
@@ -108,7 +108,7 @@ def test_renew_files_permissions(context):
 
     assert_cert_count_for_lineage(context.config_dir, certname, 2)
     assert_world_permissions(
-        join(context.config_dir, 'archive', certname, '/privkey2.pem'), 0)
+        join(context.config_dir, 'archive', certname, 'privkey2.pem'), 0)
     assert_equals_group_owner(
         join(context.config_dir, 'archive', certname, 'privkey1.pem'),
         join(context.config_dir, 'archive', certname, 'privkey2.pem'))

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -244,7 +244,7 @@ def generate_csr(domains, key_path, csr_path, key_type='RSA'):
     req.add_extensions([san_constraint])
 
     req.set_pubkey(key)
-    req.sign(key, b'sha256')
+    req.sign(key, 'sha256')
 
     with open(csr_path, 'wb') as file:
         file.write(crypto.dump_certificate_request(crypto.FILETYPE_ASN1, req))

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -16,6 +16,9 @@ from distutils.version import LooseVersion
 
 import requests
 from OpenSSL import crypto
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
 from six.moves import socketserver, SimpleHTTPServer
 
 
@@ -209,3 +212,52 @@ def get_certbot_version():
     # Typical response is: output = 'certbot 0.31.0.dev0'
     version_str = output.split(' ')[1].strip()
     return LooseVersion(version_str)
+
+
+def generate_csr(domains, key_path, csr_path, key_type='RSA'):
+    """
+    Generate a CSR for the given domains, using the provided private key path.
+    This method uses the script demo to generate CSR that is available in `examples/generate-csr.py`.
+    :param str[] domains: the domain names to include in the CSR
+    :param str key_path: path to the private key
+    :param str csr_path: path to the CSR that will be generated
+    :param str key_type: type of the key (RSA or ECDSA)
+    """
+    san = ','.join(['DNS:{0}'.format(item) for item in domains])
+
+    if key_type == 'RSA':
+        key = crypto.PKey()
+        key.generate_key(crypto.TYPE_RSA, 2048)
+    elif key_type == 'ECDSA':
+        key = ec.generate_private_key(ec.SECP384R1(), default_backend())
+        key = key.private_bytes(encoding=Encoding.PEM, format=PrivateFormat.TraditionalOpenSSL,
+                                encryption_algorithm=NoEncryption())
+        key = crypto.load_privatekey(crypto.FILETYPE_PEM, key)
+    else:
+        raise ValueError('Invalid key type: {0}'.format(key_type))
+
+    with open(key_path, 'wb') as file:
+        file.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
+
+    req = crypto.X509Req()
+    san_constraint = crypto.X509Extension(b'subjectAltName', False, san.encode('utf-8'))
+    req.add_extensions([san_constraint])
+
+    req.set_pubkey(key)
+    req.sign(key, b'sha256')
+
+    with open(csr_path, 'wb') as file:
+        file.write(crypto.dump_certificate_request(crypto.FILETYPE_ASN1, req))
+
+
+def read_certificate(cert_path):
+    """
+    Load the certificate from the provided path, and return a human readable version of it (TEXT mode).
+    :param str cert_path: the path to the certificate
+    :return: the TEXT version of the certificate, as it would be displayed by openssl binary
+    """
+    with open(cert_path, 'r') as file:
+        data = file.read()
+
+    cert = crypto.load_certificate(crypto.FILETYPE_PEM, data.encode('utf-8'))
+    return crypto.dump_certificate(crypto.FILETYPE_TEXT, cert).decode('utf-8')

--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 version = '0.32.0.dev0'
 
 install_requires = [
-    'acme'
+    'acme',
     'coverage',
     'cryptography',
     'pyopenssl',

--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -5,6 +5,7 @@ from setuptools import find_packages
 version = '0.32.0.dev0'
 
 install_requires = [
+    'acme'
     'coverage',
     'cryptography',
     'pyopenssl',


### PR DESCRIPTION
Following #6821, this PR continues to convert certbot integration tests into certbot-ci.

This PR add tests covering on L268-282 in `tests/certbot-boulder-integration.sh`. Previous lines are covered with existing tests, or by #6946.