### PR TITLE
Clean the useless entries in MANIFEST.in

### DIFF
--- a/certbot-apache/MANIFEST.in
+++ b/certbot-apache/MANIFEST.in
@@ -2,7 +2,5 @@ include LICENSE.txt
 include README.rst
 recursive-include docs *
 recursive-include certbot_apache/tests/testdata *
-include certbot_apache/centos-options-ssl-apache.conf
-include certbot_apache/options-ssl-apache.conf
 recursive-include certbot_apache/augeas_lens *.aug
 recursive-include certbot_apache/tls_configs *.conf


### PR DESCRIPTION
Since #7191, TLS configuration files for Apache have been moved to a dedicated folder `tls_configs`. Then the entries in `MANIFEST.in` removed by this PR do not correspond to an existing path, and so are not useful anymore.