### PR TITLE
[Apache v2] Allow initialization of ParserNode instances using metadata dictionary instead of required arguments

### DIFF
--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -239,7 +239,7 @@ class CommentNode(ParserNode):
         super(CommentNode, self).__init__(ancestor=kwargs['ancestor'],
                                           dirty=kwargs.get('dirty', False),
                                           filepath=kwargs['filepath'],
-                                          metadata=kwargs.get('metadata', {})  # pragma: no cover
+                                          metadata=kwargs.get('metadata', {}))  # pragma: no cover
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -304,7 +304,7 @@ class DirectiveNode(ParserNode):
         super(DirectiveNode, self).__init__(ancestor=kwargs['ancestor'],
                                             dirty=kwargs.get('dirty', False),
                                             filepath=kwargs['filepath'],
-                                            metadata=kwargs.get('metadata', {})  # pragma: no cover
+                                            metadata=kwargs.get('metadata', {}))  # pragma: no cover
 
     @abc.abstractmethod
     def set_parameters(self, parameters):

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -240,7 +240,7 @@ class CommentNode(ParserNode):
         super(CommentNode, self).__init__(ancestor=kwargs['ancestor'],
                                           dirty=kwargs.get('dirty', False),
                                           filepath=kwargs['filepath'],
-                                          metadata=kwargs['metadata'])  # pragma: no cover
+                                          metadata=kwargs.get('metadata', {})  # pragma: no cover
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -308,7 +308,7 @@ class DirectiveNode(ParserNode):
         super(DirectiveNode, self).__init__(ancestor=kwargs['ancestor'],
                                             dirty=kwargs.get('dirty', False),
                                             filepath=kwargs['filepath'],
-                                            metadata=kwargs['metadata'])  # pragma: no cover
+                                            metadata=kwargs.get('metadata', {})  # pragma: no cover
 
     @abc.abstractmethod
     def set_parameters(self, parameters):

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -62,7 +62,7 @@ Initialization
 When the user of a ParserNode class is creating these objects, they must specify
 the parameters as described in the documentation for the __init__ methods below.
 When these objects are created internally, however, some parameters may not be
-needed because (possible more detailed) information is included in the metadata
+needed because (possibly more detailed) information is included in the metadata
 parameter. In this case, implementations can deviate from the required parameters
 from __init__, however, they should still behave the same when metadata is not
 provided.

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -71,10 +71,6 @@ For consistency internally, if an argument is provided directly in the ParserNod
 initialization parameters as well as within metadata it's recommended to establish
 clear behavior around this scenario within the implementation.
 
-If an argument is provided directly in the ParserNode initialization parameters
-as well as within metadata it's important to establish clear precedence rules around
-this scenario within the implementation.
-
 Conditional blocks
 
 Apache configuration can have conditional blocks, for example: <IfModule ...>,

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -59,15 +59,17 @@ specific functionalities that are not described by the interface itself.
 
 Initialization
 
-As many ParserNode variables can be extracted from the information provided by
-metadata, the following otherwise required keyword arguments can be omitted if
-metadata argument is provided. The list of such arguments is as follows:
-    ParserNode
-        - filepath
-    CommentNode
-        - comment
-    DirectiveNode
-        - name
+When the user of a ParserNode class is creating these objects, they must specify
+the parameters as described in the documentation for the __init__ methods below.
+When these objects are created internally, however, some parameters may not be
+needed because (possible more detailed) information is included in the metadata
+parameter. In this case, implementations can deviate from the required parameters
+from __init__, however, they should still behave the same when metadata is not
+provided.
+
+For consistency internally, if an argument is provided directly in the ParserNode
+initialization parameters as well as within metadata it's recommended to establish
+clear behavior around this scenario within the implementation.
 
 If an argument is provided directly in the ParserNode initialization parameters
 as well as within metadata it's important to establish clear precedence rules around
@@ -147,8 +149,7 @@ class ParserNode(object):
     filepath: Optional[str]
 
     # Metadata dictionary holds all the implementation specific key-value pairs
-    # for the ParserNode instance. If metadata is provided, some of the required
-    # keyword arguments may be omitted depending on the implementation.
+    # for the ParserNode instance.
     metadata: Dict[str, Any]
     """
 
@@ -171,6 +172,7 @@ class ParserNode(object):
         :type dirty: bool
 
         :param metadata: Dictionary of metadata values for this ParserNode object.
+            Metadata information should be used only internally in the implementation.
             Default: {}
         :type metadata: dict
         """
@@ -208,9 +210,6 @@ class CommentNode(ParserNode):
 
     CommentNode objects should have the following attributes in addition to
     the ones described in ParserNode:
-
-    # If metadata is provided, the otherwise required argument "comment" may be
-    # omitted if the implementation is able to extract its value from the metadata.
 
     # Contains the contents of the comment without the directive notation
     # (typically # or /* ... */).
@@ -257,9 +256,6 @@ class DirectiveNode(ParserNode):
 
     DirectiveNode objects should have the following attributes in addition to
     the ones described in ParserNode:
-
-    # If metadata is provided, the otherwise required argument "name" may be
-    # omitted if the implementation is able to extract its value from the metadata.
 
     # True if this DirectiveNode is enabled and False if it is inside of an
     # inactive conditional block.
@@ -356,9 +352,6 @@ class BlockNode(DirectiveNode):
 
     BlockNode objects should have the following attributes in addition to
     the ones described in DirectiveNode:
-
-    # If metadata is provided, the otherwise required argument "comment" may be
-    # omitted if the implementation is able to extract its value from the metadata.
 
     # Tuple of direct children of this BlockNode object. The order of children
     # in this tuple retain the order of elements in the parsed configuration

--- a/certbot-apache/certbot_apache/parsernode_util.py
+++ b/certbot-apache/certbot_apache/parsernode_util.py
@@ -44,6 +44,8 @@ def parsernode_kwargs(kwargs):
     # (ancestor being a common exception here) make sure we permit it here as well.
     if "metadata" in kwargs:
         # Filepath can be derived from the metadata in Augeas implementation.
+        # Default is None, as in this case the responsibility of populating this
+        # variable lies on the implementation.
         kwargs.setdefault("filepath", None)
 
     kwargs.setdefault("dirty", False)
@@ -73,7 +75,9 @@ def commentnode_kwargs(kwargs):
     # (ancestor being a common exception here) make sure we permit it here as well.
     if "metadata" in kwargs:
         kwargs.setdefault("comment", None)
-        # Filepath can be derived from the metadata in Augeas implementation
+        # Filepath can be derived from the metadata in Augeas implementation.
+        # Default is None, as in this case the responsibility of populating this
+        # variable lies on the implementation.
         kwargs.setdefault("filepath", None)
 
     kwargs.setdefault("dirty", False)
@@ -106,7 +110,9 @@ def directivenode_kwargs(kwargs):
     # (ancestor being a common exception here) make sure we permit it here as well.
     if "metadata" in kwargs:
         kwargs.setdefault("name", None)
-        # Filepath can be derived from the metadata in Augeas implementation
+        # Filepath can be derived from the metadata in Augeas implementation.
+        # Default is None, as in this case the responsibility of populating this
+        # variable lies on the implementation.
         kwargs.setdefault("filepath", None)
 
     kwargs.setdefault("dirty", False)

--- a/certbot-apache/certbot_apache/parsernode_util.py
+++ b/certbot-apache/certbot_apache/parsernode_util.py
@@ -36,9 +36,17 @@ def parsernode_kwargs(kwargs):
 
     :returns: Tuple of validated and prepared arguments.
     """
+
+    # As ParserNode instances can be initialized with metadata alone, make sure
+    # we permit it here as well.
+    if "metadata" in kwargs:
+        kwargs.setdefault("filepath", None)
+
     kwargs.setdefault("dirty", False)
-    kwargs = validate_kwargs(kwargs, ["ancestor", "dirty", "filepath"])
-    return kwargs["ancestor"], kwargs["dirty"], kwargs["filepath"]
+    kwargs.setdefault("metadata", {})
+
+    kwargs = validate_kwargs(kwargs, ["ancestor", "dirty", "filepath", "metadata"])
+    return kwargs["ancestor"], kwargs["dirty"], kwargs["filepath"], kwargs["metadata"]
 
 
 def commentnode_kwargs(kwargs):
@@ -53,8 +61,18 @@ def commentnode_kwargs(kwargs):
 
     :returns: Tuple of validated and prepared arguments and ParserNode kwargs.
     """
+
+    # As ParserNode instances can be initialized with metadata alone, make sure
+    # we permit it here as well.
+    if "metadata" in kwargs:
+        kwargs.setdefault("comment", None)
+        kwargs.setdefault("filepath", None)
+
     kwargs.setdefault("dirty", False)
-    kwargs = validate_kwargs(kwargs, ["ancestor", "dirty", "filepath", "comment"])
+    kwargs.setdefault("metadata", {})
+
+    kwargs = validate_kwargs(kwargs, ["ancestor", "dirty", "filepath", "comment",
+                                      "metadata"])
 
     comment = kwargs.pop("comment")
     return comment, kwargs
@@ -72,12 +90,19 @@ def directivenode_kwargs(kwargs):
     :returns: Tuple of validated and prepared arguments and ParserNode kwargs.
     """
 
+    # As ParserNode instances can be initialized with metadata alone, make sure
+    # we permit it here as well.
+    if "metadata" in kwargs:
+        kwargs.setdefault("name", None)
+        kwargs.setdefault("filepath", None)
+
     kwargs.setdefault("dirty", False)
     kwargs.setdefault("enabled", True)
     kwargs.setdefault("parameters", ())
+    kwargs.setdefault("metadata", {})
 
     kwargs = validate_kwargs(kwargs, ["ancestor", "dirty", "filepath", "name",
-                                      "parameters", "enabled"])
+                                      "parameters", "enabled", "metadata"])
 
     name = kwargs.pop("name")
     parameters = kwargs.pop("parameters")

--- a/certbot-apache/certbot_apache/parsernode_util.py
+++ b/certbot-apache/certbot_apache/parsernode_util.py
@@ -31,15 +31,19 @@ def parsernode_kwargs(kwargs):
     dictionary, and hence the returned dictionary should be used instead in the
     caller function instead of the original kwargs.
 
+    If metadata is provided, the otherwise required argument "filepath" may be
+    omitted if the implementation is able to extract its value from the metadata.
+    This usecase is handled within this function. Filepath defaults to None.
 
     :param dict kwargs: Keyword argument dictionary to validate.
 
     :returns: Tuple of validated and prepared arguments.
     """
 
-    # As ParserNode instances can be initialized with metadata alone, make sure
-    # we permit it here as well.
+    # As many values of ParserNode instances can be derived from the metadata,
+    # (ancestor being a common exception here) make sure we permit it here as well.
     if "metadata" in kwargs:
+        # Filepath can be derived from the metadata in Augeas implementation.
         kwargs.setdefault("filepath", None)
 
     kwargs.setdefault("dirty", False)
@@ -56,16 +60,20 @@ def commentnode_kwargs(kwargs):
     returned dictionary should be used instead in the caller function instead of
     the original kwargs.
 
+    If metadata is provided, the otherwise required argument "comment" may be
+    omitted if the implementation is able to extract its value from the metadata.
+    This usecase is handled within this function.
 
     :param dict kwargs: Keyword argument dictionary to validate.
 
     :returns: Tuple of validated and prepared arguments and ParserNode kwargs.
     """
 
-    # As ParserNode instances can be initialized with metadata alone, make sure
-    # we permit it here as well.
+    # As many values of ParserNode instances can be derived from the metadata,
+    # (ancestor being a common exception here) make sure we permit it here as well.
     if "metadata" in kwargs:
         kwargs.setdefault("comment", None)
+        # Filepath can be derived from the metadata in Augeas implementation
         kwargs.setdefault("filepath", None)
 
     kwargs.setdefault("dirty", False)
@@ -85,15 +93,20 @@ def directivenode_kwargs(kwargs):
     dictionary, and hence the returned dictionary should be used instead in the
     caller function instead of the original kwargs.
 
+    If metadata is provided, the otherwise required argument "name" may be
+    omitted if the implementation is able to extract its value from the metadata.
+    This usecase is handled within this function.
+
     :param dict kwargs: Keyword argument dictionary to validate.
 
     :returns: Tuple of validated and prepared arguments and ParserNode kwargs.
     """
 
-    # As ParserNode instances can be initialized with metadata alone, make sure
-    # we permit it here as well.
+    # As many values of ParserNode instances can be derived from the metadata,
+    # (ancestor being a common exception here) make sure we permit it here as well.
     if "metadata" in kwargs:
         kwargs.setdefault("name", None)
+        # Filepath can be derived from the metadata in Augeas implementation
         kwargs.setdefault("filepath", None)
 
     kwargs.setdefault("dirty", False)

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -13,10 +13,11 @@ class DummyParserNode(interfaces.ParserNode):
         """
         Initializes the ParserNode instance.
         """
-        ancestor, dirty, filepath = util.parsernode_kwargs(kwargs)
+        ancestor, dirty, filepath, metadata = util.parsernode_kwargs(kwargs)
         self.ancestor = ancestor
         self.dirty = dirty
         self.filepath = filepath
+        self.metadata = metadata
         super(DummyParserNode, self).__init__(**kwargs)
 
     def save(self, msg):  # pragma: no cover

--- a/certbot-apache/certbot_apache/tests/parsernode_util_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_util_test.py
@@ -48,10 +48,21 @@ class ParserNodeUtilTest(unittest.TestCase):
         params = self._setup_parsernode()
         ctrl = self._setup_parsernode()
 
-        ancestor, dirty, filepath = util.parsernode_kwargs(params)
+        ancestor, dirty, filepath, metadata = util.parsernode_kwargs(params)
         self.assertEqual(ancestor, ctrl["ancestor"])
         self.assertEqual(dirty, ctrl["dirty"])
         self.assertEqual(filepath, ctrl["filepath"])
+        self.assertEqual(metadata, {})
+
+    def test_parsernode_from_metadata(self):
+        params = self._setup_parsernode()
+        params.pop("filepath")
+        md = {"some": "value"}
+        params["metadata"] = md
+
+        # Just testing that error from missing required parameters is not raised
+        _, _, _, metadata = util.parsernode_kwargs(params)
+        self.assertEqual(metadata, md)
 
     def test_commentnode(self):
         params = self._setup_commentnode()
@@ -59,6 +70,14 @@ class ParserNodeUtilTest(unittest.TestCase):
 
         comment, _ = util.commentnode_kwargs(params)
         self.assertEqual(comment, ctrl["comment"])
+
+    def test_commentnode_from_metadata(self):
+        params = self._setup_commentnode()
+        params.pop("comment")
+        params["metadata"] = {}
+
+        # Just testing that error from missing required parameters is not raised
+        util.commentnode_kwargs(params)
 
     def test_directivenode(self):
         params = self._setup_directivenode()
@@ -68,6 +87,15 @@ class ParserNodeUtilTest(unittest.TestCase):
         self.assertEqual(name, ctrl["name"])
         self.assertEqual(parameters, ctrl["parameters"])
         self.assertEqual(enabled, ctrl["enabled"])
+
+    def test_directivenode_from_metadata(self):
+        params = self._setup_directivenode()
+        params.pop("filepath")
+        params.pop("name")
+        params["metadata"] = {"irrelevant": "value"}
+
+        # Just testing that error from missing required parameters is not raised
+        util.directivenode_kwargs(params)
 
     def test_missing_required(self):
         c_params = self._setup_commentnode()


### PR DESCRIPTION
Add `metadata` keyword argument to the ParserNode interface, allowing the initialization of the object from contents of the metadata - if the implementation allows it. As an example, Augeas implementation needs nothing more than the Augeas DOM path of a configuration directive to be able to populate the ParserNode instance with all data relevant to the DirectiveNode.

The checks also allow skipping the otherwise required keyword arguments if metadata is provided.