### PR TITLE
[Apache v2] DualParserNode implementation 2/3

### DIFF
--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -1,0 +1,70 @@
+"""Dual parser node assertions"""
+from certbot_apache import interfaces
+
+
+PASS = "CERTBOT_PASS_ASSERT"
+
+
+def assertEqual(first, second):
+    """ Equality assertion """
+
+    if isinstance(first, interfaces.CommentNode):
+        assertEqualComment(first, second)
+    elif isinstance(first, interfaces.DirectiveNode):
+        assertEqualDirective(first, second)
+
+    # Skip tests if filepath includes the pass value. This is done
+    # because filepath is variable of the base ParserNode interface, and
+    # unless the implementation is actually done, we cannot assume getting
+    # correct results from boolean assertion for dirty
+    if not isPass(first.filepath, second.filepath):
+        assert first.dirty == second.dirty
+        # We might want to disable this later if testing with two separate
+        # (but identical) directory structures.
+        assert first.filepath == second.filepath
+
+def assertEqualComment(first, second): # pragma: no cover
+    """ Equality assertion for CommentNode """
+
+    assert isinstance(first, interfaces.CommentNode)
+    assert isinstance(second, interfaces.CommentNode)
+
+    if not isPass(first.comment, second.comment):
+        assert first.comment == second.comment
+
+def _assertEqualDirectiveComponents(first, second): # pragma: no cover
+    """ Handles assertion for instance variables for DirectiveNode and BlockNode"""
+
+    # Enabled value cannot be asserted, because Augeas implementation
+    # is unable to figure that out.
+    # assert first.enabled == second.enabled
+    if not isPass(first.name, second.name):
+        assert first.name == second.name
+
+    if not isPass(first.parameters, second.parameters):
+        assert first.parameters == second.parameters
+
+def assertEqualDirective(first, second):
+    """ Equality assertion for DirectiveNode """
+
+    assert isinstance(first, interfaces.DirectiveNode)
+    assert isinstance(second, interfaces.DirectiveNode)
+    _assertEqualDirectiveComponents(first, second)
+
+def isPass(first, second): # pragma: no cover
+    """ Checks if either first or second holds the assertion pass value """
+
+    if isinstance(first, (tuple, list)):
+        if PASS in first:
+            return True
+    if isinstance(second, (tuple, list)):
+        if PASS in second:
+            return True
+    if PASS in [first, second]:
+        return True
+    return False
+
+def assertSimple(first, second):
+    """ Simple assertion """
+    if not isPass(first, second):
+        assert first == second

--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -64,7 +64,7 @@ def isPass(first, second): # pragma: no cover
         return True
     return False
 
-def assertSimple(first, second):
+def assertEqualSimple(first, second):
     """ Simple assertion """
     if not isPass(first, second):
         assert first == second

--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -53,12 +53,7 @@ def assertEqualDirective(first, second):
 
 def isPass(value): # pragma: no cover
     """Checks if the value is set to PASS"""
-    if isinstance(value, (tuple, list)):
-        if PASS in value:
-            return True
-    if PASS in value:
-        return True
-    return False
+    return PASS in value
 
 def assertEqualSimple(first, second):
     """ Simple assertion """

--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -17,7 +17,7 @@ def assertEqual(first, second):
     # because filepath is variable of the base ParserNode interface, and
     # unless the implementation is actually done, we cannot assume getting
     # correct results from boolean assertion for dirty
-    if not isPass(first.filepath, second.filepath):
+    if not isPass(first.filepath) and not isPass(second.filepath):
         assert first.dirty == second.dirty
         # We might want to disable this later if testing with two separate
         # (but identical) directory structures.
@@ -29,7 +29,7 @@ def assertEqualComment(first, second): # pragma: no cover
     assert isinstance(first, interfaces.CommentNode)
     assert isinstance(second, interfaces.CommentNode)
 
-    if not isPass(first.comment, second.comment):
+    if not isPass(first.comment) and not isPass(second.comment):
         assert first.comment == second.comment
 
 def _assertEqualDirectiveComponents(first, second): # pragma: no cover
@@ -38,10 +38,10 @@ def _assertEqualDirectiveComponents(first, second): # pragma: no cover
     # Enabled value cannot be asserted, because Augeas implementation
     # is unable to figure that out.
     # assert first.enabled == second.enabled
-    if not isPass(first.name, second.name):
+    if not isPass(first.name) and not isPass(second.name):
         assert first.name == second.name
 
-    if not isPass(first.parameters, second.parameters):
+    if not isPass(first.parameters) and not isPass(second.parameters):
         assert first.parameters == second.parameters
 
 def assertEqualDirective(first, second):
@@ -51,20 +51,16 @@ def assertEqualDirective(first, second):
     assert isinstance(second, interfaces.DirectiveNode)
     _assertEqualDirectiveComponents(first, second)
 
-def isPass(first, second): # pragma: no cover
-    """ Checks if either first or second holds the assertion pass value """
-
-    if isinstance(first, (tuple, list)):
-        if PASS in first:
+def isPass(value): # pragma: no cover
+    """Checks if the value is set to PASS"""
+    if isinstance(value, (tuple, list)):
+        if PASS in value:
             return True
-    if isinstance(second, (tuple, list)):
-        if PASS in second:
-            return True
-    if PASS in [first, second]:
+    if PASS in value:
         return True
     return False
 
 def assertEqualSimple(first, second):
     """ Simple assertion """
-    if not isPass(first, second):
+    if not isPass(first) and not isPass(second):
         assert first == second

--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -1,0 +1,69 @@
+""" Augeas implementation of the ParserNode interface """
+from certbot_apache import assertions
+from certbot_apache import interfaces
+from certbot_apache import parsernode_util as util
+
+
+class AugeasParserNode(interfaces.ParserNode):
+    """ Augeas implementation of ParserNode interface """
+
+    def __init__(self, **kwargs):
+        ancestor, dirty, filepath, metadata = util.parsernode_kwargs(kwargs)  # pylint: disable=unused-variable
+        super(AugeasParserNode, self).__init__(**kwargs)
+        self.ancestor = ancestor
+        # self.filepath = filepath
+        self.filepath = assertions.PASS
+        self.dirty = dirty
+        self.metadata = metadata
+
+    def save(self, msg): # pragma: no cover
+        pass
+
+
+class AugeasCommentNode(AugeasParserNode):
+    """ Augeas implementation of CommentNode interface """
+
+    def __init__(self, **kwargs):
+        comment, kwargs = util.commentnode_kwargs(kwargs)  # pylint: disable=unused-variable
+        super(AugeasCommentNode, self).__init__(**kwargs)
+        # self.comment = comment
+        self.comment = assertions.PASS
+
+    def __eq__(self, other): # pragma: no cover
+        if isinstance(other, self.__class__):
+            return (self.comment == other.comment and
+                    self.filepath == other.filepath and
+                    self.dirty == other.dirty and
+                    self.ancestor == other.ancestor and
+                    self.metadata == other.metadata)
+        return False
+
+
+class AugeasDirectiveNode(AugeasParserNode):
+    """ Augeas implementation of DirectiveNode interface """
+
+    def __init__(self, **kwargs):
+        name, parameters, enabled, kwargs = util.directivenode_kwargs(kwargs)
+        super(AugeasDirectiveNode, self).__init__(**kwargs)
+        self.name = name
+        self.parameters = parameters
+        self.enabled = enabled
+
+    def __eq__(self, other): # pragma: no cover
+        if isinstance(other, self.__class__):
+            return (self.name == other.name and
+                    self.filepath == other.filepath and
+                    self.parameters == other.parameters and
+                    self.enabled == other.enabled and
+                    self.dirty == other.dirty and
+                    self.ancestor == other.ancestor and
+                    self.metadata == other.metadata)
+        return False
+
+    def set_parameters(self, parameters):
+        """Sets the parameters for DirectiveNode"""
+        self.parameters = parameters
+
+
+interfaces.CommentNode.register(AugeasCommentNode)
+interfaces.DirectiveNode.register(AugeasDirectiveNode)

--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -1,4 +1,4 @@
-""" Augeas implementation of the ParserNode interface """
+""" Augeas implementation of the ParserNode interfaces """
 from certbot_apache import assertions
 from certbot_apache import interfaces
 from certbot_apache import parsernode_util as util
@@ -65,5 +65,70 @@ class AugeasDirectiveNode(AugeasParserNode):
         self.parameters = parameters
 
 
+class AugeasBlockNode(AugeasDirectiveNode):
+    """ Augeas implementation of BlockNode interface """
+
+    def __init__(self, **kwargs):
+        super(AugeasBlockNode, self).__init__(**kwargs)
+        self.children = ()
+
+    def __eq__(self, other): # pragma: no cover
+        if isinstance(other, self.__class__):
+            return (self.name == other.name and
+                    self.filepath == other.filepath and
+                    self.parameters == other.parameters and
+                    self.children == other.children and
+                    self.enabled == other.enabled and
+                    self.dirty == other.dirty and
+                    self.ancestor == other.ancestor and
+                    self.metadata == other.metadata)
+        return False
+
+    def add_child_block(self, name, parameters=None, position=None):  # pylint: disable=unused-argument
+        """Adds a new BlockNode to the sequence of children"""
+        new_block = AugeasBlockNode(name=assertions.PASS,
+                                    ancestor=self,
+                                    filepath=assertions.PASS)
+        self.children += (new_block,)
+        return new_block
+
+    def add_child_directive(self, name, parameters=None, position=None):  # pylint: disable=unused-argument
+        """Adds a new DirectiveNode to the sequence of children"""
+        new_dir = AugeasDirectiveNode(name=assertions.PASS,
+                                      ancestor=self,
+                                      filepath=assertions.PASS)
+        self.children += (new_dir,)
+        return new_dir
+
+    def add_child_comment(self, comment="", position=None):  # pylint: disable=unused-argument
+        """Adds a new CommentNode to the sequence of children"""
+        new_comment = AugeasCommentNode(comment=assertions.PASS,
+                                        ancestor=self,
+                                        filepath=assertions.PASS)
+        self.children += (new_comment,)
+        return new_comment
+
+    def find_blocks(self, name, exclude=True): # pragma: no cover
+        """Recursive search of BlockNodes from the sequence of children"""
+        pass
+
+    def find_directives(self, name, exclude=True): # pragma: no cover
+        """Recursive search of DirectiveNodes from the sequence of children"""
+        pass
+
+    def find_comments(self, comment, exact=False): # pragma: no cover
+        """Recursive search of DirectiveNodes from the sequence of children"""
+        pass
+
+    def delete_child(self, child):  # pragma: no cover
+        """Deletes a ParserNode from the sequence of children"""
+        pass
+
+    def unsaved_files(self):  # pragma: no cover
+        """Returns a list of unsaved filepaths"""
+        return [assertions.PASS]
+
+
 interfaces.CommentNode.register(AugeasCommentNode)
 interfaces.DirectiveNode.register(AugeasDirectiveNode)
+interfaces.BlockNode.register(AugeasBlockNode)

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -1,4 +1,4 @@
-""" Tests for ParserNode interface """
+""" Dual ParserNode implementation """
 from certbot_apache import assertions
 from certbot_apache import augeasparser
 
@@ -17,8 +17,7 @@ class DualNodeBase(object):
         """ Attribute value assertion """
         firstval = getattr(self.primary, aname)
         secondval = getattr(self.secondary, aname)
-        if not assertions.isPass(firstval, secondval):
-            assertions.assertSimple(firstval, secondval)
+        assertions.assertEqualSimple(firstval, secondval)
         return firstval
 
 

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -176,6 +176,7 @@ class DualBlockNode(DualNodeBase):
                 try:
                     assertions.assertEqual(p, s)
                     match = s
+                    break
                 except AssertionError:
                     continue
             if match:

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -1,0 +1,99 @@
+""" Tests for ParserNode interface """
+from certbot_apache import assertions
+from certbot_apache import augeasparser
+
+
+class DualNodeBase(object):
+    """ Dual parser interface for in development testing. This is used as the
+    base class for dual parser interface classes. This class handles runtime
+    attribute value assertions."""
+
+    def save(self, msg):  # pragma: no cover
+        """ Call save for both parsers """
+        self.primary.save(msg)
+        self.secondary.save(msg)
+
+    def __getattr__(self, aname):
+        """ Attribute value assertion """
+        firstval = getattr(self.primary, aname)
+        secondval = getattr(self.secondary, aname)
+        if not assertions.isPass(firstval, secondval):
+            assertions.assertSimple(firstval, secondval)
+        return firstval
+
+
+class DualCommentNode(DualNodeBase):
+    """ Dual parser implementation of CommentNode interface """
+
+    def __init__(self, **kwargs):
+        """ This initialization implementation allows ordinary initialization
+        of CommentNode objects as well as creating a DualCommentNode object
+        using precreated or fetched CommentNode objects if provided as optional
+        arguments primary and secondary.
+
+        Parameters other than the following are from interfaces.CommentNode:
+
+        :param CommentNode primary: Primary pre-created CommentNode, mainly
+            used when creating new DualParser nodes using add_* methods.
+        :param CommentNode secondary: Secondary pre-created CommentNode
+        """
+
+        kwargs.setdefault("primary", None)
+        kwargs.setdefault("secondary", None)
+        primary = kwargs.pop("primary")
+        secondary = kwargs.pop("secondary")
+
+        if not primary:
+            self.primary = augeasparser.AugeasCommentNode(**kwargs)
+        else:
+            self.primary = primary
+        if not secondary:
+            self.secondary = augeasparser.AugeasCommentNode(**kwargs)
+        else:
+            self.secondary = secondary
+
+        assertions.assertEqual(self.primary, self.secondary)
+
+
+class DualDirectiveNode(DualNodeBase):
+    """ Dual parser implementation of DirectiveNode interface """
+
+    def __init__(self, **kwargs):
+        """ This initialization implementation allows ordinary initialization
+        of DirectiveNode objects as well as creating a DualDirectiveNode object
+        using precreated or fetched DirectiveNode objects if provided as optional
+        arguments primary and secondary.
+
+        Parameters other than the following are from interfaces.DirectiveNode:
+
+        :param DirectiveNode primary: Primary pre-created DirectiveNode, mainly
+            used when creating new DualParser nodes using add_* methods.
+        :param DirectiveNode secondary: Secondary pre-created DirectiveNode
+
+
+        """
+
+        kwargs.setdefault("primary", None)
+        kwargs.setdefault("secondary", None)
+        primary = kwargs.pop("primary")
+        secondary = kwargs.pop("secondary")
+
+        if not primary:
+            self.primary = augeasparser.AugeasDirectiveNode(**kwargs)
+        else:
+            self.primary = primary
+
+        if not secondary:
+            self.secondary = augeasparser.AugeasDirectiveNode(**kwargs)
+        else:
+            self.secondary = secondary
+
+        assertions.assertEqual(self.primary, self.secondary)
+
+    def set_parameters(self, parameters):
+        """ Sets parameters and asserts that both implementation successfully
+        set the parameter sequence """
+
+        self.primary.set_parameters(parameters)
+        self.secondary.set_parameters(parameters)
+        assertions.assertEqual(self.primary, self.secondary)

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -42,14 +42,13 @@ class DualCommentNode(DualNodeBase):
         primary = kwargs.pop("primary")
         secondary = kwargs.pop("secondary")
 
-        if not primary:
-            self.primary = augeasparser.AugeasCommentNode(**kwargs)
-        else:
+        if primary or secondary:
+            assert primary and secondary
             self.primary = primary
-        if not secondary:
-            self.secondary = augeasparser.AugeasCommentNode(**kwargs)
-        else:
             self.secondary = secondary
+        else:
+            self.primary = augeasparser.AugeasCommentNode(**kwargs)
+            self.secondary = augeasparser.AugeasCommentNode(**kwargs)
 
         assertions.assertEqual(self.primary, self.secondary)
 
@@ -77,15 +76,13 @@ class DualDirectiveNode(DualNodeBase):
         primary = kwargs.pop("primary")
         secondary = kwargs.pop("secondary")
 
-        if not primary:
-            self.primary = augeasparser.AugeasDirectiveNode(**kwargs)
-        else:
+        if primary or secondary:
+            assert primary and secondary
             self.primary = primary
-
-        if not secondary:
-            self.secondary = augeasparser.AugeasDirectiveNode(**kwargs)
-        else:
             self.secondary = secondary
+        else:
+            self.primary = augeasparser.AugeasDirectiveNode(**kwargs)
+            self.secondary = augeasparser.AugeasDirectiveNode(**kwargs)
 
         assertions.assertEqual(self.primary, self.secondary)
 

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -97,3 +97,137 @@ class DualDirectiveNode(DualNodeBase):
         self.primary.set_parameters(parameters)
         self.secondary.set_parameters(parameters)
         assertions.assertEqual(self.primary, self.secondary)
+
+
+class DualBlockNode(DualNodeBase):
+    """ Dual parser implementation of BlockNode interface """
+
+    def __init__(self, **kwargs):
+        """ This initialization implementation allows ordinary initialization
+        of BlockNode objects as well as creating a DualBlockNode object
+        using precreated or fetched BlockNode objects if provided as optional
+        arguments primary and secondary.
+
+        Parameters other than the following are from interfaces.BlockNode:
+
+        :param BlockNode primary: Primary pre-created BlockNode, mainly
+            used when creating new DualParser nodes using add_* methods.
+        :param BlockNode secondary: Secondary pre-created BlockNode
+        """
+
+        kwargs.setdefault("primary", None)
+        kwargs.setdefault("secondary", None)
+        primary = kwargs.pop("primary")
+        secondary = kwargs.pop("secondary")
+
+        if not primary:
+            self.primary = augeasparser.AugeasBlockNode(**kwargs)
+        else:
+            self.primary = primary
+
+        if not secondary:
+            self.secondary = augeasparser.AugeasBlockNode(**kwargs)
+        else:
+            self.secondary = secondary
+
+        assertions.assertEqual(self.primary, self.secondary)
+
+    def add_child_block(self, name, parameters=None, position=None):
+        """ Creates a new child BlockNode, asserts that both implementations
+        did it in a similar way, and returns a newly created DualBlockNode object
+        encapsulating both of the newly created objects """
+
+        primary_new = self.primary.add_child_block(name, parameters, position)
+        secondary_new = self.secondary.add_child_block(name, parameters, position)
+        assertions.assertEqual(primary_new, secondary_new)
+        new_block = DualBlockNode(primary=primary_new, secondary=secondary_new)
+        return new_block
+
+    def add_child_directive(self, name, parameters=None, position=None):
+        """ Creates a new child DirectiveNode, asserts that both implementations
+        did it in a similar way, and returns a newly created DualDirectiveNode
+        object encapsulating both of the newly created objects """
+
+        primary_new = self.primary.add_child_directive(name, parameters, position)
+        secondary_new = self.secondary.add_child_directive(name, parameters, position)
+        assertions.assertEqual(primary_new, secondary_new)
+        new_dir = DualDirectiveNode(primary=primary_new, secondary=secondary_new)
+        return new_dir
+
+    def add_child_comment(self, comment="", position=None):
+        """ Creates a new child CommentNode, asserts that both implementations
+        did it in a similar way, and returns a newly created DualCommentNode
+        object encapsulating both of the newly created objects """
+
+        primary_new = self.primary.add_child_comment(comment, position)
+        secondary_new = self.secondary.add_child_comment(comment, position)
+        assertions.assertEqual(primary_new, secondary_new)
+        new_comment = DualCommentNode(primary=primary_new, secondary=secondary_new)
+        return new_comment
+
+    def _create_matching_list(self, primary_list, secondary_list):  # pragma: no cover
+        """ Matches the list of primary_list to a list of secondary_list and
+        returns a list of tuples. This is used to create results for find_
+        methods. """
+
+        matched = list()
+        for p in primary_list:
+            match = None
+            for s in secondary_list:
+                try:
+                    assertions.assertEqual(p, s)
+                    match = s
+                except AssertionError:
+                    continue
+            if match:
+                matched.append((p, match))
+            else:
+                raise AssertionError("Could not find a matching node.")
+        return matched
+
+    def find_blocks(self, name, exclude=True):  # pragma: no cover
+        """
+        Performs a search for BlockNodes using both implementations and does simple
+        checks for results. This is built upon the assumption that unimplemented
+        find_* methods return a list with a single assertion passing object.
+        After the assertion, it creates a list of newly created DualBlockNode
+        instances that encapsulate the pairs of returned BlockNode objects.
+        """
+        pass
+
+    def find_directives(self, name, exclude=True):  # pragma: no cover
+        """
+        Performs a search for DirectiveNodes using both implementations and
+        checks the results. This is built upon the assumption that unimplemented
+        find_* methods return a list with a single assertion passing object.
+        After the assertion, it creates a list of newly created DualDirectiveNode
+        instances that encapsulate the pairs of returned DirectiveNode objects.
+        """
+        pass
+
+    def find_comments(self, comment, exact=False):  # pragma: no cover
+        """
+        Performs a search for CommentNodes using both implementations and
+        checks the results. This is built upon the assumption that unimplemented
+        find_* methods return a list with a single assertion passing object.
+        After the assertion, it creates a list of newly created DualCommentNode
+        instances that encapsulate the pairs of returned CommentNode objects.
+        """
+        pass
+
+    def delete_child(self, child):  # pragma: no cover
+        """Deletes a child from the ParserNode implementations. The actual
+        ParserNode implementations are used here directly in order to be able
+        to match a child to the list of children."""
+
+        self.primary.delete_child(child.primary)
+        self.secondary.delete_child(child.secondary)
+
+    def unsaved_files(self):
+        """ Fetches the list of unsaved file paths and asserts that the lists
+        match """
+        primary_files = self.primary.unsaved_files()
+        secondary_files = self.secondary.unsaved_files()
+        assertions.assertSimple(primary_files, secondary_files)
+
+        return primary_files

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -116,15 +116,13 @@ class DualBlockNode(DualNodeBase):
         primary = kwargs.pop("primary")
         secondary = kwargs.pop("secondary")
 
-        if not primary:
-            self.primary = augeasparser.AugeasBlockNode(**kwargs)
-        else:
+        if primary or secondary:
+            assert primary and secondary
             self.primary = primary
-
-        if not secondary:
-            self.secondary = augeasparser.AugeasBlockNode(**kwargs)
-        else:
             self.secondary = secondary
+        else:
+            self.primary = augeasparser.AugeasBlockNode(**kwargs)
+            self.secondary = augeasparser.AugeasBlockNode(**kwargs)
 
         assertions.assertEqual(self.primary, self.secondary)
 
@@ -164,7 +162,13 @@ class DualBlockNode(DualNodeBase):
     def _create_matching_list(self, primary_list, secondary_list):  # pragma: no cover
         """ Matches the list of primary_list to a list of secondary_list and
         returns a list of tuples. This is used to create results for find_
-        methods. """
+        methods.
+
+        This helper function exists, because we cannot ensure that the list of
+        search results returned by primary.find_* and secondary.find_* are ordered
+        in a same way. The function pairs the same search results from both
+        implementations to a list of tuples.
+        """
 
         matched = list()
         for p in primary_list:

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -224,6 +224,6 @@ class DualBlockNode(DualNodeBase):
         match """
         primary_files = self.primary.unsaved_files()
         secondary_files = self.secondary.unsaved_files()
-        assertions.assertSimple(primary_files, secondary_files)
+        assertions.assertEqualSimple(primary_files, secondary_files)
 
         return primary_files

--- a/certbot-apache/certbot_apache/tests/dualnode_test.py
+++ b/certbot-apache/certbot_apache/tests/dualnode_test.py
@@ -1,0 +1,95 @@
+"""Tests for DualParserNode implementation"""
+import unittest
+
+import mock
+
+from certbot_apache import assertions
+from certbot_apache import dualparser
+
+
+class DualParserNodeTest(unittest.TestCase):
+    """DualParserNode tests"""
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        self.directive = dualparser.DualDirectiveNode(name="directive",
+                                                      ancestor=None,
+                                                      filepath="/tmp/something")
+        self.comment = dualparser.DualCommentNode(comment="comment",
+                                                  ancestor=None,
+                                                  filepath="/tmp/something")
+
+    def test_create_with_primary(self):
+        cnode = dualparser.DualCommentNode(comment="comment",
+                                           ancestor=None,
+                                           filepath="/tmp/something",
+                                           primary=self.comment.secondary)
+        dnode = dualparser.DualDirectiveNode(name="directive",
+                                             ancestor=None,
+                                             filepath="/tmp/something",
+                                             primary=self.directive.secondary)
+        self.assertTrue(cnode.primary is self.comment.secondary)
+        self.assertTrue(dnode.primary is self.directive.secondary)
+
+    def test_create_with_secondary(self):
+        cnode = dualparser.DualCommentNode(comment="comment",
+                                           ancestor=None,
+                                           filepath="/tmp/something",
+                                           secondary=self.comment.primary)
+        dnode = dualparser.DualDirectiveNode(name="directive",
+                                             ancestor=None,
+                                             filepath="/tmp/something",
+                                             secondary=self.directive.primary)
+        self.assertTrue(cnode.secondary is self.comment.primary)
+        self.assertTrue(dnode.secondary is self.directive.primary)
+
+    def test_set_params(self):
+        params = ("first", "second")
+        self.directive.set_parameters(params)
+        self.assertEqual(self.directive.primary.parameters, params)
+        self.assertEqual(self.directive.secondary.parameters, params)
+
+    def test_set_parameters(self):
+        pparams = mock.MagicMock()
+        sparams = mock.MagicMock()
+        pparams.parameters = ("a", "b")
+        sparams.parameters = ("a", "b")
+        self.directive.primary.set_parameters = pparams
+        self.directive.secondary.set_parameters = sparams
+        self.directive.set_parameters(("param", "seq"))
+        self.assertTrue(pparams.called)
+        self.assertTrue(sparams.called)
+
+    def test_getattr_equality(self):
+        self.directive.primary.variableexception = "value"
+        self.directive.secondary.variableexception = "not_value"
+        with self.assertRaises(AssertionError):
+            _ = self.directive.variableexception
+
+        self.directive.primary.variable = "value"
+        self.directive.secondary.variable = "value"
+        try:
+            self.directive.variable
+        except AssertionError: # pragma: no cover
+            self.fail("getattr check raised an AssertionError where it shouldn't have")
+
+    def test_parsernode_dirty_assert(self):
+        # disable assertion pass
+        self.comment.primary.comment = "value"
+        self.comment.secondary.comment = "value"
+        self.comment.primary.filepath = "x"
+        self.comment.secondary.filepath = "x"
+
+        self.comment.primary.dirty = False
+        self.comment.secondary.dirty = True
+        with self.assertRaises(AssertionError):
+            assertions.assertEqual(self.comment.primary, self.comment.secondary)
+
+    def test_parsernode_filepath_assert(self):
+        # disable assertion pass
+        self.comment.primary.comment = "value"
+        self.comment.secondary.comment = "value"
+
+        self.comment.primary.filepath = "first"
+        self.comment.secondary.filepath = "second"
+        with self.assertRaises(AssertionError):
+            assertions.assertEqual(self.comment.primary, self.comment.secondary)

--- a/certbot-apache/certbot_apache/tests/dualnode_test.py
+++ b/certbot-apache/certbot_apache/tests/dualnode_test.py
@@ -25,38 +25,28 @@ class DualParserNodeTest(unittest.TestCase):
                                                   ancestor=self.block,
                                                   filepath="/tmp/something")
 
-    def test_create_with_primary(self):
+    def test_create_with_precreated(self):
         cnode = dualparser.DualCommentNode(comment="comment",
                                            ancestor=self.block,
                                            filepath="/tmp/something",
-                                           primary=self.comment.secondary)
-        dnode = dualparser.DualDirectiveNode(name="directive",
-                                             ancestor=self.block,
-                                             filepath="/tmp/something",
-                                             primary=self.directive.secondary)
-        bnode = dualparser.DualBlockNode(name="block",
-                                         ancestor=self.block,
-                                         filepath="/tmp/something",
-                                         primary=self.block.secondary)
-        self.assertTrue(cnode.primary is self.comment.secondary)
-        self.assertTrue(dnode.primary is self.directive.secondary)
-        self.assertTrue(bnode.primary is self.block.secondary)
-
-    def test_create_with_secondary(self):
-        cnode = dualparser.DualCommentNode(comment="comment",
-                                           ancestor=self.block,
-                                           filepath="/tmp/something",
+                                           primary=self.comment.secondary,
                                            secondary=self.comment.primary)
         dnode = dualparser.DualDirectiveNode(name="directive",
                                              ancestor=self.block,
                                              filepath="/tmp/something",
+                                             primary=self.directive.secondary,
                                              secondary=self.directive.primary)
         bnode = dualparser.DualBlockNode(name="block",
                                          ancestor=self.block,
                                          filepath="/tmp/something",
+                                         primary=self.block.secondary,
                                          secondary=self.block.primary)
+        # Switched around
+        self.assertTrue(cnode.primary is self.comment.secondary)
         self.assertTrue(cnode.secondary is self.comment.primary)
+        self.assertTrue(dnode.primary is self.directive.secondary)
         self.assertTrue(dnode.secondary is self.directive.primary)
+        self.assertTrue(bnode.primary is self.block.secondary)
         self.assertTrue(bnode.secondary is self.block.primary)
 
     def test_set_params(self):

--- a/certbot-apache/certbot_apache/tests/dualnode_test.py
+++ b/certbot-apache/certbot_apache/tests/dualnode_test.py
@@ -5,42 +5,59 @@ import mock
 
 from certbot_apache import assertions
 from certbot_apache import dualparser
+from certbot_apache import interfaces
 
 
 class DualParserNodeTest(unittest.TestCase):
     """DualParserNode tests"""
 
     def setUp(self):  # pylint: disable=arguments-differ
+        self.block = dualparser.DualBlockNode(name="block",
+                                              ancestor=None,
+                                              filepath="/tmp/something")
+        self.block_two = dualparser.DualBlockNode(name="block",
+                                                  ancestor=self.block,
+                                                  filepath="/tmp/something")
         self.directive = dualparser.DualDirectiveNode(name="directive",
-                                                      ancestor=None,
+                                                      ancestor=self.block,
                                                       filepath="/tmp/something")
         self.comment = dualparser.DualCommentNode(comment="comment",
-                                                  ancestor=None,
+                                                  ancestor=self.block,
                                                   filepath="/tmp/something")
 
     def test_create_with_primary(self):
         cnode = dualparser.DualCommentNode(comment="comment",
-                                           ancestor=None,
+                                           ancestor=self.block,
                                            filepath="/tmp/something",
                                            primary=self.comment.secondary)
         dnode = dualparser.DualDirectiveNode(name="directive",
-                                             ancestor=None,
+                                             ancestor=self.block,
                                              filepath="/tmp/something",
                                              primary=self.directive.secondary)
+        bnode = dualparser.DualBlockNode(name="block",
+                                         ancestor=self.block,
+                                         filepath="/tmp/something",
+                                         primary=self.block.secondary)
         self.assertTrue(cnode.primary is self.comment.secondary)
         self.assertTrue(dnode.primary is self.directive.secondary)
+        self.assertTrue(bnode.primary is self.block.secondary)
 
     def test_create_with_secondary(self):
         cnode = dualparser.DualCommentNode(comment="comment",
-                                           ancestor=None,
+                                           ancestor=self.block,
                                            filepath="/tmp/something",
                                            secondary=self.comment.primary)
         dnode = dualparser.DualDirectiveNode(name="directive",
-                                             ancestor=None,
+                                             ancestor=self.block,
                                              filepath="/tmp/something",
                                              secondary=self.directive.primary)
+        bnode = dualparser.DualBlockNode(name="block",
+                                         ancestor=self.block,
+                                         filepath="/tmp/something",
+                                         secondary=self.block.primary)
         self.assertTrue(cnode.secondary is self.comment.primary)
         self.assertTrue(dnode.secondary is self.directive.primary)
+        self.assertTrue(bnode.secondary is self.block.primary)
 
     def test_set_params(self):
         params = ("first", "second")
@@ -58,6 +75,26 @@ class DualParserNodeTest(unittest.TestCase):
         self.directive.set_parameters(("param", "seq"))
         self.assertTrue(pparams.called)
         self.assertTrue(sparams.called)
+
+    def test_delete_child(self):
+        pdel = mock.MagicMock()
+        sdel = mock.MagicMock()
+        self.block.primary.delete_child = pdel
+        self.block.secondary.delete_child = sdel
+        self.block.delete_child(self.comment)
+        self.assertTrue(pdel.called)
+        self.assertTrue(sdel.called)
+
+    def test_unsaved_files(self):
+        puns = mock.MagicMock()
+        suns = mock.MagicMock()
+        puns.return_value = assertions.PASS
+        suns.return_value = assertions.PASS
+        self.block.primary.unsaved_files = puns
+        self.block.secondary.unsaved_files = suns
+        self.block.unsaved_files()
+        self.assertTrue(puns.called)
+        self.assertTrue(suns.called)
 
     def test_getattr_equality(self):
         self.directive.primary.variableexception = "value"
@@ -93,3 +130,36 @@ class DualParserNodeTest(unittest.TestCase):
         self.comment.secondary.filepath = "second"
         with self.assertRaises(AssertionError):
             assertions.assertEqual(self.comment.primary, self.comment.secondary)
+
+    def test_add_child_block(self):
+        self.assertEqual(len(self.block.primary.children), 0)
+        self.assertEqual(len(self.block.secondary.children), 0)
+        self.block.add_child_block("Block")
+        self.assertEqual(len(self.block.primary.children), 1)
+        self.assertEqual(len(self.block.secondary.children), 1)
+        self.assertTrue(isinstance(self.block.primary.children[0],
+                                   interfaces.BlockNode))
+        self.assertEqual(self.block.primary.children[0].ancestor,
+                         self.block.primary)
+
+    def test_add_child_directive(self):
+        self.assertEqual(len(self.block.primary.children), 0)
+        self.assertEqual(len(self.block.secondary.children), 0)
+        self.block.add_child_directive("Directive")
+        self.assertEqual(len(self.block.primary.children), 1)
+        self.assertEqual(len(self.block.secondary.children), 1)
+        self.assertTrue(isinstance(self.block.primary.children[0],
+                                   interfaces.DirectiveNode))
+        self.assertEqual(self.block.primary.children[0].ancestor,
+                         self.block.primary)
+
+    def test_add_child_comment(self):
+        self.assertEqual(len(self.block.primary.children), 0)
+        self.assertEqual(len(self.block.secondary.children), 0)
+        self.block.add_child_comment("Comment")
+        self.assertEqual(len(self.block.primary.children), 1)
+        self.assertEqual(len(self.block.secondary.children), 1)
+        self.assertTrue(isinstance(self.block.primary.children[0],
+                                   interfaces.CommentNode))
+        self.assertEqual(self.block.primary.children[0].ancestor,
+                         self.block.primary)


### PR DESCRIPTION
This PR includes the second of the three PRs that are split from #7338 

The PR itself is based on the first PR for clarity, note that this needs to be changed, and this PR rebased after the part 1 is merged.

I had to add dummy methods for `find_*`, because some checks require the interface to be implemented.