### PR TITLE
Use a context manager for file handling to prevent file descriptor leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Fixed a DeprecationWarning: invalid escape sequence in rebuild_dependencies.py.
+* Fixed leaked file descriptors.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot-auto
+++ b/certbot-auto
@@ -956,16 +956,20 @@ def create_venv(venv_path, pyver, verbose):
 
     stdout = sys.stdout if verbose == '1' else open(os.devnull, 'w')
 
-    if int(pyver) <= 27:
-        # Use virtualenv binary
-        environ = os.environ.copy()
-        environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
-        command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
-        subprocess.check_call(command, stdout=stdout, env=environ)
-    else:
-        # Use embedded venv module in Python 3
-        command = [sys.executable, '-m', 'venv', venv_path]
-        subprocess.check_call(command, stdout=stdout)
+    try:
+      if int(pyver) <= 27:
+          # Use virtualenv binary
+          environ = os.environ.copy()
+          environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
+          command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
+          subprocess.check_call(command, stdout=stdout, env=environ)
+      else:
+          # Use embedded venv module in Python 3
+          command = [sys.executable, '-m', 'venv', venv_path]
+          subprocess.check_call(command, stdout=stdout)
+    finally:
+      if stdout is not sys.stdout:
+        stdout.close()
 
 
 if __name__ == '__main__':

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -326,7 +326,8 @@ def test_renew_empty_hook_scripts(context):
     for hook_dir in misc.list_renewal_hooks_dirs(context.config_dir):
         shutil.rmtree(hook_dir)
         os.makedirs(join(hook_dir, 'dir'))
-        open(join(hook_dir, 'file'), 'w').close()
+        with open(join(hook_dir, 'file'), 'w'):
+            pass
     context.certbot(['renew'])
 
     assert_cert_count_for_lineage(context.config_dir, certname, 2)
@@ -348,7 +349,8 @@ def test_renew_hook_override(context):
     assert_hook_execution(context.hook_probe, 'deploy')
 
     # Now we override all previous hooks during next renew.
-    open(context.hook_probe, 'w').close()
+    with open(context.hook_probe, 'w'):
+        pass
     context.certbot([
         'renew', '--cert-name', certname,
         '--pre-hook', misc.echo('pre_override', context.hook_probe),
@@ -367,7 +369,8 @@ def test_renew_hook_override(context):
         assert_hook_execution(context.hook_probe, 'deploy')
 
     # Expect that this renew will reuse new hooks registered in the previous renew.
-    open(context.hook_probe, 'w').close()
+    with open(context.hook_probe, 'w'):
+        pass
     context.certbot(['renew', '--cert-name', certname])
 
     assert_hook_execution(context.hook_probe, 'pre_override')

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/nginx/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/nginx/common.py
@@ -82,11 +82,12 @@ def _get_names(config):
 def _get_server_names(root, filename):
     """Returns all names in a config file path"""
     all_names = set()
-    for line in open(os.path.join(root, filename)):
-        if line.strip().startswith("server_name"):
-            names = line.partition("server_name")[2].rpartition(";")[0]
-            for n in names.split():
-                # Filter out wildcards in both all_names and test_names
-                if not n.startswith("*."):
-                    all_names.add(n)
+    with open(os.path.join(root, filename)) as fh:
+        for line in fh:
+            if line.strip().startswith("server_name"):
+                names = line.partition("server_name")[2].rpartition(";")[0]
+                for n in names.split():
+                    # Filter out wildcards in both all_names and test_names
+                    if not n.startswith("*."):
+                        all_names.add(n)
     return all_names

--- a/certbot-dns-google/certbot_dns_google/dns_google_test.py
+++ b/certbot-dns-google/certbot_dns_google/dns_google_test.py
@@ -28,7 +28,8 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         from certbot_dns_google.dns_google import Authenticator
 
         path = os.path.join(self.tempdir, 'file.json')
-        open(path, "wb").close()
+        with open(path, "wb"):
+            pass
 
         super(AuthenticatorTest, self).setUp()
         self.config = mock.MagicMock(google_credentials=path,

--- a/certbot/plugins/dns_common_test.py
+++ b/certbot/plugins/dns_common_test.py
@@ -70,7 +70,8 @@ class DNSAuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthen
     @test_util.patch_get_utility()
     def test_prompt_file(self, mock_get_utility):
         path = os.path.join(self.tempdir, 'file.ini')
-        open(path, "wb").close()
+        with open(path, "wb"):
+            pass
 
         mock_display = mock_get_utility()
         mock_display.directory_select.side_effect = ((display_util.OK, "",),

--- a/certbot/plugins/webroot_test.py
+++ b/certbot/plugins/webroot_test.py
@@ -140,7 +140,8 @@ class AuthenticatorTest(unittest.TestCase):
             f.write("thingimy")
         filesystem.chmod(self.path, 0o000)
         try:
-            open(permission_canary, "r")
+            with open(permission_canary, "r"):
+                pass
             print("Warning, running tests as root skips permissions tests...")
         except IOError:
             # ok, permissions work, test away...

--- a/certbot/storage.py
+++ b/certbot/storage.py
@@ -138,7 +138,8 @@ def write_renewal_config(o_filename, n_filename, archive_dir, target, relevant_d
     logger.debug("Writing new config %s.", n_filename)
 
     # Ensure that the file exists
-    open(n_filename, 'a').close()
+    with open(n_filename, 'a'):
+        pass
 
     # Copy permissions from the old version of the file, if it exists.
     if os.path.exists(o_filename):

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -83,7 +83,8 @@ class UpdateLiveSymlinksTest(BaseCertManagerTest):
             for kind in ALL_FOUR:
                 live_path = self.config_files[domain][kind]
                 archive_path = archive_paths[domain][kind]
-                open(archive_path, 'a').close()
+                with open(archive_path, 'a'):
+                    pass
                 # path is incorrect but base must be correct
                 os.symlink(os.path.join(self.config.config_dir, kind + "1.pem"), live_path)
 

--- a/certbot/tests/compat/filesystem_test.py
+++ b/certbot/tests/compat/filesystem_test.py
@@ -182,7 +182,8 @@ class WindowsOpenTest(TempDirTestCase):
 
     def test_existing_file_correct_permissions(self):
         path = os.path.join(self.tempdir, 'file')
-        open(path, 'w').close()
+        with open(path, 'w'):
+            pass
 
         desc = filesystem.open(path, os.O_EXCL | os.O_RDWR, 0o700)
         os.close(desc)
@@ -210,7 +211,8 @@ class WindowsOpenTest(TempDirTestCase):
 
         # os.O_CREAT + file exists (locked) = EACCES OS exception
         path = os.path.join(self.tempdir, '5')
-        open(path, 'w').close()
+        with open(path, 'w'):
+            pass
         filelock = lock.LockFile(path)
         try:
             with self.assertRaises(OSError) as raised:
@@ -403,8 +405,10 @@ class OsReplaceTest(test_util.TempDirTestCase):
         """Ensure that replace will effectively rename src into dst for all platforms."""
         src = os.path.join(self.tempdir, 'src')
         dst = os.path.join(self.tempdir, 'dst')
-        open(src, 'w').close()
-        open(dst, 'w').close()
+        with open(src, 'w'):
+            pass
+        with open(dst, 'w'):
+            pass
 
         # On Windows, a direct call to os.rename would fail because dst already exists.
         filesystem.replace(src, dst)

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -395,7 +395,8 @@ class ExitWithLogPathTest(test_util.TempDirTestCase):
 
     def test_log_file(self):
         log_file = os.path.join(self.tempdir, 'test.log')
-        open(log_file, 'w').close()
+        with open(log_file, 'w'):
+            pass
 
         err_str = self._test_common(log_file)
         self.assertTrue('logfiles' not in err_str)

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -800,7 +800,8 @@ class RenewableCertTests(BaseRenewableCertTest):
             live_path = self.config_file[kind]
             basename = kind + "1.pem"
             archive_path = os.path.join(archive_dir_path, basename)
-            open(archive_path, 'a').close()
+            with open(archive_path, 'a'):
+                pass
             os.symlink(os.path.join(self.config.config_dir, basename), live_path)
         self.assertRaises(errors.CertStorageError,
                           storage.RenewableCert, self.config_file.filename,

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -956,16 +956,20 @@ def create_venv(venv_path, pyver, verbose):
 
     stdout = sys.stdout if verbose == '1' else open(os.devnull, 'w')
 
-    if int(pyver) <= 27:
-        # Use virtualenv binary
-        environ = os.environ.copy()
-        environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
-        command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
-        subprocess.check_call(command, stdout=stdout, env=environ)
-    else:
-        # Use embedded venv module in Python 3
-        command = [sys.executable, '-m', 'venv', venv_path]
-        subprocess.check_call(command, stdout=stdout)
+    try:
+      if int(pyver) <= 27:
+          # Use virtualenv binary
+          environ = os.environ.copy()
+          environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
+          command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
+          subprocess.check_call(command, stdout=stdout, env=environ)
+      else:
+          # Use embedded venv module in Python 3
+          command = [sys.executable, '-m', 'venv', venv_path]
+          subprocess.check_call(command, stdout=stdout)
+    finally:
+      if stdout is not sys.stdout:
+        stdout.close()
 
 
 if __name__ == '__main__':

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1034,16 +1034,20 @@ def create_venv(venv_path, pyver, verbose):
 
     stdout = sys.stdout if verbose == '1' else open(os.devnull, 'w')
 
-    if int(pyver) <= 27:
-        # Use virtualenv binary
-        environ = os.environ.copy()
-        environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
-        command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
-        subprocess.check_call(command, stdout=stdout, env=environ)
-    else:
-        # Use embedded venv module in Python 3
-        command = [sys.executable, '-m', 'venv', venv_path]
-        subprocess.check_call(command, stdout=stdout)
+    try:
+      if int(pyver) <= 27:
+          # Use virtualenv binary
+          environ = os.environ.copy()
+          environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
+          command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
+          subprocess.check_call(command, stdout=stdout, env=environ)
+      else:
+          # Use embedded venv module in Python 3
+          command = [sys.executable, '-m', 'venv', venv_path]
+          subprocess.check_call(command, stdout=stdout)
+    finally:
+      if stdout is not sys.stdout:
+        stdout.close()
 
 
 if __name__ == '__main__':

--- a/letsencrypt-auto-source/pieces/create_venv.py
+++ b/letsencrypt-auto-source/pieces/create_venv.py
@@ -11,16 +11,20 @@ def create_venv(venv_path, pyver, verbose):
 
     stdout = sys.stdout if verbose == '1' else open(os.devnull, 'w')
 
-    if int(pyver) <= 27:
-        # Use virtualenv binary
-        environ = os.environ.copy()
-        environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
-        command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
-        subprocess.check_call(command, stdout=stdout, env=environ)
-    else:
-        # Use embedded venv module in Python 3
-        command = [sys.executable, '-m', 'venv', venv_path]
-        subprocess.check_call(command, stdout=stdout)
+    try:
+        if int(pyver) <= 27:
+            # Use virtualenv binary
+            environ = os.environ.copy()
+            environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
+            command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
+            subprocess.check_call(command, stdout=stdout, env=environ)
+        else:
+            # Use embedded venv module in Python 3
+            command = [sys.executable, '-m', 'venv', venv_path]
+            subprocess.check_call(command, stdout=stdout)
+    finally:
+        if stdout is not sys.stdout:
+            stdout.close()
 
 
 if __name__ == '__main__':

--- a/tools/deactivate.py
+++ b/tools/deactivate.py
@@ -30,7 +30,8 @@ if len(sys.argv) != 2:
     print("Usage: python deactivate.py private_key.pem")
     sys.exit(1)
 
-data = open(sys.argv[1], "r").read()
+with open(sys.argv[1], "r") as fh:
+    data = fh.read()
 key = jose.JWKRSA(key=serialization.load_pem_private_key(
     data, None, default_backend()))
 


### PR DESCRIPTION
Yet another patch, this time to fix/prevent file descriptor leaks. The is not very important, but it is always better to have less warnings printed in the console.

I do not knwo if you are open to such patch, but I try :)

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>

## Pull Request Checklist

- [x] Edit the `master` section of `CHANGELOG.md` to include a description of
  the change being made.
- [x] Add [mypy type
  annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations)
  for any functions that were added or modified.
- [x] Include your name in `AUTHORS.md` if you like.
