### PR TITLE
Use latest RHEL 7 AMI

### DIFF
--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -40,7 +40,7 @@ targets:
     #     - [ apt-get, install, -y, curl ]
   #-----------------------------------------------------------------------------
   # Other Redhat Distros
-  - ami: ami-a8d369c0
+  - ami: ami-0916c408cb02e310b
     name: RHEL7
     type: centos
     virt: hvm


### PR DESCRIPTION
(Hopefully) fixes https://github.com/certbot/certbot/issues/7319 with the reasoning in my initial post there.

AMI ID was found by following the instructions at https://access.redhat.com/solutions/15356 for RHEL 7 and selecting the newest image.

You can see all test farm tests we run passing at https://travis-ci.com/certbot/certbot/builds/124140696 with this change.