### PR TITLE
 Update Debian Jessie AMI to continue being able to use apt

### DIFF
--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -98,7 +98,7 @@ PROFILE = cl_args.aws_profile
 
 # Globals
 #-------------------------------------------------------------------------------
-BOULDER_AMI = 'ami-5f490b35' # premade shared boulder AMI 14.04LTS us-east-1
+BOULDER_AMI = 'ami-072a9534772bec854' # premade shared boulder AMI 18.04LTS us-east-1
 LOGDIR = "" #points to logging / working directory
 # boto3/AWS api globals
 AWS_SESSION = None
@@ -290,8 +290,7 @@ def deploy_script(scriptpath, *args):
 
 def run_boulder():
     with cd('$GOPATH/src/github.com/letsencrypt/boulder'):
-        run('go run cmd/rabbitmq-setup/main.go -server amqp://localhost')
-        run('nohup ./start.py >& /dev/null < /dev/null &')
+        run('sudo docker-compose up -d')
 
 def config_and_launch_boulder(instance):
     execute(deploy_script, 'scripts/boulder_config.sh')

--- a/tests/letstest/scripts/boulder_config.sh
+++ b/tests/letstest/scripts/boulder_config.sh
@@ -1,32 +1,26 @@
 #!/bin/bash -x
 
 # Configures and Launches Boulder Server installed on
-# us-east-1 ami-5f490b35 bouldertestserver (boulder commit 8b433f54dab)
+# us-east-1 ami-072a9534772bec854 bouldertestserver3 (boulder commit b24fe7c3ea4)
 
 # fetch instance data from EC2 metadata service
 public_host=$(curl -s http://169.254.169.254/2014-11-05/meta-data/public-hostname)
 public_ip=$(curl -s http://169.254.169.254/2014-11-05/meta-data/public-ipv4)
 private_ip=$(curl -s http://169.254.169.254/2014-11-05/meta-data/local-ipv4)
 
-# get local DNS resolver for VPC
-resolver_ip=$(grep nameserver /etc/resolv.conf |cut -d" " -f2 |head -1)
+# set to public DNS resolver
+resolver_ip=8.8.8.8
 resolver=$resolver_ip':53'
 
 # modifies integration testing boulder setup for local AWS VPC network
 # connections instead of localhost
 cd $GOPATH/src/github.com/letsencrypt/boulder
-# configure boulder to receive outside connection on 4000
-sed -i '/listenAddress/ s/127.0.0.1:4000/'$private_ip':4000/' ./test/boulder-config.json
-sed -i '/baseURL/ s/127.0.0.1:4000/'$private_ip':4000/' ./test/boulder-config.json
 # change test ports to real
-sed -i '/httpPort/ s/5002/80/' ./test/boulder-config.json
-sed -i '/httpsPort/ s/5001/443/' ./test/boulder-config.json
-sed -i '/tlsPort/ s/5001/443/' ./test/boulder-config.json
-# set local dns resolver
-sed -i '/dnsResolver/ s/127.0.0.1:8053/'$resolver'/' ./test/boulder-config.json
-
-# start rabbitMQ
-#go run cmd/rabbitmq-setup/main.go -server amqp://localhost
-# start acme services
-#nohup ./start.py >& /dev/null < /dev/null &
-#./start.py
+sed -i '/httpPort/ s/5002/80/' ./test/config/va.json
+sed -i '/httpsPort/ s/5001/443/' ./test/config/va.json
+sed -i '/tlsPort/ s/5001/443/' ./test/config/va.json
+# set dns resolver
+sed -i 's/"127.0.0.1:8053",/"'$resolver'"/' ./test/config/ra.json
+sed -i 's/"127.0.0.1:8054"//' ./test/config/ra.json
+sed -i 's/"127.0.0.1:8053",/"'$resolver'"/' ./test/config/va.json
+sed -i 's/"127.0.0.1:8054"//' ./test/config/va.json

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -33,7 +33,7 @@ targets:
     type: ubuntu
     virt: hvm
     user: admin
-  - ami: ami-116d857a
+  - ami: ami-077bf3962f29d3fa4
     name: debian8.1
     type: ubuntu
     virt: hvm


### PR DESCRIPTION
This branch is based on #7002, which should be merged first. Fixes #6907.