### PR TITLE
Remove warning about 3 year old letsencrypt-auto

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -163,24 +163,6 @@ def report_config_interaction(modified, modifiers):
         VAR_MODIFIERS.setdefault(var, set()).update(modifiers)
 
 
-def possible_deprecation_warning(config):
-    "A deprecation warning for users with the old, not-self-upgrading letsencrypt-auto."
-    if cli_command != LEAUTO:
-        return
-    if config.no_self_upgrade:
-        # users setting --no-self-upgrade might be hanging on a client version like 0.3.0
-        # or 0.5.0 which is the new script, but doesn't set CERTBOT_AUTO; they don't
-        # need warnings
-        return
-    if "CERTBOT_AUTO" not in os.environ:
-        logger.warning("You are running with an old copy of letsencrypt-auto"
-            " that does not receive updates, and is less reliable than more"
-            " recent versions. The letsencrypt client has also been renamed"
-            " to Certbot. We recommend upgrading to the latest certbot-auto"
-            " script, or using native OS packages.")
-        logger.debug("Deprecation warning circumstances: %s / %s", sys.argv[0], os.environ)
-
-
 class _Default(object):
     """A class to use as a default to detect if a value is set by a user"""
 
@@ -641,8 +623,6 @@ class HelpfulArgumentParser(object):
         if parsed_args.hsts and parsed_args.auto_hsts:
             raise errors.Error(
                 "Parameters --hsts and --auto-hsts cannot be used simultaneously.")
-
-        possible_deprecation_warning(parsed_args)
 
         return parsed_args
 


### PR DESCRIPTION
This code prints a warning if you are running on a 3+ year old letsencrypt-auto that doesn't automatically upgrade itself. This functionality was added in our [0.6.0 release](https://github.com/certbot/certbot/blob/v0.6.0/letsencrypt-auto#L77).

I think anyone who will ever act on this warning has seen it by now.