### PR TITLE
Fix test_symlink_resolution on macOS.

### DIFF
--- a/certbot/tests/compat/filesystem_test.py
+++ b/certbot/tests/compat/filesystem_test.py
@@ -329,6 +329,8 @@ class RealpathTest(test_util.TempDirTestCase):
         self.probe_path = _create_probe(self.tempdir)
 
     def test_symlink_resolution(self):
+        # Remove any symlinks already in probe_path
+        self.probe_path = filesystem.realpath(self.probe_path)
         # Absolute resolution
         link_path = os.path.join(self.tempdir, 'link_abs')
         os.symlink(self.probe_path, link_path)


### PR DESCRIPTION
This fixes the test failures which can be seen at
https://travis-ci.com/certbot/certbot/builds/120123338.

The problem here is the path returned by tempfile.mkdtemp() contains a symlink.
For instance, one run of the function produced
'/var/folders/3b/zg8fdh5j71x92yyzc1tyllfw0000gp/T/tmp3k9ytfj1' which is a
symlink to
'/private/var/folders/3b/zg8fdh5j71x92yyzc1tyllfw0000gp/T/tmp3k9ytfj1'.

Removing this symlink before testing filesystem.realpath solves the problem.

You can see the macOS tests passing with this change at https://travis-ci.com/certbot/certbot/builds/120250667.