### PR TITLE
Checks for delegated acme and no check root domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * The error message when Certbot's Apache plugin is unable to modify your
   Apache configuration has been improved.
 * `certbot config_changes` no longer accepts a --num parameter.
+* DNS plugins also checks _acme-challenge.(domain) for more specific DNS delegation.
+* DNS plugins no longer check the root-level domain, e.g. must be two-levels.
 
 ### Fixed
 

--- a/certbot/plugins/dns_common.py
+++ b/certbot/plugins/dns_common.py
@@ -331,6 +331,6 @@ def base_domain_name_guesses(domain):
     :returns: The a list of less specific domain names.
     :rtype: list
     """
-
+    domain = '_acme-challenge.' + domain
     fragments = domain.split('.')
-    return ['.'.join(fragments[i:]) for i in range(0, len(fragments))]
+    return ['.'.join(fragments[i:]) for i in range(0, len(fragments)-1)]

--- a/certbot/plugins/dns_common_test.py
+++ b/certbot/plugins/dns_common_test.py
@@ -224,6 +224,18 @@ class DomainNameGuessTest(unittest.TestCase):
             dns_common.base_domain_name_guesses("foo.bar.baz.example.co.uk")
         )
 
+    def test_most_specific_domain(self):
+        self.assertTrue(
+            '_acme-challenge.foo.bar.baz.example.co.uk' in
+            dns_common.base_domain_name_guesses("foo.bar.baz.example.co.uk")
+        )
+
+    def test_no_root_domain(self):
+        self.assertFalse(
+            'uk' in
+            dns_common.base_domain_name_guesses("foo.bar.baz.example.co.uk")
+        )
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
These changes allow one to have a delegated DNS domain for the most-specific part to reduce the level of DNS modification access that needs to be provided to certbot container.

e.g. One could delegate `_acme-challenge.example.com` to a new zone, and create the access keys that only allow updates within that zone.

It also prevents returning the root DNS domain from `base_domain_name_guesses()` as looking for that zone is likely not useful.

Tests have been updated for both.