### PR TITLE
[Unix] Create a framework for certbot integration tests: PART 3c

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -61,8 +61,30 @@ def test_manual_dns_auth(context):
     assert_save_renew_hook(context.config_dir, certname)
 
 
+def test_renew_files_permissions(context):
+    """Test proper certificate file permissions upon renewal"""
+    certname = context.get_domain('renew')
+    context.certbot(['-d', certname])
+
+    assert_cert_count_for_lineage(context.config_dir, certname, 1)
+    assert_world_permissions(
+        join(context.config_dir, 'archive', certname, 'privkey1.pem'), 0)
+
+    context.certbot(['renew'])
+
+    assert_cert_count_for_lineage(context.config_dir, certname, 2)
+    assert_world_permissions(
+        join(context.config_dir, 'archive', certname, 'privkey2.pem'), 0)
+    assert_equals_group_owner(
+        join(context.config_dir, 'archive', certname, 'privkey1.pem'),
+        join(context.config_dir, 'archive', certname, 'privkey2.pem'))
+    assert_equals_permissions(
+        join(context.config_dir, 'archive', certname, 'privkey1.pem'),
+        join(context.config_dir, 'archive', certname, 'privkey2.pem'), 0o074)
+
+
 def test_renew_with_hook_scripts(context):
-    """Test proper certificate renewal with script hooks."""
+    """Test certificate renewal with script hooks."""
     certname = context.get_domain('renew')
     context.certbot(['-d', certname])
 

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -113,7 +113,7 @@ def test_renew_files_propagate_permissions(context):
 
     assert_cert_count_for_lineage(context.config_dir, certname, 2)
     assert_world_permissions(
-        join(context.config_dir, 'archive', certname, 'privkey2.pem'), 0)
+        join(context.config_dir, 'archive', certname, 'privkey2.pem'), 4)
     assert_equals_permissions(
         join(context.config_dir, 'archive', certname, 'privkey1.pem'),
         join(context.config_dir, 'archive', certname, 'privkey2.pem'), 0o074)

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -60,6 +60,10 @@ def test_manual_dns_auth(context):
         assert_hook_execution(context.hook_probe, 'renew')
     assert_save_renew_hook(context.config_dir, certname)
 
+    context.certbot(['renew', '--cert-name', certname, '--authenticator', 'manual'])
+
+    assert_cert_count_for_lineage(context.config_dir, certname, 2)
+
 
 def test_renew_files_permissions(context):
     """Test proper certificate file permissions upon renewal"""

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -183,7 +183,6 @@ def test_renew_ignoring_directory_hooks(context):
 
     assert_cert_count_for_lineage(context.config_dir, certname, 1)
 
-    # Force renew. Assert certificate renewal and hook scripts execution.
     misc.generate_test_file_hooks(context.config_dir, context.hook_probe)
     context.certbot(['renew', '--no-directory-hooks'])
 


### PR DESCRIPTION
Following #6821, this PR continues to convert certbot integration tests into certbot-ci.

This PR add tests covering about renew, on L283-396 in `tests/certbot-boulder-integration.sh` (by including existing `test_renew_files_permissions` and `test_renew_with_hook_scripts`). Previous lines are covered with existing tests, or by #6946 and #6947.