### PR TITLE
Pin/upgrade virtualenv in our tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -268,7 +268,10 @@ addons:
 
 # tools/pip_install.py is used to pin packages to a known working version
 # except in tests where the environment variable CERTBOT_NO_PIN is set.
-install: "tools/pip_install.py -U codecov tox"
+# virtualenv is listed here explicitly to make sure it is upgraded when
+# CERTBOT_NO_PIN is set to work around failures we've seen when using an older
+# version of virtualenv.
+install: "tools/pip_install.py -U codecov tox virtualenv"
 script: tox
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'

--- a/.travis.yml
+++ b/.travis.yml
@@ -268,7 +268,9 @@ addons:
 
 # tools/pip_install.py is used to pin packages to a known working version
 # except in tests where the environment variable CERTBOT_NO_PIN is set.
-install: "tools/pip_install.py codecov tox"
+# virtualenv is listed here explicitly to make sure it is upgraded when
+# CERTBOT_NO_PIN is set.
+install: "tools/pip_install.py codecov tox virtualenv"
 script: tox
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'

--- a/.travis.yml
+++ b/.travis.yml
@@ -255,9 +255,8 @@ sudo: false
 
 addons:
   apt:
-    packages:  # Keep in sync with letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh and Boulder.
+    packages:
     - python-dev
-    - python-virtualenv
     - gcc
     - libaugeas0
     - libssl-dev
@@ -267,7 +266,9 @@ addons:
     - nginx-light
     - openssl
 
-install: "$(command -v pip || command -v pip3) install codecov tox"
+# tools/pip_install.py is used to pin packages to a known working version
+# except in tests where the environment variable CERTBOT_NO_PIN is set.
+install: "tools/pip_install.py install codecov tox"
 script: tox
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'

--- a/.travis.yml
+++ b/.travis.yml
@@ -268,9 +268,7 @@ addons:
 
 # tools/pip_install.py is used to pin packages to a known working version
 # except in tests where the environment variable CERTBOT_NO_PIN is set.
-# virtualenv is listed here explicitly to make sure it is upgraded when
-# CERTBOT_NO_PIN is set.
-install: "tools/pip_install.py codecov tox virtualenv"
+install: "tools/pip_install.py -U codecov tox"
 script: tox
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'

--- a/.travis.yml
+++ b/.travis.yml
@@ -255,7 +255,7 @@ sudo: false
 
 addons:
   apt:
-    packages:
+    packages:  # Keep in sync with letsencrypt-auto-source/pieces/bootstrappers/deb_common.sh and Boulder.
     - python-dev
     - gcc
     - libaugeas0

--- a/.travis.yml
+++ b/.travis.yml
@@ -268,7 +268,7 @@ addons:
 
 # tools/pip_install.py is used to pin packages to a known working version
 # except in tests where the environment variable CERTBOT_NO_PIN is set.
-install: "tools/pip_install.py install codecov tox"
+install: "tools/pip_install.py codecov tox"
 script: tox
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ install:
   # Upgrade pip to avoid warnings
   - "python -m pip install --upgrade pip"
   # Ready to install tox and coverage
-  - "pip install tox codecov"
+  # tools/pip_install.py is used to pin packages to a known working version.
+  - "tools/pip_install.py tox codecov"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - "python -m pip install --upgrade pip"
   # Ready to install tox and coverage
   # tools/pip_install.py is used to pin packages to a known working version.
-  - "tools\\pip_install.py tox codecov"
+  - "python tools\\pip_install.py tox codecov"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - "python -m pip install --upgrade pip"
   # Ready to install tox and coverage
   # tools/pip_install.py is used to pin packages to a known working version.
-  - "tools/pip_install.py tox codecov"
+  - "tools\\pip_install.py tox codecov"
 
 build: off
 

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -48,7 +48,7 @@ pkginfo==1.4.2
 pluggy==0.5.2
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
-py==1.4.34
+py==1.8.0
 pyasn1==0.1.9
 pyasn1-modules==0.0.10
 Pygments==2.2.0

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -13,6 +13,7 @@ backports.shutil-get-terminal-size==1.0.0
 boto3==1.9.36
 botocore==1.12.36
 cloudflare==1.5.1
+codecov==2.0.15
 configparser==3.7.4
 coverage==4.4.2
 decorator==4.1.2

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -81,6 +81,6 @@ twine==1.11.0
 typed-ast==1.1.0
 typing==3.6.4
 uritemplate==0.6
-virtualenv==15.1.0
+virtualenv==16.6.1
 wcwidth==0.1.7
 wrapt==1.11.1


### PR DESCRIPTION
This PR fixes our nightly test failures which can be seen at https://travis-ci.com/certbot/certbot/jobs/212188745.

The cause of these failures is that [older versions of virtualenv provide their own copy of distutils' `__init__.py`](https://github.com/pypa/virtualenv/blob/16.1.0/virtualenv_embedded/distutils-init.py#L1). This file imports the imp module which is deprecated in Python 3.7. When we import distutils in our Certbot tests, this causes a deprecation warning to be given and our tests to fail.

To fix this, I stopped using the virtualenv package from OS packages/CI and instead grab a pinned copy from PyPI in both AppVeyor and Travis. As part of doing this, we now also pin codecov, tox, and their dependencies (except when `CERTBOT_NO_PIN` is set which can be see [here](https://travis-ci.com/certbot/certbot/jobs/212441226#L283) using newer versions of those packages).

I also had to update the version of py in our tests to fix failures in AppVeyor seen at https://ci.appveyor.com/project/certbot/certbot/builds/25670201/job/0860r2utpryovrax#L117. I checked both [py's](https://py.readthedocs.io/en/latest/changelog.html#changelog) and [virtualenv's](https://virtualenv.pypa.io/en/stable/changes/) changelog to make sure they didn't drop support for any systems we care about.

I'm running our full test suite on these changes at https://travis-ci.com/certbot/certbot/builds/117578552.

Unfortunately, I wasn't able to figure out why the `CERTBOT_NO_PIN` tests were failing but our normal py37 unit tests were not ☹️ Regardless of that though, this PR fixes the problem and I think it's an improvement to pin/upgrade more of Certbot's dependencies while running tests.