### PR TITLE
Get integration tests working on python 3.8

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
+[run]
+omit = */setup.py
+
 [report]
 omit = */setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
   include:
     # Main test suite
     - python: "2.7"
-      env: ACME_SERVER=pebble TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=pebble TOXENV=integration
       <<: *not-on-master
 
     # This job is always executed, including on master
@@ -122,12 +122,12 @@ matrix:
       env: TOXENV=py37 CERTBOT_NO_PIN=1
       <<: *extended-test-suite
     - python: "2.7"
-      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v1 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "2.7"
-      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v2 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
@@ -169,54 +169,54 @@ matrix:
       env: TOXENV=py38
       <<: *extended-test-suite
     - python: "3.4"
-      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v1 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.4"
-      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v2 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.5"
-      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v1 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.5"
-      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v2 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.6"
-      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v1 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.6"
-      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v2 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.7"
       dist: xenial
-      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v1 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.7"
       dist: xenial
-      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v2 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.8-dev"
       dist: xenial
-      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v1 TOXENV=integration
       <<: *extended-test-suite
     - python: "3.8-dev"
       dist: xenial
-      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
+      env: ACME_SERVER=boulder-v2 TOXENV=integration
       <<: *extended-test-suite
     - sudo: required
       env: TOXENV=le_auto_jessie

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,10 @@ matrix:
       dist: xenial
       env: TOXENV=py37
       <<: *not-on-master
+    - python: "3.8-dev"
+      dist: xenial
+      env: TOXENV=py38
+      <<: *not-on-master
     - sudo: required
       env: TOXENV=apache_compat
       services: docker
@@ -159,6 +163,10 @@ matrix:
     - python: "3.7"
       dist: xenial
       env: TOXENV=py37
+      <<: *extended-test-suite
+    - python: "3.8-dev"
+      dist: xenial
+      env: TOXENV=py38
       <<: *extended-test-suite
     - python: "3.4"
       env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
   include:
     # Main test suite
     - python: "2.7"
-      env: ACME_SERVER=pebble TOXENV=integration
+      env: ACME_SERVER=pebble TOXENV=clean,integration,integration-report
       <<: *not-on-master
 
     # This job is always executed, including on master
@@ -118,12 +118,12 @@ matrix:
       env: TOXENV=py37 CERTBOT_NO_PIN=1
       <<: *extended-test-suite
     - python: "2.7"
-      env: ACME_SERVER=boulder-v1 TOXENV=integration
+      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "2.7"
-      env: ACME_SERVER=boulder-v2 TOXENV=integration
+      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
@@ -161,46 +161,54 @@ matrix:
       env: TOXENV=py37
       <<: *extended-test-suite
     - python: "3.4"
-      env: ACME_SERVER=boulder-v1 TOXENV=integration
+      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.4"
-      env: ACME_SERVER=boulder-v2 TOXENV=integration
+      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.5"
-      env: ACME_SERVER=boulder-v1 TOXENV=integration
+      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.5"
-      env: ACME_SERVER=boulder-v2 TOXENV=integration
+      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.6"
-      env: ACME_SERVER=boulder-v1 TOXENV=integration
+      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.6"
-      env: ACME_SERVER=boulder-v2 TOXENV=integration
+      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.7"
       dist: xenial
-      env: ACME_SERVER=boulder-v1 TOXENV=integration
+      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.7"
       dist: xenial
-      env: ACME_SERVER=boulder-v2 TOXENV=integration
+      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
       sudo: required
       services: docker
+      <<: *extended-test-suite
+    - python: "3.8-dev"
+      dist: xenial
+      env: ACME_SERVER=boulder-v1 TOXENV=clean,integration,integration-report
+      <<: *extended-test-suite
+    - python: "3.8-dev"
+      dist: xenial
+      env: ACME_SERVER=boulder-v2 TOXENV=clean,integration,integration-report
       <<: *extended-test-suite
     - sudo: required
       env: TOXENV=le_auto_jessie

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,9 @@ matrix:
       env: TOXENV=py34
       <<: *not-on-master
     - python: "3.7"
-      dist: xenial
       env: TOXENV=py37
       <<: *not-on-master
     - python: "3.8-dev"
-      dist: xenial
       env: TOXENV=py38
       <<: *not-on-master
     - sudo: required
@@ -161,11 +159,9 @@ matrix:
       env: TOXENV=py36
       <<: *extended-test-suite
     - python: "3.7"
-      dist: xenial
       env: TOXENV=py37
       <<: *extended-test-suite
     - python: "3.8-dev"
-      dist: xenial
       env: TOXENV=py38
       <<: *extended-test-suite
     - python: "3.4"
@@ -199,23 +195,19 @@ matrix:
       services: docker
       <<: *extended-test-suite
     - python: "3.7"
-      dist: xenial
       env: ACME_SERVER=boulder-v1 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.7"
-      dist: xenial
       env: ACME_SERVER=boulder-v2 TOXENV=integration
       sudo: required
       services: docker
       <<: *extended-test-suite
     - python: "3.8-dev"
-      dist: xenial
       env: ACME_SERVER=boulder-v1 TOXENV=integration
       <<: *extended-test-suite
     - python: "3.8-dev"
-      dist: xenial
       env: ACME_SERVER=boulder-v2 TOXENV=integration
       <<: *extended-test-suite
     - sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Run tests on Python3.8.
 
 ### Changed
 

--- a/certbot-ci/certbot_integration_tests/.coveragerc
+++ b/certbot-ci/certbot_integration_tests/.coveragerc
@@ -2,6 +2,7 @@
 # Avoid false warnings because certbot packages are not installed in the thread that executes
 # the coverage: indeed, certbot is launched as a CLI from a subprocess.
 disable_warnings = module-not-imported,no-data-collected
+omit = **/*_test.py,**/tests/*,**/dns_common*,**/certbot_nginx/parser_obj.py
 
 [report]
 # Exclude unit tests in coverage during integration tests.

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -15,7 +15,7 @@ botocore==1.12.36
 cloudflare==1.5.1
 codecov==2.0.15
 configparser==3.7.4
-coverage==4.4.2
+coverage==4.5.4
 decorator==4.1.2
 dns-lexicon==3.2.1
 dnspython==1.15.0

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -76,7 +76,7 @@ Sphinx==1.7.5
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-websupport==1.0.1
 tldextract==2.2.0
-tox==2.9.1
+tox==3.14.0
 tqdm==4.19.4
 traitlets==4.3.2
 twine==1.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -221,26 +221,17 @@ whitelist_externals =
     docker-compose
 passenv = DOCKER_*
 
-[testenv:clean]
-deps = coverage
-skip_install = true
-commands = coverage erase
-
 [testenv:integration]
 commands =
     {[base]pip_install} acme . certbot-nginx certbot-ci
     pytest certbot-ci/certbot_integration_tests \
-        --acme-server={env:ACME_SERVER:pebble} --cov-append \
+        --acme-server={env:ACME_SERVER:pebble} \
         --cov=acme --cov=certbot --cov=certbot_nginx --cov-report= \
         --cov-config=certbot-ci/certbot_integration_tests/.coveragerc
-passenv = DOCKER_*
-
-[testenv:integration-report]
-deps = coverage
-skip_install = true
-commands =
     coverage report --include 'certbot/*' --show-missing --fail-under=65
     coverage report --include 'certbot-nginx/*' --show-missing --fail-under=74
+passenv = DOCKER_*
+
 
 [testenv:integration-certbot]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -232,7 +232,6 @@ commands =
     coverage report --include 'certbot-nginx/*' --show-missing --fail-under=74
 passenv = DOCKER_*
 
-
 [testenv:integration-certbot]
 commands =
     {[base]pip_install} acme . certbot-ci

--- a/tox.ini
+++ b/tox.ini
@@ -221,16 +221,26 @@ whitelist_externals =
     docker-compose
 passenv = DOCKER_*
 
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
 [testenv:integration]
 commands =
     {[base]pip_install} acme . certbot-nginx certbot-ci
     pytest certbot-ci/certbot_integration_tests \
-        --acme-server={env:ACME_SERVER:pebble} \
+        --acme-server={env:ACME_SERVER:pebble} --cov-append \
         --cov=acme --cov=certbot --cov=certbot_nginx --cov-report= \
         --cov-config=certbot-ci/certbot_integration_tests/.coveragerc
+passenv = DOCKER_*
+
+[testenv:integration-report]
+deps = coverage
+skip_install = true
+commands =
     coverage report --include 'certbot/*' --show-missing --fail-under=65
     coverage report --include 'certbot-nginx/*' --show-missing --fail-under=74
-passenv = DOCKER_*
 
 [testenv:integration-certbot]
 commands =


### PR DESCRIPTION
Supersedes #7369.

Fixes #7333.