### PR TITLE
Upgrade compatibility tests to stretch

### DIFF
--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER Brad Warren <bmw@eff.org>
 
 # no need to mkdir anything:


### PR DESCRIPTION
Inspired by https://github.com/certbot/certbot/issues/7180, there's no reason for these tests to be running on old stable. This upgrades them to the latest stable version of Debian.

You can see tests passing with these changes at https://travis-ci.com/certbot/certbot/builds/116844923.