### PR TITLE
[Apache v2] Implement parsed_files

### DIFF
--- a/certbot-apache/certbot_apache/apacheparser.py
+++ b/certbot-apache/certbot_apache/apacheparser.py
@@ -151,6 +151,10 @@ class ApacheBlockNode(ApacheDirectiveNode):
         """Returns a list of unsaved filepaths"""
         return [assertions.PASS]
 
+    def parsed_paths(self):  # pragma: no cover
+        """Returns a list of parsed configuration file paths"""
+        return [assertions.PASS]
+
 
 interfaces.CommentNode.register(ApacheCommentNode)
 interfaces.DirectiveNode.register(ApacheDirectiveNode)

--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -105,11 +105,15 @@ def assertEqualSimple(first, second):
     if not isPass(first) and not isPass(second):
         assert first == second
 
-def assertEqualPathsList(first, second):
+def assertEqualPathsList(first, second):  # pragma: no cover
     """
     Checks that the two lists of file paths match. This assertion allows for wildcard
     paths.
     """
+    if any([isPass(path) for path in first]):
+        return
+    if any([isPass(path) for path in second]):
+        return
     for fpath in first:
         assert any([fnmatch.fnmatch(fpath, spath) for spath in second])
     for spath in second:

--- a/certbot-apache/certbot_apache/assertions.py
+++ b/certbot-apache/certbot_apache/assertions.py
@@ -1,4 +1,6 @@
 """Dual parser node assertions"""
+import fnmatch
+
 from certbot_apache import interfaces
 
 
@@ -102,3 +104,13 @@ def assertEqualSimple(first, second):
     """ Simple assertion """
     if not isPass(first) and not isPass(second):
         assert first == second
+
+def assertEqualPathsList(first, second):
+    """
+    Checks that the two lists of file paths match. This assertion allows for wildcard
+    paths.
+    """
+    for fpath in first:
+        assert any([fnmatch.fnmatch(fpath, spath) for spath in second])
+    for spath in second:
+        assert any([fnmatch.fnmatch(fpath, spath) for fpath in first])

--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -386,7 +386,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
     def parsed_paths(self):
         """
         Returns a list of file paths that have currently been parsed into the parser
-        tree. The returned list  may include paths with wildcard characters, for
+        tree. The returned list may include paths with wildcard characters, for
         example: ['/etc/apache2/conf.d/*.load']
 
         This is typically called on the root node of the ParserNode tree.

--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -384,7 +384,15 @@ class AugeasBlockNode(AugeasDirectiveNode):
         return self.parser.unsaved_files()
 
     def parsed_paths(self):
-        """Returns a list of parsed filepaths"""
+        """
+        Returns a list of file paths that have currently been parsed into the parser
+        tree. The returned list  may include paths with wildcard characters, for
+        example: ['/etc/apache2/conf.d/*.load']
+
+        This is typically called on the root node of the ParserNode tree.
+
+        :returns: list of file paths of files that have been parsed
+        """
 
         parsed_paths = self.parser.aug.match("/augeas/load/Httpd/incl")
         return [self.parser.aug.get(path) for path in parsed_paths]

--- a/certbot-apache/certbot_apache/augeasparser.py
+++ b/certbot-apache/certbot_apache/augeasparser.py
@@ -317,6 +317,12 @@ class AugeasBlockNode(AugeasDirectiveNode):
         """Returns a list of unsaved filepaths"""
         return self.parser.unsaved_files()
 
+    def parsed_paths(self):
+        """Returns a list of parsed filepaths"""
+
+        parsed_paths = self.parser.aug.match("/augeas/load/Httpd/incl")
+        return [self.parser.aug.get(path) for path in parsed_paths]
+
     def _create_commentnode(self, path):
         """Helper function to create a CommentNode from Augeas path"""
 

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -292,7 +292,7 @@ class DualBlockNode(DualNodeBase):
     def parsed_paths(self):
         """
         Returns a list of file paths that have currently been parsed into the parser
-        tree. The returned list  may include paths with wildcard characters, for
+        tree. The returned list may include paths with wildcard characters, for
         example: ['/etc/apache2/conf.d/*.load']
 
         This is typically called on the root node of the ParserNode tree.

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -54,7 +54,7 @@ class DualNodeBase(object):
         if pass_primary and pass_secondary:
             # Both unimplemented
             new_nodes.append(nodeclass(primary=primary_res[0],
-                                       secondary=secondary_res[0])) # pragma: no cover
+                                       secondary=secondary_res[0]))  # pragma: no cover
         elif pass_primary:
             for c in secondary_res:
                 new_nodes.append(nodeclass(primary=primary_res[0],
@@ -272,7 +272,6 @@ class DualBlockNode(DualNodeBase):
 
         return self._find_helper(DualCommentNode, "find_comments", comment)
 
-
     def delete_child(self, child):
         """Deletes a child from the ParserNode implementations. The actual
         ParserNode implementations are used here directly in order to be able
@@ -291,7 +290,15 @@ class DualBlockNode(DualNodeBase):
         return primary_files
 
     def parsed_paths(self):
-        """Returns a list of files that were parsed into the parser node tree"""
+        """
+        Returns a list of file paths that have currently been parsed into the parser
+        tree. The returned list  may include paths with wildcard characters, for
+        example: ['/etc/apache2/conf.d/*.load']
+
+        This is typically called on the root node of the ParserNode tree.
+
+        :returns: list of file paths of files that have been parsed
+        """
 
         primary_paths = self.primary.parsed_paths()
         secondary_paths = self.secondary.parsed_paths()

--- a/certbot-apache/certbot_apache/dualparser.py
+++ b/certbot-apache/certbot_apache/dualparser.py
@@ -277,3 +277,11 @@ class DualBlockNode(DualNodeBase):
         assertions.assertEqualSimple(primary_files, secondary_files)
 
         return primary_files
+
+    def parsed_paths(self):
+        """Returns a list of files that were parsed into the parser node tree"""
+
+        primary_paths = self.primary.parsed_paths()
+        secondary_paths = self.secondary.parsed_paths()
+        assertions.assertEqualPathsList(primary_paths, secondary_paths)
+        return primary_paths

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -507,7 +507,7 @@ class BlockNode(DirectiveNode):
     def parsed_paths(self):
         """
         Returns a list of file paths that have currently been parsed into the parser
-        tree. The returned list  may include paths with wildcard characters, for
+        tree. The returned list may include paths with wildcard characters, for
         example: ['/etc/apache2/conf.d/*.load']
 
         This is typically called on the root node of the ParserNode tree.

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -498,7 +498,7 @@ class BlockNode(DirectiveNode):
         tree. The returned list  may include paths with wildcard characters, for
         example: ['/etc/apache2/conf.d/*.load']
 
-        This is typically called for the root node of the ParserNode tree.
+        This is typically called on the root node of the ParserNode tree.
 
         :returns: list of file paths of files that have been parsed
         """

--- a/certbot-apache/certbot_apache/interfaces.py
+++ b/certbot-apache/certbot_apache/interfaces.py
@@ -490,3 +490,15 @@ class BlockNode(DirectiveNode):
         :returns: list of file paths of files that have been changed but not yet
             saved to disk.
         """
+
+    @abc.abstractmethod
+    def parsed_paths(self):
+        """
+        Returns a list of file paths that have currently been parsed into the parser
+        tree. The returned list  may include paths with wildcard characters, for
+        example: ['/etc/apache2/conf.d/*.load']
+
+        This is typically called for the root node of the ParserNode tree.
+
+        :returns: list of file paths of files that have been parsed
+        """

--- a/certbot-apache/certbot_apache/tests/augeasnode_test.py
+++ b/certbot-apache/certbot_apache/tests/augeasnode_test.py
@@ -281,3 +281,7 @@ class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-
             self.config.parser_root.primary.add_child_directive,
             "ThisRaisesErrorBecauseMissingParameters"
         )
+
+    def test_parsed_paths(self):
+        paths = self.config.parser_root.parsed_paths()
+        self.assertEqual(len(paths), 6)

--- a/certbot-apache/certbot_apache/tests/dualnode_test.py
+++ b/certbot-apache/certbot_apache/tests/dualnode_test.py
@@ -415,3 +415,22 @@ class DualParserNodeTest(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertFalse(self.block == ne_block)
         self.assertFalse(self.directive == ne_directive)
         self.assertFalse(self.comment == ne_comment)
+
+    def test_parsed_paths(self):
+        mock_p = mock.MagicMock(return_value=['/path/file.conf',
+                                              '/another/path',
+                                              '/path/other.conf'])
+        mock_s = mock.MagicMock(return_value=['/path/*.conf', '/another/path'])
+        self.block.primary.parsed_paths = mock_p
+        self.block.secondary.parsed_paths = mock_s
+        self.block.parsed_paths()
+        self.assertTrue(mock_p.called)
+        self.assertTrue(mock_s.called)
+
+    def test_parsed_paths_error(self):
+        mock_p = mock.MagicMock(return_value=['/path/file.conf'])
+        mock_s = mock.MagicMock(return_value=['/path/*.conf', '/another/path'])
+        self.block.primary.parsed_paths = mock_p
+        self.block.secondary.parsed_paths = mock_s
+        with self.assertRaises(AssertionError):
+            self.block.parsed_paths()


### PR DESCRIPTION
Add new function to BlockNode interfaces: parsed_files(). This is needed in order for ApacheConfigurator to figure out if a file path (typically a VirtualHost that was added) is included in the main Apache configuration or if Certbot should enable it to make it available.