### PR TITLE
[Apache v2] Implement save() and unsaved_files()

### DIFF
--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -97,8 +97,8 @@ class AugeasParserNode(interfaces.ParserNode):
         except KeyError:
             raise errors.PluginError("Augeas path is required")
 
-    def save(self, msg): # pragma: no cover
-        pass
+    def save(self, msg):
+        self.parser.save(msg)
 
 
 class AugeasCommentNode(AugeasParserNode):
@@ -290,9 +290,9 @@ class AugeasBlockNode(AugeasDirectiveNode):
         """Deletes a ParserNode from the sequence of children"""
         pass
 
-    def unsaved_files(self):  # pragma: no cover
+    def unsaved_files(self):
         """Returns a list of unsaved filepaths"""
-        return [assertions.PASS]
+        return self.parser.unsaved_files()
 
     def _create_commentnode(self, path):
         """Helper function to create a CommentNode from Augeas path"""

--- a/certbot-apache/certbot_apache/tests/augeasnode_test.py
+++ b/certbot-apache/certbot_apache/tests/augeasnode_test.py
@@ -20,6 +20,18 @@ class AugeasParserNodeTest(util.ApacheTest):
         self.vh_truth = util.get_vh_truth(
             self.temp_dir, "debian_apache_2_4/multiple_vhosts")
 
+    def test_save(self):
+        with mock.patch('certbot_apache.parser.ApacheParser.save') as mock_save:
+            self.config.parser_root.save("A save message")
+        self.assertTrue(mock_save.called)
+        self.assertEqual(mock_save.call_args[0][0], "A save message")
+
+    def test_unsaved_files(self):
+        with mock.patch('certbot_apache.parser.ApacheParser.unsaved_files') as mock_uf:
+            mock_uf.return_value = ["first", "second"]
+            files = self.config.parser_root.unsaved_files()
+        self.assertEqual(files, ["first", "second"])
+
     def test_get_block_node_name(self):
         from certbot_apache.augeasparser import AugeasBlockNode
         block = AugeasBlockNode(

--- a/certbot-apache/certbot_apache/tests/augeasnode_test.py
+++ b/certbot-apache/certbot_apache/tests/augeasnode_test.py
@@ -9,7 +9,7 @@ from certbot_apache import assertions
 from certbot_apache.tests import util
 
 
-class AugeasParserNodeTest(util.ApacheTest):
+class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-methods
     """Test AugeasParserNode using available test configurations"""
 
     def setUp(self):  # pylint: disable=arguments-differ


### PR DESCRIPTION
This PR implement save() and unsaved_files(). In this implementation, they are merely just call-through functions for underlying `ApacheParser`.