### PR TITLE
[Unix] Create a framework for certbot integration tests: PART 3f

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -130,6 +130,10 @@ def test_manual_dns_auth(context):
         assert_hook_execution(context.hook_probe, 'renew')
     assert_saved_renew_hook(context.config_dir, certname)
 
+    context.certbot(['renew', '--cert-name', certname, '--authenticator', 'manual'])
+
+    assert_cert_count_for_lineage(context.config_dir, certname, 2)
+
 
 def test_certonly(context):
     """Test the certonly verb on certbot."""
@@ -161,10 +165,6 @@ def test_auth_and_install_with_csr(context):
         '--cert-path', cert_path,
         '--key-path', key_path
     ])
-
-    context.certbot(['renew', '--cert-name', certname, '--authenticator', 'manual'])
-
-    assert_cert_count_for_lineage(context.config_dir, certname, 2)
 
 
 def test_renew_files_permissions(context):


### PR DESCRIPTION
Following #6821, this PR continues to convert certbot integration tests into certbot-ci.

This PR add tests covering checks on L448-530 in `tests/certbot-boulder-integration.sh`. Previous lines are covered with existing tests, or by #6946, #6947, #6948, #6949, #6951.