### PR TITLE
Execute certbot version in a different directory

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/certbot_integration_tests/utils/certbot_call.py
@@ -39,7 +39,15 @@ def _prepare_args_env(certbot_args, directory_url, http_01_port, tls_alpn_01_por
     new_environ['TMPDIR'] = workspace
 
     additional_args = []
-    if misc.get_certbot_version(workspace) >= LooseVersion('0.30.0'):
+
+    version_output = subprocess.check_output(['certbot', '--version'],
+                                     universal_newlines=True, stderr=subprocess.STDOUT,
+                                     cwd=workspace)
+    # Typical response is: output = 'certbot 0.31.0.dev0'
+    version_str = version_output.split(' ')[1].strip()
+    version = LooseVersion(version_str)
+
+    if version >= LooseVersion('0.30.0'):
         additional_args.append('--no-random-sleep-on-renew')
 
     if force_renew:

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -209,19 +209,6 @@ shutil.rmtree(well_known)
         shutil.rmtree(tempdir)
 
 
-def get_certbot_version(workspace):
-    """
-    Find the version of the certbot available in PATH.
-    :return str: the certbot version
-    """
-    output = subprocess.check_output(['certbot', '--version'],
-                                     universal_newlines=True, stderr=subprocess.STDOUT,
-                                     cwd=workspace)
-    # Typical response is: output = 'certbot 0.31.0.dev0'
-    version_str = output.split(' ')[1].strip()
-    return LooseVersion(version_str)
-
-
 def generate_csr(domains, key_path, csr_path, key_type=RSA_KEY_TYPE):
     """
     Generate a private key, and a CSR for the given domains using this key.


### PR DESCRIPTION
Python prefers files in its CWD over what's actually installed, so let's change directories before executing the tests so that things like https://travis-ci.com/certbot/certbot/jobs/227892868 pass.