### PR TITLE
Fix shebang in rebuild_deps

### DIFF
--- a/letsencrypt-auto-source/rebuild_dependencies.py
+++ b/letsencrypt-auto-source/rebuild_dependencies.py
@@ -62,8 +62,7 @@ CERTBOT_REPO_PATH = dirname(dirname(abspath(__file__)))
 #     without pinned dependencies, and respecting input authoritative requirements
 #   - `certbot plugins` is called to check we have an healthy environment
 #   - finally current set of dependencies is extracted out of the docker using pip freeze
-SCRIPT = r"""\
-#!/bin/sh
+SCRIPT = r"""#!/bin/sh
 set -e
 
 cd /tmp/certbot


### PR DESCRIPTION
When you try to run this script, it crashes with:
```
standard_init_linux.go:211: exec user process caused "exec format error"
```
This is caused by the script being written to have the contents:
```
\
#!/bin/sh
set -e
...
```
This fixes the problem by removing the slash and moving the shebang to the first line of the string.