### PR TITLE
Remove dependency on acme in certbot-ci

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -22,8 +22,6 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
 from six.moves import socketserver, SimpleHTTPServer
 
-from acme import crypto_util
-
 
 RSA_KEY_TYPE = 'rsa'
 ECDSA_KEY_TYPE = 'ecdsa'
@@ -241,13 +239,19 @@ def generate_csr(domains, key_path, csr_path, key_type=RSA_KEY_TYPE):
     else:
         raise ValueError('Invalid key type: {0}'.format(key_type))
 
-    key_bytes = crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
-    with open(key_path, 'wb') as file:
-        file.write(key_bytes)
+    with open(key_path, 'wb') as file_h:
+        file_h.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
 
-    csr_bytes = crypto_util.make_csr(key_bytes, domains)
-    with open(csr_path, 'wb') as file:
-        file.write(csr_bytes)
+    req = crypto.X509Req()
+    san = ', '.join(['DNS:{0}'.format(item) for item in domains])
+    san_constraint = crypto.X509Extension(b'subjectAltName', False, san.encode('utf-8'))
+    req.add_extensions([san_constraint])
+
+    req.set_pubkey(key)
+    req.sign(key, 'sha256')
+
+    with open(csr_path, 'wb') as file_h:
+        file_h.write(crypto.dump_certificate_request(crypto.FILETYPE_ASN1, req))
 
 
 def read_certificate(cert_path):

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -248,6 +248,7 @@ def generate_csr(domains, key_path, csr_path, key_type=RSA_KEY_TYPE):
     req.add_extensions([san_constraint])
 
     req.set_pubkey(key)
+    req.set_version(2)
     req.sign(key, 'sha256')
 
     with open(csr_path, 'wb') as file_h:

--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -5,7 +5,6 @@ from setuptools import find_packages
 version = '0.32.0.dev0'
 
 install_requires = [
-    'acme',
     'coverage',
     'cryptography',
     'pyopenssl',


### PR DESCRIPTION
Following discussion in https://github.com/certbot/certbot/pull/6947#discussion_r275082889, I have second thoughts about relying on `acme` in certbot-ci.

Indeed, I think it is a good design to not rely in tests on the code you are testing. Obviously in unit tests it is very difficult, since most of the time the unit that is tested needs input generated by other part of the code. However it is not really a problem in a unit test, as its purpose is to make assertions about a specific portion of the code, not the others parts.

In the scope of integration tests, the software tested is treated as a black box. In this case, having some parts of the test logic that use in fact part of the code in the black box, increase the risk that some assertions compared two results coming from the same flawed logic from the tested software.

Since using acme in certbot-ci is only saving few lines of code, I think it does not worth the risk and the added complexity to declare `acme` as a dependency. I prefer to duplicate these lines and keep certbot-ci free of any dependency coming from the certbot project.