### PR TITLE
Regularly print output in the test farm tests

### DIFF
--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -552,6 +552,7 @@ try:
             p.join(5 * 60)
             # Regularly print output to keep Travis happy
             print('.', end='')
+            sys.stdout.flush()
     print()
     # add SENTINEL to output queue
     outqueue.put(SENTINEL)

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -546,9 +546,13 @@ try:
     # add SENTINELs to end client processes
     for i in range(num_processes):
         inqueue.put(SENTINEL)
-    # wait on termination of client processes
+    print('Waiting on client processes', end='')
     for p in jobs:
-        p.join()
+        while p.is_alive():
+            p.join(5 * 60)
+            # Regularly print output to keep Travis happy
+            print('.', end='')
+    print()
     # add SENTINEL to output queue
     outqueue.put(SENTINEL)
 


### PR DESCRIPTION
One issue I had moving these test farm tests into Travis is Travis kills the tests if they don't produce any output for 10 minutes. This step regularly takes longer than that so this output keeps the tests running.