### PR TITLE
Fix invalid escape sequence \. rebuild_dependencies.py

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -167,6 +167,7 @@ Authors
 * [Michael Watters](https://github.com/blackknight36)
 * [Michal Moravec](https://github.com/https://github.com/Majkl578)
 * [Michal Papis](https://github.com/mpapis)
+* [Mickaël Schoentgen](https://github.com/BoboTiG)
 * [Minn Soe](https://github.com/MinnSoe)
 * [Min RK](https://github.com/minrk)
 * [Miquel Ruiz](https://github.com/miquelruiz)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fixed a DeprecationWarning: invalid escape sequence in rebuild_dependencies.py.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/letsencrypt-auto-source/rebuild_dependencies.py
+++ b/letsencrypt-auto-source/rebuild_dependencies.py
@@ -62,7 +62,7 @@ CERTBOT_REPO_PATH = dirname(dirname(abspath(__file__)))
 #     without pinned dependencies, and respecting input authoritative requirements
 #   - `certbot plugins` is called to check we have an healthy environment
 #   - finally current set of dependencies is extracted out of the docker using pip freeze
-SCRIPT = """\
+SCRIPT = r"""\
 #!/bin/sh
 set -e
 


### PR DESCRIPTION
Hello,

This is a small patch to fix that warning:
```shell
letsencrypt-auto-source/rebuild_dependencies.py:79: DeprecationWarning: invalid escape sequence \.
  """
```

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>

## Pull Request Checklist

- [x] Edit the `master` section of `CHANGELOG.md` to include a description of
  the change being made.
- [x] Add [mypy type annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations) for any functions that were added or modified.
- [x] Include your name in `AUTHORS.md` if you like.
