### PR TITLE
Try to use platform.linux_distribution() before distro equivalent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 * Don't send OCSP requests for expired certificates
+* Return to using platform.linux_distribution instead of distro.linux_distribution in OS fingerprinting for Python < 3.8 
 
 ### Fixed
 

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -520,13 +520,15 @@ class OsInfoTest(unittest.TestCase):
 
             with mock.patch('platform.system_alias',
                             return_value=('linux', '', '')):
-                with mock.patch('distro.linux_distribution',
-                                return_value=('', '', '')):
-                    self.assertEqual(get_python_os_info(), ("linux", ""))
+                with mock.patch('platform.linux_distribution',
+                                side_effect=AttributeError):
+                    with mock.patch('distro.linux_distribution',
+                                    return_value=('', '', '')):
+                        self.assertEqual(get_python_os_info(), ("linux", ""))
 
-                with mock.patch('distro.linux_distribution',
-                                return_value=('testdist', '42', '')):
-                    self.assertEqual(get_python_os_info(), ("testdist", "42"))
+                    with mock.patch('distro.linux_distribution',
+                                    return_value=('testdist', '42', '')):
+                        self.assertEqual(get_python_os_info(), ("testdist", "42"))
 
             with mock.patch('platform.system_alias',
                             return_value=('freebsd', '9.3-RC3-p1', '')):

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -521,7 +521,8 @@ class OsInfoTest(unittest.TestCase):
             with mock.patch('platform.system_alias',
                             return_value=('linux', '', '')):
                 with mock.patch('platform.linux_distribution',
-                                side_effect=AttributeError):
+                                side_effect=AttributeError,
+                                create=True):
                     with mock.patch('distro.linux_distribution',
                                     return_value=('', '', '')):
                         self.assertEqual(get_python_os_info(), ("linux", ""))

--- a/certbot/util.py
+++ b/certbot/util.py
@@ -392,7 +392,7 @@ def get_python_os_info():
     os_type, os_ver, _ = info
     os_type = os_type.lower()
     if os_type.startswith('linux'):
-        info = distro.linux_distribution()
+        info = _get_linux_distribution()
         # On arch, distro.linux_distribution() is reportedly ('','',''),
         # so handle it defensively
         if info[0]:
@@ -423,6 +423,14 @@ def get_python_os_info():
         # Cases known to fall here: Cygwin python
         os_ver = ''
     return os_type, os_ver
+
+def _get_linux_distribution():
+    """Gets the linux distribution name from the underlying OS"""
+
+    try:
+        return platform.linux_distribution()
+    except AttributeError:
+        return distro.linux_distribution()
 
 # Just make sure we don't get pwned... Make sure that it also doesn't
 # start with a period or have two consecutive periods <- this needs to


### PR DESCRIPTION
Try to primarily fall back to using `platform.linux_distribution()` if `/etc/os-release` isn't available. Only use `distro.linux_distribution()` on Python >= 3.8.