### PR TITLE
Fix codecov quality gate since flags have been removed

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,11 +4,11 @@ coverage:
       default: off
       linux:
         flags: linux
-        target: auto
+        target: 98.0
         threshold: 0.1
         base: auto
       windows:
         flags: windows
-        target: auto
+        target: 96.9
         threshold: 0.1
         base: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,11 +4,15 @@ coverage:
       default: off
       linux:
         flags: linux
+        # Fixed target instead of auto set by #7173, can
+        # be removed when flags in Codecov are added back.
         target: 98.0
         threshold: 0.1
         base: auto
       windows:
         flags: windows
+        # Fixed target instead of auto set by #7173, can
+        # be removed when flags in Codecov are added back.
         target: 96.9
         threshold: 0.1
         base: auto


### PR DESCRIPTION
Because some users were complaining about staled workflow when flags (https://docs.codecov.io/docs/flags) are enabled, Codecov decided to remove them when calculating the coverage on branches until they improved this functionality.

See: https://docs.codecov.io/docs/flags#section-flags-in-the-codecov-ui

The flags are still taken into account on PR builds, but not on based branch.

This is a problem for us, because we use the flags to compare specifically the coverage of a PR against its base branch for Windows on one side, and Linux on the other side. Without flags taken into account on the base branch, the CI fails because the coverage on Windows is too low.

As a temporary fix until the situation is clarified on Codecov side, this PR replaces the validation condition, that was a comparison against the base branch, to a fixed coverage registered in the local `.codecov.yml` file in Certbot repository.

This way, the coverage on PR builds, that takes into account the flags, is validated against an appropriate value.

This is a temporary solution, that will require an explicit update of `.codecov.yml` in the mean time if the coverage significantly increases, or decreases on some developments. But until the situation is fixed, this will allow to have a functional quality gate.