### PR TITLE
Upgrade to the latest macOS image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -234,6 +234,7 @@ matrix:
     - language: generic
       env: TOXENV=py27
       os: osx
+      osx_image: xcode10.2
       addons:
         homebrew:
           packages:
@@ -243,6 +244,7 @@ matrix:
     - language: generic
       env: TOXENV=py3
       os: osx
+      osx_image: xcode10.2
       addons:
         homebrew:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -234,6 +234,8 @@ matrix:
     - language: generic
       env: TOXENV=py27
       os: osx
+      # Using this osx_image is a workaround for
+      # https://travis-ci.community/t/xcode-8-3-homebrew-outdated-error/3798.
       osx_image: xcode10.2
       addons:
         homebrew:
@@ -244,6 +246,8 @@ matrix:
     - language: generic
       env: TOXENV=py3
       os: osx
+      # Using this osx_image is a workaround for
+      # https://travis-ci.community/t/xcode-8-3-homebrew-outdated-error/3798.
       osx_image: xcode10.2
       addons:
         homebrew:


### PR DESCRIPTION
This fixes the test failures we saw last night at https://travis-ci.com/certbot/certbot/builds/116073070.

The problem is that the Homebrew installation included in the Travis image is outdated and when it tries to install packages, it fails. You can see this at https://travis-ci.com/certbot/certbot/jobs/209185570#L83. There is a thread in Travis' community froum about this at https://travis-ci.community/t/xcode-8-3-homebrew-outdated-error/3798.

To fix this, we could either upgrade Hombrew which can be a slow process according to both [Travis](https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos) and [the original poster of the issue](https://travis-ci.community/t/xcode-8-3-homebrew-outdated-error/3798) or we could upgrade to a newer [version of macOS](https://docs.travis-ci.com/user/reference/osx/#macos-version). I chose the latter to avoid the speed problems and picked the latest version available.

You can see tests passing with these changes at https://travis-ci.com/certbot/certbot/builds/116186095.