### PR TITLE
Match our Travis logic in Azure

### DIFF
--- a/.azure-pipelines/advanced.yml
+++ b/.azure-pipelines/advanced.yml
@@ -4,7 +4,6 @@ trigger:
   - '*.x'
 pr:
   - test-*
-  - '*.x'
 # This pipeline is also nightly run on master
 schedules:
   - cron: "0 4 * * *"

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -6,6 +6,7 @@ trigger:
 pr:
   - apache-parser-v2
   - master
+  - '*.x'
 
 jobs:
   - template: templates/tests-suite.yml


### PR DESCRIPTION
In Travis, the full test suite doesn't run on PRs for point release branches, just on commits for them. I think this behavior makes sense because what we actually want to test before a point release is the exact commit we want to release after any squashing/merging has been done. This PR modifies Azure to match this behavior.

After this PR lands, I need to update the tests required to pass on GitHub.