### PR TITLE
Fix dns-rfc2136 validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fixed issue with dns-rfc2136 validator
 
 Despite us having broken lockstep, we are continuing to release new versions of
 all Certbot components during releases for the time being, however, the only

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136.py
@@ -98,7 +98,7 @@ class _RFC2136Client(object):
     """
     Encapsulates all communication with the target DNS server.
     """
-    def __init__(self, server, port, base_domain, key):
+    def __init__(self, server, port, key, base_domain):
         self.server = server
         self.port = port
         self.keyring = dns.tsigkeyring.from_text({

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136_test.py
@@ -77,8 +77,8 @@ class RFC2136ClientTest(unittest.TestCase):
 
         self.rfc2136_client = _RFC2136Client(SERVER,
                                              PORT,
-                                             None,
-                                             _RFC2136Key(NAME, SECRET, dns.tsig.HMAC_MD5))
+                                             _RFC2136Key(NAME, SECRET, dns.tsig.HMAC_MD5),
+                                             None)
 
     @mock.patch("dns.query.tcp")
     def test_add_txt_record(self, query_mock):


### PR DESCRIPTION
There is a bug in the dns-rfc2136 code that causes all renewals and issues to fail because of parameter order.