### PR TITLE
cli: allow --dry-run to be combined with --server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 * Removed `--fast` flag from the test farm tests
+* `--server` may now be combined with `--dry-run`. Certbot will, as before, use the
+  staging server instead of the live server when `--dry-run` is used.
 
 ### Fixed
 


### PR DESCRIPTION
The value of --server will now be respected, except when it is the
default value, in which case it will be changed to the staging server,
preserving Certbot's existing behavior.

This change is a prerequisite to dry-run authz deactivation as suggested by @bmw in https://github.com/certbot/certbot/pull/7266#issuecomment-526403040

## Pull Request Checklist

- [x] Edit the `master` section of `CHANGELOG.md` to include a description of
  the change being made.
- [ ] Add [mypy type annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations) for any functions that were added or modified.
- [x] Include your name in `AUTHORS.md` if you like.

NB: I did not add a mypy annotation to `set_test_server` because `parsed_args` is an `OrderedDict`, but I could not work out a way to make mypy happy given how the attributes are being dereferenced (e.g. `parsed_args.server` vs `parsed_args['server']`).