### PR TITLE
[Apache v2] Adding nodes 3/3 : add_child_comment() 

### DIFF
--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -229,14 +229,24 @@ class AugeasBlockNode(AugeasDirectiveNode):
         self.children += (new_dir,)
         return new_dir
 
-    def add_child_comment(self, comment="", position=None):  # pylint: disable=unused-argument
+    def add_child_comment(self, comment="", position=None):
         """Adds a new CommentNode to the sequence of children"""
-        new_metadata = {"augeasparser": self.parser, "augeaspath": assertions.PASS}
-        new_comment = AugeasCommentNode(comment=assertions.PASS,
-                                        ancestor=self,
-                                        filepath=assertions.PASS,
+
+        insertpath, realpath, before = self._aug_resolve_child_position(
+            "#comment",
+            position
+        )
+        new_metadata = {"augeasparser": self.parser, "augeaspath": realpath}
+
+        # Create the new comment
+        self.parser.aug.insert(insertpath, "#comment", before)
+        # Set the comment content
+        self.parser.aug.set(realpath, comment)
+
+        new_comment = AugeasCommentNode(comment=comment,
+                                        ancestor=assertions.PASS,
+                                        filepath=apache_util.get_file_path(realpath),
                                         metadata=new_metadata)
-        self.children += (new_comment,)
         return new_comment
 
     def find_blocks(self, name, exclude=True): # pylint: disable=unused-argument

--- a/certbot-apache/certbot_apache/tests/augeasnode_test.py
+++ b/certbot-apache/certbot_apache/tests/augeasnode_test.py
@@ -132,6 +132,16 @@ class AugeasParserNodeTest(util.ApacheTest):
                 found = True
         self.assertTrue(found)
 
+    def test_add_child_comment(self):
+        newc = self.config.parser_root.primary.add_child_comment("The content")
+        comments = self.config.parser_root.find_comments("The content")
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(
+            newc.metadata["augeaspath"],
+            comments[0].primary.metadata["augeaspath"]
+        )
+        self.assertEqual(newc.comment, comments[0].comment)
+
     def test_add_child_block(self):
         nb = self.config.parser_root.primary.add_child_block(
             "NewBlock",

--- a/certbot-apache/certbot_apache/tests/dualnode_test.py
+++ b/certbot-apache/certbot_apache/tests/dualnode_test.py
@@ -6,7 +6,6 @@ import mock
 from certbot_apache import assertions
 from certbot_apache import augeasparser
 from certbot_apache import dualparser
-from certbot_apache import interfaces
 
 
 class DualParserNodeTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
@@ -151,15 +150,13 @@ class DualParserNodeTest(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertTrue(mock_second.called)
 
     def test_add_child_comment(self):
-        self.assertEqual(len(self.block.primary.children), 0)
-        self.assertEqual(len(self.block.secondary.children), 0)
+        mock_first = mock.MagicMock(return_value=self.comment.primary)
+        mock_second = mock.MagicMock(return_value=self.comment.secondary)
+        self.block.primary.add_child_comment = mock_first
+        self.block.secondary.add_child_comment = mock_second
         self.block.add_child_comment("Comment")
-        self.assertEqual(len(self.block.primary.children), 1)
-        self.assertEqual(len(self.block.secondary.children), 1)
-        self.assertTrue(isinstance(self.block.primary.children[0],
-                                   interfaces.CommentNode))
-        self.assertEqual(self.block.primary.children[0].ancestor,
-                         self.block.primary)
+        self.assertTrue(mock_first.called)
+        self.assertTrue(mock_second.called)
 
     def test_find_comments(self):
         pri_comments = [augeasparser.AugeasCommentNode(comment="some comment",


### PR DESCRIPTION
This PR implements add_child_comment()

Note: this PR uses temporarily #7497 as base to help to hide the unnecessary diffs. This also means that the tests won't run before it's changed back to apache-parser-v2