### PR TITLE
Install Python3 only dev tools with tools/venv3.py

### DIFF
--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -177,11 +177,8 @@ def prepare_venv_path(venv_name):
     return venv_name
 
 
-def install_packages(venv_name, pip_args=None):
+def install_packages(venv_name, pip_args):
     """Installs packages in the given venv.
-
-    If pip_args is given, they are the arguments given to pip,
-    otherwise, REQUIREMENTS is used.
 
     :param str venv_name: The name or path at where the virtual
         environment should be created.
@@ -190,9 +187,6 @@ def install_packages(venv_name, pip_args=None):
     :type pip_args: `list` of `str`
 
     """
-    if not pip_args:
-        pip_args = REQUIREMENTS
-
     # Using the python executable from venv, we ensure to execute following commands in this venv.
     py_venv = get_venv_python_path(venv_name)
     subprocess_with_print([py_venv, os.path.abspath('letsencrypt-auto-source/pieces/pipstrap.py')])

--- a/tools/venv.py
+++ b/tools/venv.py
@@ -25,6 +25,10 @@ def main(pip_args=None):
 
     venv_path = _venv_common.prepare_venv_path('venv')
     create_venv(venv_path)
+
+    if not pip_args:
+        pip_args = _venv_common.REQUIREMENTS
+
     _venv_common.install_packages(venv_path, pip_args)
 
 

--- a/tools/venv3.py
+++ b/tools/venv3.py
@@ -19,6 +19,10 @@ def create_venv(venv_path):
 def main(pip_args=None):
     venv_path = _venv_common.prepare_venv_path('venv3')
     create_venv(venv_path)
+
+    if not pip_args:
+        pip_args = _venv_common.REQUIREMENTS + ['-e .[dev3]']
+
     _venv_common.install_packages(venv_path, pip_args)
 
 


### PR DESCRIPTION
These packages can be useful and I found that they aren't being installed in our Python 3 development environment. Let's fix that.