### PR TITLE
Update Ubuntu 18.04 AMI to fix blocking on input

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -6,7 +6,7 @@ targets:
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-012fd5eb46f56731f
+  - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu
     virt: hvm

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -6,7 +6,7 @@ targets:
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-012fd5eb46f56731f
+  - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu
     virt: hvm


### PR DESCRIPTION
Test farm tests have been failing for the last few days because they block on user input and get timed out. The cause of this is that as part of installing Certbot, some packages are updated which causes running services to need to be restarted. debconf as invoked by apt-get install is blocking asking if it's OK to restart these packages. Updating to a newer version of the Ubuntu AMI solves these problems.

This AMI ID comes from https://cloud-images.ubuntu.com/locator/ec2/ where it is the only Ubuntu AMI in us-east-1, for Ubuntu 18.04 Bionic, not running on ARM, and is using EBS for storage.

You can see the tests passing with this change at https://travis-ci.com/certbot/certbot/builds/116001774. I also ran `test_tests.sh` locally which passed.