### PR TITLE
Upload coverage for integration tests

### DIFF
--- a/.azure-pipelines/templates/tests-suite.yml
+++ b/.azure-pipelines/templates/tests-suite.yml
@@ -30,7 +30,7 @@ jobs:
         curl -s https://codecov.io/bash -o codecov-bash || echo "Failed to download codecov-bash"
         chmod +x codecov-bash || echo "Failed to apply execute permissions on codecov-bash"
         ./codecov-bash -F windows  || echo "Codecov did not collect coverage reports"
-      condition: containsValue(['py37-cover', 'integration-certbot'], variables['TOXENV'])
+      condition: in(variables['TOXENV'], 'py37-cover', 'integration-certbot')
       env:
         CODECOV_TOKEN: $(codecov_token)
       displayName: Publish coverage

--- a/.azure-pipelines/templates/tests-suite.yml
+++ b/.azure-pipelines/templates/tests-suite.yml
@@ -30,7 +30,7 @@ jobs:
         curl -s https://codecov.io/bash -o codecov-bash || echo "Failed to download codecov-bash"
         chmod +x codecov-bash || echo "Failed to apply execute permissions on codecov-bash"
         ./codecov-bash -F windows  || echo "Codecov did not collect coverage reports"
-      condition: eq(variables['TOXENV'], 'py37-cover')
+      condition: containsValue(['py37-cover', 'integration-certbot'], variables['TOXENV'])
       env:
         CODECOV_TOKEN: $(codecov_token)
       displayName: Publish coverage


### PR DESCRIPTION
In AppVeyor, we upload coverage from both [unit tests](https://ci.appveyor.com/project/certbot/certbot/builds/27973759/job/c47a2mojahxrmomd#L831) and [integration tests](https://ci.appveyor.com/project/certbot/certbot/builds/27973759/job/hbecdexqvt7fudik#L275). Currently in Azure Pipelines, we only upload coverage from our unit tests which will cause a drop in coverage.

This fixes that by also uploading coverage from our integration tests.