### PR TITLE
Fix test_leauto_upgrades.sh on CentOS 6.

### DIFF
--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -15,8 +15,17 @@ if ! command -v git ; then
         exit 1
     fi
 fi
-# 0.33.x is the oldest version of letsencrypt-auto that works on Fedora 29+.
-INITIAL_VERSION="0.33.1"
+# If we're on a RHEL 6 based system, we can be confident Python is already
+# installed because the package manager is written in Python.
+if command -v python && [ $(python -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -eq 26 ]; then
+    # 0.20.0 is the latest version of letsencrypt-auto that doesn't install
+    # Python 3 on RHEL 6.
+    INITIAL_VERSION="0.20.0"
+    RUN_PYTHON3_TESTS=1
+else
+    # 0.33.x is the oldest version of letsencrypt-auto that works on Fedora 29+.
+    INITIAL_VERSION="0.33.1"
+fi
 git checkout -f "v$INITIAL_VERSION" letsencrypt-auto
 if ! ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | tail -n1 | grep "^certbot $INITIAL_VERSION$" ; then
     echo initial installation appeared to fail
@@ -63,8 +72,7 @@ iQIDAQAB
 -----END PUBLIC KEY-----
 "
 
-if [ $(python -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -eq 26 ]; then
-    RUN_PYTHON3_TESTS=1
+if [ "$RUN_PYTHON3_TESTS" = 1 ]; then
     if command -v python3; then
         echo "Didn't expect Python 3 to be installed!"
         exit 1


### PR DESCRIPTION
I chose this approach because "rebootstrapping" is one of the more complicated pieces of certbot-auto and this test makes sure that things work properly.

The main value in the "Python 3 tests" is not in the initial `if [ "$RUN_PYTHON3_TESTS" = 1 ]; then` branch which is mainly testing that the initial installation worked as expected. The value is in the second branch like this which is testing that we properly rebootstrapped using the latest version of the script.

Alternatively, we could move these tests to another script, but I don't think making a 6th script to run at release time is worth it.