### PR TITLE
Ignore editor backups when running hooks.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -75,6 +75,7 @@ Authors
 * [Fabian](https://github.com/faerbit)
 * [Faidon Liambotis](https://github.com/paravoid)
 * [Fan Jiang](https://github.com/tcz001)
+* [Felix Lechner](https://github.com/lechner)
 * [Felix Schwarz](https://github.com/FelixSchwarz)
 * [Felix Yan](https://github.com/felixonmars)
 * [Filip Ochnik](https://github.com/filipochnik)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Renewal parameter `webroot_path` is always saved, avoiding some regressions
   when `webroot` authenticator plugin is invoked with no challenge to perform.
+* Scripts in Certbot hook directories are no longer executed when their
+  filenames end in a tilde.
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only

--- a/certbot/hooks.py
+++ b/certbot/hooks.py
@@ -266,5 +266,6 @@ def list_hooks(dir_path):
     :rtype: sorted list of absolute paths to executables in dir_path
 
     """
-    paths = (os.path.join(dir_path, f) for f in os.listdir(dir_path))
-    return sorted(path for path in paths if util.is_exe(path))
+    allpaths = (os.path.join(dir_path, f) for f in os.listdir(dir_path))
+    hooks = [path for path in allpaths if util.is_exe(path) and not path.endswith('~')]
+    return sorted(hooks)

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -480,6 +480,12 @@ class ListHooksTest(util.TempDirTestCase):
 
         self.assertEqual(self._call(self.tempdir), [name])
 
+    def test_ignore_tilde(self):
+        name = os.path.join(self.tempdir, "foo~")
+        create_hook(name)
+
+        self.assertEqual(self._call(self.tempdir), [])
+
 
 def create_hook(file_path):
     """Creates an executable file at the specified path.


### PR DESCRIPTION
**Sorry, new contributor; no changelog entry provided.**

When processing hooks, certbot also runs editor backups even though such files are outdated, clearly warranted correction and may quite possibly be defective.

That behavior could lead to unexpected breakage, and perhaps even pose security risks—for example, if a previous script was careless with file permissions. As an aggravating factor, the backup runs after the corrected version and could unintentionally override a fix the user thought was properly implemented.

This commit causes editor backup files ending in tilde (~) to be excluded when running hooks.

Additional information can be found here:

https://github.com/certbot/certbot/issues/7107
https://community.letsencrypt.org/t/editor-backup-files-executed-as-renewal-hooks/94750
