### PR TITLE
dns-rfc2136: find the correct zone/name when CNAME/DNAMEs are used

### DIFF
--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136.py
@@ -15,6 +15,7 @@ import zope.interface
 from certbot import errors
 from certbot import interfaces
 from certbot.plugins import dns_common
+from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
@@ -109,11 +110,9 @@ class _RFC2136Client(object):
         :raises certbot.errors.PluginError: if an error occurs communicating with the DNS server
         """
 
-        domain = self._find_domain(record_name)
+        logger.debug('Adding TXT record: %s %d "%s"', record_name, record_ttl, record_content)
 
-        n = dns.name.from_text(record_name)
-        o = dns.name.from_text(domain)
-        rel = n.relativize(o)
+        (rel, domain) = self._find_domain(record_name)
 
         update = dns.update.Update(
             domain,
@@ -144,11 +143,7 @@ class _RFC2136Client(object):
         :raises certbot.errors.PluginError: if an error occurs communicating with the DNS server
         """
 
-        domain = self._find_domain(record_name)
-
-        n = dns.name.from_text(record_name)
-        o = dns.name.from_text(domain)
-        rel = n.relativize(o)
+        (rel, domain) = self._find_domain(record_name)
 
         update = dns.update.Update(
             domain,
@@ -174,49 +169,153 @@ class _RFC2136Client(object):
         Find the closest domain with an SOA record for a given domain name.
 
         :param str record_name: The record name for which to find the closest SOA record.
-        :returns: The domain, if found.
-        :rtype: str
-        :raises certbot.errors.PluginError: if no SOA record can be found.
+        :returns: tuple of (`entry`, `zone`) where
+                `entry` - canonical relative entry into the target zone;
+                `zone` - canonical absolute name of the zone to be modified.
+        :rtype: (`dns.name.Name`, `dns.name.Name`)
+        :raises certbot.errors.PluginError: if the search failed for any reason.
         """
 
-        domain_name_guesses = dns_common.base_domain_name_guesses(record_name)
+        # Note: an absolute dns.name.Name ends in dns.name.root, which
+        # is non-empty. Therefore the first prefix.split(1) splits off
+        # dns.name.root, i.e. example.com. -> (example.com, .), not
+        # example.com. -> (example, com.).  dns.name.empty, however,
+        # is an actual empty name, has a truth value of False, and is
+        # an identity element for the append operation; thus
+        # dns.name.root + dns.name.empty == dns.name.root.
+        #
+        # This code relies on these properties.
 
-        # Loop through until we find an authoritative SOA record
-        for guess in domain_name_guesses:
-            if self._query_soa(guess):
-                return guess
+        domain = dns.name.from_text(record_name)
+        prefix = domain
+        suffix = dns.name.empty
+        found  = None
+        domstr = str(domain)    # For messages, may have a DNAME/CNAME added
 
-        raise errors.PluginError('Unable to determine base domain for {0} using names: {1}.'
-                                 .format(record_name, domain_name_guesses))
+        # The domains already queried and the corresponding results
+        domain_names_searched = dict()
 
-    def _query_soa(self, domain_name):
+        while prefix:
+            (prefix, next_label) = prefix.split(1)
+            suffix = next_label + suffix
+
+            # Don't re-query if we have already been here (normal
+            # during DNAME/CNAME re-walk)
+            if suffix in domain_names_searched:
+                result = domain_names_searched[suffix]
+            else:
+                result = self._query_soa(suffix)
+                domain_names_searched[suffix] = result
+
+            (auth, rr) = result
+            if rr is None:
+                # Nothing to do, just descend the DNS hierarchy
+                pass
+            elif rr.rdtype == dns.rdatatype.SOA:
+                # We found an SOA, authoritative or not
+                found = (auth, prefix, suffix)
+            else:
+                # We found a DNAME or CNAME. We need to start the walk over
+                # from the common point of departure.
+                target = rr.target
+                if target in domain_names_searched:
+                    # DNAME/CNAME loop!
+                    errors.PluginError('%s %s loops seeking SOA for %s',
+                                       suffix, repr(rr), domstr)
+
+                # Restart from the root, replacing the current suffix
+                prefix = prefix + target
+                suffix = dns.name.empty
+                found  = None
+                domstr = str(domain)+' ('+str(prefix)+')' # For messages
+
+        if not found:
+            raise errors.PluginError('No SOA of any kind found for %s',
+                                     domstr)
+
+        (auth, prefix, suffix) = found
+        if not auth:
+            raise errors.PluginError('SOA %s for %s not authoritative',
+                                     suffix, domstr)
+        return (prefix, suffix)
+
+    def _query_soa(self, domain):
         """
         Query a domain name for an authoritative SOA record.
 
-        :param str domain_name: The domain name to query for an SOA record.
-        :returns: True if found, False otherwise.
-        :rtype: bool
+        :param dns.name.Name domain: The domain name to query for an SOA record.
+        :returns: (`authoritative`, `rdata`) if found
+                autoritative bool if response was authoritative
+                rdata dns.rdata.Rdata or None the returned record
+        :rtype: (`bool`, `dns.rdata.Rdata` or `None`)
         :raises certbot.errors.PluginError: if no response is received.
         """
 
-        domain = dns.name.from_text(domain_name)
+        # In order to capture any possible CNAMEs, we have to do the
+        # search upward from the root. On the way, any time we find a
+        # SOA record, save it; the final SOA record captured is the
+        # target. If that SOA record is not authoritative, then
+        # we have a fatal error.
+        #
+        # As we want to know about either type, we request recursion
+        # from the target name server. If the target nameserver does
+        # not provide recursion services, it will still work for
+        # finding an authoritative SOA, DNAME or CNAME record
+        # in a zone for which the nameserver is authoritarive; this is
+        # expected to be the common case, although it is not 100%
+        # guaranteed. The only ways to avoid that, ultimately, is to use
+        # a trusted recursive nameserver instead if we get a !RA response
+        # (e.g. using dns.resolver?) or actually query the authoritative name
+        # servers all the way from the top.
+        #
+        # We intentionally only look in the answer section, not in
+        # the authority or additional sections, and only for records
+        # which match the requested domain name exactly.
+        #
+        # If we get more than one SOA, DNAME, or CNAME record of the
+        # same type and exactly matching the requested domain in the
+        # *answer* section we are really in an error situation (these
+        # are all singleton RRs), but try to make the best of the
+        # situation.
 
         request = dns.message.make_query(domain, dns.rdatatype.SOA, dns.rdataclass.IN)
-        # Turn off Recursion Desired bit in query
-        request.flags ^= dns.flags.RD
 
         try:
+            logmsg = 'Query '+str(domain)
             response = dns.query.udp(request, self.server, port=self.port)
             rcode = response.rcode()
+            logmsg += ': '+dns.rcode.to_text(rcode)
 
-            # Authoritative Answer bit should be set
-            if (rcode == dns.rcode.NOERROR and response.get_rrset(response.answer,
-                domain, dns.rdataclass.IN, dns.rdatatype.SOA) and response.flags & dns.flags.AA):
-                logger.debug('Received authoritative SOA response for %s', domain_name)
-                return True
+            auth = (response.flags & dns.flags.AA) != 0
+            if auth:
+                logmsg += ', authoritative'
+            else:
+                logmsg += ', non-authoritative'
 
-            logger.debug('No authoritative SOA record found for %s', domain_name)
-            return False
+            found = dict()
+            for rrset in response.answer:
+                if rrset.name != domain: continue
+                if rrset.rdclass != dns.rdataclass.IN: continue
+                for rr in rrset:
+                    if not rr.rdtype in found:
+                        found[rr.rdtype] = [rr]
+                    elif not rr in found[rr.rdtype]:
+                        # Explicitly ignore exact duplicate RRs
+                        found[rr.rdtype].append(rr)
+
+            for rdtype in found:
+                logmsg += ' %s %d' % (dns.rdatatype.to_text(rdtype), len(found[rdtype]))
+
+            retrr = None
+            for rdtype in dns.rdatatype.SOA, dns.rdatatype.DNAME, dns.rdatatype.CNAME:
+                if rdtype in found:
+                    retrr = found[rdtype][0]    # Use the first one returned
+                    break
+
+            logmsg += ', returning '+repr(retrr)
+            logger.debug(logmsg)
+            return (auth, retrr)
+
         except Exception as e:
-            raise errors.PluginError('Encountered error when making query: {0}'
+           raise errors.PluginError('Encountered error when making query: {0}'
                                      .format(e))

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/dns_rfc2136_test.py
@@ -3,7 +3,17 @@
 import unittest
 
 import dns.flags
+import dns.message
+import dns.name
+import dns.namedict
 import dns.rcode
+import dns.rdata
+import dns.rdataclass
+import dns.rdatatype
+import dns.rdtypes
+import dns.rdtypes.ANY.CNAME
+import dns.rdtypes.ANY.DNAME
+import dns.rdtypes.ANY.SOA
 import dns.tsig
 import mock
 
@@ -13,12 +23,13 @@ from certbot.plugins import dns_test_common
 from certbot.plugins.dns_test_common import DOMAIN
 from certbot.tests import util as test_util
 
+from collections import defaultdict
+
 SERVER = '192.0.2.1'
 PORT = 53
 NAME = 'a-tsig-key.'
 SECRET = 'SSB3b25kZXIgd2hvIHdpbGwgYm90aGVyIHRvIGRlY29kZSB0aGlzIHRleHQK'
 VALID_CONFIG = {"rfc2136_server": SERVER, "rfc2136_name": NAME, "rfc2136_secret": SECRET}
-
 
 class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthenticatorTest):
 
@@ -72,27 +83,59 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
 class RFC2136ClientTest(unittest.TestCase):
 
+    def _stub_query_soa(self, domain):
+        (rrname, retval) = self._query_soa_return.get_deepest_match(domain)
+        if domain != rrname:
+            return (retval[0], None) # Just the authoritative flag
+        else:
+            return retval
+
     def setUp(self):
         from certbot_dns_rfc2136.dns_rfc2136 import _RFC2136Client
 
         self.rfc2136_client = _RFC2136Client(SERVER, PORT, NAME, SECRET, dns.tsig.HMAC_MD5)
+        self.domain = dns.name.from_text(DOMAIN)
+        self.prefix = dict()
+        self.subdom = dict()
+        for pfx in 'foo', 'bar', 'foo.bar', 'baz', 'quux', 'cname', 'dname', 'subzone', 'bad':
+                self.prefix[pfx] = dns.name.from_text(pfx, dns.name.empty)
+                self.subdom[pfx] = self.prefix[pfx] + self.domain
+
+        # _find_domain stub -> (bar, DOMAIN.)
+        self._mock_find_domain = mock.MagicMock(return_value=(self.prefix['bar'], self.domain))
+
+        # Mock DNS records
+        soa_rr = dns.rdtypes.ANY.SOA.SOA(dns.rdataclass.IN, dns.rdatatype.SOA,
+                                         SERVER, SERVER, 1, 2, 3, 4, 5)
+        cname_rr = dns.rdtypes.ANY.CNAME.CNAME(dns.rdataclass.IN, dns.rdatatype.CNAME,
+                                               self.subdom['subzone'])
+        dname_rr = dns.rdtypes.ANY.DNAME.DNAME(dns.rdataclass.IN, dns.rdatatype.DNAME,
+                                               self.subdom['subzone'])
+        self._query_soa_return = \
+            dns.namedict.NameDict({dns.name.root : (False, soa_rr),
+                                   self.domain : (True, soa_rr),
+                                   self.subdom['subzone'] : (True, soa_rr),
+                                   self.subdom['cname'] : (True, cname_rr),
+                                   self.subdom['dname'] : (False, dname_rr),
+                                   self.subdom['bad'] : (False, soa_rr)})
+        self._mock_query_soa = mock.MagicMock(side_effect=self._stub_query_soa)
 
     @mock.patch("dns.query.tcp")
     def test_add_txt_record(self, query_mock):
         query_mock.return_value.rcode.return_value = dns.rcode.NOERROR
         # _find_domain | pylint: disable=protected-access
-        self.rfc2136_client._find_domain = mock.MagicMock(return_value="example.com")
+        self.rfc2136_client._find_domain = self._mock_find_domain
 
-        self.rfc2136_client.add_txt_record("bar", "baz", 42)
+        self.rfc2136_client.add_txt_record("bar"+DOMAIN, "baz", 42)
 
         query_mock.assert_called_with(mock.ANY, SERVER, port=PORT)
-        self.assertTrue("bar. 42 IN TXT \"baz\"" in str(query_mock.call_args[0][0]))
+        self.assertTrue("bar 42 IN TXT \"baz\"" in str(query_mock.call_args[0][0]))
 
     @mock.patch("dns.query.tcp")
     def test_add_txt_record_wraps_errors(self, query_mock):
         query_mock.side_effect = Exception
         # _find_domain | pylint: disable=protected-access
-        self.rfc2136_client._find_domain = mock.MagicMock(return_value="example.com")
+        self.rfc2136_client._find_domain = self._mock_find_domain
 
         self.assertRaises(
             errors.PluginError,
@@ -103,7 +146,7 @@ class RFC2136ClientTest(unittest.TestCase):
     def test_add_txt_record_server_error(self, query_mock):
         query_mock.return_value.rcode.return_value = dns.rcode.NXDOMAIN
         # _find_domain | pylint: disable=protected-access
-        self.rfc2136_client._find_domain = mock.MagicMock(return_value="example.com")
+        self.rfc2136_client._find_domain = self._mock_find_domain
 
         self.assertRaises(
             errors.PluginError,
@@ -114,18 +157,18 @@ class RFC2136ClientTest(unittest.TestCase):
     def test_del_txt_record(self, query_mock):
         query_mock.return_value.rcode.return_value = dns.rcode.NOERROR
         # _find_domain | pylint: disable=protected-access
-        self.rfc2136_client._find_domain = mock.MagicMock(return_value="example.com")
+        self.rfc2136_client._find_domain = self._mock_find_domain
 
         self.rfc2136_client.del_txt_record("bar", "baz")
 
         query_mock.assert_called_with(mock.ANY, SERVER, port=PORT)
-        self.assertTrue("bar. 0 NONE TXT \"baz\"" in str(query_mock.call_args[0][0]))
+        self.assertTrue("bar 0 NONE TXT \"baz\"" in str(query_mock.call_args[0][0]))
 
     @mock.patch("dns.query.tcp")
     def test_del_txt_record_wraps_errors(self, query_mock):
         query_mock.side_effect = Exception
         # _find_domain | pylint: disable=protected-access
-        self.rfc2136_client._find_domain = mock.MagicMock(return_value="example.com")
+        self.rfc2136_client._find_domain = self._mock_find_domain
 
         self.assertRaises(
             errors.PluginError,
@@ -135,53 +178,87 @@ class RFC2136ClientTest(unittest.TestCase):
     @mock.patch("dns.query.tcp")
     def test_del_txt_record_server_error(self, query_mock):
         query_mock.return_value.rcode.return_value = dns.rcode.NXDOMAIN
+
         # _find_domain | pylint: disable=protected-access
-        self.rfc2136_client._find_domain = mock.MagicMock(return_value="example.com")
+        self.rfc2136_client._find_domain = self._mock_find_domain
 
         self.assertRaises(
             errors.PluginError,
             self.rfc2136_client.del_txt_record,
-             "bar", "baz")
+            "bar", "baz")
 
     def test_find_domain(self):
         # _query_soa | pylint: disable=protected-access
-        self.rfc2136_client._query_soa = mock.MagicMock(side_effect=[False, False, True])
+        self.rfc2136_client._query_soa = self._mock_query_soa
 
         # _find_domain | pylint: disable=protected-access
-        domain = self.rfc2136_client._find_domain('foo.bar.'+DOMAIN)
+        (prefix, domain) = self.rfc2136_client._find_domain('foo.bar.'+DOMAIN)
 
-        self.assertTrue(domain == DOMAIN)
+        self.assertTrue(domain == self.domain)
+        self.assertTrue(prefix == self.prefix['foo.bar'])
+
+    def test_find_domain_cname(self):
+        # _query_soa | pylint: disable=protected-access
+        self.rfc2136_client._query_soa =  self._mock_query_soa
+
+        # _find_domain | pylint: disable=protected-access
+        (prefix, domain) = self.rfc2136_client._find_domain('foo.bar.cname.'+DOMAIN)
+
+        self.assertTrue(domain == self.subdom['subzone'])
+        self.assertTrue(prefix == self.prefix['foo.bar'])
+
+    def test_find_domain_dname(self):
+        query = self.prefix['foo.bar'] + self.subdom['dname']
+
+        # _query_soa | pylint: disable=protected-access
+        self.rfc2136_client._query_soa =  self._mock_query_soa
+
+        # _find_domain | pylint: disable=protected-access
+        (prefix, domain) = self.rfc2136_client._find_domain('foo.bar.dname.'+DOMAIN)
+
+        self.assertTrue(domain == self.subdom['subzone'])
+        self.assertTrue(prefix == self.prefix['foo.bar'])
 
     def test_find_domain_wraps_errors(self):
         # _query_soa | pylint: disable=protected-access
-        self.rfc2136_client._query_soa = mock.MagicMock(return_value=False)
+        self.rfc2136_client._query_soa =  self._mock_query_soa
 
         self.assertRaises(
             errors.PluginError,
             # _find_domain | pylint: disable=protected-access
-            self.rfc2136_client._find_domain,
-            'foo.bar.'+DOMAIN)
+            self.rfc2136_client._find_domain, 'error.bad.domain')
+
+    def _stub_dns_noerror(self, dns_query, server, port=PORT):
+        response = dns.message.make_response(dns_query)
+        response.rcode = dns.rcode.NOERROR
+        repoose.flags = dns.flags.AA
+        return response
 
     @mock.patch("dns.query.udp")
     def test_query_soa_found(self, query_mock):
-        query_mock.return_value = mock.MagicMock(answer=[mock.MagicMock()], flags=dns.flags.AA)
-        query_mock.return_value.rcode.return_value = dns.rcode.NOERROR
+        query_mock.return_value = mock.MagicMock(side_effect=self._stub_dns_noerror)
 
         # _query_soa | pylint: disable=protected-access
-        result = self.rfc2136_client._query_soa(DOMAIN)
+        result = self.rfc2136_client._query_soa(self.domain)
 
         query_mock.assert_called_with(mock.ANY, SERVER, port=PORT)
-        self.assertTrue(result)
+        self.assertTrue(result == (True, None))
+
+    def _stub_dns_nxdomain(self, dns_query, server, port=PORT):
+        response = dns.message.make_response(dns_query)
+        response.rcode = dns.rcode.NXDOMAIN
+        repoose.flags = dns.flags.AA
+        return response
 
     @mock.patch("dns.query.udp")
     def test_query_soa_not_found(self, query_mock):
-        query_mock.return_value.rcode.return_value = dns.rcode.NXDOMAIN
+        query_mock.return_value = mock.MagicMock(side_effect=self._stub_dns_nxdomain)
 
         # _query_soa | pylint: disable=protected-access
-        result = self.rfc2136_client._query_soa(DOMAIN)
+        result = self.rfc2136_client._query_soa(self.domain)
 
         query_mock.assert_called_with(mock.ANY, SERVER, port=PORT)
-        self.assertFalse(result)
+        self.assertTrue(result == (True, None))
 
     @mock.patch("dns.query.udp")
     def test_query_soa_wraps_errors(self, query_mock):


### PR DESCRIPTION
Dynamic zones have significant problems with DNSSEC and with redundant
servers (which, of course is highly desirable for DNS.) The obvious
solution to that is to use a CNAME or DNAME record to point the
_acme-challenge to a different zone which can have different NS and
TTL properties. In particular, breaking DNSSEC support breaks exactly
the chain of trust on which ACME depends, and is thus extremely
undesirable.

In order to find the correct base zone and name-in-zone when
CNAME/DNAMEs might be present, search from the top down instead of the
bottom up, and allow non-authoritative answers for anything other than
the final SOA. There is no guarantee that the authentication server is
authoritative for anything but the zone into which the TXT record is
to be placed.

If the authentication server disallows recursion, this code will this
do the right thing as long as the server is authoritative for the
dynamic zone and any zone which contains a CNAME or DNAME record. If
that is not the case, then the server must support recursion for its
dynamic clients; it obviously does not need to offer that service to
the general public. If even this turns out to be unacceptable, then
the solution would be to query the normal nameservers (using the
system resolver), at least if an !AA !RA response is returned. The
dns.resolver module has a zone_for_name() function, but unfortunately
it does not return the name-in-zone, and to me its algorithm appears
to be incorrect (at least for our purposes) in a way that is similar
to the previous dns-rfc2136 code.

This patch changes several levels of the interface to use
dns.name.Name objects instead of strings, and passes dns.rdata.Rdata
objects between _query_soa() and _find_domain(). This turns out to
significantly simplify a fair number of things, but requires a fair
number of changes to the test suite. Clean up the test suite by
implementing a mock resolver with a mapping instead of a simple
sequence of return values, and by precomputing dns.name.Name objects
for (sub)domains and prefixes used.

Signed-off-by: H. Peter Anvin <hpa@zytor.com>

## Pull Request Checklist

- [ ] Edit the `master` section of `CHANGELOG.md` to include a description of
  the change being made.
- [ ] Add [mypy type
  annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations)
  for any functions that were added or modified.
- [ ] Include your name in `AUTHORS.md` if you like.
