### PR TITLE
certbot-plugin-gandi is not an installer.

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -274,7 +274,7 @@ Plugin             Auth Inst Notes
 plesk_             Y    Y    Integration with the Plesk web hosting tool
 haproxy_           Y    Y    Integration with the HAProxy load balancer
 s3front_           Y    Y    Integration with Amazon CloudFront distribution of S3 buckets
-gandi_             Y    Y    Integration with Gandi LiveDNS API
+gandi_             Y    N    Obtain certificates via the Gandi LiveDNS API
 varnish_           Y    N    Obtain certificates via a Varnish server
 external_          Y    N    A plugin for convenient scripting (See also ticket 2782_)
 icecast_           N    Y    Deploy certificates to Icecast 2 streaming media servers


### PR DESCRIPTION
This [plugin](https://github.com/obynio/certbot-plugin-gandi) is an authenticator but not an installer. It's a DNS authenticator plugin.