### PR TITLE
[POC] Lexicon plugin provider

### DIFF
--- a/certbot/certbot/_internal/cli.py
+++ b/certbot/certbot/_internal/cli.py
@@ -26,10 +26,12 @@ from certbot import util
 from certbot._internal import constants
 from certbot._internal import hooks
 from certbot._internal.plugins import disco as plugins_disco
+from certbot._internal.plugins import dns_lexicon
 import certbot._internal.plugins.selection as plugin_selection
 from certbot.compat import os
 from certbot.display import util as display_util
 import certbot.plugins.enhancements as enhancements
+
 
 logger = logging.getLogger(__name__)
 
@@ -1446,6 +1448,9 @@ def _plugins_parsing(helpful, plugins):
                 default=flag_default("dns_sakuracloud"),
                 help=("Obtain certificates using a DNS TXT record "
                      "(if you are using Sakura Cloud for DNS)."))
+
+    # Add lexicon provider plugins
+    dns_lexicon.LexiconProvider.cli_plugins(helpful)
 
     # things should not be reorder past/pre this comment:
     # plugins_group should be displayed in --help before plugin

--- a/certbot/certbot/_internal/plugins/dns_lexicon.py
+++ b/certbot/certbot/_internal/plugins/dns_lexicon.py
@@ -1,0 +1,37 @@
+"""Lexicon DNS Authenticator Plugin."""
+
+import logging
+
+from certbot._internal import constants
+from certbot._internal.plugins.lexicon import godaddy
+
+logger = logging.getLogger(__name__)
+
+class LexiconProvider(object):
+    """Lexicon Provider
+    """
+
+    plugins = [godaddy.PLUGIN]
+
+    # Update constants.CLI_DEFAULTS
+    constants.CLI_DEFAULTS['dns_godaddy'] = False
+
+    @classmethod
+    def cli_plugins(cls, helpful):
+        """
+        Called from cli.py to add supported providers as DNS plugins.
+        """
+        for plugin in cls.plugins:
+            helpful.add(["plugins", "certonly"], plugin.option,
+                action="store_true",
+                default=plugin.default,
+                help=plugin.help)
+
+    @classmethod
+    def cli_plugin_requests(cls, config, req_auth, set_configurator):
+        """
+        Called from selection.py to handle supported providers.
+        """
+        if config.dns_godaddy:
+            req_auth = set_configurator(req_auth, "dns-godaddy")
+        return req_auth

--- a/certbot/certbot/_internal/plugins/lexicon/__init__.py
+++ b/certbot/certbot/_internal/plugins/lexicon/__init__.py
@@ -1,0 +1,1 @@
+"""Lexicon provider plugins"""

--- a/certbot/certbot/_internal/plugins/lexicon/common.py
+++ b/certbot/certbot/_internal/plugins/lexicon/common.py
@@ -1,0 +1,157 @@
+"""Lexicon plugin provider common methods"""
+
+import zope.interface
+
+from certbot import interfaces
+from certbot.plugins import dns_common
+from certbot.plugins import dns_common_lexicon
+
+class LexiconPluginInfo(object):
+    """
+    Contains all information required to present a lexicon provider as a
+    dns plugin to certbot.
+    """
+
+    # pylint: disable-msg=R0913,W0622
+    def __init__(self, name, option, default, help, info,
+            default_propagation_seconds, parser_arguments,
+            fn_setup_credentials, fn_get_lexicon_client):
+        """
+        :param str name: Name of the plugin to present to certbot.
+        :param str option: Command line option.
+        :param bool default: Default value for the option.
+        :param str help: Help text for the plugin.
+        :param str info: Info text for the plugin. Shown mainly during plugin selection.
+        :param int default_propagation_seconds: Default DNS propagation time.
+        :param dict parser_arguments: Command line arguments for parser.
+        :param fn_setup_credentials: Function that sets up credentials.
+        :param fn_get_lexicon_client: Function that creats and returns a lexicon client.
+        """
+        self.name = name
+        self.option = option
+        self.default = default
+        self.help = help
+        self.info = info
+        self.default_propagation_seconds = default_propagation_seconds
+        self.parser_arguments = parser_arguments
+        self.fn_setup_credentials = fn_setup_credentials
+        self.fn_get_lexicon_client = fn_get_lexicon_client
+        self.cls = build_lexicon_authenticator(self)
+
+def build_lexicon_authenticator(plugin_info):
+    """
+    Create authenticator class for a single provider.
+
+    :param plugin_info: Plugin information object for provider.
+    """
+
+    @zope.interface.implementer(interfaces.IAuthenticator)
+    @zope.interface.provider(interfaces.IPluginFactory)
+    class LexiconAuthenticator(dns_common.DNSAuthenticator):
+        """Lexicon DNS Authenticator
+
+        This Authenticator uses Lexicon to fulfill a dns-01 challenge.
+        """
+
+        plugin_info = None  # type: LexiconPluginInfo
+        description = None
+
+        def __init__(self, *args, **kwargs):
+            super(LexiconAuthenticator, self).__init__(*args, **kwargs)
+            self.credentials = None
+
+        @classmethod
+        def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
+            super(LexiconAuthenticator, cls).add_parser_arguments(add,
+                default_propagation_seconds=cls.plugin_info.default_propagation_seconds)
+
+            for key, value in cls.plugin_info.parser_arguments.items():
+                add(key, help=value)
+
+        def more_info(self):  # pylint: disable=missing-docstring,no-self-use
+            return LexiconAuthenticator.plugin_info.info
+
+        def _perform(self, domain, validation_name, validation):
+            self._get_lexicon_client().add_txt_record(domain, validation_name, validation)
+
+        def _cleanup(self, domain, validation_name, validation):
+            self._get_lexicon_client().del_txt_record(domain, validation_name, validation)
+
+        def _setup_credentials(self):
+            return LexiconAuthenticator.plugin_info.fn_setup_credentials(self)
+
+        def _get_lexicon_client(self):
+            return LexiconAuthenticator.plugin_info.fn_get_lexicon_client(self)
+
+    LexiconAuthenticator.plugin_info = plugin_info
+    LexiconAuthenticator.description = plugin_info.help
+    return LexiconAuthenticator
+
+def build_lexicon_client(general_error_handler, http_error_handler):
+    """
+    Create lexicon client with specified error handlers.
+
+    :param general_error_handler: General error handler function or None to use default.
+    :param http_error_handler: HTTP error handler function or None to use default.
+    """
+
+    class LexiconClient(dns_common_lexicon.LexiconClient):
+        """
+        Generic lexicon client.
+        """
+
+        fn_handle_general_error = None
+        fn_handle_http_error = None
+
+        def __init__(self, provider):
+            super(LexiconClient, self).__init__()
+            self.provider = provider
+
+        def _handle_general_error(self, e, domain_name):
+            if LexiconClient.fn_handle_general_error:
+                # pylint: disable-msg=E1102
+                LexiconClient.fn_handle_general_error(self, e, domain_name)
+            else:
+                super(LexiconClient, self)._handle_general_error(e, domain_name)
+
+        def _handle_http_error(self, e, domain_name):
+            if LexiconClient.fn_handle_http_error:
+                # pylint: disable-msg=E1102
+                LexiconClient.fn_handle_http_error(self, e, domain_name)
+            else:
+                super(LexiconClient, self)._handle_http_error(e, domain_name)
+
+    if general_error_handler:
+        LexiconClient.fn_handle_general_error = general_error_handler
+
+    if http_error_handler:
+        LexiconClient.fn_handle_http_error = http_error_handler
+
+    return LexiconClient
+
+def default_get_lexicon_client(lexicon_name, lexicon_cls, config_map,
+    general_error_handler=None, http_error_handler=None):
+    """
+    Create a function that creates lexicon provider and lexicon client.
+
+    :param str lexicon_name: Name of provider in lexicon library.
+    :param lexicon_cls: The provider class in lexicon library.
+    :param dict config_map: Mapping of configuration from certbot to lexicon.
+    :param general_error_handler: General error handler function or None to use default.
+    :param http_error_handler: HTTP error handler function or None to use default.
+    """
+
+    def get_lexicon_client(self):
+        """
+        Create and return a lexicon client.
+        """
+        # Map certbot config to lexicon config
+        lexicon_config = {}
+        for key, value in config_map.items():
+            lexicon_config[value] = self.credentials.conf(key)
+
+        config = dns_common_lexicon.build_lexicon_config(lexicon_name, {}, lexicon_config)
+        provider = lexicon_cls(config)
+        return build_lexicon_client(general_error_handler, http_error_handler)(provider)
+
+    return get_lexicon_client

--- a/certbot/certbot/_internal/plugins/lexicon/godaddy.py
+++ b/certbot/certbot/_internal/plugins/lexicon/godaddy.py
@@ -1,0 +1,42 @@
+"""Lexicon Godaddy DNS plugin"""
+
+from lexicon.providers import godaddy as provider_godaddy
+
+from certbot._internal.plugins.lexicon import common
+
+def godaddy_setup_credentials(self):
+    """
+    Customized _setup_credentials for Godaddy provider.
+    """
+    self.credentials = self._configure_credentials(     # pylint: disable=protected-access
+        'credentials',
+        'Godaddy credentials INI file.', {
+            'key': 'API key for Godaddy account',
+            'secret': 'API secret for Godaddy account'
+        })
+
+def godaddy_http_error_handler(self, e, domain_name):   # pylint: disable=unused-argument
+    """
+    Customized HTTP error handler for Godaddy provider.
+    """
+    response = e.response
+    response_body = response.json()
+    if response.status_code == 404 and response_body['code'] == 'NOT_FOUND':
+        # Lexicon client is just looking for the TLD.
+        return None
+    else:
+        raise e
+
+PLUGIN = common.LexiconPluginInfo(
+    name='dns-godaddy',
+    option='--dns-godaddy',
+    default=False,
+    help="Obtain certificates using a DNS TXT record (if you are using Godaddy for DNS).",
+    info="Obtain certs using a DNS TXT record (if you are using Godaddy for DNS).",
+    default_propagation_seconds=60,
+    parser_arguments={'credentials': 'Godaddy credentials INI file.'},
+    fn_setup_credentials=godaddy_setup_credentials,
+    fn_get_lexicon_client=common.default_get_lexicon_client('godaddy', provider_godaddy.Provider, {
+            'key': 'auth_key',
+            'secret': 'auth_secret'
+        }, None, godaddy_http_error_handler))

--- a/certbot/certbot/_internal/plugins/lexicon/linode.py
+++ b/certbot/certbot/_internal/plugins/lexicon/linode.py
@@ -1,0 +1,87 @@
+"""Lexicon Linode DNS Plugin"""
+
+import re
+
+from lexicon.providers import linode as provider_linode
+from lexicon.providers import linode4 as provider_linode4
+
+from certbot import errors
+from certbot.plugins import dns_common_lexicon
+from certbot._internal.plugins.lexicon import common
+
+API_KEY_URL = 'https://manager.linode.com/profile/api'
+API_KEY_URL_V4 = 'https://cloud.linode.com/profile/tokens'
+
+
+def linode_setup_credentials(self):
+    """
+    Customized _setup_credentials for Linode provider.
+    """
+    self.credentials = self._configure_credentials(     # pylint: disable=protected-access
+        'credentials',
+        'Linode credentials INI file.', {
+            'key': 'API key for Linode account, obtained from {0} or {1}'
+                .format(API_KEY_URL, API_KEY_URL_V4)
+        })
+
+
+def linode_http_error_handler(self, e, domain_name):   # pylint: disable=unused-argument
+    """
+    Customized HTTP error handler for Linode provider.
+    """
+    if not str(e).startswith('Domain not found'):
+        return errors.PluginError('Unexpected error determining zone identifier for {0}: {1}'
+                                  .format(domain_name, e))
+    return None
+
+
+def linode_get_lexicon_client(self):
+    """
+    Create and return a lexicon client.
+    """
+    api_key = self.credentials.conf('key')
+    api_version = self.credentials.conf('version')
+    if api_version == '':
+        api_version = None
+
+    if not api_version:
+        api_version = 3
+
+        # Match for v4 api key
+        regex_v4 = re.compile('^[0-9a-f]{64}$')
+        regex_match = regex_v4.match(api_key)
+        if regex_match:
+            api_version = 4
+    else:
+        api_version = int(api_version)
+
+    provider = None
+    if api_version == 3:
+        config = dns_common_lexicon.build_lexicon_config('linode', {}, {
+            'auth_token': api_key,
+        })
+
+        provider = provider_linode.Provider(config)
+    elif api_version == 4:
+        config = dns_common_lexicon.build_lexicon_config('linode4', {}, {
+            'auth_token': api_key,
+        })
+
+        provider = provider_linode4.Provider(config)
+    else:
+        raise errors.PluginError('Invalid api version specified: {0}. (Supported: 3, 4)'
+                                 .format(api_version))
+
+    return common.build_lexicon_client(None, linode_http_error_handler)(provider)
+
+
+PLUGIN = common.LexiconPluginInfo(
+    name='dns-linode',
+    option='--dns-linode',
+    default=False,
+    help="Obtain certificates using a DNS TXT record (if you are using Linode for DNS).",
+    info="Obtain certs using a DNS TXT record (if you are using Linode for DNS).",
+    default_propagation_seconds=1200,
+    parser_arguments={'credentials': 'Linode credentials INI file.'},
+    fn_setup_credentials=linode_setup_credentials,
+    fn_get_lexicon_client=linode_get_lexicon_client)

--- a/certbot/certbot/_internal/plugins/selection.py
+++ b/certbot/certbot/_internal/plugins/selection.py
@@ -10,6 +10,7 @@ from certbot import errors
 from certbot import interfaces
 from certbot.compat import os
 from certbot.display import util as display_util
+from certbot._internal.plugins import dns_lexicon
 
 logger = logging.getLogger(__name__)
 z_util = zope.component.getUtility
@@ -303,6 +304,11 @@ def cli_plugin_requests(config):
         req_auth = set_configurator(req_auth, "dns-route53")
     if config.dns_sakuracloud:
         req_auth = set_configurator(req_auth, "dns-sakuracloud")
+
+    # Lexicon provider plugins
+    req_auth = dns_lexicon.LexiconProvider.cli_plugin_requests(config,
+        req_auth, set_configurator)
+
     logger.debug("Requested authenticator %s and installer %s", req_auth, req_inst)
     return req_auth, req_inst
 

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -44,6 +44,7 @@ install_requires = [
     'configobj',
     'cryptography>=1.2.3',  # load_pem_x509_certificate
     'distro>=1.0.1',
+    'dns-lexicon>=2.2.1',
     # 1.1.0+ is required to avoid the warnings described at
     # https://github.com/certbot/josepy/issues/13.
     'josepy>=1.1.0',


### PR DESCRIPTION
This PR implements a way to provide lexicon providers to certbot as discussed in issue #6178 .
Each provider has to be explicitly added in order to be provided to certbot with a few lines of code.
Also, I've made it so that a single DNS plugin provided to certbot can be mapped to more than one lexicon provider if desired/required.
Almost all possible modifications needed to instantiate a lexicon provider is provided and the implementation details are all hidden away from certbot.

I had to put this in certbot itself because of the way certbot is structured right now. I could not find a way to properly hook into the system from a plugin.

This PR is a POC only at the time being and is here for discussion. That is why there is no tests as of now.