### PR TITLE
Add EC key option

### DIFF
--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -629,8 +629,9 @@ class NginxConfigurator(common.Installer):
         """Generate invalid certs that let us create ssl directives for Nginx"""
         # TODO: generate only once
         tmp_dir = os.path.join(self.config.work_dir, "snakeoil")
+        key_prop = { "key_type": "rsa", "key_size": 1024 }
         le_key = crypto_util.init_save_key(
-            key_size=1024, key_dir=tmp_dir, keyname="key.pem")
+            key_prop, key_dir=tmp_dir, keyname="key.pem")
         key = OpenSSL.crypto.load_privatekey(
             OpenSSL.crypto.FILETYPE_PEM, le_key.pem)
         cert = acme_crypto_util.gen_ss_cert(key, domains=[socket.gethostname()])

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -629,7 +629,7 @@ class NginxConfigurator(common.Installer):
         """Generate invalid certs that let us create ssl directives for Nginx"""
         # TODO: generate only once
         tmp_dir = os.path.join(self.config.work_dir, "snakeoil")
-        key_prop = { "key_type": "rsa", "key_size": 1024 }
+        key_prop = {"key_type": "rsa", "key_size": 1024}
         le_key = crypto_util.init_save_key(
             key_prop, key_dir=tmp_dir, keyname="key.pem")
         key = OpenSSL.crypto.load_privatekey(

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1127,6 +1127,10 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
         "security", "--rsa-key-size", type=int, metavar="N",
         default=flag_default("rsa_key_size"), help=config_help("rsa_key_size"))
     helpful.add(
+        ["testing", "certonly", "renew", "run"], "--curve-type", dest="curve_type",
+        default=flag_default("curve_type"),
+        help="EC curve type (prime256v1, ... etc.)")
+    helpful.add(
         "security", "--must-staple", action="store_true",
         dest="must_staple", default=flag_default("must_staple"),
         help=config_help("must_staple"))

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -336,8 +336,8 @@ class Client(object):
         # Create CSR from names
         if self.config.dry_run:
             key = key or util.Key(file=None,
-                                  pem=crypto_util.make_key({"key_type": (self.config.curve_type or "rsa"),
-                                                            "key_size": self.config.rsa_key_size}))
+                  pem=crypto_util.make_key({"key_type": (self.config.curve_type or "rsa"),
+                                            "key_size": self.config.rsa_key_size}))
             csr = util.CSR(file=None, form="pem",
                            data=acme_crypto_util.make_csr(
                                key.pem, domains, self.config.must_staple))

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -333,15 +333,23 @@ class Client(object):
             # The key is set to None here but will be created below.
             key = None
 
+        # Prepare key property
+        key_prop = {
+            "key_type": "rsa",
+            "key_size": self.config.rsa_key_size
+        }
+        if self.config.curve_type:
+            key_prop["key_type"] = self.config.curve_type
+
         # Create CSR from names
         if self.config.dry_run:
             key = key or util.Key(file=None,
-                                  pem=crypto_util.make_key(self.config.rsa_key_size))
+                                  pem=crypto_util.make_key(key_prop))
             csr = util.CSR(file=None, form="pem",
                            data=acme_crypto_util.make_csr(
                                key.pem, domains, self.config.must_staple))
         else:
-            key = key or crypto_util.init_save_key(self.config.rsa_key_size,
+            key = key or crypto_util.init_save_key(key_prop,
                                                    self.config.key_dir)
             csr = crypto_util.init_save_csr(key, domains, self.config.csr_dir)
 

--- a/certbot/client.py
+++ b/certbot/client.py
@@ -333,23 +333,17 @@ class Client(object):
             # The key is set to None here but will be created below.
             key = None
 
-        # Prepare key property
-        key_prop = {
-            "key_type": "rsa",
-            "key_size": self.config.rsa_key_size
-        }
-        if self.config.curve_type:
-            key_prop["key_type"] = self.config.curve_type
-
         # Create CSR from names
         if self.config.dry_run:
             key = key or util.Key(file=None,
-                                  pem=crypto_util.make_key(key_prop))
+                                  pem=crypto_util.make_key({"key_type": (self.config.curve_type or "rsa"),
+                                                            "key_size": self.config.rsa_key_size}))
             csr = util.CSR(file=None, form="pem",
                            data=acme_crypto_util.make_csr(
                                key.pem, domains, self.config.must_staple))
         else:
-            key = key or crypto_util.init_save_key(key_prop,
+            key = key or crypto_util.init_save_key({"key_type": (self.config.curve_type or "rsa"),
+                                                    "key_size": self.config.rsa_key_size},
                                                    self.config.key_dir)
             csr = crypto_util.init_save_csr(key, domains, self.config.csr_dir)
 

--- a/certbot/constants.py
+++ b/certbot/constants.py
@@ -73,6 +73,7 @@ CLI_DEFAULTS = dict(
     random_sleep_on_renew=True,
     eab_hmac_key=None,
     eab_kid=None,
+    curve_type=None,
 
     # Subparsers
     num=None,

--- a/certbot/crypto_util.py
+++ b/certbot/crypto_util.py
@@ -185,22 +185,24 @@ def make_key(key_prop):
     :rtype: str
 
     """
+    key_str = ""
     if key_prop["key_type"] == "rsa":
         bits = key_prop["key_size"]
         assert bits >= 1024  # XXX
         key = crypto.PKey()
         key.generate_key(crypto.TYPE_RSA, bits)
-        return crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
+        key_str = crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
     else:
         curve_type = key_prop["key_type"]
         assert curve_type in ec._CURVE_TYPES  # XXX
         cv = ec._CURVE_TYPES[curve_type]
         key = ec.generate_private_key(cv(), default_backend())
-        return key.private_bytes(
+        key_str =  key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.TraditionalOpenSSL,
             encryption_algorithm=serialization.NoEncryption()
 	)
+    return key_str
 
 def valid_privkey(privkey):
     """Is valid RSA private key?

--- a/certbot/crypto_util.py
+++ b/certbot/crypto_util.py
@@ -197,7 +197,7 @@ def make_key(key_prop):
         assert curve_type in ec._CURVE_TYPES  # XXX
         cv = ec._CURVE_TYPES[curve_type]
         key = ec.generate_private_key(cv(), default_backend())
-        key_str =  key.private_bytes(
+        key_str = key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.TraditionalOpenSSL,
             encryption_algorithm=serialization.NoEncryption()

--- a/certbot/renewal.py
+++ b/certbot/renewal.py
@@ -34,7 +34,8 @@ logger = logging.getLogger(__name__)
 # the renewal configuration process loses this information.
 STR_CONFIG_ITEMS = ["config_dir", "logs_dir", "work_dir", "user_agent",
                     "server", "account", "authenticator", "installer",
-                    "renew_hook", "pre_hook", "post_hook", "http01_address"]
+                    "renew_hook", "pre_hook", "post_hook", "http01_address",
+                    "curve_type"]
 INT_CONFIG_ITEMS = ["rsa_key_size", "http01_port"]
 BOOL_CONFIG_ITEMS = ["must_staple", "allow_subset_of_names", "reuse_key",
                      "autorenew"]

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -316,8 +316,9 @@ class ClientTest(ClientTestCommon):
 
         self._test_obtain_certificate_common(mock.sentinel.key, csr)
 
+        key_prop = { "key_type": "rsa", "key_size": self.config.rsa_key_size }
         mock_crypto_util.init_save_key.assert_called_once_with(
-            self.config.rsa_key_size, self.config.key_dir)
+            key_prop, self.config.key_dir)
         mock_crypto_util.init_save_csr.assert_called_once_with(
             mock.sentinel.key, self.eg_domains, self.config.csr_dir)
         mock_crypto_util.cert_and_chain_from_fullchain.assert_called_once_with(
@@ -353,7 +354,8 @@ class ClientTest(ClientTestCommon):
         self.client.config.dry_run = True
         self._test_obtain_certificate_common(key, csr)
 
-        mock_crypto.make_key.assert_called_once_with(self.config.rsa_key_size)
+        key_prop = { "key_type": "rsa", "key_size": self.config.rsa_key_size }
+        mock_crypto.make_key.assert_called_once_with(key_prop)
         mock_acme_crypto.make_csr.assert_called_once_with(
             mock.sentinel.key_pem, self.eg_domains, self.config.must_staple)
         mock_crypto.init_save_key.assert_not_called()

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -316,7 +316,7 @@ class ClientTest(ClientTestCommon):
 
         self._test_obtain_certificate_common(mock.sentinel.key, csr)
 
-        key_prop = { "key_type": "rsa", "key_size": self.config.rsa_key_size }
+        key_prop = {"key_type": "rsa", "key_size": self.config.rsa_key_size}
         mock_crypto_util.init_save_key.assert_called_once_with(
             key_prop, self.config.key_dir)
         mock_crypto_util.init_save_csr.assert_called_once_with(
@@ -354,7 +354,7 @@ class ClientTest(ClientTestCommon):
         self.client.config.dry_run = True
         self._test_obtain_certificate_common(key, csr)
 
-        key_prop = { "key_type": "rsa", "key_size": self.config.rsa_key_size }
+        key_prop = {"key_type": "rsa", "key_size": self.config.rsa_key_size}
         mock_crypto.make_key.assert_called_once_with(key_prop)
         mock_acme_crypto.make_csr.assert_called_once_with(
             mock.sentinel.key_pem, self.eg_domains, self.config.must_staple)

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -45,7 +45,8 @@ class InitSaveKeyTest(test_util.TempDirTestCase):
     @classmethod
     def _call(cls, key_size, key_dir):
         from certbot.crypto_util import init_save_key
-        return init_save_key(key_size, key_dir, 'key-certbot.pem')
+        key_prop = { "key_type": "rsa", "key_size": key_size }
+        return init_save_key(key_prop, key_dir, 'key-certbot.pem')
 
     @mock.patch('certbot.crypto_util.make_key')
     def test_success(self, mock_make):
@@ -170,8 +171,9 @@ class MakeKeyTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
     def test_it(self):  # pylint: disable=no-self-use
         from certbot.crypto_util import make_key
         # Do not test larger keys as it takes too long.
+        key_prop = { "key_type": "rsa", "key_size": 1024 }
         OpenSSL.crypto.load_privatekey(
-            OpenSSL.crypto.FILETYPE_PEM, make_key(1024))
+            OpenSSL.crypto.FILETYPE_PEM, make_key(key_prop))
 
 
 class VerifyCertSetup(unittest.TestCase):

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -45,7 +45,7 @@ class InitSaveKeyTest(test_util.TempDirTestCase):
     @classmethod
     def _call(cls, key_size, key_dir):
         from certbot.crypto_util import init_save_key
-        key_prop = { "key_type": "rsa", "key_size": key_size }
+        key_prop = {"key_type": "rsa", "key_size": key_size}
         return init_save_key(key_prop, key_dir, 'key-certbot.pem')
 
     @mock.patch('certbot.crypto_util.make_key')
@@ -171,7 +171,7 @@ class MakeKeyTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
     def test_it(self):  # pylint: disable=no-self-use
         from certbot.crypto_util import make_key
         # Do not test larger keys as it takes too long.
-        key_prop = { "key_type": "rsa", "key_size": 1024 }
+        key_prop = {"key_type": "rsa", "key_size": 1024}
         OpenSSL.crypto.load_privatekey(
             OpenSSL.crypto.FILETYPE_PEM, make_key(key_prop))
 


### PR DESCRIPTION
### Changes
-  Added --curve-type command line option to indicate EC key type. Types are one of _CURVE_TYPES from cryptography.hazmat.primitives.asymmetric.ec. e.g. prive256v1, ...
-  If --curve-type is not none, EC private key will be generated. --rsa-key-size is ignored.
-  If No --curve-type option, RSA privvate key will be generated as usual.
-  --curve-type value will be saved in renewal configuration.
-  --curve-type rsa is valid as side-effect.
