### PR TITLE
Run at 4:00AM UTC not 0:04AM UTC.

### DIFF
--- a/.azure-pipelines/advanced.yml
+++ b/.azure-pipelines/advanced.yml
@@ -7,7 +7,7 @@ pr:
   - '*.x'
 # This pipeline is also nightly run on master
 schedules:
-  - cron: "4 0 * * *"
+  - cron: "0 4 * * *"
     displayName: Nightly build
     branches:
       include:


### PR DESCRIPTION
Fixes [cron syntax](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#supported-cron-syntax) to get the behavior I had in mind in https://github.com/certbot/certbot/pull/7377#discussion_r331295897.