### PR TITLE
Update known good apache2 targets.

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -1,13 +1,18 @@
 targets:
   #-----------------------------------------------------------------------------
-  # Apache 2.4
-  - ami: ami-26d5af4c
-    name: ubuntu15.10
+  #Ubuntu
+  - ami: ami-064bd2d44a1d6c097
+    name: ubuntu18.10
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-d92e6bb3
-    name: ubuntu15.04LTS
+  - ami: ami-012fd5eb46f56731f
+    name: ubuntu18.04LTS
+    type: ubuntu
+    virt: hvm
+    user: ubuntu
+  - ami: ami-09677e0a6b14905b0
+    name: ubuntu16.04LTS
     type: ubuntu
     virt: hvm
     user: ubuntu
@@ -21,37 +26,29 @@ targets:
     type: ubuntu
     virt: pv
     user: ubuntu
-  - ami: ami-116d857a
-    name: debian8.1
-    type: debian
+  #-----------------------------------------------------------------------------
+  # Debian
+  - ami: ami-003f19e0e687de1cd
+    name: debian9
+    type: ubuntu
     virt: hvm
     user: admin
-    userdata: |
-      #cloud-init
-      runcmd:
-        - [ apt-get, install, -y, curl ]
+  - ami: ami-077bf3962f29d3fa4
+    name: debian8.1
+    type: ubuntu
+    virt: hvm
+    user: admin
   #-----------------------------------------------------------------------------
-  # Apache 2.2
-  # - ami: ami-0611546c
-  #   name: ubuntu12.04LTS
-  #   type: ubuntu
-  #   virt: hvm
-  #   user: ubuntu
-  # - ami: ami-e0efab88
-  #   name: debian7.8.aws.1
-  #   type: debian
-  #   virt: hvm
-  #   user: admin
-  #   userdata: |
-  #     #cloud-init
-  #     runcmd:
-  #       - [ apt-get, install, -y, curl ]
-  # - ami: ami-e6eeaa8e
-  #   name: debian7.8.aws.1_32bit
-  #   type: debian
-  #   virt: pv
-  #   user: admin
-  #   userdata: |
-  #     #cloud-init
-  #     runcmd:
-  #       - [ apt-get, install, -y, curl ]
+  # Fedora
+  - ami: ami-5c69df23
+    name: fedora28
+    type: centos
+    virt: hvm
+    user: fedora
+  #-----------------------------------------------------------------------------
+  # CentOS
+  - ami: ami-9887c6e7
+    name: centos7
+    type: centos
+    virt: hvm
+    user: centos


### PR DESCRIPTION
We currently do not use this file. When running the release, we run the Apache tests against all targets and just ignore the ones we know to be failing. In Travis, we should only run against the targets we expect to work.

After this lands, we could update the release instructions to also use this file if we wanted.