### PR TITLE
Improve Apache error message when run with insufficient privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* The error message when Certbot's Apache plugin is unable to modify your
+  Apache configuration has been improved.
 
 ### Fixed
 
@@ -20,7 +21,7 @@ Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only
 package with changes other than its version number was:
 
-*
+* certbot-apache
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -277,7 +277,9 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
         except (OSError, errors.LockError):
             logger.debug("Encountered error:", exc_info=True)
             raise errors.PluginError(
-                "Unable to create a lock file in {0}".format(self.option("server_root")))
+                "Unable to create a lock file in {0}. Are you running"
+                " Certbot with sufficient privileges to modify your"
+                " Apache configuration?".format(self.option("server_root")))
         self._prepared = True
 
     def _verify_exe_availability(self, exe):

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -276,7 +276,8 @@ class ApacheConfigurator(augeas_configurator.AugeasConfigurator):
             util.lock_dir_until_exit(self.option("server_root"))
         except (OSError, errors.LockError):
             logger.debug("Encountered error:", exc_info=True)
-            raise errors.PluginError("Unable to lock {0}".format(self.option("server_root")))
+            raise errors.PluginError(
+                "Unable to create a lock file in {0}".format(self.option("server_root")))
         self._prepared = True
 
     def _verify_exe_availability(self, exe):


### PR DESCRIPTION
Stale bot caused me to look into https://github.com/certbot/certbot/issues/6369 and I think a fix is so trivial I thought I'd just write one myself. Prior to this PR, Certbot's output here would be something like:
```
Saving debug log to /tmp/tmp.Nda2Z7h8Yx/letsencrypt.log
The apache plugin is not working; there may be problems with your existing configuration.
The error was: PluginError('Unable to lock /etc/apache2',)
```
Now it is:
```
Saving debug log to /tmp/tmp.Cwv0ksVdBP/letsencrypt.log
The apache plugin is not working; there may be problems with your existing configuration.
The error was: PluginError('Unable to create a lock file in /etc/apache2. Are you running Certbot with sufficient privileges to modify your Apache configuration?',)
```