### PR TITLE
Replace Some Platform-Specific Line Separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Replace some unnecessary platform-specific line separation.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -114,7 +114,7 @@ class FileDisplay(object):
             message = _wrap_lines(message)
         self.outfile.write(
             "{line}{frame}{line}{msg}{line}{frame}{line}".format(
-                line=os.linesep, frame=SIDE_FRAME, msg=message))
+                line='\n', frame=SIDE_FRAME, msg=message))
         self.outfile.flush()
         if pause:
             if self._can_interact(force_interactive):

--- a/certbot/reverter.py
+++ b/certbot/reverter.py
@@ -178,10 +178,10 @@ class Reverter(object):
                     for path in filepaths:
                         output.append("  {0}".format(path))
 
-            output.append(os.linesep)
+            output.append('\n')
 
         zope.component.getUtility(interfaces.IDisplay).notification(
-            os.linesep.join(output), force_interactive=True, pause=False)
+            '\n'.join(output), force_interactive=True, pause=False)
         return None
 
     def add_to_temp_checkpoint(self, save_files, save_notes):
@@ -497,9 +497,9 @@ class Reverter(object):
                         os.remove(path)
                     else:
                         logger.warning(
-                            "File: %s - Could not be found to be deleted %s - "
-                            "Certbot probably shut down unexpectedly",
-                            os.linesep, path)
+                            "File: %s - Could not be found to be deleted\n"
+                            " - Certbot probably shut down unexpectedly",
+                            path)
         except (IOError, OSError):
             logger.critical(
                 "Unable to remove filepaths contained within %s", file_list)


### PR DESCRIPTION
os.linesep isn't supposed to be used when writing to files opened in
text mode, where '\n' is escaped to the platform-specific ASCII
sequence.  For example, on Windows, os.linesep is '\r\n' and in text
mode is escaped to ASCII sequence CR CR LF rather than just CR LF.
This is also true for the default logger and IDisplay notifications.

Replacing os.linesep with '\n' ensures the right sequence is escaped.

Resolves: #6899