### PR TITLE
Add Debian ARM AMI

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -33,6 +33,12 @@ targets:
     type: ubuntu
     virt: hvm
     user: admin
+  - ami: ami-0ed54dd1b25657636
+    name: debian9_arm64
+    type: ubuntu
+    virt: hvm
+    user: admin
+    machine_type: a1.medium
   - ami: ami-077bf3962f29d3fa4
     name: debian8.1
     type: ubuntu

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -307,7 +307,9 @@ def grab_certbot_log():
 
 def create_client_instance(ec2_client, target, security_group_id, subnet_id):
     """Create a single client instance for running tests."""
-    if target['virt'] == 'hvm':
+    if 'machine_type' in target:
+        machine_type = target['machine_type']
+    elif target['virt'] == 'hvm':
         machine_type = 't2.medium' if cl_args.fast else 't2.micro'
     else:
         # 32 bit systems

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -33,6 +33,12 @@ targets:
     type: ubuntu
     virt: hvm
     user: admin
+  - ami: ami-0ed54dd1b25657636
+    name: debian9_arm64
+    type: ubuntu
+    virt: hvm
+    user: admin
+    machine_type: a1.medium
   - ami: ami-077bf3962f29d3fa4
     name: debian8.1
     type: ubuntu


### PR DESCRIPTION
Inspired by the [number of ARM users we have](https://gist.github.com/c36e9bf6171f0b953e116dd4dc2c9558) (and because I want to rip out the only 32 bit test we have which without this PR would remove all tests we have on non-x86_64 architectures), this test adds an ARM image to the test farm tests. The image ID was taken from https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch, you can see tests passing at https://travis-ci.com/certbot/certbot/builds/116857897, and I ran `test_tests.sh` locally and it passed.