### PR TITLE
Fix to run with Apache on RHEL 6

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -127,6 +127,7 @@ Authors
 * [Joubin Jabbari](https://github.com/joubin)
 * [Juho Juopperi](https://github.com/jkjuopperi)
 * [Kane York](https://github.com/riking)
+* [Kenichi Maehashi](https://github.com/kmaehashi)
 * [Kenneth Skovhede](https://github.com/kenkendk)
 * [Kevin Burke](https://github.com/kevinburke)
 * [Kevin London](https://github.com/kevinlondon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fixed OS detection in the Apache plugin on RHEL 6.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot-apache/certbot_apache/entrypoint.py
+++ b/certbot-apache/certbot_apache/entrypoint.py
@@ -24,6 +24,7 @@ OVERRIDE_CLASSES = {
     "fedora_old": override_centos.CentOSConfigurator,
     "fedora": override_fedora.FedoraConfigurator,
     "ol": override_centos.CentOSConfigurator,
+    "redhatenterpriseserver": override_centos.CentOSConfigurator,
     "red hat enterprise linux server": override_centos.CentOSConfigurator,
     "rhel": override_centos.CentOSConfigurator,
     "amazon": override_centos.CentOSConfigurator,


### PR DESCRIPTION
This PR fixes a regression in #7337 (0.38.0) that certbot cannot run with Apache on RHEL 6.

In RHEL 6, `distro.linux_distribution()` returns `RedHatEnterpriseServer`.

In RHEL 6:

```py
>>> import distro
>>> distro.linux_distribution()
(u'RedHatEnterpriseServer', u'6.10', u'Santiago')

>>> import platform
>>> platform.linux_distribution()
('Red Hat Enterprise Linux Server', '6.10', 'Santiago')
```

In RHEL 7:

```py
>>> import distro
>>> distro.linux_distribution()
('Red Hat Enterprise Linux Server', '7.6', 'Maipo')

>>> import platform
>>> platform.linux_distribution()
('Red Hat Enterprise Linux Server', '7.6', 'Maipo')
```

## Pull Request Checklist

- [x] Edit the `master` section of `CHANGELOG.md` to include a description of the change being made.
- [x] Add [mypy type annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations) for any functions that were added or modified.
- [x] Include your name in `AUTHORS.md` if you like.