### PR TITLE
Fix integration tests errors against Boulder in nightly tests

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -99,6 +99,14 @@ def _construct_workspace(acme_type):
                 pass
             print('=> Finished tear down of {0} instance.'.format(acme_type))
 
+        if acme_type == 'boulder' and os.path.exists(os.path.join(workspace, 'boulder')):
+            # Boulder docker generates build artifacts owned by root user with 0o744 permissions.
+            # If we started the acme server from a normal user that has access to the Docker
+            # daemon, this user will not be able to delete these artifacts from the host.
+            # We need to do it through a docker.
+            _launch_command(['docker', 'run', '--rm', '-v', '{0}:/workspace'.format(workspace),
+                             'alpine', 'rm', '-rf', '/workspace/boulder'])
+
         shutil.rmtree(workspace)
 
     return workspace, cleanup


### PR DESCRIPTION
Currently integration tests against Boulder fail during nightly tests. See https://travis-ci.com/certbot/certbot/builds/115373954.

This is due to a failure to cleanup the workspace associated to the Boulder docker started during the integration tests. Indeed this docker compile several artifacts whose owner is root, and permissions are `0744`. These files are persisted in the workspace folder attached to the Docker.

Since tox is run as a non-root user (but this user still have access to the Docker daemon), everything works fine until the end of the test suite, when all resources are cleaned up. At this point, pytest fires a `PermissionError` when failing to delete these artifacts, return with a non-zero exit code, and so fail the build.

Since this situation could happen outside of the CI, I made appropriate corrections to allow the integration tests to be run as a non-root user, instead of changing Travis to execute tests as root user.

The correction is to add a step to the cleanup process: the deletion of these artifacts through an ad-hoc docker instance.