### PR TITLE
[Apache v2] Modifications to ParserNode interfaces

### DIFF
--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -124,7 +124,7 @@ class ParserNode(object):
 
     # Filepath of the file where the configuration element for this ParserNode
     # object resides.
-    filepath: str
+    filepath: Optional[str]
     """
 
     @abc.abstractmethod

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -121,7 +121,20 @@ class ParserNode(object):
 
     # True if this node has been modified since last save.
     dirty: bool
+
+    # Filepath of the file where the configuration element for this ParserNode
+    # object resides.
+    filepath: str
     """
+
+    @abc.abstractmethod
+    def metadata(self, key):
+        """
+        Gets an element from the metadata dictionary for this ParserNode object.
+
+        :param str key: Element key name
+        :returns: Requested metadata element
+        """
 
     @abc.abstractmethod
     def save(self, msg):
@@ -142,7 +155,7 @@ class ParserNode(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class CommentNode(ParserNode):
+class CommentNode(object):
     """
     CommentNode class is used for representation of comments within the parsed
     configuration structure. Because of the nature of comments, it is not able
@@ -161,7 +174,7 @@ class CommentNode(ParserNode):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class DirectiveNode(ParserNode):
+class DirectiveNode(object):
     """
     DirectiveNode class represents a configuration directive within the configuration.
     It can have zero or more parameters attached to it. Because of the nature of
@@ -195,7 +208,7 @@ class DirectiveNode(ParserNode):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class BlockNode(ParserNode):
+class BlockNode(object):
     """
     BlockNode class represents a block of nested configuration directives, comments
     and other blocks as its children. A BlockNode can have zero or more parameters

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -135,6 +135,12 @@ class ParserNode(object):
         Initializes the ParserNode instance, and sets the ParserNode specific
         instance variables. This is not meant to be used directly, but through
         specific classes implementing ParserNode interface.
+
+        :param ancestor: BlockNode ancestor for this CommentNode.
+        :param filepath: Filesystem path for the file where this CommentNode
+            does or should exist in the filesystem.
+        :param bool dirty: Boolean flag for denoting if this CommentNode has been
+            created or changed after the last save.
         """
 
     @abc.abstractmethod
@@ -182,8 +188,8 @@ class CommentNode(ParserNode):
         Initializes the CommentNode instance and sets its instance variables.
 
         :param str comment: Contents of the comment.
-        :param BlockNode ancestor: BlockNode ancestor for this CommentNode.
-        :param str filepath: Filesystem path for the file where this CommentNode
+        :param ancestor: BlockNode ancestor for this CommentNode.
+        :param filepath: Filesystem path for the file where this CommentNode
             does or should exist in the filesystem.
         :param bool dirty: Boolean flag for denoting if this CommentNode has been
             created or changed after the last save.
@@ -209,7 +215,9 @@ class DirectiveNode(ParserNode):
     # inactive conditional block. Default: True
     enabled: bool
 
-    # Name, or key of the configuration directive. Required.
+    # Name, or key of the configuration directive. If BlockNode subclass of
+    # DirectiveNode is the root configuration node, the name should be None.
+    # Required.
     name: str
 
     # Tuple of parameters of this ParserNode object, excluding whitespaces.
@@ -217,7 +225,7 @@ class DirectiveNode(ParserNode):
     parameters: Tuple[str, ...]
 
     """
-    # pylint: disable=too-many-arguments, super-init-not-called
+    # pylint: disable=super-init-not-called
     def __init__(self, **kwargs):
         """
         Initializes the DirectiveNode instance and sets its instance variables.
@@ -225,8 +233,8 @@ class DirectiveNode(ParserNode):
         :param name: Name or key of the DirectiveNode object.
         :param tuple parameters: Tuple of str parameters for this DirectiveNode.
         :param ancestor: BlockNode ancestor for this DirectiveNode, or None for
-            directives introduced at the httpd command line.
-        :param str filepath: Filesystem path for the file where this DirectiveNode
+            root configuratio node.
+        :param filepath: Filesystem path for the file where this DirectiveNode
             does or should exist in the filesystem, or None for directives introduced
             in the httpd command line.
         :param bool dirty: Boolean flag for denoting if this DirectiveNode has been
@@ -250,7 +258,7 @@ class DirectiveNode(ParserNode):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class BlockNode(ParserNode):
+class BlockNode(DirectiveNode):
     """
     BlockNode class represents a block of nested configuration directives, comments
     and other blocks as its children. A BlockNode can have zero or more parameters
@@ -281,26 +289,9 @@ class BlockNode(ParserNode):
     The applicable parameters are dependent on the underlying configuration language
     and its grammar.
 
-    BlockNode objects should have the following attributes in addition to
-    the ones described in ParserNode:
-
-    # True if this BlockNode is enabled and False if it is inside of an
-    # inactive conditional block. If a BlockNode contains an unmatched
-    # conditional statement, it should itself be flagged as enabled as it's
-    # parsed, but its children should be flagged as disabled. Default: True
-    enabled: bool
-
-    # Name, or key of the configuration directive. If the BlockNode is the root
-    # configuration node, the name should be None. Required.
-    name: Optional[str]
-
-    # Tuple of parameters of this ParserNode object, excluding whitespaces.
-    # Default: ()
-    parameters: Tuple[str, ...]
-
     """
 
-    # pylint: disable=too-many-arguments, super-init-not-called
+    # pylint: disable=super-init-not-called
     @abc.abstractmethod
     def __init__(self, **kwargs):
         """
@@ -441,17 +432,6 @@ class BlockNode(ParserNode):
 
         :param ParserNode child: Child ParserNode object to remove from the list
             of children of the callee.
-        """
-
-    @abc.abstractmethod
-    def set_parameters(self, parameters):
-        """
-        Sets the sequence of parameters for this ParserNode object without
-        whitespaces. While the whitespaces for parameters are discarded when using
-        this method, the whitespacing preceeding the ParserNode itself should be
-        kept intact.
-
-        :param list parameters: sequence of parameters
         """
 
     @abc.abstractmethod

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -116,16 +116,16 @@ class ParserNode(object):
     ParserNode objects should have the following attributes:
 
     # Reference to ancestor node, or None if the node is the root node of the
-    # configuration tree. Required.
+    # configuration tree.
     ancestor: Optional[ParserNode]
 
-    # True if this node has been modified since last save. Default: False
+    # True if this node has been modified since last save.
     dirty: bool
 
     # Filepath of the file where the configuration element for this ParserNode
     # object resides. For root node, the value for filepath is the httpd root
     # configuration file. Filepath can be None if a configuration directive is
-    # defined in for example the httpd command line. Required.
+    # defined in for example the httpd command line.
     filepath: Optional[str]
     """
 
@@ -176,12 +176,11 @@ class CommentNode(ParserNode):
     the ones described in ParserNode:
 
     # Contains the contents of the comment without the directive notation
-    # (typically # or /* ... */). Required.
+    # (typically # or /* ... */).
     comment: str
 
     """
 
-    # pylint: disable=super-init-not-called
     @abc.abstractmethod
     def __init__(self, **kwargs):
         """
@@ -194,6 +193,7 @@ class CommentNode(ParserNode):
         :param bool dirty: Boolean flag for denoting if this CommentNode has been
             created or changed after the last save. Default: False.
         """
+        super(CommentNode, self).__init__(**kwargs)
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -212,20 +212,18 @@ class DirectiveNode(ParserNode):
     the ones described in ParserNode:
 
     # True if this DirectiveNode is enabled and False if it is inside of an
-    # inactive conditional block. Default: True
+    # inactive conditional block.
     enabled: bool
 
     # Name, or key of the configuration directive. If BlockNode subclass of
     # DirectiveNode is the root configuration node, the name should be None.
-    # Required.
     name: str
 
     # Tuple of parameters of this ParserNode object, excluding whitespaces.
-    # Default: ()
     parameters: Tuple[str, ...]
 
     """
-    # pylint: disable=super-init-not-called
+    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
         """
         Initializes the DirectiveNode instance and sets its instance variables.
@@ -245,6 +243,7 @@ class DirectiveNode(ParserNode):
             unmatched conditional configuration block. Default: True.
 
         """
+        super(DirectiveNode, self).__init__(**kwargs)
 
     @abc.abstractmethod
     def set_parameters(self, parameters):
@@ -291,27 +290,6 @@ class BlockNode(DirectiveNode):
     and its grammar.
 
     """
-
-    # pylint: disable=super-init-not-called
-    @abc.abstractmethod
-    def __init__(self, **kwargs):
-        """
-        Initializes the BlockNode instance and sets its instance variables.
-
-        :param name: Name or key of the BlockNode object, or None for root
-            configuration node. Required.
-        :param tuple parameters: Tuple of str parameters for this BlockNode.
-            Default: ().
-        :param ancestor: BlockNode ancestor for this BlockNode, or None for root
-            configuration node. Required.
-        :param str filepath: Filesystem path for the file where this BlockNode does
-            or should exist in the filesystem. Required.
-        :param bool dirty: Boolean flag for denoting if this BlockNode has been
-            created or changed after the last save. Default: False.
-        :param bool enabled: True if this BlockNode object is parsed in the active
-            configuration object by the httpd. False if the BlockNode exists within
-            a unmatched conditional configuration block. Default: True.
-        """
 
     @abc.abstractmethod
     def add_child_block(self, name, parameters=None, position=None):

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -116,20 +116,21 @@ class ParserNode(object):
     ParserNode objects should have the following attributes:
 
     # Reference to ancestor node, or None if the node is the root node of the
-    # configuration tree.
+    # configuration tree. Required.
     ancestor: Optional[ParserNode]
 
-    # True if this node has been modified since last save.
+    # True if this node has been modified since last save. Default: False
     dirty: bool
 
     # Filepath of the file where the configuration element for this ParserNode
-    # object resides. This can be None if a configuration directive is defined in
-    # for example the httpd command line.
+    # object resides. For root node, the value for filepath is the httpd root
+    # configuration file. Filepath can be None if a configuration directive is
+    # defined in for example the httpd command line. Required.
     filepath: Optional[str]
     """
 
     @abc.abstractmethod
-    def __init__(self, ancestor=None, filepath="", dirty=False):  # pragma: no cover
+    def __init__(self, **kwargs):
         """
         Initializes the ParserNode instance, and sets the ParserNode specific
         instance variables. This is not meant to be used directly, but through
@@ -153,6 +154,7 @@ class ParserNode(object):
 
         """
 
+
 # Linter rule exclusion done because of https://github.com/PyCQA/pylint/issues/179
 @six.add_metaclass(abc.ABCMeta)  # pylint: disable=abstract-method
 class CommentNode(ParserNode):
@@ -164,17 +166,18 @@ class CommentNode(ParserNode):
     CommentNode stores its contents in class variable 'comment' and does not
     have a specific name.
 
-    CommentNode objects should have the following attributes:
+    CommentNode objects should have the following attributes in addition to
+    the ones described in ParserNode:
 
     # Contains the contents of the comment without the directive notation
-    # (typically # or /* ... */).
+    # (typically # or /* ... */). Required.
     comment: str
 
     """
 
     # pylint: disable=super-init-not-called
     @abc.abstractmethod
-    def __init__(self, comment, ancestor, filepath, dirty=False):  # pragma: no cover
+    def __init__(self, **kwargs):
         """
         Initializes the CommentNode instance and sets its instance variables.
 
@@ -199,22 +202,23 @@ class DirectiveNode(ParserNode):
     variable for this DirectiveNode should be None, and it should be inserted to the
     beginning of root BlockNode children sequence.
 
-    DirectiveNode objects should have the following attributes:
+    DirectiveNode objects should have the following attributes in addition to
+    the ones described in ParserNode:
 
     # True if this DirectiveNode is enabled and False if it is inside of an
-    # inactive conditional block.
+    # inactive conditional block. Default: True
     enabled: bool
 
-    # Name, or key of the configuration directive
+    # Name, or key of the configuration directive. Required.
     name: str
 
     # Tuple of parameters of this ParserNode object, excluding whitespaces.
+    # Default: ()
     parameters: Tuple[str, ...]
 
     """
     # pylint: disable=too-many-arguments, super-init-not-called
-    def __init__(self, name, parameters=(), ancestor=None, filepath="",
-                 dirty=False, enabled=True):  # pragma: no cover
+    def __init__(self, **kwargs):
         """
         Initializes the DirectiveNode instance and sets its instance variables.
 
@@ -277,37 +281,34 @@ class BlockNode(ParserNode):
     The applicable parameters are dependent on the underlying configuration language
     and its grammar.
 
-    BlockNode objects should have the following attributes:
+    BlockNode objects should have the following attributes in addition to
+    the ones described in ParserNode:
 
     # True if this BlockNode is enabled and False if it is inside of an
     # inactive conditional block. If a BlockNode contains an unmatched
     # conditional statement, it should itself be flagged as enabled as it's
-    # parsed, but its children should be flagged as disabled.
+    # parsed, but its children should be flagged as disabled. Default: True
     enabled: bool
 
     # Name, or key of the configuration directive. If the BlockNode is the root
-    # configuration node, the name should be None.
+    # configuration node, the name should be None. Required.
     name: Optional[str]
 
     # Tuple of parameters of this ParserNode object, excluding whitespaces.
+    # Default: ()
     parameters: Tuple[str, ...]
 
-    # Tuple of ParserNode objects that are the children for this node. The order
-    # of the children is the same s that of the parsed configuration block.
-    children: Tuple[ParserNode, ...]
     """
 
     # pylint: disable=too-many-arguments, super-init-not-called
     @abc.abstractmethod
-    def __init__(self, name="", parameters=(), children=(), ancestor=None,
-                 filepath="", dirty=False, enabled=True):  # pragma: no cover
+    def __init__(self, **kwargs):
         """
         Initializes the BlockNode instance and sets its instance variables.
 
         :param name: Name or key of the BlockNode object, or None for root
             configuration node.
         :param tuple parameters: Tuple of str parameters for this BlockNode.
-        :param tuple children: Tuple of ParserNode children for this BlockNode.
         :param ancestor: BlockNode ancestor for this BlockNode, or None for root
             configuration node.
         :param str filepath: Filesystem path for the file where this BlockNode does

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -1,3 +1,4 @@
+# pylint: disable=abstract-method
 """ParserNode interface for interacting with configuration tree.
 
 General description
@@ -155,7 +156,7 @@ class ParserNode(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class CommentNode(object):
+class CommentNode(ParserNode):
     """
     CommentNode class is used for representation of comments within the parsed
     configuration structure. Because of the nature of comments, it is not able
@@ -174,7 +175,7 @@ class CommentNode(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class DirectiveNode(object):
+class DirectiveNode(ParserNode):
     """
     DirectiveNode class represents a configuration directive within the configuration.
     It can have zero or more parameters attached to it. Because of the nature of
@@ -208,7 +209,7 @@ class DirectiveNode(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class BlockNode(object):
+class BlockNode(ParserNode):
     """
     BlockNode class represents a block of nested configuration directives, comments
     and other blocks as its children. A BlockNode can have zero or more parameters

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -136,11 +136,11 @@ class ParserNode(object):
         instance variables. This is not meant to be used directly, but through
         specific classes implementing ParserNode interface.
 
-        :param ancestor: BlockNode ancestor for this CommentNode.
+        :param ancestor: BlockNode ancestor for this CommentNode. Required.
         :param filepath: Filesystem path for the file where this CommentNode
-            does or should exist in the filesystem.
+            does or should exist in the filesystem. Required.
         :param bool dirty: Boolean flag for denoting if this CommentNode has been
-            created or changed after the last save.
+            created or changed after the last save. Default: False.
         """
 
     @abc.abstractmethod
@@ -187,12 +187,12 @@ class CommentNode(ParserNode):
         """
         Initializes the CommentNode instance and sets its instance variables.
 
-        :param str comment: Contents of the comment.
-        :param ancestor: BlockNode ancestor for this CommentNode.
+        :param str comment: Contents of the comment. Required.
+        :param ancestor: BlockNode ancestor for this CommentNode. Required.
         :param filepath: Filesystem path for the file where this CommentNode
-            does or should exist in the filesystem.
+            does or should exist in the filesystem. Required.
         :param bool dirty: Boolean flag for denoting if this CommentNode has been
-            created or changed after the last save.
+            created or changed after the last save. Default: False.
         """
 
 
@@ -230,18 +230,19 @@ class DirectiveNode(ParserNode):
         """
         Initializes the DirectiveNode instance and sets its instance variables.
 
-        :param name: Name or key of the DirectiveNode object.
+        :param name: Name or key of the DirectiveNode object. Required.
         :param tuple parameters: Tuple of str parameters for this DirectiveNode.
+            Default: ().
         :param ancestor: BlockNode ancestor for this DirectiveNode, or None for
-            root configuratio node.
+            root configuratio node. Required.
         :param filepath: Filesystem path for the file where this DirectiveNode
             does or should exist in the filesystem, or None for directives introduced
-            in the httpd command line.
+            in the httpd command line. Required.
         :param bool dirty: Boolean flag for denoting if this DirectiveNode has been
-            created or changed after the last save.
+            created or changed after the last save. Default: False.
         :param bool enabled: True if this DirectiveNode object is parsed in the active
             configuration of the httpd. False if the DirectiveNode exists within a
-            unmatched conditional configuration block.
+            unmatched conditional configuration block. Default: True.
 
         """
 
@@ -298,17 +299,18 @@ class BlockNode(DirectiveNode):
         Initializes the BlockNode instance and sets its instance variables.
 
         :param name: Name or key of the BlockNode object, or None for root
-            configuration node.
+            configuration node. Required.
         :param tuple parameters: Tuple of str parameters for this BlockNode.
+            Default: ().
         :param ancestor: BlockNode ancestor for this BlockNode, or None for root
-            configuration node.
+            configuration node. Required.
         :param str filepath: Filesystem path for the file where this BlockNode does
-            or should exist in the filesystem.
+            or should exist in the filesystem. Required.
         :param bool dirty: Boolean flag for denoting if this BlockNode has been
-            created or changed after the last save.
+            created or changed after the last save. Default: False.
         :param bool enabled: True if this BlockNode object is parsed in the active
             configuration object by the httpd. False if the BlockNode exists within
-            a unmatched conditional configuration block.
+            a unmatched conditional configuration block. Default: True.
         """
 
     @abc.abstractmethod

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -145,8 +145,7 @@ class ParserNode(object):
         """
 
 # Linter rule exclusion done because of https://github.com/PyCQA/pylint/issues/179
-# pylint: disable=abstract-method
-@six.add_metaclass(abc.ABCMeta)
+@six.add_metaclass(abc.ABCMeta)  # pylint: disable=abstract-method
 class CommentNode(ParserNode):
     """
     CommentNode class is used for representation of comments within the parsed

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -137,10 +137,15 @@ class ParserNode(object):
         specific classes implementing ParserNode interface.
 
         :param ancestor: BlockNode ancestor for this CommentNode. Required.
+        :type ancestor: BlockNode or None
+
         :param filepath: Filesystem path for the file where this CommentNode
             does or should exist in the filesystem. Required.
-        :param bool dirty: Boolean flag for denoting if this CommentNode has been
+        :type filepath: str or None
+
+        :param dirty: Boolean flag for denoting if this CommentNode has been
             created or changed after the last save. Default: False.
+        :type dirty: bool or None
         """
 
     @abc.abstractmethod
@@ -157,6 +162,8 @@ class ParserNode(object):
         of actual configuration files that reside in the filesystem. To handle
         file writes properly, the file specific temporary trees should be extracted
         from the full ParserNode tree where necessary when writing to disk.
+
+        :param str msg: Message describing the reason for the save.
 
         """
 
@@ -186,12 +193,19 @@ class CommentNode(ParserNode):
         """
         Initializes the CommentNode instance and sets its instance variables.
 
-        :param str comment: Contents of the comment. Required.
+        :param comment: Contents of the comment. Required.
+        :type comment: str
+
         :param ancestor: BlockNode ancestor for this CommentNode. Required.
+        :type ancestor: BlockNode or None
+
         :param filepath: Filesystem path for the file where this CommentNode
             does or should exist in the filesystem. Required.
-        :param bool dirty: Boolean flag for denoting if this CommentNode has been
+        :type filepath: str or None
+
+        :param dirty: Boolean flag for denoting if this CommentNode has been
             created or changed after the last save. Default: False.
+        :type dirty: bool
         """
         super(CommentNode, self).__init__(ancestor=kwargs['ancestor'],
                                           dirty=kwargs.get('dirty', False),
@@ -232,18 +246,29 @@ class DirectiveNode(ParserNode):
         Initializes the DirectiveNode instance and sets its instance variables.
 
         :param name: Name or key of the DirectiveNode object. Required.
+        :type name: str or None
+
         :param tuple parameters: Tuple of str parameters for this DirectiveNode.
             Default: ().
+        :type parameters: tuple
+
         :param ancestor: BlockNode ancestor for this DirectiveNode, or None for
             root configuration node. Required.
+        :type ancestor: BlockNode or None
+
         :param filepath: Filesystem path for the file where this DirectiveNode
             does or should exist in the filesystem, or None for directives introduced
             in the httpd command line. Required.
-        :param bool dirty: Boolean flag for denoting if this DirectiveNode has been
+        :type filepath: str or None
+
+        :param dirty: Boolean flag for denoting if this DirectiveNode has been
             created or changed after the last save. Default: False.
-        :param bool enabled: True if this DirectiveNode object is parsed in the active
+        :type dirty: bool
+
+        :param enabled: True if this DirectiveNode object is parsed in the active
             configuration of the httpd. False if the DirectiveNode exists within a
             unmatched conditional configuration block. Default: True.
+        :type enabled: bool
 
         """
         super(DirectiveNode, self).__init__(ancestor=kwargs['ancestor'],

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -193,7 +193,9 @@ class CommentNode(ParserNode):
         :param bool dirty: Boolean flag for denoting if this CommentNode has been
             created or changed after the last save. Default: False.
         """
-        super(CommentNode, self).__init__(**kwargs)  # pragma: no cover
+        super(CommentNode, self).__init__(ancestor=kwargs['ancestor'],
+                                          dirty=kwargs.get('dirty', False),
+                                          filepath=kwargs['filepath'])  # pragma: no cover
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -224,7 +226,6 @@ class DirectiveNode(ParserNode):
 
     """
 
-    # pylint: disable=useless-super-delegation
     @abc.abstractmethod
     def __init__(self, **kwargs):
         """
@@ -245,7 +246,9 @@ class DirectiveNode(ParserNode):
             unmatched conditional configuration block. Default: True.
 
         """
-        super(DirectiveNode, self).__init__(**kwargs)  # pragma: no cover
+        super(DirectiveNode, self).__init__(ancestor=kwargs['ancestor'],
+                                            dirty=kwargs.get('dirty', False),
+                                            filepath=kwargs['filepath'])  # pragma: no cover
 
     @abc.abstractmethod
     def set_parameters(self, parameters):

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -145,7 +145,7 @@ class ParserNode(object):
 
         :param dirty: Boolean flag for denoting if this CommentNode has been
             created or changed after the last save. Default: False.
-        :type dirty: bool or None
+        :type dirty: bool
         """
 
     @abc.abstractmethod

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -159,7 +159,7 @@ class CommentNode(ParserNode):
     CommentNode objects should have the following attributes:
 
     # Contains the contents of the comment without the directive notation
-    # (typically # or /* ... */
+    # (typically # or /* ... */).
     comment: str
 
     """

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -193,7 +193,7 @@ class CommentNode(ParserNode):
         :param bool dirty: Boolean flag for denoting if this CommentNode has been
             created or changed after the last save. Default: False.
         """
-        super(CommentNode, self).__init__(**kwargs)
+        super(CommentNode, self).__init__(**kwargs)  # pragma: no cover
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -223,7 +223,9 @@ class DirectiveNode(ParserNode):
     parameters: Tuple[str, ...]
 
     """
+
     # pylint: disable=useless-super-delegation
+    @abc.abstractmethod
     def __init__(self, **kwargs):
         """
         Initializes the DirectiveNode instance and sets its instance variables.
@@ -243,7 +245,7 @@ class DirectiveNode(ParserNode):
             unmatched conditional configuration block. Default: True.
 
         """
-        super(DirectiveNode, self).__init__(**kwargs)
+        super(DirectiveNode, self).__init__(**kwargs)  # pragma: no cover
 
     @abc.abstractmethod
     def set_parameters(self, parameters):

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -183,7 +183,7 @@ class DirectiveNode(ParserNode):
     name: str
 
     # Tuple of parameters of this ParserNode object, excluding whitespaces.
-    parameters: Tuple[str]
+    parameters: Tuple[str, ...]
 
     """
 

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -319,6 +319,14 @@ class BlockNode(DirectiveNode):
     The applicable parameters are dependent on the underlying configuration language
     and its grammar.
 
+    BlockNode objects should have the following attributes in addition to
+    the ones described in DirectiveNode:
+
+    # Tuple of direct children of this BlockNode object. The order of children
+    # in this tuple retain the order of elements in the parsed configuration
+    # block.
+    children: Tuple[ParserNode, ...]
+
     """
 
     @abc.abstractmethod

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -233,7 +233,7 @@ class DirectiveNode(ParserNode):
 
     # Name, or key of the configuration directive. If BlockNode subclass of
     # DirectiveNode is the root configuration node, the name should be None.
-    name: str
+    name: Optional[str]
 
     # Tuple of parameters of this ParserNode object, excluding whitespaces.
     parameters: Tuple[str, ...]

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -1,4 +1,3 @@
-# pylint: disable=abstract-method
 """ParserNode interface for interacting with configuration tree.
 
 General description
@@ -129,15 +128,6 @@ class ParserNode(object):
     """
 
     @abc.abstractmethod
-    def metadata(self, key):
-        """
-        Gets an element from the metadata dictionary for this ParserNode object.
-
-        :param str key: Element key name
-        :returns: Requested metadata element
-        """
-
-    @abc.abstractmethod
     def save(self, msg):
         """
         Save traverses the children, and attempts to write the AST to disk for
@@ -154,7 +144,8 @@ class ParserNode(object):
 
         """
 
-
+# Linter rule exclusion done because of https://github.com/PyCQA/pylint/issues/179
+# pylint: disable=abstract-method
 @six.add_metaclass(abc.ABCMeta)
 class CommentNode(ParserNode):
     """

--- a/certbot-apache/certbot_apache/parsernode_util.py
+++ b/certbot-apache/certbot_apache/parsernode_util.py
@@ -1,0 +1,74 @@
+"""ParserNode utils"""
+
+
+def validate_kwargs(kwargs, required_names):
+    """
+    Ensures that the kwargs dict has all the expected values.
+
+    :param dict kwargs: Dictionary of keyword arguments to validate.
+    :param list required_names: List of required parameter names.
+    """
+
+    validated_kwargs = dict()
+    for name in required_names:
+        try:
+            validated_kwargs[name] = kwargs.pop(name)
+        except KeyError:
+            raise TypeError("Required keyword argument: {} undefined.".format(name))
+
+    # Raise exception if unknown key word arguments are found.
+    if kwargs:
+        unknown = ", ".join(kwargs.keys())
+        raise TypeError("Unknown keyword argument(s): {}".format(unknown))
+    return validated_kwargs
+
+
+def parsernode_kwargs(kwargs):
+    """
+    Validates keyword arguments for ParserNode.
+
+    :param dict kwargs: Keyword argument dictionary to validate.
+
+    :returns: Tuple of validated and prepared arguments.
+    """
+    kwargs.setdefault("dirty", False)
+    kwargs = validate_kwargs(kwargs, ["ancestor", "dirty", "filepath"])
+    return kwargs["ancestor"], kwargs["dirty"], kwargs["filepath"]
+
+
+def commentnode_kwargs(kwargs):
+    """
+    Validates keyword arguments for CommentNode and sets the default values for
+    optional kwargs.
+
+    :param dict kwargs: Keyword argument dictionary to validate.
+
+    :returns: Tuple of validated and prepared arguments and the remaining kwargs.
+    """
+    kwargs.setdefault("dirty", False)
+    kwargs = validate_kwargs(kwargs, ["ancestor", "dirty", "filepath", "comment"])
+
+    comment = kwargs.pop("comment")
+    return comment, kwargs
+
+
+def node_kwargs(kwargs):
+    """
+    Validates keyword arguments for DirectiveNode and BlockNode and sets the
+    default values for optional kwargs.
+
+    :param dict kwargs: Keyword argument dictionary to validate.
+
+    :returns: Tuple of validated and prepared arguments.
+    """
+    kwargs.setdefault("dirty", False)
+    kwargs.setdefault("enabled", True)
+    kwargs.setdefault("parameters", ())
+
+    kwargs = validate_kwargs(kwargs, ["ancestor", "dirty", "filepath", "name",
+                                      "parameters", "enabled"])
+
+    name = kwargs.pop("name")
+    parameters = kwargs.pop("parameters")
+    enabled = kwargs.pop("enabled")
+    return name, parameters, enabled, kwargs

--- a/certbot-apache/certbot_apache/parsernode_util.py
+++ b/certbot-apache/certbot_apache/parsernode_util.py
@@ -3,7 +3,9 @@
 
 def validate_kwargs(kwargs, required_names):
     """
-    Ensures that the kwargs dict has all the expected values.
+    Ensures that the kwargs dict has all the expected values. This function modifies
+    the kwargs dictionary, and hence the returned dictionary should be used instead
+    in the caller function instead of the original kwargs.
 
     :param dict kwargs: Dictionary of keyword arguments to validate.
     :param list required_names: List of required parameter names.

--- a/certbot-apache/certbot_apache/parsernode_util.py
+++ b/certbot-apache/certbot_apache/parsernode_util.py
@@ -27,7 +27,10 @@ def validate_kwargs(kwargs, required_names):
 
 def parsernode_kwargs(kwargs):
     """
-    Validates keyword arguments for ParserNode.
+    Validates keyword arguments for ParserNode. This function modifies the kwargs
+    dictionary, and hence the returned dictionary should be used instead in the
+    caller function instead of the original kwargs.
+
 
     :param dict kwargs: Keyword argument dictionary to validate.
 
@@ -41,7 +44,10 @@ def parsernode_kwargs(kwargs):
 def commentnode_kwargs(kwargs):
     """
     Validates keyword arguments for CommentNode and sets the default values for
-    optional kwargs.
+    optional kwargs. This function modifies the kwargs dictionary, and hence the
+    returned dictionary should be used instead in the caller function instead of
+    the original kwargs.
+
 
     :param dict kwargs: Keyword argument dictionary to validate.
 
@@ -54,15 +60,18 @@ def commentnode_kwargs(kwargs):
     return comment, kwargs
 
 
-def node_kwargs(kwargs):
+def directivenode_kwargs(kwargs):
     """
     Validates keyword arguments for DirectiveNode and BlockNode and sets the
-    default values for optional kwargs.
+    default values for optional kwargs. This function modifies the kwargs
+    dictionary, and hence the returned dictionary should be used instead in the
+    caller function instead of the original kwargs.
 
     :param dict kwargs: Keyword argument dictionary to validate.
 
     :returns: Tuple of validated and prepared arguments and ParserNode kwargs.
     """
+
     kwargs.setdefault("dirty", False)
     kwargs.setdefault("enabled", True)
     kwargs.setdefault("parameters", ())

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -13,6 +13,15 @@ class DummyParserNode(interfaces.ParserNode):
     dirty = False
     filepath = None
 
+    def __init__(self, ancestor=None, filepath=str(), dirty=False):
+        """
+        Initializes the ParserNode instance.
+        """
+        super(DummyParserNode, self).__init__(ancestor, filepath, dirty)
+        self.ancestor = ancestor
+        self.dirty = dirty
+        self.filepath = filepath
+
     def save(self, msg):  # pragma: no cover
         """Save"""
         pass
@@ -20,7 +29,13 @@ class DummyParserNode(interfaces.ParserNode):
 
 class DummyCommentNode(DummyParserNode):
     """ A dummy class implementing CommentNode interface """
-    comment = ""
+
+    def __init__(self, comment, ancestor, filepath, dirty=False):
+        """
+        Initializes the CommentNode instance and sets its instance variables.
+        """
+        super(DummyCommentNode, self).__init__(ancestor, filepath, dirty)
+        self.comment = comment
 
 
 class DummyDirectiveNode(DummyParserNode):
@@ -28,6 +43,17 @@ class DummyDirectiveNode(DummyParserNode):
     parameters = tuple()  # type: Tuple[str, ...]
     enabled = True
     name = ""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, parameters=(), ancestor=None, filepath="",
+                 dirty=False, enabled=True):
+        """
+        Initializes the DirectiveNode instance and sets its instance variables.
+        """
+        super(DummyDirectiveNode, self).__init__(ancestor, filepath, dirty)
+        self.name = name
+        self.parameters = parameters
+        self.enabled = enabled
 
     def set_parameters(self, parameters):  # pragma: no cover
         """Set parameters"""
@@ -40,6 +66,18 @@ class DummyBlockNode(DummyParserNode):
     children = tuple()  # type: Tuple[interfaces.ParserNode, ...]
     enabled = True
     name = ""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name="", parameters=(), children=(), ancestor=None,
+                 filepath="", dirty=False, enabled=True):
+        """
+        Initializes the BlockNode instance and sets its instance variables.
+        """
+        super(DummyBlockNode, self).__init__(ancestor, filepath, dirty)
+        self.name = name
+        self.parameters = parameters
+        self.children = children
+        self.enabled = enabled
 
     def add_child_block(self, name, parameters=None, position=None):  # pragma: no cover
         """Add child block"""
@@ -87,8 +125,8 @@ class ParserNodeTest(unittest.TestCase):
 
     def test_dummy(self):
         dummyblock = DummyBlockNode()
-        dummydirective = DummyDirectiveNode()
-        dummycomment = DummyCommentNode()
+        dummydirective = DummyDirectiveNode("Name")
+        dummycomment = DummyCommentNode("Comment", dummyblock, "/some/file")
 
 
 if __name__ == "__main__":

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -7,58 +7,39 @@ from acme.magic_typing import Optional, Tuple  # pylint: disable=unused-import, 
 from certbot_apache import interfaces
 
 
-
-class DummyCommentNode(interfaces.ParserNode):
-    """ A dummy class implementing CommentNode interface """
+class DummyParserNode(interfaces.ParserNode):
+    """ A dummy class implementing ParserNode interface """
     ancestor = None
-    comment = ""
     dirty = False
-    filename = ""
-
-    def metadata(self, key):  # pragma: no cover
-        """Metadata"""
-        pass
+    filepath = None
 
     def save(self, msg):  # pragma: no cover
         """Save"""
         pass
 
 
-class DummyDirectiveNode(interfaces.ParserNode):
+class DummyCommentNode(DummyParserNode):
+    """ A dummy class implementing CommentNode interface """
+    comment = ""
+
+
+class DummyDirectiveNode(DummyParserNode):
     """ A dummy class implementing DirectiveNode interface """
-    ancestor = None
     parameters = tuple()  # type: Tuple[str, ...]
-    dirty = False
     enabled = True
     name = ""
-    filename = ""
-
-    def metadata(self, key):  # pragma: no cover
-        """Metadata"""
-        pass
-
-    def save(self, msg):  # pragma: no cover
-        """Save"""
-        pass
 
     def set_parameters(self, parameters):  # pragma: no cover
         """Set parameters"""
         pass
 
 
-class DummyBlockNode(interfaces.BlockNode):
+class DummyBlockNode(DummyParserNode):
     """ A dummy class implementing BlockNode interface """
-    ancestor = None
     parameters = tuple()  # type: Tuple[str, ...]
     children = tuple()  # type: Tuple[interfaces.ParserNode, ...]
-    dirty = False
     enabled = True
     name = ""
-    filename = ""
-
-    def save(self, msg):  # pragma: no cover
-        """Save"""
-        pass
 
     def add_child_block(self, name, parameters=None, position=None):  # pragma: no cover
         """Add child block"""
@@ -86,10 +67,6 @@ class DummyBlockNode(interfaces.BlockNode):
 
     def delete_child(self, child):  # pragma: no cover
         """Delete child"""
-        pass
-
-    def metadata(self, key):  # pragma: no cover
-        """Metadata"""
         pass
 
     def set_parameters(self, parameters):  # pragma: no cover

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -2,8 +2,6 @@
 
 import unittest
 
-from acme.magic_typing import Optional, Tuple  # pylint: disable=unused-import, no-name-in-module
-
 from certbot_apache import interfaces
 from certbot_apache import parsernode_util as util
 
@@ -61,18 +59,6 @@ class DummyDirectiveNode(DummyParserNode):
 class DummyBlockNode(DummyDirectiveNode):
     """ A dummy class implementing BlockNode interface """
 
-    def __init__(self, **kwargs):
-        """
-        Initializes the BlockNode instance and sets its instance variables.
-        """
-
-        name, parameters, enabled, kwargs = util.node_kwargs(kwargs)
-        self.name = name
-        self.parameters = parameters
-        self.enabled = enabled
-
-        super(DummyBlockNode, self).__init__(**kwargs)
-
     def add_child_block(self, name, parameters=None, position=None):  # pragma: no cover
         """Add child block"""
         pass
@@ -115,7 +101,7 @@ class ParserNodeTest(unittest.TestCase):
 
     def test_dummy(self):
         dummyblock = DummyBlockNode(
-            name=None,
+            name="None",
             parameters=(),
             ancestor=None,
             dirty=False,

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -44,7 +44,7 @@ class DummyDirectiveNode(DummyParserNode):
         """
         Initializes the DirectiveNode instance and sets its instance variables.
         """
-        name, parameters, enabled, kwargs = util.node_kwargs(kwargs)
+        name, parameters, enabled, kwargs = util.directivenode_kwargs(kwargs)
         self.name = name
         self.parameters = parameters
         self.enabled = enabled

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -8,28 +8,41 @@ from certbot_apache import interfaces
 
 
 
-class DummyCommentNode(interfaces.CommentNode):
+class DummyCommentNode(interfaces.ParserNode):
     """ A dummy class implementing CommentNode interface """
     ancestor = None
     comment = ""
     dirty = False
+    filename = ""
+
+    def metadata(self, key):  # pragma: no cover
+        """Metadata"""
+        pass
 
     def save(self, msg):  # pragma: no cover
+        """Save"""
         pass
 
 
-class DummyDirectiveNode(interfaces.DirectiveNode):
+class DummyDirectiveNode(interfaces.ParserNode):
     """ A dummy class implementing DirectiveNode interface """
     ancestor = None
     parameters = tuple()  # type: Tuple[str, ...]
     dirty = False
     enabled = True
     name = ""
+    filename = ""
+
+    def metadata(self, key):  # pragma: no cover
+        """Metadata"""
+        pass
 
     def save(self, msg):  # pragma: no cover
+        """Save"""
         pass
 
     def set_parameters(self, parameters):  # pragma: no cover
+        """Set parameters"""
         pass
 
 
@@ -41,37 +54,56 @@ class DummyBlockNode(interfaces.BlockNode):
     dirty = False
     enabled = True
     name = ""
+    filename = ""
 
     def save(self, msg):  # pragma: no cover
+        """Save"""
         pass
 
     def add_child_block(self, name, parameters=None, position=None):  # pragma: no cover
+        """Add child block"""
         pass
 
     def add_child_directive(self, name, parameters=None, position=None):  # pragma: no cover
+        """Add child directive"""
         pass
 
     def add_child_comment(self, comment="", position=None):  # pragma: no cover
+        """Add child comment"""
         pass
 
     def find_blocks(self, name, exclude=True):  # pragma: no cover
+        """Find blocks"""
         pass
 
     def find_directives(self, name, exclude=True):  # pragma: no cover
+        """Find directives"""
         pass
 
     def find_comments(self, comment, exact=False):  # pragma: no cover
+        """Find comments"""
         pass
 
     def delete_child(self, child):  # pragma: no cover
+        """Delete child"""
+        pass
+
+    def metadata(self, key):  # pragma: no cover
+        """Metadata"""
         pass
 
     def set_parameters(self, parameters):  # pragma: no cover
+        """Set parameters"""
         pass
 
     def unsaved_files(self):  # pragma: no cover
+        """Unsaved files"""
         pass
 
+
+interfaces.CommentNode.register(DummyCommentNode)
+interfaces.DirectiveNode.register(DummyDirectiveNode)
+interfaces.BlockNode.register(DummyBlockNode)
 
 class ParserNodeTest(unittest.TestCase):
     """Dummy placeholder test case for ParserNode interfaces"""

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -118,28 +118,6 @@ class ParserNodeTest(unittest.TestCase):
             filepath="/some/file"
         )
 
-    def test_unknown_parameter(self):
-        params = {
-            "comment": "x",
-            "ancestor": None,
-            "dirty": False,
-            "filepath": "/tmp",
-            "unknown": "x"
-        }
-        self.assertRaises(TypeError, DummyCommentNode, **params)
-        params["name"] = "unnamed"
-        params.pop("comment")
-        self.assertRaises(TypeError, DummyDirectiveNode, **params)
-        self.assertRaises(TypeError, DummyBlockNode, **params)
-
-    def test_missing_required(self):
-        params = {
-            "ancestor": None,
-            "dirty": False,
-            "filepath": "/tmp",
-        }
-        self.assertRaises(TypeError, DummyCommentNode, **params)
-
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -58,7 +58,7 @@ class DummyDirectiveNode(DummyParserNode):
         pass
 
 
-class DummyBlockNode(DummyParserNode):
+class DummyBlockNode(DummyDirectiveNode):
     """ A dummy class implementing BlockNode interface """
 
     def __init__(self, **kwargs):
@@ -99,10 +99,6 @@ class DummyBlockNode(DummyParserNode):
 
     def delete_child(self, child):  # pragma: no cover
         """Delete child"""
-        pass
-
-    def set_parameters(self, parameters):  # pragma: no cover
-        """Set parameters"""
         pass
 
     def unsaved_files(self):  # pragma: no cover

--- a/certbot-apache/certbot_apache/tests/parsernode_util_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_util_test.py
@@ -1,32 +1,86 @@
 """ Tests for ParserNode utils """
 import unittest
 
-from certbot_apache.tests import parsernode_test
+from certbot_apache import parsernode_util as util
 
 
 class ParserNodeUtilTest(unittest.TestCase):
     """Tests for ParserNode utils"""
-    def test_unknown_parameter(self):
-        params = {
-            "comment": "x",
+
+    def _setup_parsernode(self):
+        """ Sets up kwargs dict for ParserNode """
+        return {
             "ancestor": None,
             "dirty": False,
             "filepath": "/tmp",
-            "unknown": "x"
         }
-        self.assertRaises(TypeError, parsernode_test.DummyCommentNode, **params)
-        params["name"] = "unnamed"
-        params.pop("comment")
-        self.assertRaises(TypeError, parsernode_test.DummyDirectiveNode, **params)
-        self.assertRaises(TypeError, parsernode_test.DummyBlockNode, **params)
+
+    def _setup_commentnode(self):
+        """ Sets up kwargs dict for CommentNode """
+
+        pn = self._setup_parsernode()
+        pn["comment"] = "x"
+        return pn
+
+    def _setup_directivenode(self):
+        """ Sets up kwargs dict for DirectiveNode """
+
+        pn = self._setup_parsernode()
+        pn["name"] = "Name"
+        pn["parameters"] = ("first",)
+        pn["enabled"] = True
+        return pn
+
+    def test_unknown_parameter(self):
+        params = self._setup_parsernode()
+        params["unknown"] = "unknown"
+        self.assertRaises(TypeError, util.parsernode_kwargs, params)
+
+        params = self._setup_commentnode()
+        params["unknown"] = "unknown"
+        self.assertRaises(TypeError, util.commentnode_kwargs, params)
+
+        params = self._setup_directivenode()
+        params["unknown"] = "unknown"
+        self.assertRaises(TypeError, util.directivenode_kwargs, params)
+
+    def test_parsernode(self):
+        params = self._setup_parsernode()
+        ctrl = self._setup_parsernode()
+
+        ancestor, dirty, filepath = util.parsernode_kwargs(params)
+        self.assertEqual(ancestor, ctrl["ancestor"])
+        self.assertEqual(dirty, ctrl["dirty"])
+        self.assertEqual(filepath, ctrl["filepath"])
+
+    def test_commentnode(self):
+        params = self._setup_commentnode()
+        ctrl = self._setup_commentnode()
+
+        comment, _ = util.commentnode_kwargs(params)
+        self.assertEqual(comment, ctrl["comment"])
+
+    def test_directivenode(self):
+        params = self._setup_directivenode()
+        ctrl = self._setup_directivenode()
+
+        name, parameters, enabled, _ = util.directivenode_kwargs(params)
+        self.assertEqual(name, ctrl["name"])
+        self.assertEqual(parameters, ctrl["parameters"])
+        self.assertEqual(enabled, ctrl["enabled"])
 
     def test_missing_required(self):
-        params = {
-            "ancestor": None,
-            "dirty": False,
-            "filepath": "/tmp",
-        }
-        self.assertRaises(TypeError, parsernode_test.DummyCommentNode, **params)
+        c_params = self._setup_commentnode()
+        c_params.pop("comment")
+        self.assertRaises(TypeError, util.commentnode_kwargs, c_params)
+
+        d_params = self._setup_directivenode()
+        d_params.pop("ancestor")
+        self.assertRaises(TypeError, util.directivenode_kwargs, d_params)
+
+        p_params = self._setup_parsernode()
+        p_params.pop("filepath")
+        self.assertRaises(TypeError, util.parsernode_kwargs, p_params)
 
 
 if __name__ == "__main__":

--- a/certbot-apache/certbot_apache/tests/parsernode_util_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_util_test.py
@@ -1,0 +1,33 @@
+""" Tests for ParserNode utils """
+import unittest
+
+from certbot_apache.tests import parsernode_test
+
+
+class ParserNodeUtilTest(unittest.TestCase):
+    """Tests for ParserNode utils"""
+    def test_unknown_parameter(self):
+        params = {
+            "comment": "x",
+            "ancestor": None,
+            "dirty": False,
+            "filepath": "/tmp",
+            "unknown": "x"
+        }
+        self.assertRaises(TypeError, parsernode_test.DummyCommentNode, **params)
+        params["name"] = "unnamed"
+        params.pop("comment")
+        self.assertRaises(TypeError, parsernode_test.DummyDirectiveNode, **params)
+        self.assertRaises(TypeError, parsernode_test.DummyBlockNode, **params)
+
+    def test_missing_required(self):
+        params = {
+            "ancestor": None,
+            "dirty": False,
+            "filepath": "/tmp",
+        }
+        self.assertRaises(TypeError, parsernode_test.DummyCommentNode, **params)
+
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover


### PR DESCRIPTION
This PR contains the changes requested in initial pre-review comments of #7308 

- Move properties to class pydocs in `interfaces.py`
- Prefer class ABC register() functionality instead of class inheritance for interface classes
- Add apache implementation specific functions to interfaces