### PR TITLE
Revert "Fix unpinned dependencies tests towards botocore and urllib3 (#7081)"

### DIFF
--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -6,11 +6,6 @@ version = '0.35.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    # boto3 requires urllib<1.25 while requests 2.22+ requires urllib<1.26
-    # Since pip lacks a real dependency graph resolver, it will peak the constraint only from
-    # requests, and install urllib==1.25.2. Setting an explicit dependency here solves the issue.
-    # Check https://github.com/boto/botocore/issues/1733 for resolution in botocore.
-    'urllib3<1.25',
     'acme>=0.29.0',
     'certbot>=0.34.0',
     'boto3',


### PR DESCRIPTION
Fixes #7083. 

This reverts commit 51a7e7cd1928352a96b6849004e176bbd6cd1863.

The problem has been fixed in later versions of botocore. You can see tests passing at https://travis-ci.com/certbot/certbot/builds/113154178.