### PR TITLE
Remove changelog entry about unpackaged scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-* Fixed a DeprecationWarning: invalid escape sequence in rebuild_dependencies.py.
+*
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
We don't package `rebuild_dependencies.py` so I don't think we need to mention changes to it in our changelog which is primarily read by users and packagers.