### PR TITLE
Fix integration tests with Pebble v2.1.0 +

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -147,8 +147,6 @@ def _prepare_acme_server(workspace, acme_type, acme_xdist):
             config['services']['pebble']['command'] = config['services']['pebble']['command']\
                 .replace('-strict', '')
 
-            print(yaml.dump(config))
-
             with open(os.path.join(instance_path, 'docker-compose.yml'), 'w') as file_handler:
                 file_handler.write(yaml.dump(config))
 

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -142,7 +142,7 @@ def _prepare_acme_server(workspace, acme_type, acme_xdist):
 
             # Also disable strict mode for now, since Pebble v2.1.0 added specs in
             # strict mode for which Certbot is not compliant for now.
-            # See https://github.com/letsencrypt/pebble/commit/3a2ce1c2facf20dacf65bb476209c389d4060935
+            # See https://github.com/certbot/certbot/pull/7175
             # TODO: Add back -strict mode once Certbot is compliant with Pebble v2.1.0+
             config['services']['pebble']['command'] = config['services']['pebble']['command']\
                 .replace('-strict', '')

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -132,13 +132,23 @@ def _prepare_acme_server(workspace, acme_type, acme_xdist):
             os.rename(join(instance_path, 'test/rate-limit-policies-b.yml'),
                       join(instance_path, 'test/rate-limit-policies.yml'))
         if acme_type == 'pebble':
-            # Configure Pebble at full speed (PEBBLE_VA_NOSLEEP=1) and not randomly refusing valid
-            # nonce (PEBBLE_WFE_NONCEREJECT=0) to have a stable test environment.
             with open(os.path.join(instance_path, 'docker-compose.yml'), 'r') as file_handler:
                 config = yaml.load(file_handler.read())
 
+            # Configure Pebble at full speed (PEBBLE_VA_NOSLEEP=1) and not randomly refusing valid
+            # nonce (PEBBLE_WFE_NONCEREJECT=0) to have a stable test environment.
             config['services']['pebble'].setdefault('environment', [])\
                 .extend(['PEBBLE_VA_NOSLEEP=1', 'PEBBLE_WFE_NONCEREJECT=0'])
+
+            # Also disable strict mode for now, since Pebble v2.1.0 added specs in
+            # strict mode for which Certbot is not compliant for now.
+            # See https://github.com/letsencrypt/pebble/commit/3a2ce1c2facf20dacf65bb476209c389d4060935
+            # TODO: Add back -strict mode once Certbot is compliant with Pebble v2.1.0+
+            config['services']['pebble']['command'] = config['services']['pebble']['command']\
+                .replace('-strict', '')
+
+            print(yaml.dump(config))
+
             with open(os.path.join(instance_path, 'docker-compose.yml'), 'w') as file_handler:
                 file_handler.write(yaml.dump(config))
 


### PR DESCRIPTION
Since Pebble v2.1.0, new controls have been added on ACME specs compliance on Pebble with strict mode enabled. These controls are described here: https://github.com/letsencrypt/pebble/commit/3a2ce1c2facf20dacf65bb476209c389d4060935

Currently Certbot is not compliant enough to pass these new controls. One part of the work to do is described here: https://github.com/certbot/certbot/issues/7171

As a consequence, our CI is currently broken, both on PR builds and nightly builds.

This PR disables the strict mode during integration tests, fixing temporarily our CI. This will give us some time to fix theses deviations, and add back the strict mode in a future PR once it is merged.
