### PR TITLE
Drop quay.io Docker images

### DIFF
--- a/tools/docker-warning.sh
+++ b/tools/docker-warning.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -e
-echo "Warning: This Docker image will soon be switching to Alpine Linux." >&2
-echo "You can switch now using the certbot/certbot repo on Docker Hub." >&2
+echo 'Warning: This Docker image is no longer receiving updates!' >&2
+echo 'You should switch to the Docker images on Docker Hub at:' >&2
+echo 'https://hub.docker.com/u/certbot' >&2
 exec /opt/certbot/venv/bin/certbot $@


### PR DESCRIPTION
In this spirt of cleaning up some low hanging cruft, this fixes #4343.

There are no (recent) release tags on quay.io and the builds are just following master. See https://quay.io/repository/letsencrypt/letsencrypt?tab=tags.

Once this lands, I can disable the automated builds on quay.io and we can delete `Dockerfile-old` and `tools/docker-warning.sh`.