### PR TITLE
Configure the stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,28 @@
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 180
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  To help us better see what issues are still affecting our users, this issue
+  has been automatically marked as stale. If you still have this issue with an
+  up-to-date version of Certbot and are interested in seeing it resolved,
+  please add a comment letting us know.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been closed due to lack of activity, but if you think it
+  should be reopened, please open a new issue with a link to this one and we'll
+  take a look.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 1
+
+# Don't mark pull requests as stale.
+only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,3 +1,5 @@
+# Configuration for https://github.com/marketplace/stale
+
 # Number of days of inactivity before an Issue or Pull Request becomes stale
 daysUntilStale: 180
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,9 @@ daysUntilStale: 180
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
 daysUntilClose: 7
 
+# Ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
 # Label to use when marking as stale
 staleLabel: stale
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -18,7 +18,8 @@ markComment: >
   To help us better see what issues are still affecting our users, this issue
   has been automatically marked as stale. If you still have this issue with an
   up-to-date version of Certbot and are interested in seeing it resolved,
-  please add a comment letting us know.
+  please add a comment letting us know. If there is no further activity, this
+  issue will be automatically closed.
 
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >


### PR DESCRIPTION
This PR configures a conservative [stale](https://github.com/marketplace/stale) bot for this repo. To learn more about the options we can configure, see https://github.com/probot/stale#usage.

Please review this PR, but do not merge it. I think we should wait until the beginning of a week so we can better initially monitor things.