### PR TITLE
Run nightly on Azure even if no commits landed

### DIFF
--- a/.azure-pipelines/advanced.yml
+++ b/.azure-pipelines/advanced.yml
@@ -12,6 +12,7 @@ schedules:
     branches:
       include:
       - master
+    always: true
 
 jobs:
   - template: templates/tests-suite.yml


### PR DESCRIPTION
No nightly builds have run on Azure in 9 days. In https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#scheduled-triggers it says that the default is to only run if the source code changes. I think there is value in always running to catch changes problems in our dependencies, build environment, etc.

This PR changes Azure to always run nightly and you can see the file being successfully parsed by Azure at https://dev.azure.com/certbot/certbot/_build/results?buildId=49.