### PR TITLE
Delimit FORUM_POST_URL From File Paths

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -63,6 +63,7 @@ Authors
 * [David Kreitschmann](https://kreitschmann.de)
 * [David Xia](https://github.com/davidxia)
 * [Devin Howard](https://github.com/devvmh)
+* [dkp](https://github.com/commit-dkp)
 * [dokazaki](https://github.com/dokazaki)
 * [Dominic Cleal](https://github.com/domcleal)
 * [Dominic Lüchinger](https://github.com/dol)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Prevent linkifying of file paths in emailed cron output.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1033,7 +1033,7 @@ def main(certbot_auto_path):
 
     if not permissions_ok:
         print('{0} has insecure permissions!'.format(certbot_auto_path))
-        print('To learn how to fix them, visit {0}'.format(FORUM_POST_URL))
+        print('To learn how to fix them, visit <{0}>'.format(FORUM_POST_URL))
 
 
 if __name__ == '__main__':

--- a/letsencrypt-auto-source/pieces/check_permissions.py
+++ b/letsencrypt-auto-source/pieces/check_permissions.py
@@ -74,7 +74,7 @@ def main(certbot_auto_path):
 
     if not permissions_ok:
         print('{0} has insecure permissions!'.format(certbot_auto_path))
-        print('To learn how to fix them, visit {0}'.format(FORUM_POST_URL))
+        print('To learn how to fix them, visit <{0}>'.format(FORUM_POST_URL))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Extra whitespace is added to break a long URI across lines, so Gmail
and others ignore it and extract FORUM_POST_URL and a following file
path as a single URL.

Per https://tools.ietf.org/html/rfc3986#section-1.2.2 , <> angle
brackets have been placed around each replacement field that
FORUM_POST_URL replaces.

Resolves: #7144