### PR TITLE
[Windows] Fix closing files descriptors during unit tests

### DIFF
--- a/certbot-nginx/certbot_nginx/tests/util.py
+++ b/certbot-nginx/certbot_nginx/tests/util.py
@@ -1,9 +1,9 @@
 """Common utilities for certbot_nginx."""
 import copy
+import logging
 import shutil
 import tempfile
 import unittest
-import warnings
 
 import josepy as jose
 import mock
@@ -11,6 +11,7 @@ import pkg_resources
 import zope.component
 
 from certbot import configuration
+from certbot import util
 from certbot.compat import os
 from certbot.plugins import common
 from certbot.tests import util as test_util
@@ -34,20 +35,20 @@ class NginxTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
             "rsa512_key.pem"))
 
     def tearDown(self):
-        # On Windows we have various files which are not correctly closed at the time of tearDown.
-        # For know, we log them until a proper file close handling is written.
-        # Useful for development only, so no warning when we are on a CI process.
-        def onerror_handler(_, path, excinfo):
-            """On error handler"""
-            if not os.environ.get('APPVEYOR'):  # pragma: no cover
-                message = ('Following error occurred when deleting path {0}'
-                           'during tearDown process: {1}'.format(path, str(excinfo)))
-                warnings.warn(message)
+        # Cleanup opened resources after a test. This is usually done through atexit handlers in
+        # Certbot, but during tests, atexit will not run registered functions before tearDown is
+        # called and instead will run them right before the entire test process exits.
+        # It is a problem on Windows, that does not accept to clean resources before closing them.
+        logging.shutdown()
+        # Remove logging handlers that have been closed so they won't be
+        # accidentally used in future tests.
+        logging.getLogger().handlers = []
+        util._release_locks()  # pylint: disable=protected-access
 
-        shutil.rmtree(self.temp_dir, onerror=onerror_handler)
-        shutil.rmtree(self.config_dir, onerror=onerror_handler)
-        shutil.rmtree(self.work_dir, onerror=onerror_handler)
-        shutil.rmtree(self.logs_dir, onerror=onerror_handler)
+        shutil.rmtree(self.temp_dir)
+        shutil.rmtree(self.config_dir)
+        shutil.rmtree(self.work_dir)
+        shutil.rmtree(self.logs_dir)
 
 
 def get_data_filename(filename):

--- a/certbot-nginx/certbot_nginx/tests/util.py
+++ b/certbot-nginx/certbot_nginx/tests/util.py
@@ -39,10 +39,6 @@ class NginxTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
         # Certbot, but during tests, atexit will not run registered functions before tearDown is
         # called and instead will run them right before the entire test process exits.
         # It is a problem on Windows, that does not accept to clean resources before closing them.
-        logging.shutdown()
-        # Remove logging handlers that have been closed so they won't be
-        # accidentally used in future tests.
-        logging.getLogger().handlers = []
         util._release_locks()  # pylint: disable=protected-access
 
         shutil.rmtree(self.temp_dir)

--- a/certbot-nginx/certbot_nginx/tests/util.py
+++ b/certbot-nginx/certbot_nginx/tests/util.py
@@ -1,6 +1,5 @@
 """Common utilities for certbot_nginx."""
 import copy
-import logging
 import shutil
 import tempfile
 import unittest

--- a/certbot/tests/compat/filesystem_test.py
+++ b/certbot/tests/compat/filesystem_test.py
@@ -210,15 +210,15 @@ class WindowsOpenTest(TempDirTestCase):
     def _test_one_creation(self, num, file_exist, flags):
         one_file = os.path.join(self.tempdir, str(num))
         if file_exist and not os.path.exists(one_file):
-            open(one_file, 'w').close()
+            with open(one_file, 'w'):
+                pass
 
         handler = None
         try:
             handler = filesystem.open(one_file, flags)
-        except BaseException as err:
+        finally:
             if handler:
                 os.close(handler)
-            raise err
 
 
 @unittest.skipIf(POSIX_MODE, reason='Test specific to Windows security')

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -339,16 +339,7 @@ class TempDirTestCase(unittest.TestCase):
         logging.getLogger().handlers = []
         util._release_locks()  # pylint: disable=protected-access
 
-        def handle_rw_files(_, path, __):
-            """Handle read-only files, that will fail to be removed on Windows."""
-            filesystem.chmod(path, stat.S_IWRITE)
-            try:
-                os.remove(path)
-            except (IOError, OSError):
-                # TODO: remote the try/except once all logic from windows file permissions is merged
-                if os.name != 'nt':
-                    raise
-        shutil.rmtree(self.tempdir, onerror=handle_rw_files)
+        shutil.rmtree(self.tempdir)
 
 
 class ConfigTestCase(TempDirTestCase):

--- a/certbot/tests/util.py
+++ b/certbot/tests/util.py
@@ -5,7 +5,6 @@
 """
 import logging
 import shutil
-import stat
 import sys
 import tempfile
 import unittest


### PR DESCRIPTION
Some scars were still there from the dark age of unit tests failures on Windows. They are ignoring exceptions that occurs during the tearDown phase of a test when some file handles are not properly closed.

This PR fixes that, ensuring that all file handles are really closed at the end of each test, and so these workarounds are not needed anymore, so removed.

