### PR TITLE
Require newer versions of oauth2client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Removed `--fast` flag from the test farm tests
 * `--server` may now be combined with `--dry-run`. Certbot will, as before, use the
   staging server instead of the live server when `--dry-run` is used.
+* Updated certbot-dns-google to depend on newer versions of
+  google-api-python-client and oauth2client.
 
 ### Fixed
 

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -9,11 +9,9 @@ version = '0.40.0.dev0'
 install_requires = [
     'acme>=0.29.0',
     'certbot>=0.39.0',
-    # 1.5 is the first version that supports oauth2client>=2.0
-    'google-api-python-client>=1.5',
+    'google-api-python-client>=1.5.5',
     'mock',
-    # for oauth2client.service_account.ServiceAccountCredentials
-    'oauth2client>=2.0',
+    'oauth2client>=4.0',
     'setuptools',
     'zope.interface',
     # already a dependency of google-api-python-client, but added for consistency

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -4,6 +4,7 @@
 # files during tests (eg. letsencrypt-auto-source/pieces/dependency-requirements.txt).
 alabaster==0.7.10
 apipkg==1.4
+appnope==0.1.0
 asn1crypto==0.22.0
 astroid==1.6.5
 attrs==17.3.0
@@ -15,6 +16,7 @@ botocore==1.12.36
 cloudflare==1.5.1
 codecov==2.0.15
 configparser==3.7.4
+contextlib2==0.6.0.post1
 coverage==4.5.4
 decorator==4.1.2
 dns-lexicon==3.2.1
@@ -23,9 +25,11 @@ docutils==0.12
 execnet==1.5.0
 future==0.16.0
 futures==3.1.1
+filelock==3.0.12
 google-api-python-client==1.5.5
 httplib2==0.10.3
 imagesize==0.7.1
+importlib-metadata==0.23
 ipdb==0.10.2
 ipython==5.5.0
 ipython-genutils==0.2.0
@@ -38,9 +42,11 @@ logger==1.4
 logilab-common==1.4.1
 MarkupSafe==1.0
 mccabe==0.6.1
+more-itertools==5.0.0
 mypy==0.600
 ndg-httpsclient==0.3.2
 oauth2client==4.0.0
+packaging==19.2
 pathlib2==2.3.0
 pexpect==4.7.0
 pickleshare==0.7.4
@@ -79,13 +85,15 @@ Sphinx==1.7.5
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-websupport==1.0.1
 tldextract==2.2.0
+toml==0.10.0
 tox==3.14.0
 tqdm==4.19.4
 traitlets==4.3.2
 twine==1.11.0
 typed-ast==1.1.0
 typing==3.6.4
-uritemplate==0.6
+uritemplate==3.0.0
 virtualenv==16.6.2
 wcwidth==0.1.7
 wrapt==1.11.1
+zipp==0.6.0

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -23,7 +23,7 @@ docutils==0.12
 execnet==1.5.0
 future==0.16.0
 futures==3.1.1
-google-api-python-client==1.5
+google-api-python-client==1.5.5
 httplib2==0.10.3
 imagesize==0.7.1
 ipdb==0.10.2
@@ -40,7 +40,7 @@ MarkupSafe==1.0
 mccabe==0.6.1
 mypy==0.600
 ndg-httpsclient==0.3.2
-oauth2client==2.0.0
+oauth2client==4.0.0
 pathlib2==2.3.0
 pexpect==4.7.0
 pickleshare==0.7.4

--- a/tools/oldest_constraints.txt
+++ b/tools/oldest_constraints.txt
@@ -16,6 +16,7 @@ pyOpenSSL==0.13.1
 pyparsing==1.5.6
 pyRFC3339==1.0
 python-augeas==0.5.0
+oauth2client==4.0.0
 six==1.9.0
 # setuptools 0.9.8 is the actual version packaged, but some other dependencies
 # in this file require setuptools>=1.0 and there are no relevant changes for us
@@ -35,11 +36,12 @@ idna==2.0
 pbr==1.8.0
 pytz==2012rc0
 
+# Debian Buster constraints
+google-api-python-client==1.5.5
+
 # Our setup.py constraints
 cloudflare==1.5.1
 cryptography==1.2.3
-google-api-python-client==1.5
-oauth2client==2.0
 parsedatetime==1.3
 pyparsing==1.5.5
 python-digitalocean==1.11


### PR DESCRIPTION
Over the weekend, nightly tests on Windows failed for certbot-dns-google: https://dev.azure.com/certbot/web/build.aspx?pcguid=74ef9c03-9faf-405b-9d03-9acf8c43e8d6&builduri=vstfs%3a%2f%2f%2fBuild%2fBuild%2f72

The error occurred inside `oauth2client`'s locking code and the failure seems spurious as it did not reproduce this morning: https://dev.azure.com/certbot/certbot/_build/results?buildId=73

I could not find a relevant changelog entry in `oauth2client` saying they've fixed the problem, but the problematic code no longer exists in `oauth2client>=4.0`. This PR updates our minimum dependency required in an attempt to avoid spurious failures for us in the future. The only downside I am aware of is it'll make it harder for certbot-dns-google to be packaged in Debian Old Stable or Ubuntu 16.04, but I don't expect either of those things to happen anytime soon.