### PR TITLE
Fixes #7220 to allow config to be loaded from <(envsubst < template)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+* Template support `--dns-rfc2136-credentials <(/usr/bin/envsubst < /usr/local/share/rfc2136.ini.template)`
 * Support for Ubuntu 14.04 Trusty has been removed.
 * Update the 'manage your account' help to be more generic.
 * The error message when Certbot's Apache plugin is unable to modify your

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-* Template support `--dns-rfc2136-credentials <(/usr/bin/envsubst < /usr/local/share/rfc2136.ini.template)`
 * Support for Ubuntu 14.04 Trusty has been removed.
 * Update the 'manage your account' help to be more generic.
 * The error message when Certbot's Apache plugin is unable to modify your

--- a/certbot/plugins/dns_common.py
+++ b/certbot/plugins/dns_common.py
@@ -303,8 +303,8 @@ def validate_file(filename):
     if not os.path.exists(filename):
         raise errors.PluginError('File not found: {0}'.format(filename))
 
-    if not os.path.isfile(filename):
-        raise errors.PluginError('Path is not a file: {0}'.format(filename))
+    if os.path.isdir(filename):
+        raise errors.PluginError('Path is a directory: {0}'.format(filename))
 
 
 def validate_file_permissions(filename):


### PR DESCRIPTION
Requires an upstream [PR in configobj](https://github.com/DiffSK/configobj/pull/187)