### PR TITLE
Add safedns support via lexicon

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -157,6 +157,7 @@ Authors
 * [Martin Brugger](https://github.com/mbrugger)
 * [Mathieu Leduc-Hamel](https://github.com/mlhamel)
 * [Matt Bostock](https://github.com/mattbostock)
+* [Matt Calvert](https://github.com/miff2000)
 * [Matthew Ames](https://github.com/SuperMatt)
 * [Michael Schumacher](https://github.com/schumaml)
 * [Michael Strache](https://github.com/Jarodiv)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Turn off session tickets for nginx plugin by default
 * Added missing error types from RFC8555 to acme
+* Add support for SafeDNS DNS auth via Lexicon library
 
 ### Changed
 
@@ -21,6 +22,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * The functions `certbot.plugins.common.Installer.view_config_changes` and
   `certbot.reverter.Reverter.view_config_changes` have been deprecated and will
   be removed in a future release.
+* Update `dns-lexicon` required version to 3.2.9 (providing SafeDNS support)
 
 ### Fixed
 

--- a/certbot-dns-safedns/certbot_dns_safedns/__init__.py
+++ b/certbot-dns-safedns/certbot_dns_safedns/__init__.py
@@ -1,0 +1,85 @@
+"""
+The `~certbot_dns_safedns.dns_safedns` plugin automates the process of
+completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) by creating, and
+subsequently removing, TXT records using the SafeDNS API.
+
+
+Named Arguments
+---------------
+
+========================================  =====================================
+``--dns-safedns-credentials``            SafeDNS credentials_ INI file.
+                                          (Required)
+``--dns-safedns-propagation-seconds``    The number of seconds to wait for DNS
+                                          to propagate before asking the ACME
+                                          server to verify the DNS record.
+                                          (Default: 30)
+========================================  =====================================
+
+
+Credentials
+-----------
+
+Use of this plugin requires a configuration file containing SafeDNS API
+credentials, obtained from your SafeDNS
+`API page <https://my.ukfast.co.uk/applications/index.php>`_.
+
+.. code-block:: ini
+   :name: credentials.ini
+   :caption: Example credentials file:
+
+   # SafeDNS API token used by Certbot
+   dns_safedns_auth_token = 1234567890abcdef1234567890abcdef
+
+The path to this file can be provided interactively or using the
+``--dns-safedns-credentials`` command-line argument. Certbot records the path
+to this file for use during renewal, but does not store the file's contents.
+
+.. caution::
+   You should protect these API credentials as you would the password to your
+   SafeDNS account. Users who can read this file can use these credentials to
+   issue arbitrary API calls on your behalf. Users who can cause Certbot to run
+   using these credentials can complete a ``dns-01`` challenge to acquire new
+   certificates or revoke existing certificates for associated domains, even if
+   those domains aren't being managed by this server.
+
+Certbot will emit a warning if it detects that the credentials file can be
+accessed by other users on your system. The warning reads "Unsafe permissions
+on credentials configuration file", followed by the path to the credentials
+file. This warning will be emitted each time Certbot uses the credentials file,
+including for renewal, and cannot be silenced except by addressing the issue
+(e.g., by using a command like ``chmod 600`` to restrict access to the file).
+
+
+Examples
+--------
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``
+
+   certbot certonly \\
+     --dns-safedns \\
+     --dns-safedns-credentials ~/.secrets/certbot/safedns.ini \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com``
+
+   certbot certonly \\
+     --dns-safedns \\
+     --dns-safedns-credentials ~/.secrets/certbot/safedns.ini \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``, waiting 60 seconds
+             for DNS propagation
+
+   certbot certonly \\
+     --dns-safedns \\
+     --dns-safedns-credentials ~/.secrets/certbot/safedns.ini \\
+     --dns-safedns-propagation-seconds 60 \\
+     -d example.com
+
+"""

--- a/certbot-dns-safedns/certbot_dns_safedns/dns_safedns.py
+++ b/certbot-dns-safedns/certbot_dns_safedns/dns_safedns.py
@@ -1,0 +1,91 @@
+"""DNS Authenticator for UKFast's SafeDNS service."""
+import logging
+
+import zope.interface
+from lexicon.providers import safedns
+
+from certbot import errors
+from certbot import interfaces
+from certbot.plugins import dns_common
+from certbot.plugins import dns_common_lexicon
+
+logger = logging.getLogger(__name__)
+
+ACCOUNT_URL = 'https://my.ukfast.co.uk/applications/index.php'
+
+
+@zope.interface.implementer(interfaces.IAuthenticator)
+@zope.interface.provider(interfaces.IPluginFactory)
+class Authenticator(dns_common.DNSAuthenticator):
+    """DNS Authenticator for UKFast's SafeDNS
+
+    This Authenticator uses the SafeDNS API to fulfill a dns-01 challenge.
+    """
+
+    description = 'Obtain certificates using a DNS TXT record (if you are using SafeDNS for DNS).'
+    ttl = 60
+
+    def __init__(self, *args, **kwargs):
+        super(Authenticator, self).__init__(*args, **kwargs)
+        self.credentials = None
+
+    @classmethod
+    def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
+        super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=30)
+        add('credentials', help='SafeDNS credentials INI file.')
+
+    def more_info(self):  # pylint: disable=missing-docstring,no-self-use
+        return 'This plugin configures a DNS TXT record to respond to a dns-01 challenge using ' + \
+               'the SafeDNS API.'
+
+    def _setup_credentials(self):
+        self.credentials = self._configure_credentials(
+            'credentials',
+            'SafeDNS credentials INI file',
+            {
+                'auth_token': 'API Application Token for SafeDNS account, obtained from {0}'
+                .format(ACCOUNT_URL)
+            }
+        )
+
+    def _perform(self, domain, validation_name, validation):
+        self._get_safedns_client().add_txt_record(domain, validation_name, validation)
+
+    def _cleanup(self, domain, validation_name, validation):
+        self._get_safedns_client().del_txt_record(domain, validation_name, validation)
+
+    def _get_safedns_client(self):
+        return _SafeDNSLexiconClient(
+            self.credentials.conf('auth_token'),
+            self.ttl
+        )
+
+class _SafeDNSLexiconClient(dns_common_lexicon.LexiconClient):
+    """
+    Encapsulates all communication with SafeDNS via Lexicon.
+    """
+
+    def __init__(self, auth_token, ttl):
+        super(_SafeDNSLexiconClient, self).__init__()
+
+        config = dns_common_lexicon.build_lexicon_config('safedns', {
+            'ttl': ttl,
+        }, {
+            'auth_token': auth_token,
+        })
+
+        self.provider = safedns.Provider(config)
+
+    def _handle_http_error(self, e, domain_name):
+        hint = None
+        if str(e).startswith('400 Client Error:'):
+            hint = 'Are your API key and Secret key values correct?'
+
+        return errors.PluginError('Error determining zone identifier for {0}: {1}.{2}'
+                                  .format(domain_name, e, ' ({0})'.format(hint) if hint else ''))
+
+    def _handle_general_error(self, e, domain_name):
+        if domain_name in str(e) and str(e).endswith('not found'):
+            return
+
+        super(_SafeDNSLexiconClient, self)._handle_general_error(e, domain_name)

--- a/certbot-dns-safedns/certbot_dns_safedns/dns_safedns_test.py
+++ b/certbot-dns-safedns/certbot_dns_safedns/dns_safedns_test.py
@@ -1,0 +1,53 @@
+"""Tests for certbot_dns_safedns.dns_safedns."""
+
+import unittest
+
+import mock
+from requests.exceptions import HTTPError, RequestException
+
+from certbot.compat import os
+from certbot.plugins import dns_test_common
+from certbot.plugins import dns_test_common_lexicon
+from certbot.tests import util as test_util
+
+DOMAIN_NOT_FOUND = Exception('No domain found')
+GENERIC_ERROR = RequestException
+LOGIN_ERROR = HTTPError('400 Client Error: ...')
+
+AUTH_TOKEN = 'foo'
+
+
+class AuthenticatorTest(test_util.TempDirTestCase,
+                        dns_test_common_lexicon.BaseLexiconAuthenticatorTest):
+
+    def setUp(self):
+        super(AuthenticatorTest, self).setUp()
+
+        from certbot_dns_safedns.dns_safedns import Authenticator
+
+        path = os.path.join(self.tempdir, 'file.ini')
+        dns_test_common.write({"safedns_auth_token": AUTH_TOKEN}, path)
+
+        self.config = mock.MagicMock(safedns_credentials=path,
+                                     safedns_propagation_seconds=0)  # don't wait during tests
+
+        self.auth = Authenticator(self.config, "safedns")
+
+        self.mock_client = mock.MagicMock()
+        # _get_safedns_client | pylint: disable=protected-access
+        self.auth._get_safedns_client = mock.MagicMock(return_value=self.mock_client)
+
+
+class SafeDNSLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexiconClientTest):
+
+    def setUp(self):
+        from certbot_dns_safedns.dns_safedns import _SafeDNSLexiconClient
+
+        self.client = _SafeDNSLexiconClient(AUTH_TOKEN, 0)
+
+        self.provider_mock = mock.MagicMock()
+        self.client.provider = self.provider_mock
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot-dns-safedns/local-oldest-requirements.txt
+++ b/certbot-dns-safedns/local-oldest-requirements.txt
@@ -1,0 +1,4 @@
+# Remember to update setup.py to match the package versions below.
+acme[dev]==0.31.0
+certbot[dev]==0.34.0
+dns-lexicon==3.2.8

--- a/certbot-dns-safedns/readthedocs.org.requirements.txt
+++ b/certbot-dns-safedns/readthedocs.org.requirements.txt
@@ -1,0 +1,12 @@
+# readthedocs.org gives no way to change the install command to "pip
+# install -e .[docs]" (that would in turn install documentation
+# dependencies), but it allows to specify a requirements.txt file at
+# https://readthedocs.org/dashboard/letsencrypt/advanced/ (c.f. #259)
+
+# Although ReadTheDocs certainly doesn't need to install the project
+# in --editable mode (-e), just "pip install .[docs]" does not work as
+# expected and "pip install -e .[docs]" must be used instead
+
+-e acme
+-e .
+-e certbot-dns-safedns[docs]

--- a/certbot-dns-safedns/setup.py
+++ b/certbot-dns-safedns/setup.py
@@ -1,0 +1,66 @@
+from setuptools import setup
+from setuptools import find_packages
+
+
+version = '0.36.0.dev0'
+
+# Remember to update local-oldest-requirements.txt when changing the minimum
+# acme/certbot version.
+install_requires = [
+    'acme>=0.31.0',
+    'certbot>=0.34.0',
+    'dns-lexicon>=3.2.8', # Includes SafeDNS support
+    'mock',
+    'setuptools',
+    'zope.interface',
+]
+
+docs_extras = [
+    'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags
+    'sphinx_rtd_theme',
+]
+
+setup(
+    name='certbot-dns-safedns',
+    version=version,
+    description="SafeDNS Authenticator plugin for Certbot",
+    url='https://github.com/certbot/certbot',
+    author="Certbot Project",
+    author_email='client-dev@letsencrypt.org',
+    license='Apache License 2.0',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Plugins',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Security',
+        'Topic :: System :: Installation/Setup',
+        'Topic :: System :: Networking',
+        'Topic :: System :: Systems Administration',
+        'Topic :: Utilities',
+    ],
+
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=install_requires,
+    extras_require={
+        'docs': docs_extras,
+    },
+    entry_points={
+        'certbot.plugins': [
+            'dns-safedns = certbot_dns_safedns.dns_safedns:Authenticator',
+        ],
+    },
+    test_suite='certbot_dns_safedns',
+)

--- a/tools/_venv_common.py
+++ b/tools/_venv_common.py
@@ -38,6 +38,7 @@ REQUIREMENTS = [
     '-e certbot-dns-rfc2136',
     '-e certbot-dns-route53',
     '-e certbot-dns-sakuracloud',
+    '-e certbot-dns-safedns',
     '-e certbot-nginx',
     '-e letshelp-certbot',
     '-e certbot-compatibility-test',

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -17,7 +17,7 @@ codecov==2.0.15
 configparser==3.7.4
 coverage==4.4.2
 decorator==4.1.2
-dns-lexicon==3.2.1
+dns-lexicon==3.2.9
 dnspython==1.15.0
 docutils==0.12
 execnet==1.5.0

--- a/tox.cover.py
+++ b/tox.cover.py
@@ -9,7 +9,7 @@ DEFAULT_PACKAGES = [
     'certbot_dns_digitalocean', 'certbot_dns_dnsimple', 'certbot_dns_dnsmadeeasy',
     'certbot_dns_gehirn', 'certbot_dns_google', 'certbot_dns_linode', 'certbot_dns_luadns',
     'certbot_dns_nsone', 'certbot_dns_ovh', 'certbot_dns_rfc2136', 'certbot_dns_route53',
-    'certbot_dns_sakuracloud', 'certbot_nginx', 'letshelp_certbot']
+    'certbot_dns_sakuracloud', 'certbot_dns_safedns', 'certbot_nginx', 'letshelp_certbot']
 
 COVER_THRESHOLDS = {
     'certbot': {'linux': 96, 'windows': 96},
@@ -29,6 +29,7 @@ COVER_THRESHOLDS = {
     'certbot_dns_rfc2136': {'linux': 99, 'windows': 99},
     'certbot_dns_route53': {'linux': 92, 'windows': 92},
     'certbot_dns_sakuracloud': {'linux': 97, 'windows': 97},
+    'certbot_dns_safedns': {'linux': 100, 'windows': 100},
     'certbot_nginx': {'linux': 97, 'windows': 97},
     'letshelp_certbot': {'linux': 100, 'windows': 100}
 }

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ dns_packages =
     certbot-dns-ovh \
     certbot-dns-rfc2136 \
     certbot-dns-route53 \
-    certbot-dns-sakuracloud
+    certbot-dns-sakuracloud \
+    certbot-dns-safedns
 all_packages =
     acme[dev] \
     .[dev] \
@@ -57,6 +58,7 @@ source_paths =
     certbot-dns-rfc2136/certbot_dns_rfc2136
     certbot-dns-route53/certbot_dns_route53
     certbot-dns-sakuracloud/certbot_dns_sakuracloud
+    certbot-dns-safedns/certbot_dns_safedns
     certbot-nginx/certbot_nginx
     letshelp-certbot/letshelp_certbot
     tests/lock_test.py


### PR DESCRIPTION
Add support for UKFast's SafeDNS service to Certbot, using the Lexicon library version 3.2.8.
Closes https://github.com/certbot/certbot/issues/7217

What I'm unsure about here is how the cli gets updated.  Is it constructed in the CI pipeline?