### PR TITLE
Revert " Add FreeBSD specific paths (#6702)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-* Add FreeBSD specific paths to certbot
 *
 
 ### Changed

--- a/certbot/compat/misc.py
+++ b/certbot/compat/misc.py
@@ -129,11 +129,7 @@ LINUX_DEFAULT_FOLDERS = {
     'work': '/var/lib/letsencrypt',
     'logs': '/var/log/letsencrypt',
 }
-FREEBSD_DEFAULT_FOLDERS = {
-    'config': '/usr/local/etc/letsencrypt',
-    'work': '/var/db/letsencrypt',
-    'logs': '/var/log/letsencrypt',
-}
+
 
 def get_default_folder(folder_type):
     """
@@ -146,10 +142,6 @@ def get_default_folder(folder_type):
 
     """
     if os.name != 'nt':
-        # Unix-like
-        if sys.platform.startswith('freebsd') or sys.platform.startswith('dragonfly'):
-            # FreeBSD specific
-            return FREEBSD_DEFAULT_FOLDERS[folder_type]
         # Linux specific
         return LINUX_DEFAULT_FOLDERS[folder_type]
     # Windows specific


### PR DESCRIPTION
Revert #6702

After some discussions, we realized that changing the path for FreeBSD users, if it corresponds to the path used when Certbot is installed using ports, will break for users that installed it through certbot-auto.

Indeed in this case, the path used was the one for Linux. After #6702, Certbot would not find anymore the existing config path by default.

It would require, to be integrated, a proper documentation and a migration path. For now, it is preferable to revert it.