### PR TITLE
Deprecate more code related to TLS-SNI-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * CLI flags --tls-sni-01-port and --tls-sni-01-address have been removed.
 * The values tls-sni and tls-sni-01 for the --preferred-challenges flag are no
   longer accepted.
+* acme.standalone.BaseRequestHandlerWithLogging and
+  acme.standalone.simple_tls_sni_01_server have been deprecated and will be
+  removed in a future release of the library.
 
 ### Fixed
 

--- a/acme/acme/__init__.py
+++ b/acme/acme/__init__.py
@@ -35,7 +35,7 @@ class _TLSSNI01DeprecationModule(object):
         self.__dict__['_module'] = module
 
     def __getattr__(self, attr):
-        if 'TLSSNI01' in attr:
+        if 'TLSSNI01' in attr or attr == 'BaseRequestHandlerWithLogging':
             warnings.warn('{0} attribute is deprecated, and will be removed soon.'.format(attr),
                           DeprecationWarning, stacklevel=2)
         return getattr(self._module, attr)

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -7,6 +7,7 @@ import os
 import socket
 import sys
 import threading
+import warnings
 
 from six.moves import BaseHTTPServer  # type: ignore  # pylint: disable=import-error
 from six.moves import http_client  # pylint: disable=import-error
@@ -267,6 +268,9 @@ class HTTP01RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
 def simple_tls_sni_01_server(cli_args, forever=True):
     """Run simple standalone TLSSNI01 server."""
+    warnings.warn(
+        'simple_tls_sni_01_server is deprecated and will be removed soon.',
+        DeprecationWarning, stacklevel=2)
     logging.basicConfig(level=logging.DEBUG)
 
     parser = argparse.ArgumentParser()
@@ -299,7 +303,3 @@ def simple_tls_sni_01_server(cli_args, forever=True):
 
 # Patching ourselves to warn about TLS-SNI challenge deprecation and removal.
 sys.modules[__name__] = _TLSSNI01DeprecationModule(sys.modules[__name__])
-
-
-if __name__ == "__main__":
-    sys.exit(simple_tls_sni_01_server(sys.argv))  # pragma: no cover

--- a/acme/acme/standalone_test.py
+++ b/acme/acme/standalone_test.py
@@ -6,6 +6,7 @@ import socket
 import threading
 import tempfile
 import unittest
+import warnings
 import time
 from contextlib import closing
 
@@ -65,6 +66,16 @@ class TLSSNI01ServerTest(unittest.TestCase):
             b'localhost', host=host, port=port, timeout=1)
         self.assertEqual(jose.ComparableX509(cert),
                          jose.ComparableX509(self.certs[b'localhost'][1]))
+
+
+class BaseRequestHandlerWithLoggingTest(unittest.TestCase):
+    """Test for acme.standalone.BaseRequestHandlerWithLogging."""
+
+    def test_it(self):
+        with mock.patch('acme.standalone.warnings.warn') as mock_warn:
+            # pylint: disable=unused-variable
+            from acme.standalone import BaseRequestHandlerWithLogging
+        mock_warn.call_args[0][0].startswith('BaseRequestHandlerWithLogging')
 
 
 class HTTP01ServerTest(unittest.TestCase):
@@ -266,8 +277,7 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self.port = sock.getsockname()[1]
 
-        from acme.standalone import simple_tls_sni_01_server
-        self.process = multiprocessing.Process(target=simple_tls_sni_01_server,
+        self.process = multiprocessing.Process(target=_simple_tls_sni_01_server_no_warnings,
                                                args=(['path', '-p', str(self.port)],))
         self.old_cwd = os.getcwd()
         os.chdir(self.test_cwd)
@@ -284,8 +294,8 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
 
     @mock.patch('acme.standalone.TLSSNI01Server.handle_request')
     def test_mock(self, handle):
-        from acme.standalone import simple_tls_sni_01_server
-        simple_tls_sni_01_server(cli_args=['path', '-p', str(self.port)], forever=False)
+        _simple_tls_sni_01_server_no_warnings(cli_args=['path', '-p', str(self.port)],
+                                              forever=False)
         self.assertEqual(handle.call_count, 1)
 
     def test_live(self):
@@ -300,6 +310,13 @@ class TestSimpleTLSSNI01Server(unittest.TestCase):
                 pass
         self.assertEqual(jose.ComparableX509(cert),
                          test_util.load_comparable_cert('rsa2048_cert.pem'))
+
+
+def _simple_tls_sni_01_server_no_warnings(*args, **kwargs):
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', 'simple_tls.*')
+        from acme.standalone import simple_tls_sni_01_server
+        return simple_tls_sni_01_server(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/acme/acme/standalone_test.py
+++ b/acme/acme/standalone_test.py
@@ -75,7 +75,9 @@ class BaseRequestHandlerWithLoggingTest(unittest.TestCase):
         with mock.patch('acme.standalone.warnings.warn') as mock_warn:
             # pylint: disable=unused-variable
             from acme.standalone import BaseRequestHandlerWithLogging
-        mock_warn.call_args[0][0].startswith('BaseRequestHandlerWithLogging')
+        self.assertTrue(mock_warn.called)
+        msg = mock_warn.call_args[0][0]
+        self.assertTrue(msg.startswith('BaseRequestHandlerWithLogging'))
 
 
 class HTTP01ServerTest(unittest.TestCase):


### PR DESCRIPTION
I tried to finish up https://github.com/certbot/certbot/issues/7214 by removing the code in `acme` but we can't really do that until https://github.com/certbot/certbot/issues/7478 is resolved which we cannot do until we release 0.40.0.

Since we have to wait, this PR adds deprecation warnings for code that uses the TLS-SNI-01 code or was only used by the long deprecated TLS-SNI-01 code.

I'd like this PR to land before our next release.