### PR TITLE
Update Ubuntu AMI to 19.04

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -1,8 +1,8 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
-  - ami: ami-064bd2d44a1d6c097
-    name: ubuntu18.10
+  - ami: ami-08ab45c4343f5f5c6
+    name: ubuntu19.04
     type: ubuntu
     virt: hvm
     user: ubuntu

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -1,8 +1,8 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
-  - ami: ami-064bd2d44a1d6c097
-    name: ubuntu18.10
+  - ami: ami-08ab45c4343f5f5c6
+    name: ubuntu19.04
     type: ubuntu
     virt: hvm
     user: ubuntu


### PR DESCRIPTION
Fixes #6720.

You can see tests successfully running with this change at https://travis-ci.com/certbot/certbot/builds/113022682.

This PR updates the Ubuntu 18.10 AMI in our test farm tests to Ubuntu 19.04. The AMI-ID was taken from https://cloud-images.ubuntu.com/locator/ec2/. As of writing this, it is the only Ubuntu 19.04 AMI on that page in `us-east-1` using ESB for storage that isn't running on ARM. The instance store AMI cannot be used because that storage type is not available for the instance size we use. See https://aws.amazon.com/ec2/pricing/on-demand/ and https://travis-ci.com/certbot/certbot/builds/113021661 for proof of that.

I chose to update the Ubuntu 18.10 AMI to Ubuntu 19.04 instead of just adding an additional test because:

1. At this point, Ubuntu 18.10 is EOL'd in 2 months.
2. Due to the way Ubuntu ensures an upgrade path between versions, it seems extremely unlikely that tests on Ubuntu 18.04 and Ubuntu 19.04 would pass and tests on Ubuntu 18.10 would fail.

I kept the Ubuntu 14.04 images around because now that Ubuntu has announced ESM support, Ubuntu 14.04 isn't fully EOL'd until 2022. We may not need/want to worry about keeping support since standard support ended last month, but I think that's a separate conversation that shouldn't block this PR.