### PR TITLE
Stop turning session tickets off in Nginx (#7344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.37.2 - master
+
+### Fixed
+
+* Stop disabling TLS session tickets in Nginx as it caused TLS failures on
+  some systems.
+
+More details about these changes can be found on our GitHub repo.
+
 ## 0.37.1 - 2019-08-08
 
 ### Fixed

--- a/certbot-nginx/certbot_nginx/constants.py
+++ b/certbot-nginx/certbot_nginx/constants.py
@@ -24,6 +24,7 @@ UPDATED_MOD_SSL_CONF_DIGEST = ".updated-options-ssl-nginx-conf-digest.txt"
 
 SSL_OPTIONS_HASHES_NEW = [
     '108c4555058a087496a3893aea5d9e1cee0f20a3085d44a52dc1a66522299ac3',
+    'd5e021706ecdccc7090111b0ae9a29ef61523e927f020e410caf0a1fd7063981',
 ]
 """SHA256 hashes of the contents of versions of MOD_SSL_CONF_SRC for nginx >= 1.13.0"""
 
@@ -31,6 +32,7 @@ SSL_OPTIONS_HASHES_MEDIUM = [
     '63e2bddebb174a05c9d8a7cf2adf72f7af04349ba59a1a925fe447f73b2f1abf',
     '2901debc7ecbc10917edd9084c05464c9c5930b463677571eaf8c94bffd11ae2',
     '30baca73ed9a5b0e9a69ea40e30482241d8b1a7343aa79b49dc5d7db0bf53b6c',
+    '02329eb19930af73c54b3632b3165d84571383b8c8c73361df940cb3894dd426',
 ]
 """SHA256 hashes of the contents of versions of MOD_SSL_CONF_SRC for nginx >= 1.5.9
    and nginx < 1.13.0"""

--- a/certbot-nginx/certbot_nginx/tls_configs/options-ssl-nginx-tls12-only.conf
+++ b/certbot-nginx/certbot_nginx/tls_configs/options-ssl-nginx-tls12-only.conf
@@ -6,7 +6,6 @@
 
 ssl_session_cache shared:le_nginx_SSL:10m;
 ssl_session_timeout 1440m;
-ssl_session_tickets off;
 
 ssl_protocols TLSv1.2;
 ssl_prefer_server_ciphers off;

--- a/certbot-nginx/certbot_nginx/tls_configs/options-ssl-nginx.conf
+++ b/certbot-nginx/certbot_nginx/tls_configs/options-ssl-nginx.conf
@@ -6,7 +6,6 @@
 
 ssl_session_cache shared:le_nginx_SSL:10m;
 ssl_session_timeout 1440m;
-ssl_session_tickets off;
 
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_prefer_server_ciphers off;


### PR DESCRIPTION
Related to #7322.

* Stop turning session tickets off in Nginx

* update changelog

(cherry picked from commit 17c1d016c16dc9d41516308dadb8cd6812959981)
