### PR TITLE
Pin all build dependencies for the Windows installer

### DIFF
--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -53,9 +53,9 @@ def _compile_wheels(repo_path, build_path, venv_python):
 def _prepare_build_tools(venv_path, venv_python, repo_path):
     print('Prepare build tools')
     subprocess.check_call([sys.executable, '-m', 'venv', venv_path])
+    subprocess.check_call([venv_python, os.path.join(repo_path, 'letsencrypt-auto-source', 'pieces', 'pipstrap.py')])
+    subprocess.check_call([venv_python, os.path.join(repo_path, 'tools', 'pip_install.py'), 'pynsist'])
     subprocess.check_call(['choco', 'upgrade', '-y', 'nsis'])
-    subprocess.check_call([venv_python, '-m', 'pip', 'install', '--upgrade', 'pip'])
-    subprocess.check_call([venv_python, os.path.join(repo_path, 'tools', 'pip_install.py'), 'wheel', 'pynsist'])
 
 
 @contextlib.contextmanager

--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -12,6 +12,7 @@ import time
 PYTHON_VERSION = (3, 7, 4)
 PYTHON_BITNESS = 32
 PYWIN32_VERSION = 225  # do not forget to edit pywin32 dependency accordingly in setup.py
+NSIS_VERSION = '3.04'
 
 
 def main():
@@ -55,7 +56,7 @@ def _prepare_build_tools(venv_path, venv_python, repo_path):
     subprocess.check_call([sys.executable, '-m', 'venv', venv_path])
     subprocess.check_call([venv_python, os.path.join(repo_path, 'letsencrypt-auto-source', 'pieces', 'pipstrap.py')])
     subprocess.check_call([venv_python, os.path.join(repo_path, 'tools', 'pip_install.py'), 'pynsist'])
-    subprocess.check_call(['choco', 'upgrade', '-y', 'nsis'])
+    subprocess.check_call(['choco', 'upgrade', '-y', 'nsis', '--version', NSIS_VERSION])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This PR uses pipstrap to bootstrap the venv used to build Windows installers. This effectively pin all build dependencies, since `pynsist` is already installed through `pip_install.py` script.