### PR TITLE
[Apache v2] Adding nodes 2/3 : add_child_directive()

### DIFF
--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -221,12 +221,26 @@ class AugeasBlockNode(AugeasDirectiveNode):
     # pylint: disable=unused-argument
     def add_child_directive(self, name, parameters=None, position=None):  # pragma: no cover
         """Adds a new DirectiveNode to the sequence of children"""
-        new_metadata = {"augeasparser": self.parser, "augeaspath": assertions.PASS}
-        new_dir = AugeasDirectiveNode(name=assertions.PASS,
-                                      ancestor=self,
-                                      filepath=assertions.PASS,
+
+        if not parameters:
+            raise errors.PluginError("Directive requires parameters and none were set.")
+
+        insertpath, realpath, before = self._aug_resolve_child_position(
+            "directive",
+            position
+        )
+        new_metadata = {"augeasparser": self.parser, "augeaspath": realpath}
+
+        # Create the new directive
+        self.parser.aug.insert(insertpath, "directive", before)
+        # Set the directive key
+        self.parser.aug.set(realpath, name)
+
+        new_dir = AugeasDirectiveNode(name=name,
+                                      parameters=parameters,
+                                      ancestor=assertions.PASS,
+                                      filepath=apache_util.get_file_path(realpath),
                                       metadata=new_metadata)
-        self.children += (new_dir,)
         return new_dir
 
     def add_child_comment(self, comment="", position=None):  # pylint: disable=unused-argument

--- a/certbot-apache/certbot_apache/tests/augeasnode_test.py
+++ b/certbot-apache/certbot_apache/tests/augeasnode_test.py
@@ -9,7 +9,7 @@ from certbot_apache import assertions
 from certbot_apache.tests import util
 
 
-class AugeasParserNodeTest(util.ApacheTest):
+class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-methods
     """Test AugeasParserNode using available test configurations"""
 
     def setUp(self):  # pylint: disable=arguments-differ
@@ -216,6 +216,7 @@ class AugeasParserNodeTest(util.ApacheTest):
             AugeasBlockNode,
             **parameters
         )
+
     def test_node_init_error_missing_augeaspath(self):
         from certbot_apache.augeasparser import AugeasBlockNode
         parameters = {
@@ -230,4 +231,23 @@ class AugeasParserNodeTest(util.ApacheTest):
             errors.PluginError,
             AugeasBlockNode,
             **parameters
+        )
+
+    def test_add_child_directive(self):
+        self.config.parser_root.primary.add_child_directive(
+            "ThisWasAdded",
+            ["with", "parameters"],
+            position=0
+        )
+        dirs = self.config.parser_root.find_directives("ThisWasAdded")
+        self.assertEqual(len(dirs), 1)
+        self.assertEqual(dirs[0].parameters, ("with", "parameters"))
+        # The new directive was added to the very first line of the config
+        self.assertTrue(dirs[0].metadata["augeaspath"].endswith("[1]"))
+
+    def test_add_child_directive_exception(self):
+        self.assertRaises(
+            errors.PluginError,
+            self.config.parser_root.primary.add_child_directive,
+            "ThisRaisesErrorBecauseMissingParameters"
         )


### PR DESCRIPTION
This PR implements add_child_directive() and is built on top of #7497

Note: this PR uses temporarily #7497 as base to help to hide the unnecessary diffs. This also means that the tests won't run before it's changed back to `apache-parser-v2`