### PR TITLE
Add test farm tests for Debian 10

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -18,6 +18,11 @@ targets:
     user: ubuntu
   #-----------------------------------------------------------------------------
   # Debian
+  - ami: ami-01db78123b2b99496
+    name: debian10
+    type: ubuntu
+    virt: hvm
+    user: admin
   - ami: ami-003f19e0e687de1cd
     name: debian9
     type: ubuntu

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -18,6 +18,11 @@ targets:
     user: ubuntu
   #-----------------------------------------------------------------------------
   # Debian
+  - ami: ami-01db78123b2b99496
+    name: debian10
+    type: ubuntu
+    virt: hvm
+    user: admin
   - ami: ami-003f19e0e687de1cd
     name: debian9
     type: ubuntu


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/7225.

I got the AMI ID from https://wiki.debian.org/Cloud/AmazonEC2Image/Buster.

You can see all test farm tests including `test_tests.sh` passing with these changes at https://travis-ci.com/certbot/certbot/builds/130318446.