### PR TITLE
[Apache v2] Implement find_ancestors

### DIFF
--- a/certbot-apache/certbot_apache/apacheparser.py
+++ b/certbot-apache/certbot_apache/apacheparser.py
@@ -24,6 +24,14 @@ class ApacheParserNode(interfaces.ParserNode):
     def save(self, msg): # pragma: no cover
         pass
 
+    def find_ancestors(self, name):  # pylint: disable=unused-variable
+        """Find ancestor BlockNodes with a given name"""
+        return [ApacheBlockNode(name=assertions.PASS,
+                                parameters=assertions.PASS,
+                                ancestor=self,
+                                filepath=assertions.PASS,
+                                metadata=self.metadata)]
+
 
 class ApacheCommentNode(ApacheParserNode):
     """ apacheconfig implementation of CommentNode interface """

--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -134,8 +134,6 @@ class AugeasParserNode(interfaces.ParserNode):
         name = self._aug_get_name(path)
         metadata = {"augeasparser": self.parser, "augeaspath": path}
 
-        # Because of the dynamic nature, and the fact that we're not populating
-        # the complete ParserNode tree, we use the search parent as ancestor
         return AugeasBlockNode(name=name,
                                ancestor=assertions.PASS,
                                filepath=apache_util.get_file_path(path),

--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -101,7 +101,7 @@ class AugeasParserNode(interfaces.ParserNode):
 
     def find_ancestors(self, name):
         """
-        Searches ancestor BlockNodes with a given name.
+        Searches for ancestor BlockNodes with a given name.
 
         :param str name: Name of the BlockNode parent to search for
 

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -18,17 +18,58 @@ class DualNodeBase(object):
         """ Attribute value assertion """
         firstval = getattr(self.primary, aname)
         secondval = getattr(self.secondary, aname)
-        if not callable(firstval):
+        exclusions = [
+            # Metadata will inherently be different, as ApacheParserNode does
+            # not have Augeas paths and so on.
+            aname == "metadata",
+            callable(firstval)
+        ]
+        if not any(exclusions):
             assertions.assertEqualSimple(firstval, secondval)
         return firstval
 
     def find_ancestors(self, name):
         """ Traverses the ancestor tree and returns ancestors matching name """
+        return self._find_helper(DualBlockNode, "find_ancestors", name)
 
-        primary_ancs = self.primary.find_ancestors(name)
-        secondary_ancs = self.secondary.find_ancestors(name)
-        assert primary_ancs == secondary_ancs
-        return primary_ancs
+    def _find_helper(self, nodeclass, findfunc, search, **kwargs):
+        """A helper for find_* functions. The function specific attributes should
+        be passed as keyword arguments.
+
+        :param interfaces.ParserNode nodeclass: The node class for results.
+        :param str findfunc: Name of the find function to call
+        :param str search: The search term
+        """
+
+        primary_res = getattr(self.primary, findfunc)(search, **kwargs)
+        secondary_res = getattr(self.secondary, findfunc)(search, **kwargs)
+
+        # The order of search results for Augeas implementation cannot be
+        # assured.
+
+        pass_primary = assertions.isPassNodeList(primary_res)
+        pass_secondary = assertions.isPassNodeList(secondary_res)
+        new_nodes = list()
+
+        if pass_primary and pass_secondary:
+            # Both unimplemented
+            new_nodes.append(nodeclass(primary=primary_res[0],
+                                       secondary=secondary_res[0])) # pragma: no cover
+        elif pass_primary:
+            for c in secondary_res:
+                new_nodes.append(nodeclass(primary=primary_res[0],
+                                           secondary=c))
+        elif pass_secondary:
+            for c in primary_res:
+                new_nodes.append(nodeclass(primary=c,
+                                           secondary=secondary_res[0]))
+        else:
+            assert len(primary_res) == len(secondary_res)
+            matches = self._create_matching_list(primary_res, secondary_res)
+            for p, s in matches:
+                new_nodes.append(nodeclass(primary=p, secondary=s))
+
+        return new_nodes
 
 
 class DualCommentNode(DualNodeBase):
@@ -231,44 +272,6 @@ class DualBlockNode(DualNodeBase):
 
         return self._find_helper(DualCommentNode, "find_comments", comment)
 
-    def _find_helper(self, nodeclass, findfunc, search, **kwargs):
-        """A helper for find_* functions. The function specific attributes should
-        be passed as keyword arguments.
-
-        :param interfaces.ParserNode nodeclass: The node class for results.
-        :param str findfunc: Name of the find function to call
-        :param str search: The search term
-        """
-
-        primary_res = getattr(self.primary, findfunc)(search, **kwargs)
-        secondary_res = getattr(self.secondary, findfunc)(search, **kwargs)
-
-        # The order of search results for Augeas implementation cannot be
-        # assured.
-
-        pass_primary = assertions.isPassNodeList(primary_res)
-        pass_secondary = assertions.isPassNodeList(secondary_res)
-        new_nodes = list()
-
-        if pass_primary and pass_secondary:
-            # Both unimplemented
-            new_nodes.append(nodeclass(primary=primary_res[0],
-                                       secondary=secondary_res[0])) # pragma: no cover
-        elif pass_primary:
-            for c in secondary_res:
-                new_nodes.append(nodeclass(primary=primary_res[0],
-                                           secondary=c))
-        elif pass_secondary:
-            for c in primary_res:
-                new_nodes.append(nodeclass(primary=c,
-                                           secondary=secondary_res[0]))
-        else:
-            assert len(primary_res) == len(secondary_res)
-            matches = self._create_matching_list(primary_res, secondary_res)
-            for p, s in matches:
-                new_nodes.append(nodeclass(primary=p, secondary=s))
-
-        return new_nodes
 
     def delete_child(self, child):
         """Deletes a child from the ParserNode implementations. The actual

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -21,6 +21,14 @@ class DualNodeBase(object):
             assertions.assertEqualSimple(firstval, secondval)
         return firstval
 
+    def find_ancestors(self, name):
+        """ Traverses the ancestor tree and returns ancestors matching name """
+
+        primary_ancs = self.primary.find_ancestors(name)
+        secondary_ancs = self.secondary.find_ancestors(name)
+        assert primary_ancs == secondary_ancs
+        return primary_ancs
+
 
 class DualCommentNode(DualNodeBase):
     """ Dual parser implementation of CommentNode interface """

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -192,6 +192,18 @@ class ParserNode(object):
 
         """
 
+    @abc.abstractmethod
+    def find_ancestors(self, name):
+        """
+        Traverses the ancestor tree up, searching for BlockNodes with a specific
+        name.
+
+        :param str name: Name of the ancestor BlockNode to search for
+
+        :returns: A list of ancestor BlockNodes that match the name
+        :rtype: list of BlockNode
+        """
+
 
 # Linter rule exclusion done because of https://github.com/PyCQA/pylint/issues/179
 @six.add_metaclass(abc.ABCMeta)  # pylint: disable=abstract-method

--- a/certbot-apache/certbot_apache/tests/augeasnode_test.py
+++ b/certbot-apache/certbot_apache/tests/augeasnode_test.py
@@ -281,3 +281,24 @@ class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-
             self.config.parser_root.primary.add_child_directive,
             "ThisRaisesErrorBecauseMissingParameters"
         )
+
+    def test_find_ancestors(self):
+        vhsblocks = self.config.parser_root.find_blocks("VirtualHost")
+        macro_test = False
+        nonmacro_test = False
+        for vh in vhsblocks:
+            if "/macro/" in vh.metadata["augeaspath"].lower():
+                ancs = vh.find_ancestors("Macro")
+                self.assertEqual(len(ancs), 1)
+                macro_test = True
+            else:
+                ancs = vh.find_ancestors("Macro")
+                self.assertEqual(len(ancs), 0)
+                nonmacro_test = True
+        self.assertTrue(macro_test)
+        self.assertTrue(nonmacro_test)
+
+    def test_find_ancestors_bad_path(self):
+        self.config.parser_root.primary.metadata["augeaspath"] = ""
+        ancs = self.config.parser_root.primary.find_ancestors("Anything")
+        self.assertEqual(len(ancs), 0)

--- a/certbot-apache/certbot_apache/tests/dualnode_test.py
+++ b/certbot-apache/certbot_apache/tests/dualnode_test.py
@@ -415,3 +415,12 @@ class DualParserNodeTest(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertFalse(self.block == ne_block)
         self.assertFalse(self.directive == ne_directive)
         self.assertFalse(self.comment == ne_comment)
+
+    def test_find_ancestors(self):
+        primarymock = mock.MagicMock(return_value=[])
+        secondarymock = mock.MagicMock(return_value=[])
+        self.block.primary.find_ancestors = primarymock
+        self.block.secondary.find_ancestors = secondarymock
+        self.block.find_ancestors("anything")
+        self.assertTrue(primarymock.called)
+        self.assertTrue(secondarymock.called)

--- a/certbot-apache/certbot_apache/tests/parsernode_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_test.py
@@ -24,6 +24,10 @@ class DummyParserNode(interfaces.ParserNode):
         """Save"""
         pass
 
+    def find_ancestors(self, name):  # pragma: no cover
+        """ Find ancestors """
+        return []
+
 
 class DummyCommentNode(DummyParserNode):
     """ A dummy class implementing CommentNode interface """


### PR DESCRIPTION
This PR implements find_ancestors that's needed by the Augeas ParserNode implementation to traverse ancestors where possible. While there's quite a few lines changed, majority of it is just moving few helper functions from `AugeasBlockNode` to `AugeasParserNode`, as all the node types need the `find_ancestors` capability.

Note: due to the nature of Augeas, we are not able to trace back the complete ancestry tree, for example in a VirtualHost file that's included from the root configuration, the Augeas path would be `/path/to/vhost.conf/Ancestor/VirtualHost`, leaving ancestor blocks that were defined in the main configuration invisible. This however isn't a regression from our current implementation in `master`, but apacheconfig will be able to do better here.