### PR TITLE
Fix test farm test cleanup logic

### DIFF
--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -375,7 +375,7 @@ def cleanup(cl_args, instances, targetlist):
     # If lengths of instances and targetlist aren't equal, instances failed to
     # start before running tests so leaving instances running for debugging
     # isn't very useful. Let's cleanup after ourselves instead.
-    if len(instances) == len(targetlist) or not cl_args.saveinstances:
+    if len(instances) != len(targetlist) or not cl_args.saveinstances:
         print('Terminating EC2 Instances')
         if cl_args.killboulder:
             boulder_server.terminate()


### PR DESCRIPTION
This problem was introduced in https://github.com/certbot/certbot/pull/7070.

As described in the code comment, the idea here was to always cleanup after ourselves if we failed to start all instances by checking that the two lists are **NOT** equal in length. This code currently does the opposite.

I started a run of test farm tests with this change at https://travis-ci.com/certbot/certbot/builds/120535621.