### PR TITLE
acme: Implement authz deactivation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ Authors
 * [Alex Gaynor](https://github.com/alex)
 * [Alex Halderman](https://github.com/jhalderm)
 * [Alex Jordan](https://github.com/strugee)
+* [Alex Zorin](https://github.com/alexzorin)
 * [Amjad Mashaal](https://github.com/TheNavigat)
 * [Andrew Murray](https://github.com/radarhere)
 * [Anselm Levskaya](https://github.com/levskaya)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* acme: Authz deactivation added to `acme` module.
 
 ### Changed
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -126,10 +126,10 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
     def deactivate_authorization(self, authzr):
         """Deactivate authorization.
 
-        :param messages.AuthorizationResources authzr: The Authorization Resources
+        :param messages.AuthorizationResources authzr: The Authorization resource
             to be deactivated.
 
-        :returns: The Authorization resources that was deactivated.
+        :returns: The Authorization resource that was deactivated.
         :rtype: `.AuthorizationResources`
 
         """

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -133,7 +133,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         :rtype: `.AuthorizationResource`
 
         """
-        body = messages.Authorization(**dict({'status': 'deactivated'}))
+        body = messages.Authorization(status='deactivated')
         response = self._post(authzr.uri, body)
         return self._authzr_from_response(response)
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -124,6 +124,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         return self.update_registration(regr, update={'status': 'deactivated'})
 
     def deactivate_authorization(self, authzr):
+        # type: (messages.AuthorizationResource) -> messages.AuthorizationResource
         """Deactivate authorization.
 
         :param messages.AuthorizationResource authzr: The Authorization resource
@@ -133,7 +134,7 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         :rtype: `.AuthorizationResource`
 
         """
-        body = messages.Authorization(status='deactivated')
+        body = messages.UpdateAuthorization(status='deactivated')
         response = self._post(authzr.uri, body)
         return self._authzr_from_response(response)
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -126,11 +126,11 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
     def deactivate_authorization(self, authzr):
         """Deactivate authorization.
 
-        :param messages.AuthorizationResources authzr: The Authorization resource
+        :param messages.AuthorizationResource authzr: The Authorization resource
             to be deactivated.
 
         :returns: The Authorization resource that was deactivated.
-        :rtype: `.AuthorizationResources`
+        :rtype: `.AuthorizationResource`
 
         """
         body = messages.Authorization(**dict({'status': 'deactivated'}))

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -123,6 +123,20 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         """
         return self.update_registration(regr, update={'status': 'deactivated'})
 
+    def deactivate_authorization(self, authzr):
+        """Deactivate authorization.
+
+        :param messages.AuthorizationResources authzr: The Authorization Resources
+            to be deactivated.
+
+        :returns: The Authorization resources that was deactivated.
+        :rtype: `.AuthorizationResources`
+
+        """
+        body = messages.Authorization(**dict({'status': 'deactivated'}))
+        response = self._post(authzr.uri, body)
+        return self._authzr_from_response(response)
+
     def _authzr_from_response(self, response, identifier=None, uri=None):
         authzr = messages.AuthorizationResource(
             body=messages.Authorization.from_json(response.json()),

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -637,6 +637,13 @@ class ClientTest(ClientTestBase):
             errors.PollError, self.client.poll_and_request_issuance,
             csr, authzrs, mintime=mintime, max_attempts=2)
 
+    def test_deactivate_authorization(self):
+        # TODO: this test doesn't seem to do anything
+        self.response.headers['Location'] = self.authzr.uri
+        self.response.json.return_value = self.authzr.body.to_json()
+        self.assertEqual(self.authzr,
+                         self.client.deactivate_authorization(self.authzr))
+
     def test_check_cert(self):
         self.response.headers['Location'] = self.certr.uri
         self.response.content = CERT_DER

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -638,7 +638,7 @@ class ClientTest(ClientTestBase):
             csr, authzrs, mintime=mintime, max_attempts=2)
 
     def test_deactivate_authorization(self):
-        authzb = self.authzr.body.update(status=messages.STATUS_INVALID)
+        authzb = self.authzr.body.update(status=messages.STATUS_DEACTIVATED)
         self.response.json.return_value = authzb.to_json()
         authzr = self.client.deactivate_authorization(self.authzr)
         self.assertEqual(authzb, authzr.body)

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -642,6 +642,8 @@ class ClientTest(ClientTestBase):
         self.response.json.return_value = authzb.to_json()
         authzr = self.client.deactivate_authorization(self.authzr)
         self.assertEqual(authzb, authzr.body)
+        self.assertEqual(self.client.net.post.call_count, 1)
+        self.assertTrue(self.authzr.uri in self.net.post.call_args_list[0][0])
 
     def test_check_cert(self):
         self.response.headers['Location'] = self.certr.uri

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -638,11 +638,10 @@ class ClientTest(ClientTestBase):
             csr, authzrs, mintime=mintime, max_attempts=2)
 
     def test_deactivate_authorization(self):
-        # TODO: this test doesn't seem to do anything
-        self.response.headers['Location'] = self.authzr.uri
-        self.response.json.return_value = self.authzr.body.to_json()
-        self.assertEqual(self.authzr,
-                         self.client.deactivate_authorization(self.authzr))
+        authzb = self.authzr.body.update(status=messages.STATUS_INVALID)
+        self.response.json.return_value = authzb.to_json()
+        authzr = self.client.deactivate_authorization(self.authzr)
+        self.assertEqual(authzb, authzr.body)
 
     def test_check_cert(self):
         self.response.headers['Location'] = self.certr.uri

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -502,6 +502,12 @@ class NewAuthorization(Authorization):
     resource = fields.Resource(resource_type)
 
 
+class UpdateAuthorization(Authorization):
+    """Update authorization."""
+    resource_type = 'authz'
+    resource = fields.Resource(resource_type)
+
+
 class AuthorizationResource(ResourceWithURI):
     """Authorization Resource.
 

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -170,6 +170,7 @@ STATUS_REVOKED = Status('revoked')
 STATUS_READY = Status('ready')
 STATUS_DEACTIVATED = Status('deactivated')
 
+
 class IdentifierType(_Constant):
     """ACME identifier type."""
     POSSIBLE_NAMES = {}  # type: dict

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -486,7 +486,7 @@ class Authorization(ResourceBody):
 
     @challenges.decoder
     def challenges(value):  # pylint: disable=missing-docstring,no-self-argument
-        return tuple(ChallengeBody.from_json(chall) for chall in value or [])
+        return tuple(ChallengeBody.from_json(chall) for chall in value)
 
     @property
     def resolved_combinations(self):

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -168,7 +168,7 @@ STATUS_VALID = Status('valid')
 STATUS_INVALID = Status('invalid')
 STATUS_REVOKED = Status('revoked')
 STATUS_READY = Status('ready')
-
+STATUS_DEACTIVATED = Status('deactivated')
 
 class IdentifierType(_Constant):
     """ACME identifier type."""
@@ -471,7 +471,7 @@ class Authorization(ResourceBody):
     :ivar datetime.datetime expires:
 
     """
-    identifier = jose.Field('identifier', decoder=Identifier.from_json)
+    identifier = jose.Field('identifier', decoder=Identifier.from_json, omitempty=True)
     challenges = jose.Field('challenges', omitempty=True)
     combinations = jose.Field('combinations', omitempty=True)
 

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -486,7 +486,7 @@ class Authorization(ResourceBody):
 
     @challenges.decoder
     def challenges(value):  # pylint: disable=missing-docstring,no-self-argument
-        return tuple(ChallengeBody.from_json(chall) for chall in value)
+        return tuple(ChallengeBody.from_json(chall) for chall in value or [])
 
     @property
     def resolved_combinations(self):

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -389,6 +389,12 @@ class AuthorizationTest(unittest.TestCase):
             (self.challbs[1],),
         ))
 
+    def test_from_json_null_challenges(self):
+        from acme.messages import Authorization
+        jobj_null_challs = self.jobj_from.copy()
+        jobj_null_challs['challenges'] = None
+        Authorization.from_json(jobj_null_challs)
+
 
 class AuthorizationResourceTest(unittest.TestCase):
     """Tests for acme.messages.AuthorizationResource."""

--- a/acme/acme/messages_test.py
+++ b/acme/acme/messages_test.py
@@ -389,12 +389,6 @@ class AuthorizationTest(unittest.TestCase):
             (self.challbs[1],),
         ))
 
-    def test_from_json_null_challenges(self):
-        from acme.messages import Authorization
-        jobj_null_challs = self.jobj_from.copy()
-        jobj_null_challs['challenges'] = None
-        Authorization.from_json(jobj_null_challs)
-
 
 class AuthorizationResourceTest(unittest.TestCase):
     """Tests for acme.messages.AuthorizationResource."""


### PR DESCRIPTION
Resolves #4945. First PR in order to address #5116.

~~@bmw I'm not sure what's going on with unit tests in the acme module. I tried to go by the example of `test_deactivate_account`, but it seems to be some kind of no-op test. Can I test the status change here somehow, or does it belong in integration?~~  I think I figured something out for the test.

## Pull Request Checklist

- [x] Edit the `master` section of `CHANGELOG.md` to include a description of the change being made.
- [x] Add [mypy type annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations) for any functions that were added or modified.
- [x] Include your name in `AUTHORS.md` if you like.
