### PR TITLE
Prevent authorization re-use for --dry-run/--staging/--deactivate-authorizations (#5116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+* CLI flag `--deactivate-authorizations` has been added. It deactivates existing valid authorizations before and after issuing new certificates, ensuring that the results of all challenges are fresh. It is automatically enabled by `--dry-run` and `--staging`, but can be disabled with `--no-deactivate-authorizations`. 
 * acme: Authz deactivation added to `acme` module.
 
 ### Changed

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -136,7 +136,8 @@ class ClientBase(object):  # pylint: disable=too-many-instance-attributes
         """
         body = messages.UpdateAuthorization(status='deactivated')
         response = self._post(authzr.uri, body)
-        return self._authzr_from_response(response)
+        return self._authzr_from_response(response,
+            authzr.body.identifier, authzr.uri)
 
     def _authzr_from_response(self, response, identifier=None, uri=None):
         authzr = messages.AuthorizationResource(

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -575,3 +575,17 @@ def test_ocsp_status_live(context):
 
     assert output.count('INVALID') == 1, 'Expected {0} to be INVALID'.format(cert)
     assert output.count('REVOKED') == 1, 'Expected {0} to be REVOKED'.format(cert)
+
+def test_deactivate_authzs(context):
+    """Test deactivation of valid authzs after a successful order"""
+    # This skip is commented because pebble doesn't seem to reuse authzs at all.
+    # if context.acme_server == 'pebble':
+    #     pytest.skip('This test is skipped for Pebble due to ' +
+    #                 'https://github.com/letsencrypt/pebble/issues/256')
+    name = context.get_domain('authz-deactivation')
+    # First run to generate a valid authz
+    context.certbot(['certonly', '--cert-name', name, '-d', name])
+    # On the second run, we expect to invalidate the authz on order creation,
+    # and then after the finalization of the re-created order.
+    context.certbot(['certonly', '--cert-name', name, '--deactivate-authorizations',
+                     '-d', name, '--force-renewal'])

--- a/certbot/auth_handler.py
+++ b/certbot/auth_handler.py
@@ -97,6 +97,27 @@ class AuthHandler(object):
 
             return authzrs_validated
 
+    def deactivate_valid_authorizations(self, orderr, refresh=True):
+        # type: (messages.OrderResource, bool) -> List[messages.AuthorizationResource]
+        """
+        Deactivate all `valid` authorizations in the order, so that they cannot be re-used
+        in subsequent orders.
+        :param messages.OrderResource orderr: must have authorizations filled in
+        :param bool refresh: whether to refresh the status of the authorization
+        :returns: list of all deactivated authorizations
+        :rtype: List
+        """
+        authzrs = []
+        for authzr in orderr.authorizations:
+            (authzr, _) = self.acme.poll(authzr) if refresh else (authzr, None)
+            if authzr.body.status != messages.STATUS_VALID:
+                continue
+            authzr = self.acme.deactivate_authorization(authzr)
+            authzrs.append(authzr)
+
+        return [authzr for authzr in authzrs
+                if authzr.body.status == messages.STATUS_DEACTIVATED]
+
     def _poll_authorizations(self, authzrs, max_retries, best_effort):
         """
         Poll the ACME CA server, to wait for confirmation that authorizations have their challenges

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -657,6 +657,10 @@ class HelpfulArgumentParser(object):
 
         parsed_args.server = constants.STAGING_URI
 
+        # Deactivate authzs for staging if the user has not expressed a preference otherwise
+        if parsed_args.deactivate_authorizations is None:
+            parsed_args.deactivate_authorizations = True
+
         if parsed_args.dry_run:
             if self.verb not in ["certonly", "renew"]:
                 raise errors.Error("--dry-run currently only works with the "
@@ -1115,6 +1119,16 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         default=flag_default("debug_challenges"),
         help="After setting up challenges, wait for user input before "
              "submitting to CA")
+    helpful.add(
+        [None, "certonly", "run", "renew"], "--deactivate-authorizations", action="store_true",
+        default=flag_default("deactivate_authorizations"),
+        help="Before and after completing an order, deactivate any existing valid "
+             "authorizations. This guarantees that all required challenges will be "
+             "performed. Automatically enabled by --staging and --dry-run.")
+    helpful.add(
+        [None, "certonly", "run", "renew"], "--no-deactivate-authorizations", action="store_false",
+        dest="deactivate_authorizations", default=flag_default("deactivate_authorizations"),
+        help=argparse.SUPPRESS)
     helpful.add(
         "testing", "--no-verify-ssl", action="store_true",
         help=config_help("no_verify_ssl"),

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -52,6 +52,7 @@ CLI_DEFAULTS = dict(
     staging=False,
     debug=False,
     debug_challenges=False,
+    deactivate_authorizations=None,
     no_verify_ssl=False,
     http01_port=challenges.HTTP01Response.PORT,
     http01_address="",

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -361,6 +361,37 @@ class HandleAuthorizationsTest(unittest.TestCase):  # pylint: disable=too-many-p
         mock_order = mock.MagicMock(authorizations=[authzr])
         self.handler.handle_authorizations(mock_order)
 
+    def test_valid_authzrs_deactivated(self):
+        # When we deactivate valid authzrs in an orderr, we expect them to become deactivated
+        # and to receive a list of deactivated authzrs in returb.
+        def _mock_deactivate(authzr):
+            if authzr.body.status == messages.STATUS_VALID:
+                authzb = authzr.body.update(status=messages.STATUS_DEACTIVATED)
+                authzr = messages.AuthorizationResource(body=authzb)
+            else:
+                raise errors.Error("Can't deactivate non-valid authz")
+            return authzr
+
+        def _mock_poll(authzr):
+            return (authzr, mock.MagicMock())
+
+        authzr = acme_util.gen_authzr(
+                messages.STATUS_VALID, "is-valid",
+                [acme_util.HTTP01],
+                [messages.STATUS_VALID], False)
+        authzr2 = gen_dom_authzr(domain="is-pending", challs=acme_util.CHALLENGES)
+        orderr = mock.MagicMock(authorizations=[authzr, authzr2])
+
+        self.mock_net.poll.side_effect = _mock_poll
+        self.mock_net.deactivate_authorization.side_effect = _mock_deactivate
+
+        authzrs = self.handler.deactivate_valid_authorizations(orderr)
+
+        self.assertEqual(self.mock_net.deactivate_authorization.call_count, 1)
+        self.assertTrue(len(authzrs) == 1)
+        self.assertEqual(authzrs[0].body.identifier.value, "is-valid")
+        self.assertEqual(authzrs[0].body.status, messages.STATUS_DEACTIVATED)
+
     @mock.patch("certbot.auth_handler.logger")
     def test_tls_sni_logs(self, logger):
         self._test_name1_tls_sni_01_1_common(combos=True)

--- a/local-oldest-requirements.txt
+++ b/local-oldest-requirements.txt
@@ -1,2 +1,2 @@
 # Remember to update setup.py to match the package versions below.
-acme[dev]==0.29.0
+-e acme[dev]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ version = meta['version']
 # specified here to avoid masking the more specific request requirements in
 # acme. See https://github.com/pypa/pip/issues/988 for more info.
 install_requires = [
-    'acme>=0.29.0',
+    'acme[dev]',
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
     # saying so here causes a runtime error against our temporary fork of 0.9.3
     # in which we added 2.6 support (see #2243), so we relax the requirement.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ version = meta['version']
 # specified here to avoid masking the more specific request requirements in
 # acme. See https://github.com/pypa/pip/issues/988 for more info.
 install_requires = [
-    'acme[dev]',
+    'acme>=0.37.0.dev0',
     # We technically need ConfigArgParse 0.10.0 for Python 2.6 support, but
     # saying so here causes a runtime error against our temporary fork of 0.9.3
     # in which we added 2.6 support (see #2243), so we relax the requirement.


### PR DESCRIPTION
First go at implementing authz deactivation in Certbot, now that #7254 is merged.

For most users, they will automatically be opted in when they use `--dry-run` or `--staging`.

Although I had not planned on it initially, it seemed necessary to also add `--[no-]deactivate-authorizations`. Firstly, for the ability to test it (though I guess an env variable could have also done the same thing without growing the collection of CLI flags). Secondly, there are now other production RFC8555 CAs, and that functionality should be available to them as well, since `--dry-run ` is Let's Encrypt specific.

As discussed in #5116, this implementation deactivates authorizations on both order creation and after order finalization. This *should* make it foolproof for users, assuming the deactivations themselves don't fail. 

However, one defect is that authorization errors raised by `_get_order_and_authorizations` prevent the deactivations from running. The design around that and `allow_subset_of_names` is a little complicated so I'm not sure how to address it. Practically speaking, it just means those authzs will get deactivated on the next order.

I have tested with Boulder and Let's Encrypt ACMEv1 and ACMEv2. Testing with Pebble did not appear possible since it does not seem to implement authz reuse. 

I do not know how to create a good integration test for this - I'm not sure whether the one I added in certbot-ci even does anything.

I am not sure what Certbot should do if authz deactivation raises any `acme.Error`. Right now, I am just swallowing them and warning about it. This way, if something goes wrong, it will hopefully not not get in the way of the user.

The other concern I have right now is the impact on the ACME server. For example, there are surely users with 100-SAN certificates, and a `--dry-run` on them is going to start blasting the server, quite probably. Depending how fast the ACME server is, we might even hit the 20 req/sec rate limit. It also necessarily makes Certbot slower - the user must wait for the 100 deactivations to finish before control is returned to them.

Edit: I'm not sure what the build failure means. Seems to me like `deactivate_authorization` should be in the mock object ... it is in Python 3. Is it because Python 2's mock does not support looking up methods in super classes? What's the fix?