### PR TITLE
Disable pylint design checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -41,7 +41,7 @@ load-plugins=linter_plugin
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=fixme,locally-disabled,locally-enabled,abstract-class-not-used,abstract-class-little-used,bad-continuation,too-few-public-methods,no-self-use,invalid-name,too-many-instance-attributes,cyclic-import,duplicate-code
+disable=fixme,locally-disabled,locally-enabled,abstract-class-not-used,abstract-class-little-used,bad-continuation,no-self-use,invalid-name,cyclic-import,duplicate-code,design
 # abstract-class-not-used cannot be disabled locally (at least in
 # pylint 1.4.1), same for abstract-class-little-used
 
@@ -295,40 +295,6 @@ valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
 valid-metaclass-classmethod-first-arg=mcs
-
-
-[DESIGN]
-
-# Maximum number of arguments for function / method
-max-args=6
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore
-ignored-argument-names=(unused)?_.*|dummy
-
-# Maximum number of locals for function / method body
-max-locals=15
-
-# Maximum number of return / yield for function / method body
-max-returns=6
-
-# Maximum number of branch for function / method body
-max-branches=12
-
-# Maximum number of statements in function / method body
-max-statements=50
-
-# Maximum number of parents for a class (see R0901).
-max-parents=12
-
-# Maximum number of attributes for a class (see R0902).
-max-attributes=7
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=20
 
 
 [EXCEPTIONS]

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -231,7 +231,7 @@ class DNS01Response(KeyAuthorizationChallengeResponse):
         return verified
 
 
-@Challenge.register  # pylint: disable=too-many-ancestors
+@Challenge.register
 class DNS01(KeyAuthorizationChallenge):
     """ACME dns-01 challenge."""
     response_cls = DNS01Response
@@ -321,7 +321,7 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
         return True
 
 
-@Challenge.register  # pylint: disable=too-many-ancestors
+@Challenge.register
 class HTTP01(KeyAuthorizationChallenge):
     """ACME http-01 challenge."""
     response_cls = HTTP01Response
@@ -372,7 +372,7 @@ class TLSALPN01Response(KeyAuthorizationChallengeResponse):
     typ = "tls-alpn-01"
 
 
-@Challenge.register  # pylint: disable=too-many-ancestors
+@Challenge.register
 class TLSALPN01(KeyAuthorizationChallenge):
     """ACME tls-alpn-01 challenge.
 

--- a/acme/acme/challenges_test.py
+++ b/acme/acme/challenges_test.py
@@ -75,7 +75,6 @@ class KeyAuthorizationChallengeResponseTest(unittest.TestCase):
 
 
 class DNS01ResponseTest(unittest.TestCase):
-    # pylint: disable=too-many-instance-attributes
 
     def setUp(self):
         from acme.challenges import DNS01Response
@@ -147,7 +146,6 @@ class DNS01Test(unittest.TestCase):
 
 
 class HTTP01ResponseTest(unittest.TestCase):
-    # pylint: disable=too-many-instance-attributes
 
     def setUp(self):
         from acme.challenges import HTTP01Response
@@ -258,7 +256,6 @@ class HTTP01Test(unittest.TestCase):
 
 
 class TLSALPN01ResponseTest(unittest.TestCase):
-    # pylint: disable=too-many-instance-attributes
 
     def setUp(self):
         from acme.challenges import TLSALPN01Response

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -44,7 +44,7 @@ DEFAULT_NETWORK_TIMEOUT = 45
 DER_CONTENT_TYPE = 'application/pkix-cert'
 
 
-class ClientBase(object):  # pylint: disable=too-many-instance-attributes
+class ClientBase(object):
     """ACME client base object.
 
     :ivar messages.Directory directory:
@@ -254,7 +254,6 @@ class Client(ClientBase):
             URI from which the resource will be downloaded.
 
         """
-        # pylint: disable=too-many-arguments
         self.key = key
         if net is None:
             net = ClientNetwork(key, alg=alg, verify_ssl=verify_ssl)
@@ -435,7 +434,6 @@ class Client(ClientBase):
             was marked by the CA as invalid
 
         """
-        # pylint: disable=too-many-locals
         assert max_attempts > 0
         attempts = collections.defaultdict(int) # type: Dict[messages.AuthorizationResource, int]
         exhausted = set()
@@ -947,7 +945,7 @@ class BackwardsCompatibleClientV2(object):
         return self.client.external_account_required()
 
 
-class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
+class ClientNetwork(object):
     """Wrapper around requests that signs POSTs for authentication.
 
     Also adds user agent, and handles Content-Type.
@@ -973,7 +971,6 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
     def __init__(self, key, account=None, alg=jose.RS256, verify_ssl=True,
                  user_agent='acme-python', timeout=DEFAULT_NETWORK_TIMEOUT,
                  source_address=None):
-        # pylint: disable=too-many-arguments
         self.key = key
         self.account = account
         self.alg = alg
@@ -1081,7 +1078,6 @@ class ClientNetwork(object):  # pylint: disable=too-many-instance-attributes
         return response
 
     def _send_request(self, method, url, *args, **kwargs):
-        # pylint: disable=too-many-locals
         """Send HTTP request.
 
         Makes sure that `verify_ssl` is respected. Logs request and

--- a/acme/acme/client_test.py
+++ b/acme/acme/client_test.py
@@ -318,7 +318,6 @@ class BackwardsCompatibleClientV2Test(ClientTestBase):
 
 class ClientTest(ClientTestBase):
     """Tests for acme.client.Client."""
-    # pylint: disable=too-many-instance-attributes,too-many-public-methods
 
     def setUp(self):
         super(ClientTest, self).setUp()
@@ -888,7 +887,7 @@ class ClientV2Test(ClientTestBase):
                 new_nonce_url='https://www.letsencrypt-demo.org/acme/new-nonce')
             self.client.net.get.assert_not_called()
 
-            class FakeError(messages.Error):  # pylint: disable=too-many-ancestors
+            class FakeError(messages.Error):
                 """Fake error to reproduce a malformed request ACME error"""
                 def __init__(self):  # pylint: disable=super-init-not-called
                     pass
@@ -917,7 +916,6 @@ class MockJSONDeSerializable(jose.JSONDeSerializable):
 
 class ClientNetworkTest(unittest.TestCase):
     """Tests for acme.client.ClientNetwork."""
-    # pylint: disable=too-many-public-methods
 
     def setUp(self):
         self.verify_ssl = mock.MagicMock()
@@ -1123,7 +1121,6 @@ class ClientNetworkTest(unittest.TestCase):
 
 class ClientNetworkWithMockedResponseTest(unittest.TestCase):
     """Tests for acme.client.ClientNetwork which mock out response."""
-    # pylint: disable=too-many-instance-attributes
 
     def setUp(self):
         from acme.client import ClientNetwork

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_SSL_METHOD = SSL.SSLv23_METHOD  # type: ignore
 
 
-class SSLSocket(object):  # pylint: disable=too-few-public-methods
+class SSLSocket(object):
     """SSL wrapper for sockets.
 
     :ivar socket sock: Original wrapped socket.
@@ -74,7 +74,7 @@ class SSLSocket(object):  # pylint: disable=too-few-public-methods
     class FakeConnection(object):
         """Fake OpenSSL.SSL.Connection."""
 
-        # pylint: disable=too-few-public-methods,missing-docstring
+        # pylint: disable=missing-docstring
 
         def __init__(self, connection):
             self._wrapped = connection

--- a/acme/acme/crypto_util_test.py
+++ b/acme/acme/crypto_util_test.py
@@ -30,7 +30,6 @@ class SSLSocketAndProbeSNITest(unittest.TestCase):
 
         class _TestServer(socketserver.TCPServer):
 
-            # pylint: disable=too-few-public-methods
             # six.moves.* | pylint: disable=attribute-defined-outside-init,no-init
 
             def server_bind(self):  # pylint: disable=missing-docstring

--- a/acme/acme/jws.py
+++ b/acme/acme/jws.py
@@ -43,7 +43,7 @@ class JWS(jose.JWS):
     __slots__ = jose.JWS._orig_slots  # pylint: disable=no-member
 
     @classmethod
-    # pylint: disable=arguments-differ,too-many-arguments
+    # pylint: disable=arguments-differ
     def sign(cls, payload, key, alg, nonce, url=None, kid=None):
         # Per ACME spec, jwk and kid are mutually exclusive, so only include a
         # jwk field if kid is not provided.

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -17,7 +17,7 @@ from acme.magic_typing import List # pylint: disable=unused-import, no-name-in-m
 logger = logging.getLogger(__name__)
 
 # six.moves.* | pylint: disable=no-member,attribute-defined-outside-init
-# pylint: disable=too-few-public-methods,no-init
+# pylint: disable=no-init
 
 
 class TLSServer(socketserver.TCPServer):

--- a/certbot-apache/certbot_apache/configurator.py
+++ b/certbot-apache/certbot_apache/configurator.py
@@ -71,7 +71,6 @@ logger = logging.getLogger(__name__)
 @zope.interface.implementer(interfaces.IAuthenticator, interfaces.IInstaller)
 @zope.interface.provider(interfaces.IPluginFactory)
 class ApacheConfigurator(common.Installer):
-    # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Apache configurator.
 
     :ivar config: Configuration.
@@ -1116,7 +1115,7 @@ class ApacheConfigurator(common.Installer):
             if "ssl_module" not in self.parser.modules:
                 self.enable_mod("ssl", temp=temp)
 
-    def make_vhost_ssl(self, nonssl_vhost):  # pylint: disable=too-many-locals
+    def make_vhost_ssl(self, nonssl_vhost):
         """Makes an ssl_vhost version of a nonssl_vhost.
 
         Duplicates vhost and adds default ssl options

--- a/certbot-apache/certbot_apache/obj.py
+++ b/certbot-apache/certbot_apache/obj.py
@@ -98,7 +98,7 @@ class Addr(common.Addr):
         return self.get_addr_obj(port)
 
 
-class VirtualHost(object):  # pylint: disable=too-few-public-methods
+class VirtualHost(object):
     """Represents an Apache Virtualhost.
 
     :ivar str filep: file path of VH
@@ -126,7 +126,6 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
     def __init__(self, filep, path, addrs, ssl, enabled, name=None,
                  aliases=None, modmacro=False, ancestor=None):
 
-        # pylint: disable=too-many-arguments
         """Initialize a VH."""
         self.filep = filep
         self.path = path

--- a/certbot-apache/certbot_apache/parser.py
+++ b/certbot-apache/certbot_apache/parser.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 
 class ApacheParser(object):
-    # pylint: disable=too-many-public-methods
     """Class handles the fine details of parsing the Apache Configuration.
 
     .. todo:: Make parsing general... remove sites-available etc...

--- a/certbot-apache/certbot_apache/tests/autohsts_test.py
+++ b/certbot-apache/certbot_apache/tests/autohsts_test.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-public-methods,too-many-lines
+# pylint: disable=too-many-lines
 """Test for certbot_apache.configurator AutoHSTS functionality"""
 import re
 import unittest

--- a/certbot-apache/certbot_apache/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/configurator_test.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-public-methods,too-many-lines
+# pylint: disable=too-many-lines
 """Test for certbot_apache.configurator."""
 import copy
 import shutil

--- a/certbot-apache/certbot_apache/tests/parser_test.py
+++ b/certbot-apache/certbot_apache/tests/parser_test.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-public-methods
 """Tests for certbot_apache.parser."""
 import shutil
 import unittest

--- a/certbot-apache/certbot_apache/tests/util.py
+++ b/certbot-apache/certbot_apache/tests/util.py
@@ -18,7 +18,7 @@ from certbot_apache import entrypoint
 from certbot_apache import obj
 
 
-class ApacheTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
+class ApacheTest(unittest.TestCase):
 
     def setUp(self, test_dir="debian_apache_2_4/multiple_vhosts",
               config_root="debian_apache_2_4/multiple_vhosts/apache2",
@@ -81,7 +81,7 @@ class ParserTest(ApacheTest):
                 self.config_path, self.vhost_path, configurator=self.config)
 
 
-def get_apache_configurator(  # pylint: disable=too-many-arguments, too-many-locals
+def get_apache_configurator(
         config_path, vhost_path,
         config_dir, work_dir, version=(2, 4, 7),
         os_info="generic",

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
@@ -18,7 +18,6 @@ from certbot_compatibility_test.configurators import common as configurators_com
 
 @zope.interface.implementer(interfaces.IConfiguratorProxy)
 class Proxy(configurators_common.Proxy):
-    # pylint: disable=too-many-instance-attributes
     """A common base for Apache test configurators"""
 
     def __init__(self, args):

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 class Proxy(object):
-    # pylint: disable=too-many-instance-attributes
     """A common base for compatibility test configurators"""
 
     @classmethod

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/nginx/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/nginx/common.py
@@ -18,7 +18,6 @@ from certbot_compatibility_test.configurators import common as configurators_com
 
 @zope.interface.implementer(interfaces.IConfiguratorProxy)
 class Proxy(configurators_common.Proxy):
-    # pylint: disable=too-many-instance-attributes
     """A common base for Nginx test configurators"""
 
     def load_config(self):

--- a/certbot-nginx/certbot_nginx/configurator.py
+++ b/certbot-nginx/certbot_nginx/configurator.py
@@ -44,7 +44,6 @@ logger = logging.getLogger(__name__)
 @zope.interface.implementer(interfaces.IAuthenticator, interfaces.IInstaller)
 @zope.interface.provider(interfaces.IPluginFactory)
 class NginxConfigurator(common.Installer):
-    # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Nginx configurator.
 
     .. todo:: Add proper support for comments in the config. Currently,

--- a/certbot-nginx/certbot_nginx/nginxparser.py
+++ b/certbot-nginx/certbot_nginx/nginxparser.py
@@ -63,7 +63,6 @@ class RawNginxParser(object):
         return self.parse().asList()
 
 class RawNginxDumper(object):
-    # pylint: disable=too-few-public-methods
     """A class that dumps nginx configuration from the provided tree."""
     def __init__(self, blocks):
         self.blocks = blocks

--- a/certbot-nginx/certbot_nginx/obj.py
+++ b/certbot-nginx/certbot_nginx/obj.py
@@ -37,7 +37,6 @@ class Addr(common.Addr):
     CANONICAL_UNSPECIFIED_ADDRESS = UNSPECIFIED_IPV4_ADDRESSES[0]
 
     def __init__(self, host, port, ssl, default, ipv6, ipv6only):
-        # pylint: disable=too-many-arguments
         super(Addr, self).__init__((host, port))
         self.ssl = ssl
         self.default = default
@@ -145,7 +144,7 @@ class Addr(common.Addr):
         return False
 
 
-class VirtualHost(object):  # pylint: disable=too-few-public-methods
+class VirtualHost(object):
     """Represents an Nginx Virtualhost.
 
     :ivar str filep: file path of VH
@@ -162,7 +161,6 @@ class VirtualHost(object):  # pylint: disable=too-few-public-methods
     """
 
     def __init__(self, filep, addrs, ssl, enabled, names, raw, path):
-        # pylint: disable=too-many-arguments
         """Initialize a VH."""
         self.filep = filep
         self.addrs = addrs

--- a/certbot-nginx/certbot_nginx/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/tests/configurator_test.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-public-methods
 """Test for certbot_nginx.configurator."""
 import unittest
 

--- a/certbot-nginx/certbot_nginx/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/tests/parser_test.py
@@ -15,7 +15,7 @@ from certbot_nginx import parser
 from certbot_nginx.tests import util
 
 
-class NginxParserTest(util.NginxTest): #pylint: disable=too-many-public-methods
+class NginxParserTest(util.NginxTest):
     """Nginx Parser Test."""
 
     def tearDown(self):

--- a/certbot-nginx/certbot_nginx/tests/util.py
+++ b/certbot-nginx/certbot_nginx/tests/util.py
@@ -17,7 +17,7 @@ from certbot_nginx import configurator
 from certbot_nginx import nginxparser
 
 
-class NginxTest(test_util.ConfigTestCase):  # pylint: disable=too-few-public-methods
+class NginxTest(test_util.ConfigTestCase):
 
     def setUp(self):
         super(NginxTest, self).setUp()
@@ -46,7 +46,6 @@ class NginxTest(test_util.ConfigTestCase):  # pylint: disable=too-few-public-met
         shutil.rmtree(self.work_dir)
         shutil.rmtree(self.logs_dir)
 
-    # pylint: disable=too-many-arguments
     def get_nginx_configurator(self, config_path, config_dir, work_dir, logs_dir,
             version=(1, 6, 2), openssl_version="1.0.2g"):
         """Create an Nginx Configurator with the specified options."""

--- a/certbot/_internal/account.py
+++ b/certbot/_internal/account.py
@@ -25,7 +25,7 @@ from certbot.compat import os
 logger = logging.getLogger(__name__)
 
 
-class Account(object):  # pylint: disable=too-few-public-methods
+class Account(object):
     """ACME protocol registration.
 
     :ivar .RegistrationResource regr: Registration Resource

--- a/certbot/_internal/cli.py
+++ b/certbot/_internal/cli.py
@@ -870,7 +870,7 @@ def _add_all_groups(helpful):
         helpful.add_group(name, description=docs["opts"])
 
 
-def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: disable=too-many-statements
+def prepare_and_parse_args(plugins, args, detect_defaults=False):
     """Returns parsed command line arguments.
 
     :param .PluginsRegistry plugins: available plugins
@@ -881,7 +881,6 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):  # pylint: dis
 
     """
 
-    # pylint: disable=too-many-statements
 
     helpful = HelpfulArgumentParser(args, plugins, detect_defaults)
     _add_all_groups(helpful)

--- a/certbot/_internal/main.py
+++ b/certbot/_internal/main.py
@@ -532,7 +532,7 @@ def _determine_account(config):
     return acc, acme
 
 
-def _delete_if_appropriate(config): # pylint: disable=too-many-locals,too-many-branches
+def _delete_if_appropriate(config):
     """Does the user want to delete their now-revoked certs? If run in non-interactive mode,
     deleting happens automatically.
 
@@ -1068,7 +1068,7 @@ def revoke(config, unused_plugins):
     return None
 
 
-def run(config, plugins):  # pylint: disable=too-many-branches,too-many-locals
+def run(config, plugins):
     """Obtain a certificate and install.
 
     :param config: Configuration object

--- a/certbot/_internal/plugins/selection.py
+++ b/certbot/_internal/plugins/selection.py
@@ -175,7 +175,6 @@ def record_chosen_plugins(config, plugins, auth, inst):
 
 
 def choose_configurator_plugins(config, plugins, verb):
-    # pylint: disable=too-many-branches
     """
     Figure out which configurator we're going to use, modifies
     config.authenticator and config.installer strings to reflect that choice if
@@ -254,7 +253,7 @@ def set_configurator(previously, now):
     return now
 
 
-def cli_plugin_requests(config):  # pylint: disable=too-many-branches
+def cli_plugin_requests(config):
     """
     Figure out which plugins the user requested with CLI and config options
 

--- a/certbot/_internal/renewal.py
+++ b/certbot/_internal/renewal.py
@@ -372,7 +372,7 @@ def _renew_describe_results(config, renew_successes, renew_failures,
     disp.notification("\n".join(out), wrap=False)
 
 
-def handle_renewal_request(config):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+def handle_renewal_request(config):
     """Examine each lineage; renew if due and report results"""
 
     # This is trivially False if config.domains is empty

--- a/certbot/_internal/storage.py
+++ b/certbot/_internal/storage.py
@@ -377,7 +377,6 @@ def delete_files(config, certname):
 
 
 class RenewableCert(object):
-    # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """Renewable certificate.
 
     Represents a lineage of certificates that is under the management of
@@ -952,7 +951,6 @@ class RenewableCert(object):
 
     @classmethod
     def new_lineage(cls, lineagename, cert, privkey, chain, cli_config):
-        # pylint: disable=too-many-locals
         """Create a new certificate lineage.
 
         Attempts to create a certificate lineage -- enrolled for

--- a/certbot/achallenges.py
+++ b/certbot/achallenges.py
@@ -27,7 +27,6 @@ from acme import challenges
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 
 class AnnotatedChallenge(jose.ImmutableMap):
     """Client annotated challenge.

--- a/certbot/display/util.py
+++ b/certbot/display/util.py
@@ -89,7 +89,6 @@ def input_with_timeout(prompt=None, timeout=36000.0):
 @zope.interface.implementer(interfaces.IDisplay)
 class FileDisplay(object):
     """File-based display."""
-    # pylint: disable=too-many-arguments
     # see https://github.com/certbot/certbot/issues/3915
 
     def __init__(self, outfile, force_interactive):
@@ -482,7 +481,7 @@ class NoninteractiveDisplay(object):
 
     def menu(self, message, choices, ok_label=None, cancel_label=None,
              help_label=None, default=None, cli_flag=None, **unused_kwargs):
-        # pylint: disable=unused-argument,too-many-arguments
+        # pylint: disable=unused-argument
         """Avoid displaying a menu.
 
         :param str message: title of menu

--- a/certbot/interfaces.py
+++ b/certbot/interfaces.py
@@ -4,7 +4,6 @@ import six
 import zope.interface
 
 # pylint: disable=no-self-argument,no-method-argument,no-init,inherit-non-class
-# pylint: disable=too-few-public-methods
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -372,7 +371,6 @@ class IInstaller(IPlugin):
 
 class IDisplay(zope.interface.Interface):
     """Generic display."""
-    # pylint: disable=too-many-arguments
     # see https://github.com/certbot/certbot/issues/3915
 
     def notification(message, pause, wrap=True, force_interactive=False):

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -93,7 +93,6 @@ class AccountMemoryStorageTest(unittest.TestCase):
 
 class AccountFileStorageTest(test_util.ConfigTestCase):
     """Tests for certbot._internal.account.AccountFileStorage."""
-    #pylint: disable=too-many-public-methods
 
     def setUp(self):
         super(AccountFileStorageTest, self).setUp()

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -56,7 +56,7 @@ class ChallengeFactoryTest(unittest.TestCase):
              errors.Error, self.handler._challenge_factory, authzr, [0])
 
 
-class HandleAuthorizationsTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
+class HandleAuthorizationsTest(unittest.TestCase):
     """handle_authorizations test.
 
     This tests everything except for all functions under _poll_challenges.

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -68,7 +68,6 @@ class UpdateLiveSymlinksTest(BaseCertManagerTest):
     """
     def test_update_live_symlinks(self):
         """Test update_live_symlinks"""
-        # pylint: disable=too-many-statements
         # create files with incorrect symlinks
         from certbot._internal import cert_manager
         archive_paths = {}
@@ -202,7 +201,7 @@ class CertificatesTest(BaseCertManagerTest):
         shutil.rmtree(empty_tempdir)
 
     @mock.patch('certbot._internal.cert_manager.ocsp.RevocationChecker.ocsp_revoked')
-    def test_report_human_readable(self, mock_revoked): #pylint: disable=too-many-statements
+    def test_report_human_readable(self, mock_revoked):
         mock_revoked.return_value = None
         from certbot._internal import cert_manager
         import datetime

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -60,7 +60,7 @@ class FlagDefaultTest(unittest.TestCase):
             self.assertEqual(cli.flag_default('logs_dir'), 'C:\\Certbot\\log')
 
 
-class ParseTest(unittest.TestCase):  # pylint: disable=too-many-public-methods
+class ParseTest(unittest.TestCase):
     '''Test the cli args entrypoint'''
 
 

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -464,7 +464,6 @@ class ClientTest(ClientTestCommon):
 
     @mock.patch("certbot._internal.cli.helpful_parser")
     def test_save_certificate(self, mock_parser):
-        # pylint: disable=too-many-locals
         certs = ["cert_512.pem", "cert-san_512.pem"]
         tmp_path = tempfile.mkdtemp()
         filesystem.chmod(tmp_path, 0o755)  # TODO: really??

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -164,7 +164,7 @@ class ImportCSRFileTest(unittest.TestCase):
                           test_util.load_vector('cert_512.pem'))
 
 
-class MakeKeyTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
+class MakeKeyTest(unittest.TestCase):
     """Tests for certbot.crypto_util.make_key."""
 
     def test_it(self):  # pylint: disable=no-self-use

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -354,7 +354,6 @@ class ChooseNamesTest(unittest.TestCase):
 
 
 class SuccessInstallationTest(unittest.TestCase):
-    # pylint: disable=too-few-public-methods
     """Test the success installation message."""
     @classmethod
     def _call(cls, names):
@@ -376,7 +375,6 @@ class SuccessInstallationTest(unittest.TestCase):
 
 
 class SuccessRenewalTest(unittest.TestCase):
-    # pylint: disable=too-few-public-methods
     """Test the success renewal message."""
     @classmethod
     def _call(cls, names):
@@ -397,7 +395,6 @@ class SuccessRenewalTest(unittest.TestCase):
             self.assertTrue(name in arg)
 
 class SuccessRevocationTest(unittest.TestCase):
-    # pylint: disable=too-few-public-methods
     """Test the success revocation message."""
     @classmethod
     def _call(cls, path):

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -58,7 +58,6 @@ class FileOutputDisplayTest(unittest.TestCase):
     functions look to a user, uncomment the test_visual function.
 
     """
-    # pylint:disable=too-many-public-methods
     def setUp(self):
         super(FileOutputDisplayTest, self).setUp()
         self.mock_stdout = mock.MagicMock()

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -356,7 +356,6 @@ class DeleteIfAppropriateTest(test_util.ConfigTestCase):
         util_mock.yesno.return_value = False
         self._test_delete_opt_out_common(mock_get_utility)
 
-    # pylint: disable=too-many-arguments
     @mock.patch('certbot._internal.storage.renewal_file_for_certname')
     @mock.patch('certbot._internal.cert_manager.delete')
     @mock.patch('certbot._internal.cert_manager.match_and_check_overlaps')
@@ -376,7 +375,6 @@ class DeleteIfAppropriateTest(test_util.ConfigTestCase):
         self._call(config)
         mock_delete.assert_not_called()
 
-    # pylint: disable=too-many-arguments
     @mock.patch('certbot._internal.storage.renewal_file_for_certname')
     @mock.patch('certbot._internal.cert_manager.match_and_check_overlaps')
     @mock.patch('certbot._internal.storage.full_archive_path')
@@ -395,7 +393,6 @@ class DeleteIfAppropriateTest(test_util.ConfigTestCase):
         self._call(config)
         self.assertEqual(mock_delete.call_count, 1)
 
-    # pylint: disable=too-many-arguments
     @mock.patch('certbot._internal.storage.renewal_file_for_certname')
     @mock.patch('certbot._internal.cert_manager.match_and_check_overlaps')
     @mock.patch('certbot._internal.storage.full_archive_path')
@@ -416,7 +413,6 @@ class DeleteIfAppropriateTest(test_util.ConfigTestCase):
         self._call(config)
         self.assertEqual(mock_delete.call_count, 1)
 
-    # pylint: disable=too-many-arguments
     @mock.patch('certbot._internal.storage.renewal_file_for_certname')
     @mock.patch('certbot._internal.cert_manager.match_and_check_overlaps')
     @mock.patch('certbot._internal.storage.full_archive_path')
@@ -507,7 +503,7 @@ class DetermineAccountTest(test_util.ConfigTestCase):
         self.assertEqual('other email', self.config.email)
 
 
-class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-methods
+class MainTest(test_util.ConfigTestCase):
     """Tests for different commands."""
 
     def setUp(self):
@@ -970,7 +966,6 @@ class MainTest(test_util.ConfigTestCase):  # pylint: disable=too-many-public-met
                              args=None, should_renew=True, error_expected=False,
                              quiet_mode=False, expiry_date=datetime.datetime.now(),
                              reuse_key=False):
-        # pylint: disable=too-many-locals,too-many-arguments,too-many-branches
         cert_path = test_util.vector_path('cert_512.pem')
         chain_path = os.path.normpath(os.path.join(self.config.config_dir,
                                                    'live/foo.bar/fullchain.pem'))

--- a/certbot/tests/reverter_test.py
+++ b/certbot/tests/reverter_test.py
@@ -14,7 +14,6 @@ from certbot.tests import util as test_util
 
 
 class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
-    # pylint: disable=too-many-instance-attributes, too-many-public-methods
     """Test the Reverter Class."""
     def setUp(self):
         super(ReverterCheckpointLocalTest, self).setUp()
@@ -277,7 +276,6 @@ class ReverterCheckpointLocalTest(test_util.ConfigTestCase):
 
 
 class TestFullCheckpointsReverter(test_util.ConfigTestCase):
-    # pylint: disable=too-many-instance-attributes
     """Tests functions having to deal with full checkpoints."""
     def setUp(self):
         super(TestFullCheckpointsReverter, self).setUp()

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -140,7 +140,6 @@ class BaseRenewableCertTest(test_util.ConfigTestCase):
 
 
 class RenewableCertTests(BaseRenewableCertTest):
-    # pylint: disable=too-many-public-methods
     """Tests for certbot._internal.storage."""
 
     def test_initialization(self):
@@ -202,7 +201,7 @@ class RenewableCertTests(BaseRenewableCertTest):
         self.assertTrue("version" in mock_logger.info.call_args[0][0])
 
     def test_consistent(self):
-        # pylint: disable=too-many-statements,protected-access
+        # pylint: disable=protected-access
         oldcert = self.test_rc.cert
         self.test_rc.cert = "relative/path"
         # Absolute path for item requirement
@@ -483,7 +482,6 @@ class RenewableCertTests(BaseRenewableCertTest):
     def test_should_autorenew(self, mock_ocsp, mock_cli):
         """Test should_autorenew on the basis of reasons other than
         expiry time window."""
-        # pylint: disable=too-many-statements
         mock_cli.set_by_cli.return_value = False
         # Autorenewal turned off
         self.test_rc.configuration["renewalparams"] = {"autorenew": "False"}


### PR DESCRIPTION
Fixes #7553.

Inspired by Erica's recent PRs, this was mostly done with:
```
for error in 'too-many-ancestors' 'too-many-instance-attributes' 'too-few-public-methods' 'too-many-public-methods' 'too-many-return-statements' 'too-many-branches' 'too-many-arguments' 'too-many-locals' 'too-many-statements' 'too-many-boolean-expressions'; do
    git grep -l "$error" | xargs sed -i "s/[ ,]*$error[ ,]*//g;/^ *# *pylint: *disable=$/d;s/ *# *pylint: *disable=$//g"
done
```

There's no rush on reviewing this PR but hopefully helps reduce the amount of time we spend fighting pylint.

cc @ohemorange 