### PR TITLE
Fix centos6 test_sdists

### DIFF
--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -1,14 +1,21 @@
 #!/bin/sh -xe
 
 cd letsencrypt
-./certbot-auto --os-packages-only -n --debug
+./certbot-auto --install-only -n --debug
 
 PLUGINS="certbot-apache certbot-nginx"
+PYTHON_MAJOR_VERSION=$(/opt/eff.org/certbot/venv/bin/python --version 2>&1 | cut -d" " -f 2 | cut -d. -f1)
 TEMP_DIR=$(mktemp -d)
 VERSION=$(letsencrypt-auto-source/version.py)
 
+if [ "$PYTHON_MAJOR_VERSION" = "3" ]; then
+    VENV_SCRIPT="tools/venv3.py"
+else
+    VENV_SCRIPT="tools/venv.py"
+fi
+
 # setup venv
-tools/venv.py --requirement letsencrypt-auto-source/pieces/dependency-requirements.txt
+"$VENV_SCRIPT" --requirement letsencrypt-auto-source/pieces/dependency-requirements.txt
 . ./venv/bin/activate
 # pytest is needed to run tests on some of our packages so we install a pinned version here.
 tools/pip_install.py pytest

--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -9,14 +9,16 @@ TEMP_DIR=$(mktemp -d)
 VERSION=$(letsencrypt-auto-source/version.py)
 
 if [ "$PYTHON_MAJOR_VERSION" = "3" ]; then
+    VENV_PATH="venv3"
     VENV_SCRIPT="tools/venv3.py"
 else
     VENV_SCRIPT="tools/venv.py"
+    VENV_PATH="venv"
 fi
 
 # setup venv
 "$VENV_SCRIPT" --requirement letsencrypt-auto-source/pieces/dependency-requirements.txt
-. ./venv/bin/activate
+. "$VENV_PATH/bin/activate"
 # pytest is needed to run tests on some of our packages so we install a pinned version here.
 tools/pip_install.py pytest
 


### PR DESCRIPTION
test_sdists.sh now passes on CentOS 6 (and should pass on other distros where certbot-auto uses Python 3 such as Fedora 29+).

Once this lands, we need to update the release instructions to document that a CentOS 6 failure is not expected.