### PR TITLE
Fix issue #7165 in _create_challenge_dirs()

### DIFF
--- a/certbot/plugins/webroot.py
+++ b/certbot/plugins/webroot.py
@@ -173,6 +173,10 @@ to serve all files under specified web root ({0})."""
                 # We ignore the last prefix in the next iteration,
                 # as it does not correspond to a folder path ('/' or 'C:')
                 for prefix in sorted(util.get_prefixes(self.full_roots[name])[:-1], key=len):
+                    if os.path.isdir(prefix):
+                        # Don't try to create directory if it already exists, as some instances
+                        # won't reliably raise EEXIST or EISDIR if directory exists.
+                        continue
                     try:
                         # Set owner as parent directory if possible, apply mode for Linux/Windows.
                         # For Linux, this is coupled with the "umask" call above because
@@ -187,10 +191,9 @@ to serve all files under specified web root ({0})."""
                             logger.info("Unable to change owner and uid of webroot directory")
                             logger.debug("Error was: %s", exception)
                     except OSError as exception:
-                        if exception.errno not in (errno.EEXIST, errno.EISDIR):
-                            raise errors.PluginError(
-                                "Couldn't create root for {0} http-01 "
-                                "challenge responses: {1}".format(name, exception))
+                        raise errors.PluginError(
+                            "Couldn't create root for {0} http-01 "
+                            "challenge responses: {1}".format(name, exception))
             finally:
                 os.umask(old_umask)
 

--- a/certbot/plugins/webroot.py
+++ b/certbot/plugins/webroot.py
@@ -71,7 +71,7 @@ to serve all files under specified web root ({0})."""
         super(Authenticator, self).__init__(*args, **kwargs)
         self.full_roots = {}  # type: Dict[str, str]
         self.performed = collections.defaultdict(set) \
-        # type: DefaultDict[str, Set[achallenges.KeyAuthorizationAnnotatedChallenge]]
+            # type: DefaultDict[str, Set[achallenges.KeyAuthorizationAnnotatedChallenge]]
         # stack of dirs successfully created by this authenticator
         self._created_dirs = []  # type: List[str]
 


### PR DESCRIPTION
Some operating systems won't reliably raise EEXIST or EISDIR if a directory exists when filesystem.mkdir() is called, instead raising `Read-only file system` errors or similar even when path is in fact writable. To work around this we include a check to see if directory already exists. See Issue #7165 for more information.

## Pull Request Checklist

- [ ] Edit the `master` section of `CHANGELOG.md` to include a description of
  the change being made.
- [ ] Add [mypy type
  annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations)
  for any functions that were added or modified.
- [ ] Include your name in `AUTHORS.md` if you like.
