### PR TITLE
Run tests on apache-parser-v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,10 @@ branches:
 not-on-master: &not-on-master
   if: NOT (type = push AND branch = master)
 
-# Jobs for the extended test suite are executed for cron jobs and pushes on non-master branches.
+# Jobs for the extended test suite are executed for cron jobs and pushes to
+# non-development branches. See the explanation for apache-parser-v2 above.
 extended-test-suite: &extended-test-suite
-  if: type = cron OR (type = push AND branch != master)
+  if: type = cron OR (type = push AND branch NOT IN (apache-parser-v2, master))
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
 # is a cap of on the number of simultaneous runs.
 branches:
   only:
+    - apache-parser-v2
     - master
     - /^\d+\.\d+\.x$/
     - /^test-.*$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_script:
 # is a cap of on the number of simultaneous runs.
 branches:
   only:
+    # apache-parser-v2 is a temporary branch for doing work related to
+    # rewriting the parser in the Apache plugin.
     - apache-parser-v2
     - master
     - /^\d+\.\d+\.x$/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
 
 branches:
   only:
+    - apache-parser-v2
     - master
     - /^\d+\.\d+\.x$/ # Version branches like X.X.X
     - /^test-.*$/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
 
 branches:
   only:
+    # apache-parser-v2 is a temporary branch for doing work related to
+    # rewriting the parser in the Apache plugin.
     - apache-parser-v2
     - master
     - /^\d+\.\d+\.x$/ # Version branches like X.X.X


### PR DESCRIPTION
We're planning on using the branch `apache-parser-v2` allowing us to incrementally work on the new Apache parser and feel comfortable landing temporary test code that we don't really want in `master`.

The `apache-parser-v2` branch is created and locked down, but neither Travis or AppVeyor are configured to run tests on it. See https://github.com/certbot/certbot/pull/7230. This PR fixes that problem.

This could probably just land in the `apache-parser-v2` branch, but why unnecessarily deviate the branch from `master`? It doesn't hurt anything there. Once it lands, I'll get this added to the `apache-parser-v2` branch too.