### PR TITLE
Use travis_retry for farm tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -276,7 +276,7 @@ addons:
 # CERTBOT_NO_PIN is set to work around failures we've seen when using an older
 # version of virtualenv.
 install: 'tools/pip_install.py -U codecov tox virtualenv'
-script: '"$TRAVIS_RETRY" tox'
+script: '$TRAVIS_RETRY tox'
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -276,6 +276,10 @@ addons:
 # CERTBOT_NO_PIN is set to work around failures we've seen when using an older
 # version of virtualenv.
 install: 'tools/pip_install.py -U codecov tox virtualenv'
+# Most of the time TRAVIS_RETRY is an empty string, and has no effect on the
+# script command. It is set only to `travis_retry` during farm tests, in
+# order to trigger the Travis retry feature, and compensate the inherent
+# flakiness of these specific tests.
 script: '$TRAVIS_RETRY tox'
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
   # On Travis, the fastest parallelization for integration tests has proved to be 4.
   - 'if [[ "$TOXENV" == *"integration"* ]]; then export PYTEST_ADDOPTS="--numprocesses 4"; fi'
   - export TOX_TESTENV_PASSENV=TRAVIS
+  - export RETRY_CMD=travis_retry
 
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-` or of the form `digit(s).digit(s).x`. This reduces the number of

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ before_script:
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ulimit -n 1024 ; fi'
   # On Travis, the fastest parallelization for integration tests has proved to be 4.
   - 'if [[ "$TOXENV" == *"integration"* ]]; then export PYTEST_ADDOPTS="--numprocesses 4"; fi'
+  # Use Travis retry feature for farm tests since they are flaky
+  - 'if [[ "$TOXENV" == "travis-test-farm"* ]]; then export TRAVIS_RETRY=travis_retry; fi'
   - export TOX_TESTENV_PASSENV=TRAVIS
-  - export RETRY_CMD=travis_retry
 
 # Only build pushes to the master branch, PRs, and branches beginning with
 # `test-` or of the form `digit(s).digit(s).x`. This reduces the number of
@@ -274,8 +275,8 @@ addons:
 # virtualenv is listed here explicitly to make sure it is upgraded when
 # CERTBOT_NO_PIN is set to work around failures we've seen when using an older
 # version of virtualenv.
-install: "tools/pip_install.py -U codecov tox virtualenv"
-script: tox
+install: 'tools/pip_install.py -U codecov tox virtualenv'
+script: '"$TRAVIS_RETRY" tox'
 
 after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'
 

--- a/tox.ini
+++ b/tox.ini
@@ -274,7 +274,7 @@ setenv = AWS_DEFAULT_REGION=us-east-1
 changedir = {[testenv:travis-test-farm-tests-base]changedir}
 commands =
     {[testenv:travis-test-farm-tests-base]commands}
-    python multitester.py apache2_targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_apache2.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
+    {env:RETRY_CMD:} python multitester.py apache2_targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_apache2.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
 deps = {[testenv:travis-test-farm-tests-base]deps}
 passenv = {[testenv:travis-test-farm-tests-base]passenv}
 setenv = {[testenv:travis-test-farm-tests-base]setenv}
@@ -283,7 +283,7 @@ setenv = {[testenv:travis-test-farm-tests-base]setenv}
 changedir = {[testenv:travis-test-farm-tests-base]changedir}
 commands =
     {[testenv:travis-test-farm-tests-base]commands}
-    python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_leauto_upgrades.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
+    {env:RETRY_CMD:} python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_leauto_upgrades.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
 deps = {[testenv:travis-test-farm-tests-base]deps}
 passenv = {[testenv:travis-test-farm-tests-base]passenv}
 setenv = {[testenv:travis-test-farm-tests-base]setenv}
@@ -292,7 +292,7 @@ setenv = {[testenv:travis-test-farm-tests-base]setenv}
 changedir = {[testenv:travis-test-farm-tests-base]changedir}
 commands =
     {[testenv:travis-test-farm-tests-base]commands}
-    python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_letsencrypt_auto_certonly_standalone.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
+    {env:RETRY_CMD:} python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_letsencrypt_auto_certonly_standalone.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
 deps = {[testenv:travis-test-farm-tests-base]deps}
 passenv = {[testenv:travis-test-farm-tests-base]passenv}
 setenv = {[testenv:travis-test-farm-tests-base]setenv}
@@ -301,7 +301,7 @@ setenv = {[testenv:travis-test-farm-tests-base]setenv}
 changedir = {[testenv:travis-test-farm-tests-base]changedir}
 commands =
     {[testenv:travis-test-farm-tests-base]commands}
-    python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_sdists.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
+    {env:RETRY_CMD:} python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_sdists.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
 deps = {[testenv:travis-test-farm-tests-base]deps}
 passenv = {[testenv:travis-test-farm-tests-base]passenv}
 setenv = {[testenv:travis-test-farm-tests-base]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -274,7 +274,7 @@ setenv = AWS_DEFAULT_REGION=us-east-1
 changedir = {[testenv:travis-test-farm-tests-base]changedir}
 commands =
     {[testenv:travis-test-farm-tests-base]commands}
-    {env:RETRY_CMD:} python multitester.py apache2_targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_apache2.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
+    python multitester.py apache2_targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_apache2.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
 deps = {[testenv:travis-test-farm-tests-base]deps}
 passenv = {[testenv:travis-test-farm-tests-base]passenv}
 setenv = {[testenv:travis-test-farm-tests-base]setenv}
@@ -283,7 +283,7 @@ setenv = {[testenv:travis-test-farm-tests-base]setenv}
 changedir = {[testenv:travis-test-farm-tests-base]changedir}
 commands =
     {[testenv:travis-test-farm-tests-base]commands}
-    {env:RETRY_CMD:} python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_leauto_upgrades.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
+    python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_leauto_upgrades.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
 deps = {[testenv:travis-test-farm-tests-base]deps}
 passenv = {[testenv:travis-test-farm-tests-base]passenv}
 setenv = {[testenv:travis-test-farm-tests-base]setenv}
@@ -292,7 +292,7 @@ setenv = {[testenv:travis-test-farm-tests-base]setenv}
 changedir = {[testenv:travis-test-farm-tests-base]changedir}
 commands =
     {[testenv:travis-test-farm-tests-base]commands}
-    {env:RETRY_CMD:} python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_letsencrypt_auto_certonly_standalone.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
+    python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_letsencrypt_auto_certonly_standalone.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
 deps = {[testenv:travis-test-farm-tests-base]deps}
 passenv = {[testenv:travis-test-farm-tests-base]passenv}
 setenv = {[testenv:travis-test-farm-tests-base]setenv}
@@ -301,7 +301,7 @@ setenv = {[testenv:travis-test-farm-tests-base]setenv}
 changedir = {[testenv:travis-test-farm-tests-base]changedir}
 commands =
     {[testenv:travis-test-farm-tests-base]commands}
-    {env:RETRY_CMD:} python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_sdists.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
+    python multitester.py targets.yaml travis-test-farm.pem SET_BY_ENV scripts/test_sdists.sh --repo {env:TRAVIS_BUILD_DIR} --branch {env:TRAVIS_BRANCH} --fast
 deps = {[testenv:travis-test-farm-tests-base]deps}
 passenv = {[testenv:travis-test-farm-tests-base]passenv}
 setenv = {[testenv:travis-test-farm-tests-base]setenv}


### PR DESCRIPTION
The farm tests are flaky, and fail at least once each two days. Personally it starts to annoy me, and by that I mean that their red flag effect on failures vanishes, since they just fail for any reason.

This is not good, and in the past some real failures have been ignored on Apache tests that were also failing all the time.

In order to improve the situation, until we setup a new approach to improve their stability, I propose to use the `travis_retry` bash method exposed by Travis, in order to rerun (at most 2 times) the failed farm tests jobs during nightly builds.

This PR does that. The retry is triggered conditionally on farm tests only, since the other jobs are failing or passing consistently.

You can see an execution of these tests here: https://travis-ci.com/certbot/certbot/builds/123250252

All tests are failing in this build, because I think I exhausted the available AMI instances (problem of clean up here ?), but you will notice in the logs that each farm test has been run 3 times before the relevant Travis job fails.