### PR TITLE
Send a POST-as-GET request to query registration in ACME v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   `malformed` error to be received from the ACME server.
 * Linode DNS plugin now supports api keys created from their new panel
   at [cloud.linode.com](https://cloud.linode.com)
+* `acme` module uses now a POST-as-GET request to retrieve the registration
+  from an ACME v2 server
 
 ### Fixed
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -606,7 +606,9 @@ class ClientV2(ClientBase):
         self.net.account = regr  # See certbot/certbot#6258
         # ACME v2 requires to use a POST-as-GET request (POST an empty JWS) here.
         # This is done by passing None instead of an empty UpdateRegistration to _post().
-        self.net.account = self._send_recv_regr(regr, None)
+        response = self._post(regr.uri, None)
+        self.net.account = self._regr_from_response(response, uri=regr.uri,
+                                                    terms_of_service=regr.terms_of_service)
         return self.net.account
 
     def update_registration(self, regr, update=None):

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -603,6 +603,9 @@ class ClientV2(ClientBase):
             Resource.
 
         """
+        self.net.account = regr  # See certbot/certbot#6258
+        # ACME v2 requires to use a POST-as-GET request (POST an empty JWS) here.
+        # This is done by passing None instead of an empty UpdateRegistration to _post().
         self.net.account = self._send_recv_regr(regr, None)
         return self.net.account
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -123,15 +123,6 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         """
         return self.update_registration(regr, update={'status': 'deactivated'})
 
-    def query_registration(self, regr):
-        """Query server about registration.
-
-        :param messages.RegistrationResource: Existing Registration
-            Resource.
-
-        """
-        return self._send_recv_regr(regr, messages.UpdateRegistration())
-
     def _authzr_from_response(self, response, identifier=None, uri=None):
         authzr = messages.AuthorizationResource(
             body=messages.Authorization.from_json(response.json()),
@@ -275,6 +266,15 @@ class Client(ClientBase):
         # "Instance of 'Field' has no key/contact member" bug:
         # pylint: disable=no-member
         return self._regr_from_response(response)
+
+    def query_registration(self, regr):
+        """Query server about registration.
+
+        :param messages.RegistrationResource: Existing Registration
+            Resource.
+
+        """
+        return self._send_recv_regr(regr, messages.UpdateRegistration())
 
     def agree_to_tos(self, regr):
         """Agree to the terms-of-service.
@@ -603,10 +603,8 @@ class ClientV2(ClientBase):
             Resource.
 
         """
-        self.net.account = regr
-        updated_regr = super(ClientV2, self).query_registration(regr)
-        self.net.account = updated_regr
-        return updated_regr
+        self.net.account = self._send_recv_regr(regr, None)
+        return self.net.account
 
     def update_registration(self, regr, update=None):
         """Update registration.


### PR DESCRIPTION
Fixes #6962

This PR modify `query_registration` method in `ClientV2` to use a POST-as-GET request, as specified by the RFC. This allows Pebble, that enforce this behavior, to work correctly with our `acme` module. `Client` (ACME v1) keep the old behavior.

Steps to reproduce the error, and confirm correct behavior in this PR:
```
cd /dev
git clone https://github.com/letsencrypt/pebble.git
cd /dev/pebble
docker-compose up -d
curl --request POST --data '{"ip":"10.30.50.1"}' http://localhost:8055/set-default-ipv4
cd /dev
git clone https://github.com/adferrand/certbot.git --branch post-as-get-query-registration
# Prepare certbot dev venv as usual
# In acme/examples/http01_example, set DIRECTORY_URL to: https://localhost:14000/dir
# In acme/examples/http01_example, set PORT to: 5002
(venv) REQUESTS_CA_BUNDLE=../pebble/test/certs/pebble.minica.pem python acme/examples/http01_example.py
```

Without the PR, pebble will send a `malformed` error when `query_registration` is invoked. With it, the certificate issuance finishes without errors.