### PR TITLE
Allow magic profile name none for configuring test farm tests.

### DIFF
--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -94,7 +94,7 @@ cl_args = parser.parse_args()
 # assumes naming: <key_filename> = <keyname>.pem
 KEYFILE = cl_args.key_file
 KEYNAME = os.path.split(cl_args.key_file)[1].split('.pem')[0]
-PROFILE = cl_args.aws_profile
+PROFILE = None if cl_args.aws_profile.lower() == 'none' else cl_args.aws_profile
 
 # Globals
 #-------------------------------------------------------------------------------

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -94,7 +94,7 @@ cl_args = parser.parse_args()
 # assumes naming: <key_filename> = <keyname>.pem
 KEYFILE = cl_args.key_file
 KEYNAME = os.path.split(cl_args.key_file)[1].split('.pem')[0]
-PROFILE = None if cl_args.aws_profile.lower() == 'none' else cl_args.aws_profile
+PROFILE = None if cl_args.aws_profile == 'SET_BY_ENV' else cl_args.aws_profile
 
 # Globals
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Unfortunately, this is pretty hacky.

The problem is that these tests require a positional command line argument to specify the profile name for AWS settings and credentials. In Travis, I don't want to set a profile name though and instead I want to pass credentials through using environment variables.

The correct solution here in my opinion is to make this an optional parameter like `--profile` and update all of our documentation and Erica's and I's muscle memory. I don't want to do this when we're about to kill these tests though.

Instead, I'm defining the magic value "SET_BY_ENV" which can be used to set `PROFILE` to `None` and allow environment variables to be used.