### PR TITLE
Fix certbot-auto on RHEL 8

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -161,6 +161,7 @@ Authors
 * [Michael Schumacher](https://github.com/schumaml)
 * [Michael Strache](https://github.com/Jarodiv)
 * [Michael Sverdlin](https://github.com/sveder)
+* [Michael Watters](https://github.com/blackknight36)
 * [Michal Moravec](https://github.com/https://github.com/Majkl578)
 * [Michal Papis](https://github.com/mpapis)
 * [Minn Soe](https://github.com/MinnSoe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fix certbot-auto failures on RHEL 8.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -758,10 +758,18 @@ elif [ -f /etc/redhat-release ]; then
   # Starting to Fedora 29, python2 is on a deprecation path. Let's move to python3 then.
   RPM_DIST_NAME=`(. /etc/os-release 2> /dev/null && echo $ID) || echo "unknown"`
   RPM_DIST_VERSION=0
-  if [ "$RPM_DIST_NAME" = "fedora" ]; then
-    RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) || echo "0"`
+  if [ "$RPM_DIST_NAME" = "fedora" ] || [ "$RPM_DIST_NAME" = "rhel" ]; then
+    RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) | cut -d '.' -f1 || echo "0"`
   fi
   if [ "$RPM_DIST_NAME" = "fedora" -a "$RPM_DIST_VERSION" -ge 29 -o "$PYVER" -eq 26 ]; then
+    Bootstrap() {
+      BootstrapMessage "RedHat-based OSes that will use Python3"
+      BootstrapRpmPython3
+    }
+    USE_PYTHON_3=1
+    BOOTSTRAP_VERSION="BootstrapRpmPython3 $BOOTSTRAP_RPM_PYTHON3_VERSION"
+  # RHEL 8 uses python3.
+  elif [ "$RPM_DIST_NAME" = "rhel" -a "$RPM_DIST_VERSION" -ge 8 ]; then
     Bootstrap() {
       BootstrapMessage "RedHat-based OSes that will use Python3"
       BootstrapRpmPython3

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -333,10 +333,18 @@ elif [ -f /etc/redhat-release ]; then
   # Starting to Fedora 29, python2 is on a deprecation path. Let's move to python3 then.
   RPM_DIST_NAME=`(. /etc/os-release 2> /dev/null && echo $ID) || echo "unknown"`
   RPM_DIST_VERSION=0
-  if [ "$RPM_DIST_NAME" = "fedora" ]; then
-    RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) || echo "0"`
+  if [ "$RPM_DIST_NAME" = "fedora" ] || [ "$RPM_DIST_NAME" = "rhel" ]; then
+    RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) | cut -d '.' -f1 || echo "0"`
   fi
   if [ "$RPM_DIST_NAME" = "fedora" -a "$RPM_DIST_VERSION" -ge 29 -o "$PYVER" -eq 26 ]; then
+    Bootstrap() {
+      BootstrapMessage "RedHat-based OSes that will use Python3"
+      BootstrapRpmPython3
+    }
+    USE_PYTHON_3=1
+    BOOTSTRAP_VERSION="BootstrapRpmPython3 $BOOTSTRAP_RPM_PYTHON3_VERSION"
+  # RHEL 8 uses python3.
+  elif [ "$RPM_DIST_NAME" = "rhel" -a "$RPM_DIST_VERSION" -ge 8 ]; then
     Bootstrap() {
       BootstrapMessage "RedHat-based OSes that will use Python3"
       BootstrapRpmPython3

--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -26,6 +26,17 @@ else
     # 0.33.x is the oldest version of letsencrypt-auto that works on Fedora 29+.
     INITIAL_VERSION="0.33.1"
 fi
+
+# If we're on RHEL 8, the initial version of certbot-auto will fail until we do
+# a release including https://github.com/certbot/certbot/pull/7240 and update
+# INITIAL_VERSION above to use a version containing this fix. This works around
+# the problem for now so we can successfully run tests on RHEL 8.
+RPM_DIST_NAME=`(. /etc/os-release 2> /dev/null && echo $ID) || echo "unknown"`
+RPM_DIST_VERSION=`(. /etc/os-release 2> /dev/null && echo $VERSION_ID) | cut -d '.' -f1 || echo "0"`
+if [ "$RPM_DIST_NAME" = "rhel" -a "$RPM_DIST_VERSION" -ge 8 ]; then
+    sudo yum install python3-virtualenv -y
+fi
+
 git checkout -f "v$INITIAL_VERSION" letsencrypt-auto
 if ! ./letsencrypt-auto -v --debug --version --no-self-upgrade 2>&1 | tail -n1 | grep "^certbot $INITIAL_VERSION$" ; then
     echo initial installation appeared to fail

--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -xe
 
 cd letsencrypt
-./certbot-auto --install-only -n --debug
+letsencrypt-auto-source/letsencrypt-auto --install-only -n --debug
 
 PLUGINS="certbot-apache certbot-nginx"
 PYTHON_MAJOR_VERSION=$(/opt/eff.org/certbot/venv/bin/python --version 2>&1 | cut -d" " -f 2 | cut -d. -f1)

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -45,6 +45,11 @@ targets:
     type: centos
     virt: hvm
     user: ec2-user
+  - ami: ami-0c322300a1dd5dc79
+    name: RHEL8
+    type: centos
+    virt: hvc
+    user: ec2-user
   - ami: ami-00bbc6858140f19ed
     name: fedora30
     type: centos


### PR DESCRIPTION
This PR builds off of #7240 to fix https://github.com/certbot/certbot/issues/7241.

The code in certbot-auto is unchanged which I +1. Someone else should give it a 2nd review.

For the code in the tests, you can see all tests passing (including `test_tests.sh`) at https://travis-ci.com/certbot/certbot/jobs/220681085.

One noteworthy thing here is I did not add the RHEL 8 AMI to the Apache tests due to https://github.com/certbot/certbot/issues/7273. This problem is not related to support in certbot-auto though, is an edge case, and I do not personally believe it should block this PR.

@adferrand, are you interested in giving this PR a review?

This PR should be merged and not squashed to preserve authorship.