### PR TITLE
[Windows] Avoid letsencrypt.log permissions error during scheduled certbot renew task

### DIFF
--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -8,8 +8,10 @@ $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument '-NoProfil
 $delay = New-TimeSpan -Hours 12
 $triggerAM = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay $delay
 $triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm -RandomDelay $delay
-# NB: For now scheduled task is set up under SYSTEM account because Certbot Installer installs Certbot for all users.
+# NB: For now scheduled task is set up under Administrators group account because Certbot Installer installs Certbot for all users.
 # If in the future we allow the Installer to install Certbot for one specific user, the scheduled task will need to
 # switch to this user, since Certbot will be available only for him.
-$principal = New-ScheduledTaskPrincipal -UserId SYSTEM -LogonType ServiceAccount -RunLevel Highest
+$adminsSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
+$adminsGroupID = $adminSID.Translate([System.Security.Principal.NTAccount]).Value
+$principal = New-ScheduledTaskPrincipal -GroupId $adminsGroupID -RunLevel Highest
 Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal

--- a/windows-installer/renew-up.ps1
+++ b/windows-installer/renew-up.ps1
@@ -12,6 +12,6 @@ $triggerPM = New-ScheduledTaskTrigger -Daily -At 12pm -RandomDelay $delay
 # If in the future we allow the Installer to install Certbot for one specific user, the scheduled task will need to
 # switch to this user, since Certbot will be available only for him.
 $adminsSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
-$adminsGroupID = $adminSID.Translate([System.Security.Principal.NTAccount]).Value
+$adminsGroupID = $adminsSID.Translate([System.Security.Principal.NTAccount]).Value
 $principal = New-ScheduledTaskPrincipal -GroupId $adminsGroupID -RunLevel Highest
 Register-ScheduledTask -Action $action -Trigger $triggerAM,$triggerPM -TaskName $taskName -Description "Execute twice a day the 'certbot renew' command, to renew managed certificates if needed." -Principal $principal


### PR DESCRIPTION
While coding for #7536, I ran into another issue. It appears that Certbot logs generated during the scheduled task execution have wrong permissions that make them almost unusable: they do not have an owner, and their ACL contains nonsense values (non existant accounts name).

The class `logging.handler.RotatingFileHandler` is responsible for these logs, and become mad when it is in a Python process run under a scheduled task owned by `SYSTEM`. This is precisely our case here.

This PR avoids (but not fix) the issue, by changing the owner of the scheduled task from `SYSTEM` to the `Administrators` group, that appears to work fine.