### PR TITLE
Added support for Pre/Post hooks to CSR (certbot certonly)

### DIFF
--- a/certbot/main.py
+++ b/certbot/main.py
@@ -1165,15 +1165,20 @@ def _csr_get_and_save_cert(config, le_client):
     :rtype: `tuple` of `str`
 
     """
+    hooks.pre_hook(config)
     csr, _ = config.actual_csr
     cert, chain = le_client.obtain_certificate_from_csr(csr)
     if config.dry_run:
         logger.debug(
             "Dry run: skipping saving certificate to %s", config.cert_path)
         return None, None
-    cert_path, _, fullchain_path = le_client.save_certificate(
-        cert, chain, os.path.normpath(config.cert_path),
-        os.path.normpath(config.chain_path), os.path.normpath(config.fullchain_path))
+    try:
+        cert_path, _, fullchain_path = le_client.save_certificate(
+            cert, chain, os.path.normpath(config.cert_path),
+            os.path.normpath(config.chain_path), os.path.normpath(config.fullchain_path))
+    finally:
+        hooks.post_hook(config)
+
     return cert_path, fullchain_path
 
 def renew_cert(config, plugins, lineage):

--- a/docs/cli-help.txt
+++ b/docs/cli-help.txt
@@ -279,7 +279,8 @@ certonly:
 
   --csr CSR             Path to a Certificate Signing Request (CSR) in DER or
                         PEM format. Currently --csr only works with the
-                        'certonly' subcommand. (default: None)
+                        'certonly' subcommand. It also calls --pre-hook and 
+                        --post-hook commands if they are defined. (default: None)
 
 renew:
   The 'renew' subcommand will attempt to renew all certificates (or more


### PR DESCRIPTION
Hi all,

we have added pre/post hooks support to certbot certonly when using csr, like in case you have FIPS compliant hardware which does not support importing private key - eg. HP blade chassis and network devices.

