### PR TITLE
Update changelog for 0.34.1. (#7021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.34.1 - master
+
+### Fixed
+
+* certbot-auto no longer prints a blank line when there are no permissions
+  problems.
+
+Despite us having broken lockstep, we are continuing to release new versions of
+all Certbot components during releases for the time being, however, the only
+changes in this release were to certbot-auto.
+
+More details about these changes can be found on our GitHub repo.
+
 ## 0.34.0 - 2019-05-01
 
 ### Changed


### PR DESCRIPTION
(cherry picked from commit 4bf6eb2091e3190282b0e2c6540186e64bf4d846)

`master` in the changelog below will be changed to the date by the release script at https://github.com/certbot/certbot/blob/b19d4801c9dea2898402c5b388da4bd10b103d01/tools/_release.sh#L69