### PR TITLE
Deprecate certbot.plugins.common.TLSSNI01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Updated certbot-dns-google to depend on newer versions of
   google-api-python-client and oauth2client.
 * Migrated CentOS 6 certbot-auto users from Python 3.4 to Python 3.6.
+* certbot.plugins.common.TLSSNI01 has been deprecated and will be removed in a
+  future release.
 
 ### Fixed
 

--- a/certbot-apache/certbot_apache/http_01.py
+++ b/certbot-apache/certbot_apache/http_01.py
@@ -14,7 +14,7 @@ from certbot_apache.parser import get_aug_path
 logger = logging.getLogger(__name__)
 
 
-class ApacheHttp01(common.TLSSNI01):
+class ApacheHttp01(common.ChallengePerformer):
     """Class that performs HTTP-01 challenges within the Apache configurator."""
 
     CONFIG_TEMPLATE22_PRE = """\

--- a/certbot/plugins/common.py
+++ b/certbot/plugins/common.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import shutil
+import sys
 import tempfile
 import warnings
 
@@ -503,3 +504,34 @@ def dir_setup(test_dir, pkg):  # pragma: no cover
         test_configs, os.path.join(temp_dir, test_dir), symlinks=True)
 
     return temp_dir, config_dir, work_dir
+
+
+# This class takes a similar approach to the cryptography project to deprecate attributes
+# in public modules. See the _ModuleWithDeprecation class here:
+# https://github.com/pyca/cryptography/blob/91105952739442a74582d3e62b3d2111365b0dc7/src/cryptography/utils.py#L129
+class _TLSSNI01DeprecationModule(object):
+    """
+    Internal class delegating to a module, and displaying warnings when
+    attributes related to TLS-SNI-01 are accessed.
+    """
+    def __init__(self, module):
+        self.__dict__['_module'] = module
+
+    def __getattr__(self, attr):
+        if attr == 'TLSSNI01':
+            warnings.warn('TLSSNI01 is deprecated and will be removed soon.',
+                          DeprecationWarning, stacklevel=2)
+        return getattr(self._module, attr)
+
+    def __setattr__(self, attr, value):  # pragma: no cover
+        setattr(self._module, attr, value)
+
+    def __delattr__(self, attr):  # pragma: no cover
+        delattr(self._module, attr)
+
+    def __dir__(self):  # pragma: no cover
+        return ['_module'] + dir(self._module)
+
+
+# Patching ourselves to warn about TLS-SNI challenge deprecation and removal.
+sys.modules[__name__] = _TLSSNI01DeprecationModule(sys.modules[__name__])

--- a/certbot/plugins/common_test.py
+++ b/certbot/plugins/common_test.py
@@ -352,6 +352,11 @@ class TLSSNI01Test(unittest.TestCase):
         self.assertEqual(self.sni.get_z_domain(achall),
             achall.response(achall.account_key).z_domain.decode("utf-8"))
 
+    def test_warning(self):
+        with mock.patch('certbot.plugins.common.warnings.warn') as mock_warn:
+            from certbot.plugins.common import TLSSNI01  # pylint: disable=unused-variable
+        self.assertTrue(mock_warn.call_args[0][0].startswith('TLSSNI01'))
+
 
 class InstallVersionControlledFileTest(test_util.TempDirTestCase):
     """Tests for certbot.plugins.common.install_version_controlled_file."""


### PR DESCRIPTION
While working on https://github.com/certbot/certbot/issues/7214, I noticed that `certbot.plugins.common.TLSSNI01` wasn't printing a deprecation warning and it was still being used in our Apache plugin. This PR fixes that.

I would like to get this PR into the next release so we can remove certbot.plugins.common.TLSSNI01 for Certbot 1.0.