### PR TITLE
[Apache v2] DualParserNode implementation 1/3

### DIFF
--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -1,0 +1,70 @@
+"""Dual parser node assertions"""
+from certbot_apache import interfaces
+
+
+PASS = "CERTBOT_PASS_ASSERT"
+
+
+def assertEqual(first, second):
+    """ Equality assertion """
+
+    if isinstance(first, interfaces.CommentNode):
+        assertEqualComment(first, second)
+    elif isinstance(first, interfaces.DirectiveNode):
+        assertEqualDirective(first, second)
+
+    # Skip tests if filepath includes the pass value. This is done
+    # because filepath is variable of the base ParserNode interface, and
+    # unless the implementation is actually done, we cannot assume getting
+    # correct results from boolean assertion for dirty
+    if not isPass(first.filepath, second.filepath):
+        assert first.dirty == second.dirty
+        # We might want to disable this later if testing with two separate
+        # (but identical) directory structures.
+        assert first.filepath == second.filepath
+
+def assertEqualComment(first, second): # pragma: no cover
+    """ Equality assertion for CommentNode """
+
+    assert isinstance(first, interfaces.CommentNode)
+    assert isinstance(second, interfaces.CommentNode)
+
+    if not isPass(first.comment, second.comment):
+        assert first.comment == second.comment
+
+def _assertEqualDirectiveComponents(first, second): # pragma: no cover
+    """ Handles assertion for instance variables for DirectiveNode and BlockNode"""
+
+    # Enabled value cannot be asserted, because Augeas implementation
+    # is unable to figure that out.
+    # assert first.enabled == second.enabled
+    if not isPass(first.name, second.name):
+        assert first.name == second.name
+
+    if not isPass(first.parameters, second.parameters):
+        assert first.parameters == second.parameters
+
+def assertEqualDirective(first, second):
+    """ Equality assertion for DirectiveNode """
+
+    assert isinstance(first, interfaces.DirectiveNode)
+    assert isinstance(second, interfaces.DirectiveNode)
+    _assertEqualDirectiveComponents(first, second)
+
+def isPass(first, second): # pragma: no cover
+    """ Checks if either first or second holds the assertion pass value """
+
+    if isinstance(first, (tuple, list)):
+        if PASS in first:
+            return True
+    if isinstance(second, (tuple, list)):
+        if PASS in second:
+            return True
+    if PASS in [first, second]:
+        return True
+    return False
+
+def assertSimple(first, second):
+    """ Simple assertion """
+    if not isPass(first, second):
+        assert first == second

--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -64,7 +64,7 @@ def isPass(first, second): # pragma: no cover
         return True
     return False
 
-def assertSimple(first, second):
+def assertEqualSimple(first, second):
     """ Simple assertion """
     if not isPass(first, second):
         assert first == second

--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -53,12 +53,7 @@ def assertEqualDirective(first, second):
 
 def isPass(value): # pragma: no cover
     """Checks if the value is set to PASS"""
-    if isinstance(value, (tuple, list)):
-        if PASS in value:
-            return True
-    if PASS in value:
-        return True
-    return False
+    return PASS in value
 
 def assertEqualSimple(first, second):
     """ Simple assertion """

--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -17,7 +17,7 @@ def assertEqual(first, second):
     # because filepath is variable of the base ParserNode interface, and
     # unless the implementation is actually done, we cannot assume getting
     # correct results from boolean assertion for dirty
-    if not isPass(first.filepath, second.filepath):
+    if not isPass(first.filepath) and not isPass(second.filepath):
         assert first.dirty == second.dirty
         # We might want to disable this later if testing with two separate
         # (but identical) directory structures.
@@ -29,7 +29,7 @@ def assertEqualComment(first, second): # pragma: no cover
     assert isinstance(first, interfaces.CommentNode)
     assert isinstance(second, interfaces.CommentNode)
 
-    if not isPass(first.comment, second.comment):
+    if not isPass(first.comment) and not isPass(second.comment):
         assert first.comment == second.comment
 
 def _assertEqualDirectiveComponents(first, second): # pragma: no cover
@@ -38,10 +38,10 @@ def _assertEqualDirectiveComponents(first, second): # pragma: no cover
     # Enabled value cannot be asserted, because Augeas implementation
     # is unable to figure that out.
     # assert first.enabled == second.enabled
-    if not isPass(first.name, second.name):
+    if not isPass(first.name) and not isPass(second.name):
         assert first.name == second.name
 
-    if not isPass(first.parameters, second.parameters):
+    if not isPass(first.parameters) and not isPass(second.parameters):
         assert first.parameters == second.parameters
 
 def assertEqualDirective(first, second):
@@ -51,20 +51,16 @@ def assertEqualDirective(first, second):
     assert isinstance(second, interfaces.DirectiveNode)
     _assertEqualDirectiveComponents(first, second)
 
-def isPass(first, second): # pragma: no cover
-    """ Checks if either first or second holds the assertion pass value """
-
-    if isinstance(first, (tuple, list)):
-        if PASS in first:
+def isPass(value): # pragma: no cover
+    """Checks if the value is set to PASS"""
+    if isinstance(value, (tuple, list)):
+        if PASS in value:
             return True
-    if isinstance(second, (tuple, list)):
-        if PASS in second:
-            return True
-    if PASS in [first, second]:
+    if PASS in value:
         return True
     return False
 
 def assertEqualSimple(first, second):
     """ Simple assertion """
-    if not isPass(first, second):
+    if not isPass(first) and not isPass(second):
         assert first == second

--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -1,0 +1,69 @@
+""" Augeas implementation of the ParserNode interface """
+from certbot_apache import assertions
+from certbot_apache import interfaces
+from certbot_apache import parsernode_util as util
+
+
+class AugeasParserNode(interfaces.ParserNode):
+    """ Augeas implementation of ParserNode interface """
+
+    def __init__(self, **kwargs):
+        ancestor, dirty, filepath, metadata = util.parsernode_kwargs(kwargs)  # pylint: disable=unused-variable
+        super(AugeasParserNode, self).__init__(**kwargs)
+        self.ancestor = ancestor
+        # self.filepath = filepath
+        self.filepath = assertions.PASS
+        self.dirty = dirty
+        self.metadata = metadata
+
+    def save(self, msg): # pragma: no cover
+        pass
+
+
+class AugeasCommentNode(AugeasParserNode):
+    """ Augeas implementation of CommentNode interface """
+
+    def __init__(self, **kwargs):
+        comment, kwargs = util.commentnode_kwargs(kwargs)  # pylint: disable=unused-variable
+        super(AugeasCommentNode, self).__init__(**kwargs)
+        # self.comment = comment
+        self.comment = assertions.PASS
+
+    def __eq__(self, other): # pragma: no cover
+        if isinstance(other, self.__class__):
+            return (self.comment == other.comment and
+                    self.filepath == other.filepath and
+                    self.dirty == other.dirty and
+                    self.ancestor == other.ancestor and
+                    self.metadata == other.metadata)
+        return False
+
+
+class AugeasDirectiveNode(AugeasParserNode):
+    """ Augeas implementation of DirectiveNode interface """
+
+    def __init__(self, **kwargs):
+        name, parameters, enabled, kwargs = util.directivenode_kwargs(kwargs)
+        super(AugeasDirectiveNode, self).__init__(**kwargs)
+        self.name = name
+        self.parameters = parameters
+        self.enabled = enabled
+
+    def __eq__(self, other): # pragma: no cover
+        if isinstance(other, self.__class__):
+            return (self.name == other.name and
+                    self.filepath == other.filepath and
+                    self.parameters == other.parameters and
+                    self.enabled == other.enabled and
+                    self.dirty == other.dirty and
+                    self.ancestor == other.ancestor and
+                    self.metadata == other.metadata)
+        return False
+
+    def set_parameters(self, parameters):
+        """Sets the parameters for DirectiveNode"""
+        self.parameters = parameters
+
+
+interfaces.CommentNode.register(AugeasCommentNode)
+interfaces.DirectiveNode.register(AugeasDirectiveNode)

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -1,4 +1,4 @@
-""" Tests for ParserNode interface """
+""" Dual ParserNode implementation """
 from certbot_apache import assertions
 from certbot_apache import augeasparser
 
@@ -17,8 +17,7 @@ class DualNodeBase(object):
         """ Attribute value assertion """
         firstval = getattr(self.primary, aname)
         secondval = getattr(self.secondary, aname)
-        if not assertions.isPass(firstval, secondval):
-            assertions.assertSimple(firstval, secondval)
+        assertions.assertEqualSimple(firstval, secondval)
         return firstval
 
 

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -1,0 +1,99 @@
+""" Tests for ParserNode interface """
+from certbot_apache import assertions
+from certbot_apache import augeasparser
+
+
+class DualNodeBase(object):
+    """ Dual parser interface for in development testing. This is used as the
+    base class for dual parser interface classes. This class handles runtime
+    attribute value assertions."""
+
+    def save(self, msg):  # pragma: no cover
+        """ Call save for both parsers """
+        self.primary.save(msg)
+        self.secondary.save(msg)
+
+    def __getattr__(self, aname):
+        """ Attribute value assertion """
+        firstval = getattr(self.primary, aname)
+        secondval = getattr(self.secondary, aname)
+        if not assertions.isPass(firstval, secondval):
+            assertions.assertSimple(firstval, secondval)
+        return firstval
+
+
+class DualCommentNode(DualNodeBase):
+    """ Dual parser implementation of CommentNode interface """
+
+    def __init__(self, **kwargs):
+        """ This initialization implementation allows ordinary initialization
+        of CommentNode objects as well as creating a DualCommentNode object
+        using precreated or fetched CommentNode objects if provided as optional
+        arguments primary and secondary.
+
+        Parameters other than the following are from interfaces.CommentNode:
+
+        :param CommentNode primary: Primary pre-created CommentNode, mainly
+            used when creating new DualParser nodes using add_* methods.
+        :param CommentNode secondary: Secondary pre-created CommentNode
+        """
+
+        kwargs.setdefault("primary", None)
+        kwargs.setdefault("secondary", None)
+        primary = kwargs.pop("primary")
+        secondary = kwargs.pop("secondary")
+
+        if not primary:
+            self.primary = augeasparser.AugeasCommentNode(**kwargs)
+        else:
+            self.primary = primary
+        if not secondary:
+            self.secondary = augeasparser.AugeasCommentNode(**kwargs)
+        else:
+            self.secondary = secondary
+
+        assertions.assertEqual(self.primary, self.secondary)
+
+
+class DualDirectiveNode(DualNodeBase):
+    """ Dual parser implementation of DirectiveNode interface """
+
+    def __init__(self, **kwargs):
+        """ This initialization implementation allows ordinary initialization
+        of DirectiveNode objects as well as creating a DualDirectiveNode object
+        using precreated or fetched DirectiveNode objects if provided as optional
+        arguments primary and secondary.
+
+        Parameters other than the following are from interfaces.DirectiveNode:
+
+        :param DirectiveNode primary: Primary pre-created DirectiveNode, mainly
+            used when creating new DualParser nodes using add_* methods.
+        :param DirectiveNode secondary: Secondary pre-created DirectiveNode
+
+
+        """
+
+        kwargs.setdefault("primary", None)
+        kwargs.setdefault("secondary", None)
+        primary = kwargs.pop("primary")
+        secondary = kwargs.pop("secondary")
+
+        if not primary:
+            self.primary = augeasparser.AugeasDirectiveNode(**kwargs)
+        else:
+            self.primary = primary
+
+        if not secondary:
+            self.secondary = augeasparser.AugeasDirectiveNode(**kwargs)
+        else:
+            self.secondary = secondary
+
+        assertions.assertEqual(self.primary, self.secondary)
+
+    def set_parameters(self, parameters):
+        """ Sets parameters and asserts that both implementation successfully
+        set the parameter sequence """
+
+        self.primary.set_parameters(parameters)
+        self.secondary.set_parameters(parameters)
+        assertions.assertEqual(self.primary, self.secondary)

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -42,14 +42,13 @@ class DualCommentNode(DualNodeBase):
         primary = kwargs.pop("primary")
         secondary = kwargs.pop("secondary")
 
-        if not primary:
-            self.primary = augeasparser.AugeasCommentNode(**kwargs)
-        else:
+        if primary or secondary:
+            assert primary and secondary
             self.primary = primary
-        if not secondary:
-            self.secondary = augeasparser.AugeasCommentNode(**kwargs)
-        else:
             self.secondary = secondary
+        else:
+            self.primary = augeasparser.AugeasCommentNode(**kwargs)
+            self.secondary = augeasparser.AugeasCommentNode(**kwargs)
 
         assertions.assertEqual(self.primary, self.secondary)
 
@@ -77,15 +76,13 @@ class DualDirectiveNode(DualNodeBase):
         primary = kwargs.pop("primary")
         secondary = kwargs.pop("secondary")
 
-        if not primary:
-            self.primary = augeasparser.AugeasDirectiveNode(**kwargs)
-        else:
+        if primary or secondary:
+            assert primary and secondary
             self.primary = primary
-
-        if not secondary:
-            self.secondary = augeasparser.AugeasDirectiveNode(**kwargs)
-        else:
             self.secondary = secondary
+        else:
+            self.primary = augeasparser.AugeasDirectiveNode(**kwargs)
+            self.secondary = augeasparser.AugeasDirectiveNode(**kwargs)
 
         assertions.assertEqual(self.primary, self.secondary)
 

--- a/certbot-apache/certbot_apache/tests/dualnode_test.py
+++ b/certbot-apache/certbot_apache/tests/dualnode_test.py
@@ -1,0 +1,95 @@
+"""Tests for DualParserNode implementation"""
+import unittest
+
+import mock
+
+from certbot_apache import assertions
+from certbot_apache import dualparser
+
+
+class DualParserNodeTest(unittest.TestCase):
+    """DualParserNode tests"""
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        self.directive = dualparser.DualDirectiveNode(name="directive",
+                                                      ancestor=None,
+                                                      filepath="/tmp/something")
+        self.comment = dualparser.DualCommentNode(comment="comment",
+                                                  ancestor=None,
+                                                  filepath="/tmp/something")
+
+    def test_create_with_primary(self):
+        cnode = dualparser.DualCommentNode(comment="comment",
+                                           ancestor=None,
+                                           filepath="/tmp/something",
+                                           primary=self.comment.secondary)
+        dnode = dualparser.DualDirectiveNode(name="directive",
+                                             ancestor=None,
+                                             filepath="/tmp/something",
+                                             primary=self.directive.secondary)
+        self.assertTrue(cnode.primary is self.comment.secondary)
+        self.assertTrue(dnode.primary is self.directive.secondary)
+
+    def test_create_with_secondary(self):
+        cnode = dualparser.DualCommentNode(comment="comment",
+                                           ancestor=None,
+                                           filepath="/tmp/something",
+                                           secondary=self.comment.primary)
+        dnode = dualparser.DualDirectiveNode(name="directive",
+                                             ancestor=None,
+                                             filepath="/tmp/something",
+                                             secondary=self.directive.primary)
+        self.assertTrue(cnode.secondary is self.comment.primary)
+        self.assertTrue(dnode.secondary is self.directive.primary)
+
+    def test_set_params(self):
+        params = ("first", "second")
+        self.directive.set_parameters(params)
+        self.assertEqual(self.directive.primary.parameters, params)
+        self.assertEqual(self.directive.secondary.parameters, params)
+
+    def test_set_parameters(self):
+        pparams = mock.MagicMock()
+        sparams = mock.MagicMock()
+        pparams.parameters = ("a", "b")
+        sparams.parameters = ("a", "b")
+        self.directive.primary.set_parameters = pparams
+        self.directive.secondary.set_parameters = sparams
+        self.directive.set_parameters(("param", "seq"))
+        self.assertTrue(pparams.called)
+        self.assertTrue(sparams.called)
+
+    def test_getattr_equality(self):
+        self.directive.primary.variableexception = "value"
+        self.directive.secondary.variableexception = "not_value"
+        with self.assertRaises(AssertionError):
+            _ = self.directive.variableexception
+
+        self.directive.primary.variable = "value"
+        self.directive.secondary.variable = "value"
+        try:
+            self.directive.variable
+        except AssertionError: # pragma: no cover
+            self.fail("getattr check raised an AssertionError where it shouldn't have")
+
+    def test_parsernode_dirty_assert(self):
+        # disable assertion pass
+        self.comment.primary.comment = "value"
+        self.comment.secondary.comment = "value"
+        self.comment.primary.filepath = "x"
+        self.comment.secondary.filepath = "x"
+
+        self.comment.primary.dirty = False
+        self.comment.secondary.dirty = True
+        with self.assertRaises(AssertionError):
+            assertions.assertEqual(self.comment.primary, self.comment.secondary)
+
+    def test_parsernode_filepath_assert(self):
+        # disable assertion pass
+        self.comment.primary.comment = "value"
+        self.comment.secondary.comment = "value"
+
+        self.comment.primary.filepath = "first"
+        self.comment.secondary.filepath = "second"
+        with self.assertRaises(AssertionError):
+            assertions.assertEqual(self.comment.primary, self.comment.secondary)

--- a/certbot-apache/certbot_apache/tests/dualnode_test.py
+++ b/certbot-apache/certbot_apache/tests/dualnode_test.py
@@ -18,28 +18,21 @@ class DualParserNodeTest(unittest.TestCase):
                                                   ancestor=None,
                                                   filepath="/tmp/something")
 
-    def test_create_with_primary(self):
+    def test_create_with_precreated(self):
         cnode = dualparser.DualCommentNode(comment="comment",
                                            ancestor=None,
                                            filepath="/tmp/something",
-                                           primary=self.comment.secondary)
-        dnode = dualparser.DualDirectiveNode(name="directive",
-                                             ancestor=None,
-                                             filepath="/tmp/something",
-                                             primary=self.directive.secondary)
-        self.assertTrue(cnode.primary is self.comment.secondary)
-        self.assertTrue(dnode.primary is self.directive.secondary)
-
-    def test_create_with_secondary(self):
-        cnode = dualparser.DualCommentNode(comment="comment",
-                                           ancestor=None,
-                                           filepath="/tmp/something",
+                                           primary=self.comment.secondary,
                                            secondary=self.comment.primary)
         dnode = dualparser.DualDirectiveNode(name="directive",
                                              ancestor=None,
                                              filepath="/tmp/something",
+                                             primary=self.directive.secondary,
                                              secondary=self.directive.primary)
+        # Switched around
+        self.assertTrue(cnode.primary is self.comment.secondary)
         self.assertTrue(cnode.secondary is self.comment.primary)
+        self.assertTrue(dnode.primary is self.directive.secondary)
         self.assertTrue(dnode.secondary is self.directive.primary)
 
     def test_set_params(self):


### PR DESCRIPTION
This PR includes the first of the three PRs that are split from #7338 

The DualParserNode itself holds two ParserNode implementations and in every turn tries to make sure that they return the same values using various assertions.