### PR TITLE
Set DEBIAN_FRONTEND=noninteractive in certbot-auto to fix test farm tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Update the 'manage your account' help to be more generic.
 * The error message when Certbot's Apache plugin is unable to modify your
   Apache configuration has been improved.
+* When running certbot-auto with --non-interactive,
+  DEBIAN_FRONTEND=noninteractive is set on Debian based systems to prevent
+  debconf prompts from waiting on user input.
 
 ### Fixed
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -342,6 +342,7 @@ BootstrapDebCommon() {
   augeas_pkg="libaugeas0 augeas-lenses"
 
   if [ "$ASSUME_YES" = 1 ]; then
+    export DEBIAN_FRONTEND='noninteractive'
     YES_FLAG="-y"
   fi
 

--- a/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
+++ b/letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh
@@ -45,6 +45,7 @@ BootstrapDebCommon() {
   augeas_pkg="libaugeas0 augeas-lenses"
 
   if [ "$ASSUME_YES" = 1 ]; then
+    export DEBIAN_FRONTEND='noninteractive'
     YES_FLAG="-y"
   fi
 

--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -6,6 +6,10 @@ set -o pipefail
 
 cd letsencrypt
 
+# Setting this variable prevents old versions of certbot-auto on Debian from
+# blocking on user input.
+export DEBIAN_FRONTEND='noninteractive'
+
 if ! command -v git ; then
     if [ "$OS_TYPE" = "ubuntu" ] ; then
         sudo apt-get update

--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -xe
 
 cd letsencrypt
-./certbot-auto --install-only -n --debug
+letsencrypt-auto-source/letsencrypt-auto --install-only -n --debug
 
 PLUGINS="certbot-apache certbot-nginx"
 PYTHON_MAJOR_VERSION=$(/opt/eff.org/certbot/venv/bin/python --version 2>&1 | cut -d" " -f 2 | cut -d. -f1)


### PR DESCRIPTION
Test farm tests have been failing for the last few days because they block on user input and get timed out. The cause of this is that as part of installing Certbot, some packages are updated which causes running services to need to be restarted. debconf as invoked by `apt-get install` is blocking asking if it's OK to restart these packages.

To fix this, I initially I tried to see if a new official Ubuntu AMI was available that solved this problem but there's not. (There is a new AMI available with the ID `079f96ce4a4a7e1c7`, however, we have the same problem there too.) Instead, we can set the environment variable `DEBIAN_FRONTEND` which is commonly done in things like [Dockerfiles](https://github.com/certbot/certbot/blob/658b7b9d47cb05fa43383b5bdf3beea0dc99b886/Dockerfile-old#L24).

As part of doing this though, I broke one of our rules: thou shall not touch `certbot-auto`. Instead of doing this, we could set this variable in every test farm test script or we could create a custom AMI with this problem solved, but to me, really fixing this problem in `certbot-auto` seemed like the better solution. If people disagree, I can take a different approach and I would like two reviews on this PR before merging it.

You can see test farm tests passing with these changes at https://travis-ci.com/certbot/certbot/builds/115883651 and I ran `test_tests.sh` locally and they passed.