### PR TITLE
Make PR template a checklist and suggest mypy

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,8 @@
-Be sure to edit the `master` section of `CHANGELOG.md` to include a description
-of the change being made in this PR.
+## Pull Request Checklist
 
-You are also welcome to add your name to `AUTHORS.md` if you like.
+- [ ] Edit the `master` section of `CHANGELOG.md` to include a description of
+  the change being made.
+- [ ] Add [mypy type
+  annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations)
+  for any functions that were added or modified.
+- [ ] Include your name in `AUTHORS.md` if you like.


### PR DESCRIPTION
Suggesting people use `mypy` here came out of our most recent postmortem: https://docs.google.com/document/d/1CDFazf8MfHa5NA4BxrU0mLMrg1TD03TDdg8cO1Kjb8w/edit?usp=sharing

Also suggesting this in https://certbot.eff.org/docs/contributing.html#mypy-type-annotations is ~~coming in another PR~~ in https://github.com/certbot/certbot/pull/7224.