### PR TITLE
Use shared variable group

### DIFF
--- a/.azure-pipelines/INSTALL.md
+++ b/.azure-pipelines/INSTALL.md
@@ -112,6 +112,8 @@ steps:
         CODECOV_TOKEN: $(codecov_token)
 ```
 
-- On Azure DevOps, go to you organization, project, pipeline tab
-- Select the pipeline, click "Edit" button, then click "Variables" button
-- Set name (eg `codecov_token`), value, tick "Keep this value secret"
+To set up a variable that is shared between pipelines, follow the instructions
+at
+https://docs.microsoft.com/en-us/azure/devops/pipelines/library/variable-groups.
+When adding variables to a group, don't forget to tick "Keep this value secret"
+if it shouldn't be shared publcily.

--- a/.azure-pipelines/templates/tests-suite.yml
+++ b/.azure-pipelines/templates/tests-suite.yml
@@ -14,6 +14,8 @@ jobs:
           PYTHON_VERSION: 3.7
           TOXENV: integration-certbot
           PYTEST_ADDOPTS: --numprocesses 4
+    variables:
+    - group: certbot-common
     steps:
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
When setting up Azure Pipelines, I didn't like having to define `codecov_token` for each pipeline. This works around it by using a shared variable group.

You can see this working successfully at https://dev.azure.com/certbot/certbot/_build/results?buildId=3.