### PR TITLE
New approach to fix oldest tests when local dependencies are used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,12 +60,7 @@ matrix:
       env: TOXENV=mypy
       <<: *not-on-master
     - python: "2.7"
-      env: TOXENV='py27-{acme,apache,certbot,nginx,postfix}-oldest'
-      sudo: required
-      services: docker
-      <<: *not-on-master
-    - python: "2.7"
-      env: TOXENV='py27-dns-oldest'
+      env: TOXENV='py27-{acme,apache,certbot,dns,nginx,postfix}-oldest'
       sudo: required
       services: docker
       <<: *not-on-master


### PR DESCRIPTION
In #7019, a solution has been integrated to fix oldest tests execution in the corner cases described in #7014.

However this solution was not very satisfactory, as it consists in making a `--force-reinstall` for all requirements on each oldest tests (apache, certbot, acme, each dns plugin ...). As a consequence, the overall execution time of these tests increased from 5 min to 10 min.

In this PR I propose a more elegant solution: instead of reinstalling all dependencies, we force reinstall only the requirements themselves describe in the relevant  `oldest-requirements.txt` files. This way only the packages that are potentially ignored by pip because they exists locally (acme, certbot, ...) are reinstalled.

The result is the same than in #7019 (we are sure that all packages are really installed by pip), but the very limited number of force reinstalled package here make the impact on execution time negligible.

As a consequence, I revert back also the tox environments to execute all oldest tests together.

A successful execution of oldest tests using this PR material in the context of a point release can be seen here: https://travis-ci.org/adferrand/certbot/builds/527513101