### PR TITLE
Avoid to delete both webroot_map and webroot_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Renewal parameter `webroot_path` is always saved, avoiding some regressions
+  when `webroot` authenticator plugin is invoked with no challenge to perform.
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only
 package with changes other than its version number was:
 
+* certbot
 * certbot-dns-rfc2136
 
 More details about these changes can be found on our GitHub repo.

--- a/certbot/plugins/webroot.py
+++ b/certbot/plugins/webroot.py
@@ -74,28 +74,27 @@ to serve all files under specified web root ({0})."""
         self._created_dirs = []  # type: List[str]
 
     def prepare(self):  # pylint: disable=missing-docstring
-        pass
+        # To understand why set_webroots is in the early prepare phase, and not in the perform phase,
+        # see https://github.com/certbot/certbot/pull/7095
+        self._set_webroots(self.config.domains)
 
     def perform(self, achalls):  # pylint: disable=missing-docstring
-        self._set_webroots(achalls)
-
         self._create_challenge_dirs()
 
         return [self._perform_single(achall) for achall in achalls]
 
-    def _set_webroots(self, achalls):
+    def _set_webroots(self, domains):
         if self.conf("path"):
             webroot_path = self.conf("path")[-1]
             logger.info("Using the webroot path %s for all unmatched domains.",
                         webroot_path)
-            for achall in achalls:
-                self.conf("map").setdefault(achall.domain, webroot_path)
+            for domain in domains:
+                self.conf("map").setdefault(domain, webroot_path)
         else:
             known_webroots = list(set(six.itervalues(self.conf("map"))))
-            for achall in achalls:
-                if achall.domain not in self.conf("map"):
-                    new_webroot = self._prompt_for_webroot(achall.domain,
-                                                           known_webroots)
+            for domain in domains:
+                if domain not in self.conf("map"):
+                    new_webroot = self._prompt_for_webroot(domain, known_webroots)
                     # Put the most recently input
                     # webroot first for easy selection
                     try:
@@ -103,7 +102,7 @@ to serve all files under specified web root ({0})."""
                     except ValueError:
                         pass
                     known_webroots.insert(0, new_webroot)
-                    self.conf("map")[achall.domain] = new_webroot
+                    self.conf("map")[domain] = new_webroot
 
     def _prompt_for_webroot(self, domain, known_webroots):
         webroot = None

--- a/certbot/plugins/webroot_test.py
+++ b/certbot/plugins/webroot_test.py
@@ -295,6 +295,19 @@ class WebrootActionTest(unittest.TestCase):
         self.assertEqual(
             config.webroot_map[self.achall.domain], self.path)
 
+    def test_webroot_map_partial_without_perform(self):
+        # This test acknowledges the fact that webroot_map content will be partial if webroot
+        # plugin perform method is not invoked (corner case when all auths are already valid).
+        # To not be a problem, the webroot_path must always been conserved during renew.
+        # This condition is challenged by:
+        # certbot.tests.renewal_tests::RenewalTest::test_webroot_params_conservation
+        # See https://github.com/certbot/certbot/pull/7095 for details.
+        other_webroot_path = tempfile.mkdtemp()
+        args = self.parser.parse_args("-w {0} -d {1} -w {2} -d bar".format(
+            self.path, self.achall.domain, other_webroot_path).split())
+        self.assertEqual(args.webroot_map, {self.achall.domain: self.path})
+        self.assertEqual(args.webroot_path, [self.path, other_webroot_path])
+
     def _get_config_after_perform(self, config):
         from certbot.plugins.webroot import Authenticator
         auth = Authenticator(config, "webroot")

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -109,6 +109,8 @@ def _restore_webroot_config(config, renewalparams):
     if "webroot_map" in renewalparams:
         if not cli.set_by_cli("webroot_map"):
             config.webroot_map = renewalparams["webroot_map"]
+    # To understand why webroot_path and webroot_map processing are not mutually exclusive, see:
+    # https://github.com/certbot/certbot/pull/7095
     if "webroot_path" in renewalparams and not renewalparams.get('webroot_map', {}):
         logger.debug("Ancient renewal conf file without webroot-map, restoring webroot-path")
         wp = renewalparams["webroot_path"]

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -106,13 +106,11 @@ def _restore_webroot_config(config, renewalparams):
     restoring logic is not able to correctly parse it from the serialized
     form.
     """
-    if "webroot_map" in renewalparams:
-        if not cli.set_by_cli("webroot_map"):
-            config.webroot_map = renewalparams["webroot_map"]
-    # To understand why webroot_path and webroot_map processing are not mutually exclusive, see:
-    # https://github.com/certbot/certbot/pull/7095
-    if "webroot_path" in renewalparams and not renewalparams.get('webroot_map', {}):
-        logger.debug("Ancient renewal conf file without webroot-map, restoring webroot-path")
+    if "webroot_map" in renewalparams and not cli.set_by_cli("webroot_map"):
+        config.webroot_map = renewalparams["webroot_map"]
+    # To understand why webroot_path and webroot_map processing are not mutually exclusive,
+    # see https://github.com/certbot/certbot/pull/7095
+    if "webroot_path" in renewalparams and not cli.set_by_cli("webroot_path"):
         wp = renewalparams["webroot_path"]
         if isinstance(wp, six.string_types):  # prior to 0.1.0, webroot_path was a string
             wp = [wp]

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -109,7 +109,7 @@ def _restore_webroot_config(config, renewalparams):
     if "webroot_map" in renewalparams:
         if not cli.set_by_cli("webroot_map"):
             config.webroot_map = renewalparams["webroot_map"]
-    elif "webroot_path" in renewalparams:
+    if "webroot_path" in renewalparams and not renewalparams.get('webroot_map', {}):
         logger.debug("Ancient renewal conf file without webroot-map, restoring webroot-path")
         wp = renewalparams["webroot_path"]
         if isinstance(wp, six.string_types):  # prior to 0.1.0, webroot_path was a string


### PR DESCRIPTION
Fixes #7048.

This PR "partially" correct #7048. By "partially" here, I mean that the issue is effectively corrected, but not revert to the previous behavior, as this would require more in-depth modifications of the plugins API and behavior.

The idea is that in the specific corner case where `certbot certonly` is invoked two times using `webroot` plugin in a row for a given domain, the second call does not in fact perform a new challenge, but instead reuse the still valid authorization from ACME server. Indeed, authorizations remain valid for a couple of time.

However, this means that the `perform` method of `webroot` here is not invoked. But this method contains some logic to fill the `webroot_map` values in the renewal configuration file, that is not invoked then. If it is not invoked, it means that the last value in `webroot_path` is not associated to the given domains that are not already in `webroot_map`. In particular, this means in the case of a single provided domain that the webroot_map is empty `{}`.

Here it becomes tricky. If we invoke `certbot renew` after that, the method `_restore_webroot_config` is puzzled: it sees that a `webroot_map` is set, and so save its empty value. Then it does not copy `webroot_path`, as there was a value for `webroot_map`, and `webroot_path` is itself a corner case from ancient values ...

Finally, we just lost both `webroot_path` values and `webroot_map`, and the renewal configuration is broken from now on.

In the case of more than one given domain, this broken behavior leads to at least one missing association webroot -> domain in the `webmap_root`.

This PR fixes that by copying the `webroot_path` value if it exists and not explicitly set by CLI. With this, even if `webroot_map` is lost, the renewal configuration remains functional with `webroot_path` using the latest value in it for all missing domains in `webroot_map`, and matches functionally the previous behavior, even if the renewal configuration file remains impacted.

I pass the lool to @bmw.