### PR TITLE
Update packaging.rst

### DIFF
--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -51,6 +51,16 @@ Notes for package maintainers
 Already ongoing efforts
 =======================
 
+Alpine
+----
+
+From our official releases:
+
+- https://pkgs.alpinelinux.org/packages?name=certbot&branch=v3.10
+
+From "edge": 
+
+- https://pkgs.alpinelinux.org/packages?name=certbot&branch=edge
 
 Arch
 ----


### PR DESCRIPTION
Alpine Linux provide support for certbot since Alpine 3.4 (before was supporting letsencrypt).
Would be nice to have Alpine listed among the distributions providing certbot.
Thanks!
.: Francesco

## Pull Request Checklist

- [ ] Edit the `master` section of `CHANGELOG.md` to include a description of
  the change being made.
- [ ] Add [mypy type
  annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations)
  for any functions that were added or modified.
- [ ] Include your name in `AUTHORS.md` if you like.
