### PR TITLE
[Critical] Fix virtualenv in AppVeyor CI jobs

### DIFF
--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -82,6 +82,6 @@ twine==1.11.0
 typed-ast==1.1.0
 typing==3.6.4
 uritemplate==0.6
-virtualenv==16.6.1
+virtualenv==16.6.2
 wcwidth==0.1.7
 wrapt==1.11.1


### PR DESCRIPTION
AppVeyor recently upgrade the Python 3.7.x installed in their VM to 3.7.4. However, virtualenv 16.6.1 is [broken](https://github.com/pypa/virtualenv/issues/1380) on that specific version of Python for Windows.

This PR upgrade virtualenv installed for a dev/test environment from 16.6.1 to 16.6.2 in order to fix this issue, and repair the CI jobs execute by AppVeyor on PRs.