### PR TITLE
Document pytest packaging problems

### DIFF
--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -26,7 +26,7 @@ We release packages and upload them to PyPI (wheels and source tarballs).
 
 The following scripts are used in the process:
 
-- https://github.com/letsencrypt/letsencrypt/blob/master/tools/release.sh
+- https://github.com/certbot/certbot/blob/master/tools/release.sh
 
 We use git tags to identify releases, using `Semantic Versioning`_. For
 example: `v0.11.1`.
@@ -40,11 +40,13 @@ Notes for package maintainers
 
 1. Do not package ``certbot-compatibility-test`` or ``letshelp-certbot`` - it's only used internally.
 
-2. If you'd like to include automated renewal in your package ``certbot renew -q`` should be added to crontab or systemd timer. Additionally you should include a random per-machine time offset to avoid having a large number of your clients hit Let's Encrypt's servers simultaneously.
+2. To run tests on our packages, you should use ``python setup.py test``. Doing things like running ``pytest`` directly on our package files may not work because Certbot relies on setuptools to register and find its plugins.
 
-3. ``jws`` is an internal script for ``acme`` module and it doesn't have to be packaged - it's mostly for debugging: you can use it as ``echo foo | jws sign | jws verify``.
+3. If you'd like to include automated renewal in your package ``certbot renew -q`` should be added to crontab or systemd timer. Additionally you should include a random per-machine time offset to avoid having a large number of your clients hit Let's Encrypt's servers simultaneously.
 
-4. Do get in touch with us. We are happy to make any changes that will make packaging easier. If you need to apply some patches don't do it downstream - make a PR here.
+4. ``jws`` is an internal script for ``acme`` module and it doesn't have to be packaged - it's mostly for debugging: you can use it as ``echo foo | jws sign | jws verify``.
+
+5. Do get in touch with us. We are happy to make any changes that will make packaging easier. If you need to apply some patches don't do it downstream - make a PR here.
 
 Already ongoing efforts
 =======================


### PR DESCRIPTION
This is probably unlikely to come up again, but this documents that people should run our tests using setuptools rather than calling something like pytest directly. See https://opensource.eff.org/eff-open-source/pl/wdrky4uyzjguppgch3r7t7qjmc for more info.