### PR TITLE
Update 0.40.x Azure config

### DIFF
--- a/.azure-pipelines/advanced.yml
+++ b/.azure-pipelines/advanced.yml
@@ -4,7 +4,6 @@ trigger:
   - '*.x'
 pr:
   - test-*
-  - '*.x'
 # This pipeline is also nightly run on master
 schedules:
   - cron: "0 4 * * *"

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -6,6 +6,7 @@ trigger:
 pr:
   - apache-parser-v2
   - master
+  - '*.x'
 
 jobs:
   - template: templates/tests-suite.yml


### PR DESCRIPTION
I hope this PR isn't needed, but I don't think it hurts since the changes are to unpackaged code and it could avoid some problems in the future.

Yesterday I noticed that we had configured our full/nightly test suite to run in Azure on PRs for point release branches, but we were requiring our normal test suite to run to make the PR mergeable on GitHub. I argued that the behavior we wanted was our normal test suite to run and this behavior was fixed in #7514, but now we have a problem:

1. If we update the branch protection rules to require our normal test suite to pass on Azure, only our nightly/full test suite will run on PRs for the 0.40.x branch because it doesn't have the updates to the Azure configuration file.
2. If we leave it unchanged to require only our nightly test suite, future point release branches will have this problem until we remember to update the branch protection rules.

Alternatively, I could try to set up separate rules for 0.40.x in GitHub, but that seems like overkill.

While the issue is fresh in our minds, I think it's worth merging this PR to avoid any headaches in the future. I've updated GitHub to require only the limited test suite to pass on PRs for point release branches as you can see here.