### PR TITLE
Update Fedora AMI

### DIFF
--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -15,13 +15,8 @@ if ! command -v git ; then
         exit 1
     fi
 fi
-# 0.17.0 is the oldest version of letsencrypt-auto that has precompiled
-# cryptography and the tagged commit is in master. 0.16.0 was the first version
-# to use precompiled cryptography, but the release PR was squashed losing the
-# commit. We want to use a precompiled version of cryptography for stability.
-# Previous versions that have to compile against OpenSSL on installation
-# started failing on newer distros with newer versions of OpenSSL.
-INITIAL_VERSION="0.17.0"
+# 0.18.0 is the oldest version of letsencrypt-auto that works on Fedora 26+.
+INITIAL_VERSION="0.18.0"
 git checkout -f "v$INITIAL_VERSION" letsencrypt-auto
 if ! ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | tail -n1 | grep "^certbot $INITIAL_VERSION$" ; then
     echo initial installation appeared to fail

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -49,8 +49,8 @@ targets:
     type: centos
     virt: hvm
     user: ec2-user
-  - ami: ami-518bfb3b
-    name: fedora23
+  - ami: ami-5c69df23
+    name: fedora28
     type: centos
     virt: hvm
     user: fedora


### PR DESCRIPTION
Fixes #6831.

I ran all test farm tests we run as part of the release process and they passed. The AMI ID was taken from https://web.archive.org/web/20180626045008/https://alt.fedoraproject.org/cloud/.