### PR TITLE
Add CentOS 8 support to certbot-auto.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 * Support for Python 3.8 was added to Certbot and all of its components.
+* Support for CentOS 8 was added to certbot-auto.
 
 ### Changed
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -775,6 +775,8 @@ elif [ -f /etc/redhat-release ]; then
     RPM_USE_PYTHON_3=1
   elif [ "$RPM_DIST_NAME" = "rhel" -a "$RPM_DIST_VERSION" -ge 8 ]; then
     RPM_USE_PYTHON_3=1
+  elif [ "$RPM_DIST_NAME" = "centos" -a "$RPM_DIST_VERSION" -ge 8 ]; then
+    RPM_USE_PYTHON_3=1
   else
     RPM_USE_PYTHON_3=0
   fi

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -350,6 +350,8 @@ elif [ -f /etc/redhat-release ]; then
     RPM_USE_PYTHON_3=1
   elif [ "$RPM_DIST_NAME" = "rhel" -a "$RPM_DIST_VERSION" -ge 8 ]; then
     RPM_USE_PYTHON_3=1
+  elif [ "$RPM_DIST_NAME" = "centos" -a "$RPM_DIST_VERSION" -ge 8 ]; then
+    RPM_USE_PYTHON_3=1
   else
     RPM_USE_PYTHON_3=0
   fi


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/7396.

Testing this PR is hard since I'm not aware of anyone offering prebuilt CentOS 8 images yet. Here's what I did though.

First, I looked at the contents of http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-release-8.0-0.1905.0.9.el8.x86_64.rpm which contains the /etc/os-release file. You can see the contents of the file machine like CentOS 7 by downloading the rpm to a temporary directory and running a command like:

```
rpm2cpio centos-release-8.0-0.1905.0.9.el8.x86_64.rpm | cpio -idmv
```

After doing this, there will be an etc folder in your CWD containing os-release.

To actually test this, I installed CentOS 8 in VirtualBox. I downloaded the installation image from https://mirrors.ocf.berkeley.edu/centos/8/isos/x86_64/CentOS-8-x86_64-1905-dvd1.iso but another mirror at https://www.centos.org/download/mirrors/ may be quicker for you if you want to do it yourself. You can compare the hash of your download to the one advertised by CentOS at https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.1905#head-e1e24c827b2c77c9fbb3df9cf5c7914dfd921557.

@adferrand and @joohoi, are you able to be my two reviewers on this PR?