### PR TITLE
Configure lint and cover to run on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,10 @@ matrix:
       <<: *not-on-master
 
     # This job is always executed, including on master
-    - python: "3.8"
-      env: TOXENV=py38-cover FYI="py38 tests + code coverage"
+    - python: "3.7"
+      env: TOXENV=py37-cover FYI="py37 tests + code coverage"
 
-    - python: "3.8"
+    - python: "3.7"
       env: TOXENV=lint
       <<: *not-on-master
     - python: "3.4"
@@ -296,7 +296,7 @@ install: 'tools/pip_install.py -U codecov tox virtualenv'
 # flakiness of these specific tests.
 script: '$TRAVIS_RETRY tox'
 
-after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'
+after_success: '[ "$TOXENV" == "py37-cover" ] && codecov -F linux'
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,10 @@ matrix:
       <<: *not-on-master
 
     # This job is always executed, including on master
-    - python: "2.7"
-      env: TOXENV=py27-cover FYI="py27 tests + code coverage"
+    - python: "3.8"
+      env: TOXENV=py38-cover FYI="py38 tests + code coverage"
 
-    - python: "2.7"
+    - python: "3.8"
       env: TOXENV=lint
       <<: *not-on-master
     - python: "3.4"

--- a/tox.ini
+++ b/tox.ini
@@ -109,14 +109,14 @@ commands =
 setenv =
     {[testenv:py27-oldest]setenv}
 
-[testenv:py38-cover]
-basepython = python3.8
+[testenv:py37-cover]
+basepython = python3.7
 commands =
     {[base]install_packages}
     python tox.cover.py
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.7
 # separating into multiple invocations disables cross package
 # duplicate code checking; if one of the commands fails, others will
 # continue, but tox return code will reflect previous error

--- a/tox.ini
+++ b/tox.ini
@@ -109,20 +109,14 @@ commands =
 setenv =
     {[testenv:py27-oldest]setenv}
 
-[testenv:py27-cover]
-basepython = python2.7
-commands =
-    {[base]install_packages}
-    python tox.cover.py
-
-[testenv:py37-cover]
-basepython = python3.7
+[testenv:py38-cover]
+basepython = python3.8
 commands =
     {[base]install_packages}
     python tox.cover.py
 
 [testenv:lint]
-basepython = python2.7
+basepython = python3.8
 # separating into multiple invocations disables cross package
 # duplicate code checking; if one of the commands fails, others will
 # continue, but tox return code will reflect previous error


### PR DESCRIPTION
This PR updates Travis configuration to run linting and coverage on Python 3.8.

NB: This PR is a part of a global action to remove Python 2 from our CI.