### PR TITLE
Fix check_permissions.py output and avoid writing script to root directory

### DIFF
--- a/certbot-auto
+++ b/certbot-auto
@@ -1017,7 +1017,7 @@ if [ "$1" = "--le-auto-phase2" ]; then
     fi
 
     say "Installing Python packages..."
-    TEMP_DIR=$(TempDir)
+    TEMP_DIR="$(TempDir)"
     trap 'rm -rf "$TEMP_DIR"' EXIT
     # There is no $ interpolation due to quotes on starting heredoc delimiter.
     # -------------------------------------------------------------------------
@@ -1501,6 +1501,8 @@ else
     exit 0
   fi
 
+  TEMP_DIR="$(TempDir)"
+  trap 'rm -rf "$TEMP_DIR"' EXIT
   DeterminePythonVersion "NOCRASH"
   # Don't warn about file permissions if the user disabled the check or we
   # can't find an up-to-date Python.

--- a/certbot-auto
+++ b/certbot-auto
@@ -1600,7 +1600,7 @@ UNLIKELY_EOF
     CHECK_PERM_OUT=$("$LE_PYTHON" "$TEMP_DIR/check_permissions.py" "$0" 2>/dev/null)
     CHECK_PERM_STATUS="$?"
     set -e
-    if [ "$CHECK_PERM_STATUS" = 0 ]; then
+    if [ "$CHECK_PERM_STATUS" = 0 ] && [ -n "$CHECK_PERM_OUT" ]; then
       error "$CHECK_PERM_OUT"
     fi
   fi


### PR DESCRIPTION
One of the two fixes was already merged into letsencrypt-auto. Since I don't know what happens with the different scripts (certbot-auto vs. letsencrypt-auto[-source]) and I have another fix, I'm posting this anyway so you can handle the patch as desired.