### PR TITLE
Add back used sys import.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import codecs
 import os
 import re
+import sys
 
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand


### PR DESCRIPTION
Fixes #6950. This import is used at https://github.com/certbot/certbot/compare/dont-forget-sys?expand=1#diff-2eeaed663bd0d25b7e608891384b7298L93.