### PR TITLE
Print warning when certbot-auto has insecure permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Adding a warning noting that future versions of Certbot will automatically configure the
   webserver so that all requests redirect to secure HTTPS access. You can control this
   behavior and disable this warning with the --redirect and --no-redirect flags.
+* certbot-auto now prints warnings when run as root with insecure file system
+  permissions. If you see these messages, you should fix the problem by
+  following the instructions at
+  https://community.letsencrypt.org/t/certbot-auto-deployment-best-practices/91979/,
+  however, these warnings can be disabled as necessary with the flag
+  --no-permissions-check.
 
 ### Fixed
 

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1090,6 +1090,11 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
              " installing OS-level dependencies (default: Prompt to install "
              " OS-wide dependencies, but exit if the user says 'No')")
     helpful.add(
+        "automation", "--no-permissions-check", action="store_true",
+        default=flag_default("no_permissions_check"),
+        help="(certbot-auto only) skip the check on the file system"
+             " permissions of the certbot-auto script")
+    helpful.add(
         ["automation", "renew", "certonly", "run"],
         "-q", "--quiet", dest="quiet", action="store_true",
         default=flag_default("quiet"),

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -46,6 +46,7 @@ CLI_DEFAULTS = dict(
     duplicate=False,
     os_packages_only=False,
     no_self_upgrade=False,
+    no_permissions_check=False,
     no_bootstrap=False,
     quiet=False,
     staging=False,

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -453,6 +453,10 @@ class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
             for topic in ['all', 'plugins', 'dns-route53']:
                 self.assertFalse('certbot-route53:auth' in self._help_output([help_flag, topic]))
 
+    def test_no_permissions_check_accepted(self):
+        namespace = self.parse(["--no-permissions-check"])
+        self.assertTrue(namespace.no_permissions_check)
+
 
 class DefaultTest(unittest.TestCase):
     """Tests for certbot.cli._Default."""

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1514,11 +1514,11 @@ argument.  It then checks that the file can only be modified by uid/gid
 < 1000 and if other users can modify the file, it prints a warning with
 a suggestion on how to solve the problem.
 
-If the absolute path of certbot-auto contains a symlink, it is not
-handled specially and the symlink is followed. Due to this, there could
-be permissions problems unreported by this script, however, issues like
-this were not caused by our documentation and are ignored for the sake
-of simplicity.
+Permissions on symlinks in the absolute path of certbot-auto are ignored
+and only the canonical path to certbot-auto is checked. There could be
+permissions problems due to the symlinks that are unreported by this
+script, however, issues like this were not caused by our documentation
+and are ignored for the sake of simplicity.
 
 All warnings are printed to stdout rather than stderr so all stderr
 output from this script can be suppressed to avoid printing messages if
@@ -1560,6 +1560,7 @@ def has_safe_permissions(path):
     :rtype: bool
 
     """
+    # os.stat follows symlinks before obtaining information about a file.
     stat_result = os.stat(path)
     if stat_result.st_mode & stat.S_IWOTH:
         return False
@@ -1571,7 +1572,7 @@ def has_safe_permissions(path):
 
 
 def main(certbot_auto_path):
-    current_path = os.path.abspath(certbot_auto_path)
+    current_path = os.path.realpath(certbot_auto_path)
     last_path = None
     permissions_ok = True
     # This loop makes use of the fact that os.path.dirname('/') == '/'.

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -45,6 +45,7 @@ Help for certbot itself cannot be provided until it is installed.
   -h, --help                                print this help
   -n, --non-interactive, --noninteractive   run without asking for user input
   --no-bootstrap                            do not install OS dependencies
+  --no-permissions-check                    do not warn about file system permissions
   --no-self-upgrade                         do not download updates
   --os-packages-only                        install OS dependencies and exit
   --install-only                            install certbot, upgrade if needed, and exit
@@ -67,6 +68,8 @@ for arg in "$@" ; do
       # Do not upgrade this script (also prevents client upgrades, because each
       # copy of the script pins a hash of the python client)
       NO_SELF_UPGRADE=1;;
+    --no-permissions-check)
+      NO_PERMISSIONS_CHECK=1;;
     --no-bootstrap)
       NO_BOOTSTRAP=1;;
     --help)
@@ -173,7 +176,9 @@ SetRootAuthMechanism() {
         SUDO="sudo -E"
         ;;
       '')
-        SKIPPED_ROOT_AUTH=1
+        # If we're not running with root, don't check that this script can only
+        # be modified by system users and groups.
+        NO_PERMISSIONS_CHECK=1
         ;;
       *)
         error "Error: unknown root authorization mechanism '$LE_AUTO_SUDO'."
@@ -1497,9 +1502,9 @@ else
   fi
 
   DeterminePythonVersion "NOCRASH"
-  # If we can't find an up-to-date Python or the user disabled root
-  # authorization, don't warn about file permissions.
-  if [ "$PYVER" -ge "$MIN_PYVER" -a "$SKIPPED_ROOT_AUTH" != 1 ]; then
+  # Don't warn about file permissions if the user disabled the check or we
+  # can't find an up-to-date Python.
+  if [ "$PYVER" -ge "$MIN_PYVER" -a "$NO_PERMISSIONS_CHECK" != 1 ]; then
     # ---------------------------------------------------------------------------
     cat << "UNLIKELY_EOF" > "$TEMP_DIR/check_permissions.py"
 """Verifies certbot-auto cannot be modified by unprivileged users.

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1505,9 +1505,9 @@ else
 """Verifies certbot-auto cannot be modified by unprivileged users.
 
 This script takes the path to certbot-auto as its only command line
-argument. It then checks that the file can only be modified by uid/gid 0
-and if other users can modify the file, it prints a warning with a
-suggestion on how to solve the problem.
+argument.  It then checks that the file can only be modified by uid/gid
+< 1000 and if other users can modify the file, it prints a warning with
+a suggestion on how to solve the problem.
 
 If the absolute path of certbot-auto contains a symlink, it is not
 handled specially and the symlink is followed. Due to this, there could
@@ -1534,7 +1534,21 @@ def has_safe_permissions(path):
     """Returns True if the given path has secure permissions.
 
     The permissions are considered safe if the file is only writable by
-    uid/gid 0.
+    uid/gid < 1000.
+
+    The reason we allow more IDs than 0 is because on some systems such
+    as Debian, system users/groups other than uid/gid 0 are used for the
+    path we recommend in our forum post which is /usr/local/bin.  1000
+    was chosen because on Debian 0-999 is reserved for system IDs[1] and
+    on RHEL 0-500 is reserved[2]. Debian recommends normal uids start at
+    uid 1000 and RHEL recommends uid 5000 to allow them to increase the
+    range used for system IDs in the future. It's possible that the
+    threshold of 1000 is too high, however, this seems unlikely and
+    avoids printing warnings when we're not confident there is a
+    problem.
+
+    [1] https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes
+    [2] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-managing_users_and_groups
 
     :param str path: filesystem path to check
     :returns: True if the path has secure permissions, otherwise, False
@@ -1544,9 +1558,9 @@ def has_safe_permissions(path):
     stat_result = os.stat(path)
     if stat_result.st_mode & stat.S_IWOTH:
         return False
-    if stat_result.st_mode & stat.S_IWGRP and stat_result.st_gid != 0:
+    if stat_result.st_mode & stat.S_IWGRP and stat_result.st_gid >= 1000:
         return False
-    if stat_result.st_mode & stat.S_IWUSR and stat_result.st_uid != 0:
+    if stat_result.st_mode & stat.S_IWUSR and stat_result.st_uid >= 1000:
         return False
     return True
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -172,7 +172,9 @@ SetRootAuthMechanism() {
       sudo)
         SUDO="sudo -E"
         ;;
-      '') ;; # Nothing to do for plain root method.
+      '')
+        SKIPPED_ROOT_AUTH=1
+        ;;
       *)
         error "Error: unknown root authorization mechanism '$LE_AUTO_SUDO'."
         exit 1
@@ -1494,6 +1496,93 @@ else
     exit 0
   fi
 
+  DeterminePythonVersion "NOCRASH"
+  # If we can't find an up-to-date Python or the user disabled root
+  # authorization, don't warn about file permissions.
+  if [ "$PYVER" -ge "$MIN_PYVER" -a "$SKIPPED_ROOT_AUTH" != 1 ]; then
+    # ---------------------------------------------------------------------------
+    cat << "UNLIKELY_EOF" > "$TEMP_DIR/check_permissions.py"
+"""Verifies certbot-auto cannot be modified by unprivileged users.
+
+This script takes the path to certbot-auto as its only command line
+argument. It then checks that the file can only be modified by uid/gid 0
+and if other users can modify the file, it prints a warning with a
+suggestion on how to solve the problem.
+
+If the absolute path of certbot-auto contains a symlink, it is not
+handled specially and the symlink is followed. Due to this, there could
+be permissions problems unreported by this script, however, issues like
+this were not caused by our documentation and are ignored for the sake
+of simplicity.
+
+All warnings are printed to stdout rather than stderr so all stderr
+output from this script can be suppressed to avoid printing messages if
+this script fails for some reason.
+
+"""
+from __future__ import print_function
+
+import os
+import stat
+import sys
+
+
+FORUM_POST_URL = 'https://community.letsencrypt.org/t/certbot-auto-deployment-best-practices/91979/'
+
+
+def has_safe_permissions(path):
+    """Returns True if the given path has secure permissions.
+
+    The permissions are considered safe if the file is only writable by
+    uid/gid 0.
+
+    :param str path: filesystem path to check
+    :returns: True if the path has secure permissions, otherwise, False
+    :rtype: bool
+
+    """
+    stat_result = os.stat(path)
+    if stat_result.st_mode & stat.S_IWOTH:
+        return False
+    if stat_result.st_mode & stat.S_IWGRP and stat_result.st_gid != 0:
+        return False
+    if stat_result.st_mode & stat.S_IWUSR and stat_result.st_uid != 0:
+        return False
+    return True
+
+
+def main(certbot_auto_path):
+    current_path = os.path.abspath(certbot_auto_path)
+    last_path = None
+    permissions_ok = True
+    # This loop makes use of the fact that os.path.dirname('/') == '/'.
+    while current_path != last_path and permissions_ok:
+        permissions_ok = has_safe_permissions(current_path)
+        last_path = current_path
+        current_path = os.path.dirname(current_path)
+
+    if not permissions_ok:
+        print('{0} has insecure permissions!'.format(certbot_auto_path))
+        print('To learn how to fix them, visit {0}'.format(FORUM_POST_URL))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])
+
+UNLIKELY_EOF
+    # ---------------------------------------------------------------------------
+    # If the script fails for some reason, don't break certbot-auto.
+    set +e
+    # Suppress unexpected error output and only print the script's output if it
+    # ran successfully.
+    CHECK_PERM_OUT=$("$LE_PYTHON" "$TEMP_DIR/check_permissions.py" "$0" 2>/dev/null)
+    CHECK_PERM_STATUS="$?"
+    set -e
+    if [ "$CHECK_PERM_STATUS" = 0 ]; then
+      error "$CHECK_PERM_OUT"
+    fi
+  fi
+
   if [ "$NO_SELF_UPGRADE" != 1 ]; then
     TEMP_DIR=$(TempDir)
     trap 'rm -rf "$TEMP_DIR"' EXIT
@@ -1650,7 +1739,6 @@ if __name__ == '__main__':
 
 UNLIKELY_EOF
     # ---------------------------------------------------------------------------
-    DeterminePythonVersion "NOCRASH"
     if [ "$PYVER" -lt "$MIN_PYVER" ]; then
       error "WARNING: couldn't find Python $MIN_PYTHON_VERSION+ to check for updates."
     elif ! REMOTE_VERSION=`"$LE_PYTHON" "$TEMP_DIR/fetch.py" --latest-version` ; then

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1543,17 +1543,17 @@ def has_safe_permissions(path):
 
     The reason we allow more IDs than 0 is because on some systems such
     as Debian, system users/groups other than uid/gid 0 are used for the
-    path we recommend in our forum post which is /usr/local/bin.  1000
+    path we recommend in our instructions which is /usr/local/bin.  1000
     was chosen because on Debian 0-999 is reserved for system IDs[1] and
-    on RHEL 0-500 is reserved[2]. Debian recommends normal uids start at
-    uid 1000 and RHEL recommends uid 5000 to allow them to increase the
-    range used for system IDs in the future. It's possible that the
-    threshold of 1000 is too high, however, this seems unlikely and
-    avoids printing warnings when we're not confident there is a
-    problem.
+    on RHEL either 0-499 or 0-999 is reserved depending on the
+    version[2][3]. Due to these differences across different OSes, this
+    detection isn't perfect so we only determine permissions are
+    insecure when we can be reasonably confident there is a problem
+    regardless of the underlying OS.
 
     [1] https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes
-    [2] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-managing_users_and_groups
+    [2] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/ch-managing_users_and_groups
+    [3] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-managing_users_and_groups
 
     :param str path: filesystem path to check
     :returns: True if the path has secure permissions, otherwise, False

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -45,6 +45,7 @@ Help for certbot itself cannot be provided until it is installed.
   -h, --help                                print this help
   -n, --non-interactive, --noninteractive   run without asking for user input
   --no-bootstrap                            do not install OS dependencies
+  --no-permissions-check                    do not warn about file system permissions
   --no-self-upgrade                         do not download updates
   --os-packages-only                        install OS dependencies and exit
   --install-only                            install certbot, upgrade if needed, and exit
@@ -67,6 +68,8 @@ for arg in "$@" ; do
       # Do not upgrade this script (also prevents client upgrades, because each
       # copy of the script pins a hash of the python client)
       NO_SELF_UPGRADE=1;;
+    --no-permissions-check)
+      NO_PERMISSIONS_CHECK=1;;
     --no-bootstrap)
       NO_BOOTSTRAP=1;;
     --help)
@@ -173,7 +176,9 @@ SetRootAuthMechanism() {
         SUDO="sudo -E"
         ;;
       '')
-        SKIPPED_ROOT_AUTH=1
+        # If we're not running with root, don't check that this script can only
+        # be modified by system users and groups.
+        NO_PERMISSIONS_CHECK=1
         ;;
       *)
         error "Error: unknown root authorization mechanism '$LE_AUTO_SUDO'."
@@ -655,9 +660,9 @@ else
   fi
 
   DeterminePythonVersion "NOCRASH"
-  # If we can't find an up-to-date Python or the user disabled root
-  # authorization, don't warn about file permissions.
-  if [ "$PYVER" -ge "$MIN_PYVER" -a "$SKIPPED_ROOT_AUTH" != 1 ]; then
+  # Don't warn about file permissions if the user disabled the check or we
+  # can't find an up-to-date Python.
+  if [ "$PYVER" -ge "$MIN_PYVER" -a "$NO_PERMISSIONS_CHECK" != 1 ]; then
     # ---------------------------------------------------------------------------
     cat << "UNLIKELY_EOF" > "$TEMP_DIR/check_permissions.py"
 {{ check_permissions.py }}

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -172,7 +172,9 @@ SetRootAuthMechanism() {
       sudo)
         SUDO="sudo -E"
         ;;
-      '') ;; # Nothing to do for plain root method.
+      '')
+        SKIPPED_ROOT_AUTH=1
+        ;;
       *)
         error "Error: unknown root authorization mechanism '$LE_AUTO_SUDO'."
         exit 1
@@ -652,6 +654,27 @@ else
     exit 0
   fi
 
+  DeterminePythonVersion "NOCRASH"
+  # If we can't find an up-to-date Python or the user disabled root
+  # authorization, don't warn about file permissions.
+  if [ "$PYVER" -ge "$MIN_PYVER" -a "$SKIPPED_ROOT_AUTH" != 1 ]; then
+    # ---------------------------------------------------------------------------
+    cat << "UNLIKELY_EOF" > "$TEMP_DIR/check_permissions.py"
+{{ check_permissions.py }}
+UNLIKELY_EOF
+    # ---------------------------------------------------------------------------
+    # If the script fails for some reason, don't break certbot-auto.
+    set +e
+    # Suppress unexpected error output and only print the script's output if it
+    # ran successfully.
+    CHECK_PERM_OUT=$("$LE_PYTHON" "$TEMP_DIR/check_permissions.py" "$0" 2>/dev/null)
+    CHECK_PERM_STATUS="$?"
+    set -e
+    if [ "$CHECK_PERM_STATUS" = 0 ]; then
+      error "$CHECK_PERM_OUT"
+    fi
+  fi
+
   if [ "$NO_SELF_UPGRADE" != 1 ]; then
     TEMP_DIR=$(TempDir)
     trap 'rm -rf "$TEMP_DIR"' EXIT
@@ -660,7 +683,6 @@ else
 {{ fetch.py }}
 UNLIKELY_EOF
     # ---------------------------------------------------------------------------
-    DeterminePythonVersion "NOCRASH"
     if [ "$PYVER" -lt "$MIN_PYVER" ]; then
       error "WARNING: couldn't find Python $MIN_PYTHON_VERSION+ to check for updates."
     elif ! REMOTE_VERSION=`"$LE_PYTHON" "$TEMP_DIR/fetch.py" --latest-version` ; then

--- a/letsencrypt-auto-source/pieces/check_permissions.py
+++ b/letsencrypt-auto-source/pieces/check_permissions.py
@@ -1,9 +1,9 @@
 """Verifies certbot-auto cannot be modified by unprivileged users.
 
 This script takes the path to certbot-auto as its only command line
-argument. It then checks that the file can only be modified by uid/gid 0
-and if other users can modify the file, it prints a warning with a
-suggestion on how to solve the problem.
+argument.  It then checks that the file can only be modified by uid/gid
+< 1000 and if other users can modify the file, it prints a warning with
+a suggestion on how to solve the problem.
 
 If the absolute path of certbot-auto contains a symlink, it is not
 handled specially and the symlink is followed. Due to this, there could
@@ -30,7 +30,21 @@ def has_safe_permissions(path):
     """Returns True if the given path has secure permissions.
 
     The permissions are considered safe if the file is only writable by
-    uid/gid 0.
+    uid/gid < 1000.
+
+    The reason we allow more IDs than 0 is because on some systems such
+    as Debian, system users/groups other than uid/gid 0 are used for the
+    path we recommend in our forum post which is /usr/local/bin.  1000
+    was chosen because on Debian 0-999 is reserved for system IDs[1] and
+    on RHEL 0-500 is reserved[2]. Debian recommends normal uids start at
+    uid 1000 and RHEL recommends uid 5000 to allow them to increase the
+    range used for system IDs in the future. It's possible that the
+    threshold of 1000 is too high, however, this seems unlikely and
+    avoids printing warnings when we're not confident there is a
+    problem.
+
+    [1] https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes
+    [2] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-managing_users_and_groups
 
     :param str path: filesystem path to check
     :returns: True if the path has secure permissions, otherwise, False
@@ -40,9 +54,9 @@ def has_safe_permissions(path):
     stat_result = os.stat(path)
     if stat_result.st_mode & stat.S_IWOTH:
         return False
-    if stat_result.st_mode & stat.S_IWGRP and stat_result.st_gid != 0:
+    if stat_result.st_mode & stat.S_IWGRP and stat_result.st_gid >= 1000:
         return False
-    if stat_result.st_mode & stat.S_IWUSR and stat_result.st_uid != 0:
+    if stat_result.st_mode & stat.S_IWUSR and stat_result.st_uid >= 1000:
         return False
     return True
 

--- a/letsencrypt-auto-source/pieces/check_permissions.py
+++ b/letsencrypt-auto-source/pieces/check_permissions.py
@@ -5,11 +5,11 @@ argument.  It then checks that the file can only be modified by uid/gid
 < 1000 and if other users can modify the file, it prints a warning with
 a suggestion on how to solve the problem.
 
-If the absolute path of certbot-auto contains a symlink, it is not
-handled specially and the symlink is followed. Due to this, there could
-be permissions problems unreported by this script, however, issues like
-this were not caused by our documentation and are ignored for the sake
-of simplicity.
+Permissions on symlinks in the absolute path of certbot-auto are ignored
+and only the canonical path to certbot-auto is checked. There could be
+permissions problems due to the symlinks that are unreported by this
+script, however, issues like this were not caused by our documentation
+and are ignored for the sake of simplicity.
 
 All warnings are printed to stdout rather than stderr so all stderr
 output from this script can be suppressed to avoid printing messages if
@@ -51,6 +51,7 @@ def has_safe_permissions(path):
     :rtype: bool
 
     """
+    # os.stat follows symlinks before obtaining information about a file.
     stat_result = os.stat(path)
     if stat_result.st_mode & stat.S_IWOTH:
         return False
@@ -62,7 +63,7 @@ def has_safe_permissions(path):
 
 
 def main(certbot_auto_path):
-    current_path = os.path.abspath(certbot_auto_path)
+    current_path = os.path.realpath(certbot_auto_path)
     last_path = None
     permissions_ok = True
     # This loop makes use of the fact that os.path.dirname('/') == '/'.

--- a/letsencrypt-auto-source/pieces/check_permissions.py
+++ b/letsencrypt-auto-source/pieces/check_permissions.py
@@ -34,17 +34,17 @@ def has_safe_permissions(path):
 
     The reason we allow more IDs than 0 is because on some systems such
     as Debian, system users/groups other than uid/gid 0 are used for the
-    path we recommend in our forum post which is /usr/local/bin.  1000
+    path we recommend in our instructions which is /usr/local/bin.  1000
     was chosen because on Debian 0-999 is reserved for system IDs[1] and
-    on RHEL 0-500 is reserved[2]. Debian recommends normal uids start at
-    uid 1000 and RHEL recommends uid 5000 to allow them to increase the
-    range used for system IDs in the future. It's possible that the
-    threshold of 1000 is too high, however, this seems unlikely and
-    avoids printing warnings when we're not confident there is a
-    problem.
+    on RHEL either 0-499 or 0-999 is reserved depending on the
+    version[2][3]. Due to these differences across different OSes, this
+    detection isn't perfect so we only determine permissions are
+    insecure when we can be reasonably confident there is a problem
+    regardless of the underlying OS.
 
     [1] https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes
-    [2] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-managing_users_and_groups
+    [2] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/ch-managing_users_and_groups
+    [3] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-managing_users_and_groups
 
     :param str path: filesystem path to check
     :returns: True if the path has secure permissions, otherwise, False

--- a/letsencrypt-auto-source/pieces/check_permissions.py
+++ b/letsencrypt-auto-source/pieces/check_permissions.py
@@ -1,0 +1,66 @@
+"""Verifies certbot-auto cannot be modified by unprivileged users.
+
+This script takes the path to certbot-auto as its only command line
+argument. It then checks that the file can only be modified by uid/gid 0
+and if other users can modify the file, it prints a warning with a
+suggestion on how to solve the problem.
+
+If the absolute path of certbot-auto contains a symlink, it is not
+handled specially and the symlink is followed. Due to this, there could
+be permissions problems unreported by this script, however, issues like
+this were not caused by our documentation and are ignored for the sake
+of simplicity.
+
+All warnings are printed to stdout rather than stderr so all stderr
+output from this script can be suppressed to avoid printing messages if
+this script fails for some reason.
+
+"""
+from __future__ import print_function
+
+import os
+import stat
+import sys
+
+
+FORUM_POST_URL = 'https://community.letsencrypt.org/t/certbot-auto-deployment-best-practices/91979/'
+
+
+def has_safe_permissions(path):
+    """Returns True if the given path has secure permissions.
+
+    The permissions are considered safe if the file is only writable by
+    uid/gid 0.
+
+    :param str path: filesystem path to check
+    :returns: True if the path has secure permissions, otherwise, False
+    :rtype: bool
+
+    """
+    stat_result = os.stat(path)
+    if stat_result.st_mode & stat.S_IWOTH:
+        return False
+    if stat_result.st_mode & stat.S_IWGRP and stat_result.st_gid != 0:
+        return False
+    if stat_result.st_mode & stat.S_IWUSR and stat_result.st_uid != 0:
+        return False
+    return True
+
+
+def main(certbot_auto_path):
+    current_path = os.path.abspath(certbot_auto_path)
+    last_path = None
+    permissions_ok = True
+    # This loop makes use of the fact that os.path.dirname('/') == '/'.
+    while current_path != last_path and permissions_ok:
+        permissions_ok = has_safe_permissions(current_path)
+        last_path = current_path
+        current_path = os.path.dirname(current_path)
+
+    if not permissions_ok:
+        print('{0} has insecure permissions!'.format(certbot_auto_path))
+        print('To learn how to fix them, visit {0}'.format(FORUM_POST_URL))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/letsencrypt-auto-source/tests/auto_test.py
+++ b/letsencrypt-auto-source/tests/auto_test.py
@@ -455,13 +455,13 @@ class AutoTests(TestCase):
         self.assertTrue('insecure permissions' in out)
 
         # Test group permissions
-        if stat_result.st_gid != 0:
+        if stat_result.st_gid >= 1000:
             chmod(path, original_mode | S_IWGRP)
             out, _ = run_le_auto_func()
             self.assertTrue('insecure permissions' in out)
 
         # Test owner permissions
-        if stat_result.st_uid != 0:
+        if stat_result.st_uid >= 1000:
             chmod(path, original_mode | S_IWUSR)
             out, _ = run_le_auto_func()
             self.assertTrue('insecure permissions' in out)

--- a/letsencrypt-auto-source/tests/auto_test.py
+++ b/letsencrypt-auto-source/tests/auto_test.py
@@ -192,7 +192,7 @@ def install_le_auto(contents, install_path):
     chmod(install_path, S_IRUSR | S_IXUSR)
 
 
-def run_le_auto(le_auto_path, venv_dir, base_url=None, le_auto_args_str=None, **kwargs):
+def run_le_auto(le_auto_path, venv_dir, base_url=None, le_auto_args_str='--version', **kwargs):
     """Run the prebuilt version of letsencrypt-auto, returning stdout and
     stderr strings.
 
@@ -223,8 +223,6 @@ iQIDAQAB
 
     env.update(d)
 
-    if le_auto_args_str is None:
-        le_auto_args_str = '--version'
     return out_and_err(
         le_auto_path + ' ' + le_auto_args_str,
         shell=True,

--- a/letsencrypt-auto-source/tests/auto_test.py
+++ b/letsencrypt-auto-source/tests/auto_test.py
@@ -409,7 +409,7 @@ class AutoTests(TestCase):
     def test_permissions_warnings(self):
         """Make sure letsencrypt-auto properly warns about permissions problems."""
         # This test assumes that only the parent of the directory containing
-        # letesncrypt-auto (usually /tmp) may have permissions letsencrypt-auto
+        # letsencrypt-auto (usually /tmp) may have permissions letsencrypt-auto
         # considers insecure.
         with temp_paths() as (le_auto_path, venv_dir):
             le_auto_path = abspath(le_auto_path)

--- a/letsencrypt-auto-source/tests/auto_test.py
+++ b/letsencrypt-auto-source/tests/auto_test.py
@@ -4,13 +4,13 @@ from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 from contextlib import contextmanager
 from functools import partial
 from json import dumps
-from os import chmod, environ, makedirs
+from os import chmod, environ, makedirs, stat
 from os.path import abspath, dirname, exists, join
 import re
 from shutil import copy, rmtree
 import socket
 import ssl
-from stat import S_IRUSR, S_IXUSR
+from stat import S_IMODE, S_IRUSR, S_IWUSR, S_IXUSR, S_IWGRP, S_IWOTH
 from subprocess import CalledProcessError, Popen, PIPE
 import sys
 from tempfile import mkdtemp
@@ -192,7 +192,7 @@ def install_le_auto(contents, install_path):
     chmod(install_path, S_IRUSR | S_IXUSR)
 
 
-def run_le_auto(le_auto_path, venv_dir, base_url, **kwargs):
+def run_le_auto(le_auto_path, venv_dir, base_url=None, le_auto_args_str=None, **kwargs):
     """Run the prebuilt version of letsencrypt-auto, returning stdout and
     stderr strings.
 
@@ -201,13 +201,17 @@ def run_le_auto(le_auto_path, venv_dir, base_url, **kwargs):
     """
     env = environ.copy()
     d = dict(VENV_PATH=venv_dir,
-             # URL to PyPI-style JSON that tell us the latest released version
-             # of LE:
-             LE_AUTO_JSON_URL=base_url + 'certbot/json',
-             # URL to dir containing letsencrypt-auto and letsencrypt-auto.sig:
-             LE_AUTO_DIR_TEMPLATE=base_url + '%s/',
-             # The public key corresponding to signing.key:
-             LE_AUTO_PUBLIC_KEY="""-----BEGIN PUBLIC KEY-----
+             NO_CERT_VERIFY='1',
+             **kwargs)
+
+    if base_url is not None:
+        # URL to PyPI-style JSON that tell us the latest released version
+        # of LE:
+        d['LE_AUTO_JSON_URL'] = base_url + 'certbot/json'
+        # URL to dir containing letsencrypt-auto and letsencrypt-auto.sig:
+        d['LE_AUTO_DIR_TEMPLATE'] = base_url + '%s/'
+        # The public key corresponding to signing.key:
+        d['LE_AUTO_PUBLIC_KEY'] = """-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsMoSzLYQ7E1sdSOkwelg
 tzKIh2qi3bpXuYtcfFC0XrvWig071NwIj+dZiT0OLZ2hPispEH0B7ISuuWg1ll7G
 hFW0VdbxL6JdGzS2ShNWkX9hE9z+j8VqwDPOBn3ZHm03qwpYkBDwQib3KqOdYbTT
@@ -215,12 +219,14 @@ uUtJmmGcuk3a9Aq/sCT6DdfmTSdP5asdQYwIcaQreDrOosaS84DTWI3IU+UYJVgl
 LsIVPBuy9IcgHidUQ96hJnoPsDCWsHwX62495QKEarauyKQrJzFes0EY95orDM47
 Z5o/NDiQB11m91yNB0MmPYY9QSbnOA9j7IaaC97AwRLuwXY+/R2ablTcxurWou68
 iQIDAQAB
------END PUBLIC KEY-----""",
-             NO_CERT_VERIFY='1',
-             **kwargs)
+-----END PUBLIC KEY-----"""
+
     env.update(d)
+
+    if le_auto_args_str is None:
+        le_auto_args_str = '--version'
     return out_and_err(
-        le_auto_path + ' --version',
+        le_auto_path + ' ' + le_auto_args_str,
         shell=True,
         env=env)
 
@@ -238,6 +244,12 @@ def set_le_script_version(venv_dir, version):
                      "from sys import stderr\n"
                      "stderr.write('letsencrypt %s\\n')" % version)
     chmod(letsencrypt_path, S_IRUSR | S_IXUSR)
+
+
+def sudo_chmod(path, mode):
+    """Runs `sudo chmod mode path`."""
+    mode = oct(mode).replace('o', '')
+    out_and_err(['sudo', 'chmod', mode, path])
 
 
 class AutoTests(TestCase):
@@ -395,3 +407,66 @@ class AutoTests(TestCase):
                 else:
                     self.fail("Pip didn't detect a bad hash and stop the "
                               "installation.")
+
+    def test_permissions_warnings(self):
+        """Make sure letsencrypt-auto properly warns about permissions problems."""
+        # This test assumes that only the parent of the directory containing
+        # letesncrypt-auto (usually /tmp) may have permissions letsencrypt-auto
+        # considers insecure.
+        with temp_paths() as (le_auto_path, venv_dir):
+            le_auto_path = abspath(le_auto_path)
+            le_auto_dir = dirname(le_auto_path)
+            le_auto_dir_parent = dirname(le_auto_dir)
+            install_le_auto(self.NEW_LE_AUTO, le_auto_path)
+
+            run_letsencrypt_auto = partial(
+                run_le_auto, le_auto_path, venv_dir,
+                le_auto_args_str='--install-only --no-self-upgrade',
+                PIP_FIND_LINKS=join(tests_dir(), 'fake-letsencrypt', 'dist'))
+            # Run letsencrypt-auto once with current permissions to avoid
+            # potential problems when the script tries to write to temporary
+            # directories.
+            run_letsencrypt_auto()
+
+            le_auto_dir_mode = stat(le_auto_dir).st_mode
+            le_auto_dir_parent_mode = S_IMODE(stat(le_auto_dir_parent).st_mode)
+            try:
+                # Make letsencrypt-auto happy with the current permissions
+                chmod(le_auto_dir, S_IRUSR | S_IXUSR)
+                sudo_chmod(le_auto_dir_parent, 0o755)
+
+                self._test_permissions_warnings_about_path(le_auto_path, run_letsencrypt_auto)
+                self._test_permissions_warnings_about_path(le_auto_dir, run_letsencrypt_auto)
+            finally:
+                chmod(le_auto_dir, le_auto_dir_mode)
+                sudo_chmod(le_auto_dir_parent, le_auto_dir_parent_mode)
+
+    def _test_permissions_warnings_about_path(self, path, run_le_auto_func):
+        # Test that there are no problems with the current permissions
+        out, _ = run_le_auto_func()
+        self.assertFalse('insecure permissions' in out)
+
+        stat_result = stat(path)
+        original_mode = stat_result.st_mode
+
+        # Test world permissions
+        chmod(path, original_mode | S_IWOTH)
+        out, _ = run_le_auto_func()
+        self.assertTrue('insecure permissions' in out)
+
+        # Test group permissions
+        if stat_result.st_gid != 0:
+            chmod(path, original_mode | S_IWGRP)
+            out, _ = run_le_auto_func()
+            self.assertTrue('insecure permissions' in out)
+
+        # Test owner permissions
+        if stat_result.st_uid != 0:
+            chmod(path, original_mode | S_IWUSR)
+            out, _ = run_le_auto_func()
+            self.assertTrue('insecure permissions' in out)
+
+        # Test that permissions were properly restored
+        chmod(path, original_mode)
+        out, _ = run_le_auto_func()
+        self.assertFalse('insecure permissions' in out)

--- a/tests/letstest/scripts/test_letsencrypt_auto_certonly_standalone.sh
+++ b/tests/letstest/scripts/test_letsencrypt_auto_certonly_standalone.sh
@@ -9,7 +9,13 @@ set -eo pipefail
 #private_ip=$(curl -s http://169.254.169.254/2014-11-05/meta-data/local-ipv4)
 
 cd letsencrypt
-export PATH="$PWD/letsencrypt-auto-source:$PATH"
+LE_AUTO_DIR="/usr/local/bin"
+LE_AUTO_PATH="$LE_AUTO_DIR/letsencrypt-auto"
+sudo cp letsencrypt-auto-source/letsencrypt-auto "$LE_AUTO_PATH"
+sudo chown root "$LE_AUTO_PATH"
+sudo chmod 0755 "$LE_AUTO_PATH"
+export PATH="$LE_AUTO_DIR:$PATH"
+
 letsencrypt-auto --os-packages-only --debug --version
 
 # Create a venv-like layout at the old virtual environment path to test that a
@@ -33,5 +39,11 @@ fi
 
 if ! letsencrypt-auto --help --no-self-upgrade | grep -F "letsencrypt-auto [SUBCOMMAND]"; then
     echo "letsencrypt-auto not included in help output!"
+    exit 1
+fi
+
+OUTPUT=$(letsencrypt-auto --install-only --no-self-upgrade --quiet 2>&1)
+if [ -n "$OUTPUT" ]; then
+    echo letsencrypt-auto produced unexpected output!
     exit 1
 fi


### PR DESCRIPTION
This PR attempts to better inform people about the problem identified at https://community.letsencrypt.org/t/certbot-auto-deployment-best-practices/91979/.

I'd like to include this PR in our release on May 1st and since making any significant change to `certbot-auto` in its current state stresses me out, I'd ideally like to have two reviews on this. 

@erikrose and @joohoi, are you able to review this by early Tuesday morning PST at the latest so I have time to address review comments? If not, no problem, but please let me know ASAP so I can try and find another reviewer in time.

I was hesitant to add the flag `--no-permissions-check`, however, if there's some obscure distro out there (or custom user setup) that has a strange users and groups, I didn't want us to either:

* Have to put out a bug fix release
* Refuse to fix the problem and let them deal with warnings on every run

In addition to running our "test farm" tests (on the OSes specified [here](https://github.com/certbot/certbot/blob/master/tests/letstest/targets.yaml)) using the modified `test_letsencrypt_auto_certonly_standalone.sh` test script, I successfully tested on these changes on macOS and FreeBSD.