### PR TITLE
Fix certbot config_changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Update the 'manage your account' help to be more generic.
 * The error message when Certbot's Apache plugin is unable to modify your
   Apache configuration has been improved.
+* `certbot config_changes` no longer accepts a --num parameter.
 
 ### Fixed
 

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -418,8 +418,8 @@ VERB_HELP = [
     }),
     ("config_changes", {
         "short": "Show changes that Certbot has made to server configurations",
-        "opts": "Options for controlling which changes are displayed",
-        "usage": "\n\n  certbot config_changes --num NUM [options]\n\n"
+        "opts": "Options for viewing configuration changes",
+        "usage": "\n\n  certbot config_changes [options]\n\n"
     }),
     ("rollback", {
         "short": "Roll back server conf changes made during certificate installation",
@@ -1289,9 +1289,6 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
 
 
 def _create_subparsers(helpful):
-    helpful.add("config_changes", "--num", type=int, default=flag_default("num"),
-                help="How many past revisions you want to be displayed")
-
     from certbot.client import sample_user_agent # avoid import loops
     helpful.add(
         None, "--user-agent", default=flag_default("user_agent"),

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -702,7 +702,7 @@ def rollback(default_installer, checkpoints, config, plugins):
         installer.restart()
 
 
-def view_config_changes(config, num=None):
+def view_config_changes(config):
     """View checkpoints and associated configuration changes.
 
     .. note:: This assumes that the installation is using a Reverter object.
@@ -713,7 +713,7 @@ def view_config_changes(config, num=None):
     """
     rev = reverter.Reverter(config)
     rev.recovery_routine()
-    rev.view_config_changes(num)
+    rev.view_config_changes()
 
 def _open_pem_file(cli_arg_path, pem_path):
     """Open a pem file.

--- a/certbot/main.py
+++ b/certbot/main.py
@@ -976,7 +976,7 @@ def config_changes(config, unused_plugins):
     :rtype: None
 
     """
-    client.view_config_changes(config, num=config.num)
+    client.view_config_changes(config)
 
 def update_symlinks(config, unused_plugins):
     """Update the certificate file family symlinks

--- a/certbot/reverter.py
+++ b/certbot/reverter.py
@@ -132,7 +132,7 @@ class Reverter(object):
                     "Unable to load checkpoint during rollback")
             rollback -= 1
 
-    def view_config_changes(self, num=None):
+    def view_config_changes(self):
         """Displays all saved checkpoints.
 
         All checkpoints are printed by
@@ -145,8 +145,6 @@ class Reverter(object):
         """
         backups = os.listdir(self.config.backup_dir)
         backups.sort(reverse=True)
-        if num:
-            backups = backups[:num]
         if not backups:
             logger.info("Certbot has not saved backups of your configuration")
 

--- a/certbot/reverter.py
+++ b/certbot/reverter.py
@@ -132,7 +132,7 @@ class Reverter(object):
                     "Unable to load checkpoint during rollback")
             rollback -= 1
 
-    def view_config_changes(self, for_logging=False, num=None):
+    def view_config_changes(self, num=None):
         """Displays all saved checkpoints.
 
         All checkpoints are printed by
@@ -182,8 +182,6 @@ class Reverter(object):
 
             output.append(os.linesep)
 
-        if for_logging:
-            return os.linesep.join(output)
         zope.component.getUtility(interfaces.IDisplay).notification(
             os.linesep.join(output), force_interactive=True, pause=False)
         return None

--- a/certbot/tests/reverter_test.py
+++ b/certbot/tests/reverter_test.py
@@ -400,15 +400,6 @@ class TestFullCheckpointsReverter(test_util.ConfigTestCase):
         self.assertRaises(
             errors.ReverterError, self.reverter.view_config_changes)
 
-    def test_view_config_changes_for_logging(self):
-        self._setup_three_checkpoints()
-
-        config_changes = self.reverter.view_config_changes(for_logging=True)
-
-        self.assertTrue("First Checkpoint" in config_changes)
-        self.assertTrue("Second Checkpoint" in config_changes)
-        self.assertTrue("Third Checkpoint" in config_changes)
-
     def _setup_three_checkpoints(self):
         """Generate some finalized checkpoints."""
         # Checkpoint1 - config1


### PR DESCRIPTION
When looking at https://github.com/certbot/certbot/issues/6899#issuecomment-506043120 I noticed a bug. [certbot.client.view_config_changes](https://github.com/certbot/certbot/blob/a778b5040361e1aa51c69d716b58ac7ac49652a7/certbot/client.py#L705) calls [certbot.reverter.Reverter.view_config_changes](https://github.com/certbot/certbot/blob/a778b5040361e1aa51c69d716b58ac7ac49652a7/certbot/reverter.py#L135) with a single positional argument which is meant to be the number of configuration changes to view, however, that is not the first argument that the function accepts. The first argument is whether or not the changes should be returned as a string for the purposes of logging.

As a result, if you first run Certbot and have it install certs with the Apache/Nginx plugin and then run `certbot config_changes --num <int>` where `<int>` is any nonzero `int`, no configuration changes are printed. It seems that this `for_logging` parameter is not used anywhere in the Certbot code base so for simplicity, I removed it and the test for it.

I went one step further though. Since this `--num` parameter does not work and no one is asking for the feature, let's just remove it entirely. `--num` isn't a very elegant name, it serves the same purpose as `--checkpoints` does for the `rollback` subcommand, and if the demand for being able to view a subset of configuration changes arises (which I don't think it will), we can always add it back. It's not very often we get to remove a flag from Certbot.

I ran our full test suite on this change at https://travis-ci.com/certbot/certbot/builds/117062414 to try and make sure I didn't miss anything.