### PR TITLE
[Windows] Create a certbot renew scheduled task using the installer

### DIFF
--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -53,6 +53,9 @@ pyasn1==0.1.9
 pyasn1-modules==0.0.10
 Pygments==2.2.0
 pylint==1.9.4
+# If pynsist version is upgraded, our NSIS template windows-installer/template.nsi
+# must be upgraded if necessary using the new built-in one from pynsist.
+pynsist==2.4
 pytest==3.2.5
 pytest-cov==2.5.1
 pytest-forked==0.2

--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -10,6 +10,7 @@ import time
 
 PYTHON_VERSION = (3, 7, 4)
 PYTHON_BITNESS = 32
+PYNSIST_VERSION = 2.3
 
 
 def main():
@@ -52,7 +53,7 @@ def _prepare_build_tools(venv_path, venv_python):
     subprocess.check_call([sys.executable, '-m', 'venv', venv_path])
     subprocess.check_call(['choco', 'upgrade', '-y', 'nsis'])
     subprocess.check_call([venv_python, '-m', 'pip', 'install', '--upgrade', 'pip'])
-    subprocess.check_call([venv_python, '-m', 'pip', 'install', 'wheel', 'pynsist'])
+    subprocess.check_call([venv_python, '-m', 'pip', 'install', 'wheel', 'pynsist=={0}'.format(PYNSIST_VERSION)])
 
 
 def _copy_assets(build_path, repo_path):
@@ -62,6 +63,9 @@ def _copy_assets(build_path, repo_path):
     os.makedirs(build_path)
     shutil.copy(os.path.join(repo_path, 'windows-installer', 'certbot.ico'), build_path)
     shutil.copy(os.path.join(repo_path, 'windows-installer', 'run.bat'), build_path)
+    shutil.copy(os.path.join(repo_path, 'windows-installer', 'template.nsi'), build_path)
+    shutil.copy(os.path.join(repo_path, 'windows-installer', 'renew-up.ps1'), build_path)
+    shutil.copy(os.path.join(repo_path, 'windows-installer', 'renew-down.ps1'), build_path)
 
 
 def _generate_pynsist_config(repo_path, build_path):
@@ -83,6 +87,7 @@ target=$INSTDIR\\run.bat
 
 [Build]
 directory=nsis
+nsi_template=template.nsi
 installer_name=certbot-{certbot_version}-installer-{installer_suffix}.exe
 
 [Python]
@@ -92,6 +97,8 @@ bitness={python_bitness}
 [Include]
 local_wheels=wheels\\*.whl
 files=run.bat
+      renew-up.ps1
+      renew-down.ps1
 
 [Command certbot]
 entry_point=certbot.main:main

--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -10,7 +10,6 @@ import time
 
 PYTHON_VERSION = (3, 7, 4)
 PYTHON_BITNESS = 32
-PYNSIST_VERSION = 2.3
 
 
 def main():
@@ -20,7 +19,7 @@ def main():
 
     installer_cfg_path = _generate_pynsist_config(repo_path, build_path)
 
-    _prepare_build_tools(venv_path, venv_python)
+    _prepare_build_tools(venv_path, venv_python, repo_path)
     _compile_wheels(repo_path, build_path, venv_python)
     _build_installer(installer_cfg_path, venv_path)
 
@@ -48,12 +47,12 @@ def _compile_wheels(repo_path, build_path, venv_python):
     subprocess.check_call(command)
 
 
-def _prepare_build_tools(venv_path, venv_python):
+def _prepare_build_tools(venv_path, venv_python, repo_path):
     print('Prepare build tools')
     subprocess.check_call([sys.executable, '-m', 'venv', venv_path])
     subprocess.check_call(['choco', 'upgrade', '-y', 'nsis'])
     subprocess.check_call([venv_python, '-m', 'pip', 'install', '--upgrade', 'pip'])
-    subprocess.check_call([venv_python, '-m', 'pip', 'install', 'wheel', 'pynsist=={0}'.format(PYNSIST_VERSION)])
+    subprocess.check_call([venv_python, os.path.join(repo_path, 'tools', 'pip_install.py'), 'wheel', 'pynsist'])
 
 
 def _copy_assets(build_path, repo_path):

--- a/windows-installer/renew-down.ps1
+++ b/windows-installer/renew-down.ps1
@@ -1,0 +1,6 @@
+$taskName = "Certbot Renew Task"
+
+$exists = Get-ScheduledTask | Where-Object {$_.TaskName -like $taskName}
+if ($exists) {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+}

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -8,5 +8,5 @@ $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfil
 $delay = New-TimeSpan -Hours 12
 $triggerAM = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay $delay
 $triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm -RandomDelay $delay
-$principal = New-ScheduledTaskPrincipal -UserId 'System' -LogonType S4U -RunLevel Highest
+$principal = New-ScheduledTaskPrincipal -UserId SYSTEM -LogonType ServiceAccount -RunLevel Highest
 Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -9,4 +9,4 @@ $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfil
 $triggerAM = New-ScheduledTaskTrigger -Daily -At 12am
 $triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm
 $principal = New-ScheduledTaskPrincipal -UserId $env:UserName -LogonType S4U -RunLevel Highest
-Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew Let's Encrypt certificates if needed." -Principal $principal
+Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -1,12 +1,22 @@
+param(
+    [string]$userLevel = "AllUsers"
+)
+
 function Get-ScriptDirectory { Split-Path $MyInvocation.ScriptName }
 $down = Join-Path (Get-ScriptDirectory) 'renew-down.ps1'
 & $down
 
 $taskName = "Certbot Renew Task"
 
+if ($userLevel -eq "CurrentUser") {
+    $taskUser = $env:UserName
+} else {
+    $taskUser = "SYSTEM"
+}
+
 $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -Command "certbot renew"'
 $delay = New-TimeSpan -Hours 12
 $triggerAM = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay $delay
 $triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm -RandomDelay $delay
-$principal = New-ScheduledTaskPrincipal -UserId SYSTEM -LogonType ServiceAccount -RunLevel Highest
+$principal = New-ScheduledTaskPrincipal -UserId $taskUser -LogonType ServiceAccount -RunLevel Highest
 Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -1,24 +1,15 @@
-param(
-    [string]$userLevel = "AllUsers"
-)
-
 function Get-ScriptDirectory { Split-Path $MyInvocation.ScriptName }
 $down = Join-Path (Get-ScriptDirectory) 'renew-down.ps1'
 & $down
 
 $taskName = "Certbot Renew Task"
 
-if ($userLevel -eq "CurrentUser") {
-    $taskUser = $env:UserName
-    $logonType = "S4U"
-} else {
-    $taskUser = "SYSTEM"
-    $logonType = "ServiceAccount"
-}
-
 $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -Command "certbot renew"'
 $delay = New-TimeSpan -Hours 12
 $triggerAM = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay $delay
 $triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm -RandomDelay $delay
-$principal = New-ScheduledTaskPrincipal -UserId $taskUser -LogonType $logonType -RunLevel Highest
+# NB: For now scheduled task is set up under SYSTEM account because Certbot Installer installs Certbot for all users.
+# If in the future we allow the Installer to install Certbot for one specific user, the scheduled task will need to
+# switch to this user, since Certbot will be available only for him.
+$principal = New-ScheduledTaskPrincipal -UserId SYSTEM -LogonType ServiceAccount -RunLevel Highest
 Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -5,7 +5,8 @@ $down = Join-Path (Get-ScriptDirectory) 'renew-down.ps1'
 $taskName = "Certbot Renew Task"
 
 $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -Command "certbot renew"'
-$triggerAM = New-ScheduledTaskTrigger -Daily -At 12am
-$triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm
+$delay = New-TimeSpan -Hours 12
+$triggerAM = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay $delay
+$triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm -RandomDelay $delay
 $principal = New-ScheduledTaskPrincipal -UserId 'System' -LogonType S4U -RunLevel Highest
 Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -1,0 +1,12 @@
+$taskName = "Certbot Renew Task"
+
+$exists = Get-ScheduledTask | Where-Object {$_.TaskName -like $taskName}
+if ($exists) {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+}
+
+$action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -Command "certbot renew"'
+$triggerAM = New-ScheduledTaskTrigger -Daily -At 12am
+$triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm
+$principal = New-ScheduledTaskPrincipal -UserId $env:UserName -LogonType S4U -RunLevel Highest
+Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew Let's Encrypt certificates if needed." -Principal $principal

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -1,12 +1,11 @@
-$taskName = "Certbot Renew Task"
+function Get-ScriptDirectory { Split-Path $MyInvocation.ScriptName }
+$down = Join-Path (Get-ScriptDirectory) 'renew-down.ps1'
+& $down
 
-$exists = Get-ScheduledTask | Where-Object {$_.TaskName -like $taskName}
-if ($exists) {
-    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
-}
+$taskName = "Certbot Renew Task"
 
 $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -Command "certbot renew"'
 $triggerAM = New-ScheduledTaskTrigger -Daily -At 12am
 $triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm
-$principal = New-ScheduledTaskPrincipal -UserId $env:UserName -LogonType S4U -RunLevel Highest
+$principal = New-ScheduledTaskPrincipal -UserId 'System' -LogonType S4U -RunLevel Highest
 Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -10,13 +10,15 @@ $taskName = "Certbot Renew Task"
 
 if ($userLevel -eq "CurrentUser") {
     $taskUser = $env:UserName
+    $logonType = "S4U"
 } else {
     $taskUser = "SYSTEM"
+    $logonType = "ServiceAccount"
 }
 
 $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -Command "certbot renew"'
 $delay = New-TimeSpan -Hours 12
 $triggerAM = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay $delay
 $triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm -RandomDelay $delay
-$principal = New-ScheduledTaskPrincipal -UserId $taskUser -LogonType ServiceAccount -RunLevel Highest
+$principal = New-ScheduledTaskPrincipal -UserId $taskUser -LogonType $logonType -RunLevel Highest
 Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal

--- a/windows-installer/template.nsi
+++ b/windows-installer/template.nsi
@@ -1,8 +1,10 @@
 ; This NSIS template is based on the built-in one in pynsist 2.3.
 ; Added lines are enclosed within "CERTBOT CUSTOM BEGIN/END" comments.
 ; If pynsist is upgraded, this template must be updated if necessary using the new built-in one.
+; Original file can be found here: https://github.com/takluyver/pynsist/blob/2.4/nsist/pyapp.nsi
 
 ; CERTBOT CUSTOM BEGIN
+; Administrator privileges are required to insert a new task in Windows Scheduler.
 RequestExecutionLevel admin
 ; CERTBOT CUSTOM END
 

--- a/windows-installer/template.nsi
+++ b/windows-installer/template.nsi
@@ -19,12 +19,13 @@ SetCompressor lzma
 
 ; CERTBOT CUSTOM BEGIN
 ; Administrator privileges are required to insert a new task in Windows Scheduler.
+; Also comment out some options to disable ability to choose AllUsers/CurrentUser install mode.
 !define MULTIUSER_EXECUTIONLEVEL Admin
 ;!define MULTIUSER_EXECUTIONLEVEL Highest
 ;!define MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER
+;!define MULTIUSER_MUI
+;!define MULTIUSER_INSTALLMODE_COMMANDLINE
 ; CERTBOT CUSTOM END
-!define MULTIUSER_MUI
-!define MULTIUSER_INSTALLMODE_COMMANDLINE
 !define MULTIUSER_INSTALLMODE_INSTDIR "[[ib.appname]]"
 [% if ib.py_bitness == 64 %]
 !define MULTIUSER_INSTALLMODE_FUNCTION correct_prog_files
@@ -44,7 +45,10 @@ SetCompressor lzma
 [% if license_file %]
 !insertmacro MUI_PAGE_LICENSE [[license_file]]
 [% endif %]
-!insertmacro MULTIUSER_PAGE_INSTALLMODE
+; CERTBOT CUSTOM BEGIN
+; Disable the installation mode page (AllUsers/CurrentUser)
+;!insertmacro MULTIUSER_PAGE_INSTALLMODE
+; CERTBOT CUSTOM END
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_PAGE_FINISH
@@ -154,6 +158,7 @@ Section "!${PRODUCT_NAME}" sec_app
                    "NoRepair" 1
 
   ; CERTBOT CUSTOM BEGIN
+  ; Execute ps script to create the certbot renew task
   DetailPrint "Setting up certbot renew scheduled task"
   nsExec::ExecToStack 'powershell -inputformat none -ExecutionPolicy RemoteSigned -File "$INSTDIR\renew-up.ps1" $MultiUser.InstallMode'
   ; CERTBOT CUSTOM END
@@ -168,6 +173,7 @@ SectionEnd
 
 Section "Uninstall"
   ; CERTBOT CUSTOM BEGIN
+  ; Execute ps script to remove the certbot renew task
   nsExec::ExecToStack 'powershell -inputformat none -ExecutionPolicy RemoteSigned -File "$INSTDIR\renew-down.ps1"'
   ; CERTBOT CUSTOM END
 

--- a/windows-installer/template.nsi
+++ b/windows-installer/template.nsi
@@ -3,11 +3,6 @@
 ; If pynsist is upgraded, this template must be updated if necessary using the new built-in one.
 ; Original file can be found here: https://github.com/takluyver/pynsist/blob/2.4/nsist/pyapp.nsi
 
-; CERTBOT CUSTOM BEGIN
-; Administrator privileges are required to insert a new task in Windows Scheduler.
-RequestExecutionLevel admin
-; CERTBOT CUSTOM END
-
 !define PRODUCT_NAME "[[ib.appname]]"
 !define PRODUCT_VERSION "[[ib.version]]"
 !define PY_VERSION "[[ib.py_version]]"
@@ -22,8 +17,12 @@ RequestExecutionLevel admin
  
 SetCompressor lzma
 
-!define MULTIUSER_EXECUTIONLEVEL Highest
-!define MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER
+; CERTBOT CUSTOM BEGIN
+; Administrator privileges are required to insert a new task in Windows Scheduler.
+!define MULTIUSER_EXECUTIONLEVEL Admin
+;!define MULTIUSER_EXECUTIONLEVEL Highest
+;!define MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER
+; CERTBOT CUSTOM END
 !define MULTIUSER_MUI
 !define MULTIUSER_INSTALLMODE_COMMANDLINE
 !define MULTIUSER_INSTALLMODE_INSTDIR "[[ib.appname]]"
@@ -156,7 +155,7 @@ Section "!${PRODUCT_NAME}" sec_app
 
   ; CERTBOT CUSTOM BEGIN
   DetailPrint "Setting up certbot renew scheduled task"
-  nsExec::ExecToStack 'powershell -inputformat none -ExecutionPolicy RemoteSigned -File "$INSTDIR\renew-up.ps1"'
+  nsExec::ExecToStack 'powershell -inputformat none -ExecutionPolicy RemoteSigned -File "$INSTDIR\renew-up.ps1" $MultiUser.InstallMode'
   ; CERTBOT CUSTOM END
 
   ; Check if we need to reboot

--- a/windows-installer/template.nsi
+++ b/windows-installer/template.nsi
@@ -183,7 +183,7 @@ Section "Uninstall"
   ; Remove ourselves from %PATH%
   [% block uninstall_commands %]
   [% if has_commands %]
-    nsExec::ExecToLog '[[ python ]] -Es ".$INSTDIR\_system_pathpy" remove "$INSTDIR\bin"'
+    nsExec::ExecToLog '[[ python ]] -Es ".$INSTDIR\_system_path.py" remove "$INSTDIR\bin"'
   [% endif %]
   [% endblock uninstall_commands %]
 

--- a/windows-installer/template.nsi
+++ b/windows-installer/template.nsi
@@ -20,6 +20,10 @@ SetCompressor lzma
 ; CERTBOT CUSTOM BEGIN
 ; Administrator privileges are required to insert a new task in Windows Scheduler.
 ; Also comment out some options to disable ability to choose AllUsers/CurrentUser install mode.
+; As a result, installer run always with admin privileges (because of MULTIUSER_EXECUTIONLEVEL),
+; using the AllUsers installation mode by default (because of MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER
+; not set), and this default behavior cannot be overridden (because of MULTIUSER_MUI not set).
+; See https://nsis.sourceforge.io/Docs/MultiUser/Readme.html
 !define MULTIUSER_EXECUTIONLEVEL Admin
 ;!define MULTIUSER_EXECUTIONLEVEL Highest
 ;!define MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER

--- a/windows-installer/template.nsi
+++ b/windows-installer/template.nsi
@@ -164,7 +164,7 @@ Section "!${PRODUCT_NAME}" sec_app
   ; CERTBOT CUSTOM BEGIN
   ; Execute ps script to create the certbot renew task
   DetailPrint "Setting up certbot renew scheduled task"
-  nsExec::ExecToStack 'powershell -inputformat none -ExecutionPolicy RemoteSigned -File "$INSTDIR\renew-up.ps1" $MultiUser.InstallMode'
+  nsExec::ExecToStack 'powershell -inputformat none -ExecutionPolicy RemoteSigned -File "$INSTDIR\renew-up.ps1"'
   ; CERTBOT CUSTOM END
 
   ; Check if we need to reboot

--- a/windows-installer/template.nsi
+++ b/windows-installer/template.nsi
@@ -1,0 +1,246 @@
+; This NSIS template is based on the built-in one in pynsist 2.3.
+; Added lines are enclosed within "CERTBOT CUSTOM BEGIN/END" comments.
+; If pynsist is upgraded, this template must be updated if necessary using the new built-in one.
+
+; CERTBOT CUSTOM BEGIN
+RequestExecutionLevel admin
+; CERTBOT CUSTOM END
+
+!define PRODUCT_NAME "[[ib.appname]]"
+!define PRODUCT_VERSION "[[ib.version]]"
+!define PY_VERSION "[[ib.py_version]]"
+!define PY_MAJOR_VERSION "[[ib.py_major_version]]"
+!define BITNESS "[[ib.py_bitness]]"
+!define ARCH_TAG "[[arch_tag]]"
+!define INSTALLER_NAME "[[ib.installer_name]]"
+!define PRODUCT_ICON "[[icon]]"
+
+; Marker file to tell the uninstaller that it's a user installation
+!define USER_INSTALL_MARKER _user_install_marker
+
+SetCompressor lzma
+
+!define MULTIUSER_EXECUTIONLEVEL Highest
+!define MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER
+!define MULTIUSER_MUI
+!define MULTIUSER_INSTALLMODE_COMMANDLINE
+!define MULTIUSER_INSTALLMODE_INSTDIR "[[ib.appname]]"
+[% if ib.py_bitness == 64 %]
+!define MULTIUSER_INSTALLMODE_FUNCTION correct_prog_files
+[% endif %]
+!include MultiUser.nsh
+
+[% block modernui %]
+; Modern UI installer stuff
+!include "MUI2.nsh"
+!define MUI_ABORTWARNING
+!define MUI_ICON "[[icon]]"
+!define MUI_UNICON "[[icon]]"
+
+; UI pages
+[% block ui_pages %]
+!insertmacro MUI_PAGE_WELCOME
+[% if license_file %]
+!insertmacro MUI_PAGE_LICENSE [[license_file]]
+[% endif %]
+!insertmacro MULTIUSER_PAGE_INSTALLMODE
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+[% endblock ui_pages %]
+!insertmacro MUI_LANGUAGE "English"
+[% endblock modernui %]
+
+Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
+OutFile "${INSTALLER_NAME}"
+ShowInstDetails show
+
+Section -SETTINGS
+  SetOutPath "$INSTDIR"
+  SetOverwrite ifnewer
+SectionEnd
+
+[% block sections %]
+
+Section "!${PRODUCT_NAME}" sec_app
+  SetRegView [[ib.py_bitness]]
+  SectionIn RO
+  File ${PRODUCT_ICON}
+  SetOutPath "$INSTDIR\pkgs"
+  File /r "pkgs\*.*"
+  SetOutPath "$INSTDIR"
+
+  ; Marker file for per-user install
+  StrCmp $MultiUser.InstallMode CurrentUser 0 +3
+    FileOpen $0 "$INSTDIR\${USER_INSTALL_MARKER}" w
+    FileClose $0
+    SetFileAttributes "$INSTDIR\${USER_INSTALL_MARKER}" HIDDEN
+
+  [% block install_files %]
+  ; Install files
+  [% for destination, group in grouped_files %]
+    SetOutPath "[[destination]]"
+    [% for file in group %]
+      File "[[ file ]]"
+    [% endfor %]
+  [% endfor %]
+
+  ; Install directories
+  [% for dir, destination in ib.install_dirs %]
+    SetOutPath "[[ pjoin(destination, dir) ]]"
+    File /r "[[dir]]\*.*"
+  [% endfor %]
+  [% endblock install_files %]
+
+  [% block install_shortcuts %]
+  ; Install shortcuts
+  ; The output path becomes the working directory for shortcuts
+  SetOutPath "%HOMEDRIVE%\%HOMEPATH%"
+  [% if single_shortcut %]
+    [% for scname, sc in ib.shortcuts.items() %]
+    CreateShortCut "$SMPROGRAMS\[[scname]].lnk" "[[sc['target'] ]]" \
+      '[[ sc['parameters'] ]]' "$INSTDIR\[[ sc['icon'] ]]"
+    [% endfor %]
+  [% else %]
+    [# Multiple shortcuts: create a directory for them #]
+    CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
+    [% for scname, sc in ib.shortcuts.items() %]
+    CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\[[scname]].lnk" "[[sc['target'] ]]" \
+      '[[ sc['parameters'] ]]' "$INSTDIR\[[ sc['icon'] ]]"
+    [% endfor %]
+  [% endif %]
+  SetOutPath "$INSTDIR"
+  [% endblock install_shortcuts %]
+
+  [% block install_commands %]
+  [% if has_commands %]
+    DetailPrint "Setting up command-line launchers..."
+    nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_assemble_launchers.py" [[ python ]] "$INSTDIR\bin"'
+
+    StrCmp $MultiUser.InstallMode CurrentUser 0 AddSysPathSystem
+      ; Add to PATH for current user
+      nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_system_path.py" add_user "$INSTDIR\bin"'
+      GoTo AddedSysPath
+    AddSysPathSystem:
+      ; Add to PATH for all users
+      nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_system_path.py" add "$INSTDIR\bin"'
+    AddedSysPath:
+  [% endif %]
+  [% endblock install_commands %]
+
+  ; Byte-compile Python files.
+  DetailPrint "Byte-compiling Python modules..."
+  nsExec::ExecToLog '[[ python ]] -m compileall -q "$INSTDIR\pkgs"'
+  WriteUninstaller $INSTDIR\uninstall.exe
+  ; Add ourselves to Add/remove programs
+  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                   "DisplayName" "${PRODUCT_NAME}"
+  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                   "UninstallString" '"$INSTDIR\uninstall.exe"'
+  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                   "InstallLocation" "$INSTDIR"
+  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                   "DisplayIcon" "$INSTDIR\${PRODUCT_ICON}"
+  [% if ib.publisher is not none %]
+    WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                     "Publisher" "[[ib.publisher]]"
+  [% endif %]
+  WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                   "DisplayVersion" "${PRODUCT_VERSION}"
+  WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                   "NoModify" 1
+  WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                   "NoRepair" 1
+
+  ; CERTBOT CUSTOM BEGIN
+  DetailPrint "Setting up certbot renew scheduled task"
+  nsExec::ExecToStack 'powershell -inputformat none -ExecutionPolicy RemoteSigned -File "$INSTDIR\renew-up.ps1"'
+  ; CERTBOT CUSTOM END
+
+  ; Check if we need to reboot
+  IfRebootFlag 0 noreboot
+    MessageBox MB_YESNO "A reboot is required to finish the installation. Do you wish to reboot now?" \
+                /SD IDNO IDNO noreboot
+      Reboot
+  noreboot:
+SectionEnd
+
+Section "Uninstall"
+  ; CERTBOT CUSTOM BEGIN
+  nsExec::ExecToStack 'powershell -inputformat none -ExecutionPolicy RemoteSigned -File "$INSTDIR\renew-down.ps1"'
+  ; CERTBOT CUSTOM END
+
+  SetRegView [[ib.py_bitness]]
+  SetShellVarContext all
+  IfFileExists "$INSTDIR\${USER_INSTALL_MARKER}" 0 +3
+    SetShellVarContext current
+    Delete "$INSTDIR\${USER_INSTALL_MARKER}"
+
+  Delete $INSTDIR\uninstall.exe
+  Delete "$INSTDIR\${PRODUCT_ICON}"
+  RMDir /r "$INSTDIR\pkgs"
+
+  ; Remove ourselves from %PATH%
+  [% block uninstall_commands %]
+  [% if has_commands %]
+    nsExec::ExecToLog '[[ python ]] -Es ".$INSTDIR\_system_pathpy" remove "$INSTDIR\bin"'
+  [% endif %]
+  [% endblock uninstall_commands %]
+
+  [% block uninstall_files %]
+  ; Uninstall files
+  [% for file, destination in ib.install_files %]
+    Delete "[[pjoin(destination, file)]]"
+  [% endfor %]
+  ; Uninstall directories
+  [% for dir, destination in ib.install_dirs %]
+    RMDir /r "[[pjoin(destination, dir)]]"
+  [% endfor %]
+  [% endblock uninstall_files %]
+
+  [% block uninstall_shortcuts %]
+  ; Uninstall shortcuts
+  [% if single_shortcut %]
+    [% for scname in ib.shortcuts %]
+      Delete "$SMPROGRAMS\[[scname]].lnk"
+    [% endfor %]
+  [% else %]
+    RMDir /r "$SMPROGRAMS\${PRODUCT_NAME}"
+  [% endif %]
+  [% endblock uninstall_shortcuts %]
+  RMDir $INSTDIR
+  DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
+SectionEnd
+
+[% endblock sections %]
+
+; Functions
+
+Function .onMouseOverSection
+    ; Find which section the mouse is over, and set the corresponding description.
+    FindWindow $R0 "#32770" "" $HWNDPARENT
+    GetDlgItem $R0 $R0 1043 ; description item (must be added to the UI)
+
+    [% block mouseover_messages %]
+    StrCmp $0 ${sec_app} "" +2
+      SendMessage $R0 ${WM_SETTEXT} 0 "STR:${PRODUCT_NAME}"
+
+    [% endblock mouseover_messages %]
+FunctionEnd
+
+Function .onInit
+  !insertmacro MULTIUSER_INIT
+FunctionEnd
+
+Function un.onInit
+  !insertmacro MULTIUSER_UNINIT
+FunctionEnd
+
+[% if ib.py_bitness == 64 %]
+Function correct_prog_files
+  ; The multiuser machinery doesn't know about the different Program files
+  ; folder for 64-bit applications. Override the install dir it set.
+  StrCmp $MultiUser.InstallMode AllUsers 0 +2
+    StrCpy $INSTDIR "$PROGRAMFILES64\${MULTIUSER_INSTALLMODE_INSTDIR}"
+FunctionEnd
+[% endif %]

--- a/windows-installer/template.nsi
+++ b/windows-installer/template.nsi
@@ -19,7 +19,7 @@ RequestExecutionLevel admin
 
 ; Marker file to tell the uninstaller that it's a user installation
 !define USER_INSTALL_MARKER _user_install_marker
-
+ 
 SetCompressor lzma
 
 !define MULTIUSER_EXECUTIONLEVEL Highest
@@ -33,7 +33,7 @@ SetCompressor lzma
 !include MultiUser.nsh
 
 [% block modernui %]
-; Modern UI installer stuff
+; Modern UI installer stuff 
 !include "MUI2.nsh"
 !define MUI_ABORTWARNING
 !define MUI_ICON "[[icon]]"
@@ -86,14 +86,14 @@ Section "!${PRODUCT_NAME}" sec_app
       File "[[ file ]]"
     [% endfor %]
   [% endfor %]
-
+  
   ; Install directories
   [% for dir, destination in ib.install_dirs %]
     SetOutPath "[[ pjoin(destination, dir) ]]"
     File /r "[[dir]]\*.*"
   [% endfor %]
   [% endblock install_files %]
-
+  
   [% block install_shortcuts %]
   ; Install shortcuts
   ; The output path becomes the working directory for shortcuts
@@ -129,7 +129,7 @@ Section "!${PRODUCT_NAME}" sec_app
     AddedSysPath:
   [% endif %]
   [% endblock install_commands %]
-
+  
   ; Byte-compile Python files.
   DetailPrint "Byte-compiling Python modules..."
   nsExec::ExecToLog '[[ python ]] -m compileall -q "$INSTDIR\pkgs"'
@@ -185,7 +185,7 @@ Section "Uninstall"
   ; Remove ourselves from %PATH%
   [% block uninstall_commands %]
   [% if has_commands %]
-    nsExec::ExecToLog '[[ python ]] -Es ".$INSTDIR\_system_path.py" remove "$INSTDIR\bin"'
+    nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_system_path.py" remove "$INSTDIR\bin"'
   [% endif %]
   [% endblock uninstall_commands %]
 
@@ -226,7 +226,7 @@ Function .onMouseOverSection
     [% block mouseover_messages %]
     StrCmp $0 ${sec_app} "" +2
       SendMessage $R0 ${WM_SETTEXT} 0 "STR:${PRODUCT_NAME}"
-
+    
     [% endblock mouseover_messages %]
 FunctionEnd
 


### PR DESCRIPTION
This PR implements the item "register a scheduled task for certificate renewal" from the list of requirements described in #7365.

This PR adds required instructions in the NSIS installer for Certbot to create a task, named "Certbot Renew Task" in the Windows Scheduler. This task is run twice a day, to execute the command `certbot renew` and keep the certificates up-to-date.

Uninstalling Certbot will also remove this scheduled task.