### PR TITLE
Remove references to TLS-SNI-01 outside of ACME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Updated certbot-dns-google to depend on newer versions of
   google-api-python-client and oauth2client.
 * Migrated CentOS 6 certbot-auto users from Python 3.4 to Python 3.6.
+* CLI flags --tls-sni-01-port and --tls-sni-01-address have been removed.
+* The values tls-sni and tls-sni-01 for the --preferred-challenges flag are no
+  longer accepted.
 
 ### Fixed
 

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -1296,13 +1296,13 @@ class MultipleVhostsTest(util.ApacheTest):
         account_key = self.rsa512jwk
         achall1 = achallenges.KeyAuthorizationAnnotatedChallenge(
             challb=acme_util.chall_to_challb(
-                challenges.TLSSNI01(
+                challenges.HTTP01(
                     token=b"jIq_Xy1mXGN37tb4L6Xj_es58fW571ZNyXekdZzhh7Q"),
                 "pending"),
             domain="encryption-example.demo", account_key=account_key)
         achall2 = achallenges.KeyAuthorizationAnnotatedChallenge(
             challb=acme_util.chall_to_challb(
-                challenges.TLSSNI01(
+                challenges.HTTP01(
                     token=b"uqnaPzxtrndteOqtrXb0Asl5gOJfWAnnx6QJyvcmlDU"),
                 "pending"),
             domain="certbot.demo", account_key=account_key)

--- a/certbot-apache/docs/api/tls_sni_01.rst
+++ b/certbot-apache/docs/api/tls_sni_01.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_apache.tls_sni_01`
-------------------------------------
-
-.. automodule:: certbot_apache.tls_sni_01
-   :members:

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -1107,7 +1107,7 @@ class NginxConfigurator(common.Installer):
     ###########################################################################
     def get_chall_pref(self, unused_domain):  # pylint: disable=no-self-use
         """Return list of challenge preferences."""
-        return [challenges.HTTP01, challenges.TLSSNI01]
+        return [challenges.HTTP01]
 
     # Entry point in main.py for performing challenges
     def perform(self, achalls):

--- a/certbot-nginx/certbot_nginx/http_01.py
+++ b/certbot-nginx/certbot_nginx/http_01.py
@@ -29,10 +29,10 @@ class NginxHttp01(common.ChallengePerformer):
     :param list indices: Meant to hold indices of challenges in a
         larger array. NginxHttp01 is capable of solving many challenges
         at once which causes an indexing issue within NginxConfigurator
-        who must return all responses in order.  Imagine NginxConfigurator
-        maintaining state about where all of the http-01 Challenges,
-        TLS-SNI-01 Challenges belong in the response array.  This is an
-        optional utility.
+        who must return all responses in order. Imagine
+        NginxConfigurator maintaining state about where all of the
+        challenges, possibly of different types, belong in the response
+        array. This is an optional utility.
 
     """
 

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -97,7 +97,7 @@ class NginxConfiguratorTest(util.NginxTest):
             errors.PluginError, self.config.enhance, 'myhost', 'unknown_enhancement')
 
     def test_get_chall_pref(self):
-        self.assertEqual([challenges.HTTP01, challenges.TLSSNI01],
+        self.assertEqual([challenges.HTTP01],
                          self.config.get_chall_pref('myhost'))
 
     def test_save(self):

--- a/certbot-nginx/certbot_nginx/tests/http_01_test.py
+++ b/certbot-nginx/certbot_nginx/tests/http_01_test.py
@@ -73,11 +73,11 @@ class HttpPerformTest(util.NginxTest):
             self.http01.add_chall(achall)
             acme_responses.append(achall.response(self.account_key))
 
-        sni_responses = self.http01.perform()
+        http_responses = self.http01.perform()
 
-        self.assertEqual(len(sni_responses), 4)
+        self.assertEqual(len(http_responses), 4)
         for i in six.moves.range(4):
-            self.assertEqual(sni_responses[i], acme_responses[i])
+            self.assertEqual(http_responses[i], acme_responses[i])
 
     def test_mod_config(self):
         self.http01.add_chall(self.achalls[0])

--- a/certbot-nginx/docs/api/tls_sni_01.rst
+++ b/certbot-nginx/docs/api/tls_sni_01.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_nginx.tls_sni_01`
------------------------------------
-
-.. automodule:: certbot_nginx.tls_sni_01
-   :members:

--- a/certbot/auth_handler.py
+++ b/certbot/auth_handler.py
@@ -182,9 +182,6 @@ class AuthHandler(object):
 
             achalls.extend(self._challenge_factory(authzr, path))
 
-        if any(isinstance(achall.chall, challenges.TLSSNI01) for achall in achalls):
-            logger.warning("TLS-SNI-01 is deprecated, and will stop working soon.")
-
         return achalls
 
     def _get_chall_pref(self, domain):

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1249,17 +1249,6 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
     helpful.add_deprecated_argument("--agree-dev-preview", 0)
     helpful.add_deprecated_argument("--dialog", 0)
 
-    # Deprecation of tls-sni-01 related cli flags
-    # TODO: remove theses flags completely in few releases
-    class _DeprecatedTLSSNIAction(util._ShowWarning):  # pylint: disable=protected-access
-        def __call__(self, parser, namespace, values, option_string=None):
-            super(_DeprecatedTLSSNIAction, self).__call__(parser, namespace, values, option_string)
-            namespace.https_port = values
-    helpful.add(
-        ["testing", "standalone", "apache", "nginx"], "--tls-sni-01-port",
-        type=int, action=_DeprecatedTLSSNIAction, help=argparse.SUPPRESS)
-    helpful.add_deprecated_argument("--tls-sni-01-address", 1)
-
     # Populate the command line parameters for new style enhancements
     enhancements.populate_cli(helpful.add)
 
@@ -1546,17 +1535,9 @@ def parse_preferred_challenges(pref_challs):
     :raises errors.Error: if pref_challs is invalid
 
     """
-    aliases = {"dns": "dns-01", "http": "http-01", "tls-sni": "tls-sni-01"}
+    aliases = {"dns": "dns-01", "http": "http-01"}
     challs = [c.strip() for c in pref_challs]
     challs = [aliases.get(c, c) for c in challs]
-
-    # Ignore tls-sni-01 from the list, and generates a deprecation warning
-    # TODO: remove this option completely in few releases
-    if "tls-sni-01" in challs:
-        logger.warning('TLS-SNI-01 support is deprecated. This value is being dropped from the '
-                       'setting of --preferred-challenges and future versions of Certbot will '
-                       'error if it is included.')
-        challs = [chall for chall in challs if chall != "tls-sni-01"]
 
     unrecognized = ", ".join(name for name in challs
                              if name not in challenges.Challenge.TYPES)

--- a/certbot/tests/acme_util.py
+++ b/certbot/tests/acme_util.py
@@ -18,12 +18,10 @@ KEY = util.load_rsa_private_key('rsa512_key.pem')
 # Challenges
 HTTP01 = challenges.HTTP01(
     token=b"evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+oA")
-TLSSNI01 = challenges.TLSSNI01(
-    token=jose.b64decode(b"evaGxfADs6pSRb2LAv9IZf17Dt3juxGJyPCt92wrDoA"))
 DNS01 = challenges.DNS01(token=b"17817c66b60ce2e4012dfad92657527a")
 DNS01_2 = challenges.DNS01(token=b"cafecafecafecafecafecafe0feedbac")
 
-CHALLENGES = [HTTP01, TLSSNI01, DNS01]
+CHALLENGES = [HTTP01, DNS01]
 
 
 def gen_combos(challbs):
@@ -47,21 +45,19 @@ def chall_to_challb(chall, status):  # pylint: disable=redefined-outer-name
 
 
 # Pending ChallengeBody objects
-TLSSNI01_P = chall_to_challb(TLSSNI01, messages.STATUS_PENDING)
 HTTP01_P = chall_to_challb(HTTP01, messages.STATUS_PENDING)
 DNS01_P = chall_to_challb(DNS01, messages.STATUS_PENDING)
 DNS01_P_2 = chall_to_challb(DNS01_2, messages.STATUS_PENDING)
 
-CHALLENGES_P = [HTTP01_P, TLSSNI01_P, DNS01_P]
+CHALLENGES_P = [HTTP01_P, DNS01_P]
 
 
 # AnnotatedChallenge objects
 HTTP01_A = auth_handler.challb_to_achall(HTTP01_P, JWK, "example.com")
-TLSSNI01_A = auth_handler.challb_to_achall(TLSSNI01_P, JWK, "example.net")
 DNS01_A = auth_handler.challb_to_achall(DNS01_P, JWK, "example.org")
 DNS01_A_2 = auth_handler.challb_to_achall(DNS01_P_2, JWK, "esimerkki.example.org")
 
-ACHALLENGES = [HTTP01_A, TLSSNI01_A, DNS01_A]
+ACHALLENGES = [HTTP01_A, DNS01_A]
 
 
 def gen_authzr(authz_status, domain, challs, statuses, combos=True):

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -39,7 +39,7 @@ class ChallengeFactoryTest(unittest.TestCase):
         self.assertEqual(
             [achall.chall for achall in achalls], acme_util.CHALLENGES)
 
-    def test_one_tls_http(self):
+    def test_one_http(self):
         achalls = self.handler._challenge_factory(self.authzr, [0])
 
         self.assertEqual(

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -342,7 +342,8 @@ class HandleAuthorizationsTest(unittest.TestCase):  # pylint: disable=too-many-p
         self.assertTrue('All challenges have failed.' in str(error.exception))
 
     def test_validated_challenge_not_rerun(self):
-        # With pending challenge, we expect the challenge to be tried, and fail.
+        # With a pending challenge that is not supported by the plugin, we
+        # expect an exception to be raised.
         authzr = acme_util.gen_authzr(
                 messages.STATUS_PENDING, "0",
                 [acme_util.DNS01],
@@ -351,7 +352,9 @@ class HandleAuthorizationsTest(unittest.TestCase):  # pylint: disable=too-many-p
         self.assertRaises(
             errors.AuthorizationError, self.handler.handle_authorizations, mock_order)
 
-        # With validated challenge; we expect the challenge not be tried again, and succeed.
+        # With a validated challenge that is not supported by the plugin, we
+        # expect the challenge to not be solved again and
+        # handle_authorizations() to succeed.
         authzr = acme_util.gen_authzr(
                 messages.STATUS_VALID, "0",
                 [acme_util.DNS01],

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -249,13 +249,6 @@ class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
         expected = [challenges.HTTP01.typ, challenges.DNS01.typ]
         self.assertEqual(namespace.pref_challs, expected)
 
-        # TODO: to be removed once tls-sni deprecation logic is removed
-        with mock.patch('certbot.cli.logger.warning') as mock_warn:
-            self.assertEqual(self.parse(['--preferred-challenges', 'http, tls-sni']).pref_challs,
-                             [challenges.HTTP01.typ])
-        self.assertEqual(mock_warn.call_count, 1)
-        self.assertTrue('deprecated' in mock_warn.call_args[0][0])
-
         short_args = ['--preferred-challenges', 'jumping-over-the-moon']
         # argparse.ArgumentError makes argparse print more information
         # to stderr and call sys.exit()

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -75,15 +75,10 @@ class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
     @mock.patch('certbot.renewal.cli.set_by_cli')
     def test_pref_challs_list(self, mock_set_by_cli):
         mock_set_by_cli.return_value = False
-        # TODO: remove tls-sni and related assertions to logger.warning call once
-        #  the deprecation logic has been removed
-        renewalparams = {'pref_challs': 'tls-sni, http-01, dns'.split(',')}
-        with mock.patch('certbot.renewal.cli.logger.warning') as mock_warn:
-            self._call(self.config, renewalparams)
+        renewalparams = {'pref_challs': 'http-01, dns'.split(',')}
+        self._call(self.config, renewalparams)
         expected = [challenges.HTTP01.typ, challenges.DNS01.typ]
         self.assertEqual(self.config.pref_challs, expected)
-        self.assertEqual(mock_warn.call_count, 1)
-        self.assertTrue('deprecated' in mock_warn.call_args[0][0])
 
     @mock.patch('certbot.renewal.cli.set_by_cli')
     def test_pref_challs_str(self, mock_set_by_cli):

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -234,7 +234,7 @@ Authenticators
 
 Authenticators are plugins that prove control of a domain name by solving a
 challenge provided by the ACME server. ACME currently defines several types of
-challenges: HTTP, TLS-SNI (deprecated), TLS-ALPR, and DNS, represented by classes in `acme.challenges`.
+challenges: HTTP, TLS-ALPN, and DNS, represented by classes in `acme.challenges`.
 An authenticator plugin should implement support for at least one challenge type.
 
 An Authenticator indicates which challenges it supports by implementing


### PR DESCRIPTION
This is a big part of https://github.com/certbot/certbot/issues/7214. It removes all references to TLS-SNI-01 outside of `acme` (and `pytest.ini`). Those changes will come in a subsequent PR. I thought this one was getting big enough.