### PR TITLE
Remove DNS plugin API docs.

### DIFF
--- a/certbot-dns-cloudflare/docs/api.rst
+++ b/certbot-dns-cloudflare/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-cloudflare/docs/api/dns_cloudflare.rst
+++ b/certbot-dns-cloudflare/docs/api/dns_cloudflare.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_cloudflare.dns_cloudflare`
---------------------------------------------
-
-.. automodule:: certbot_dns_cloudflare.dns_cloudflare
-   :members:

--- a/certbot-dns-cloudxns/docs/api.rst
+++ b/certbot-dns-cloudxns/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-cloudxns/docs/api/dns_cloudxns.rst
+++ b/certbot-dns-cloudxns/docs/api/dns_cloudxns.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_cloudxns.dns_cloudxns`
-----------------------------------------
-
-.. automodule:: certbot_dns_cloudxns.dns_cloudxns
-   :members:

--- a/certbot-dns-digitalocean/docs/api.rst
+++ b/certbot-dns-digitalocean/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-digitalocean/docs/api/dns_digitalocean.rst
+++ b/certbot-dns-digitalocean/docs/api/dns_digitalocean.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_digitalocean.dns_digitalocean`
-------------------------------------------------
-
-.. automodule:: certbot_dns_digitalocean.dns_digitalocean
-   :members:

--- a/certbot-dns-dnsimple/docs/api.rst
+++ b/certbot-dns-dnsimple/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-dnsimple/docs/api/dns_dnsimple.rst
+++ b/certbot-dns-dnsimple/docs/api/dns_dnsimple.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_dnsimple.dns_dnsimple`
-----------------------------------------
-
-.. automodule:: certbot_dns_dnsimple.dns_dnsimple
-   :members:

--- a/certbot-dns-dnsmadeeasy/docs/api.rst
+++ b/certbot-dns-dnsmadeeasy/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-dnsmadeeasy/docs/api/dns_dnsmadeeasy.rst
+++ b/certbot-dns-dnsmadeeasy/docs/api/dns_dnsmadeeasy.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_dnsmadeeasy.dns_dnsmadeeasy`
-------------------------------------
-
-.. automodule:: certbot_dns_dnsmadeeasy.dns_dnsmadeeasy
-   :members:

--- a/certbot-dns-gehirn/docs/api.rst
+++ b/certbot-dns-gehirn/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-gehirn/docs/api/dns_gehirn.rst
+++ b/certbot-dns-gehirn/docs/api/dns_gehirn.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_gehirn.dns_gehirn`
-------------------------------------
-
-.. automodule:: certbot_dns_gehirn.dns_gehirn
-   :members:

--- a/certbot-dns-google/docs/api.rst
+++ b/certbot-dns-google/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-google/docs/api/dns_google.rst
+++ b/certbot-dns-google/docs/api/dns_google.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_google.dns_google`
-------------------------------------
-
-.. automodule:: certbot_dns_google.dns_google
-   :members:

--- a/certbot-dns-linode/docs/api.rst
+++ b/certbot-dns-linode/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-linode/docs/api/dns_linode.rst
+++ b/certbot-dns-linode/docs/api/dns_linode.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_linode.dns_linode`
-------------------------------------------------
-
-.. automodule:: certbot_dns_linode.dns_linode
-   :members:

--- a/certbot-dns-luadns/docs/api.rst
+++ b/certbot-dns-luadns/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-luadns/docs/api/dns_luadns.rst
+++ b/certbot-dns-luadns/docs/api/dns_luadns.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_luadns.dns_luadns`
-----------------------------------
-
-.. automodule:: certbot_dns_luadns.dns_luadns
-   :members:

--- a/certbot-dns-nsone/docs/api.rst
+++ b/certbot-dns-nsone/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-nsone/docs/api/dns_nsone.rst
+++ b/certbot-dns-nsone/docs/api/dns_nsone.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_nsone.dns_nsone`
-----------------------------------
-
-.. automodule:: certbot_dns_nsone.dns_nsone
-   :members:

--- a/certbot-dns-ovh/docs/api.rst
+++ b/certbot-dns-ovh/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-ovh/docs/api/dns_ovh.rst
+++ b/certbot-dns-ovh/docs/api/dns_ovh.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_ovh.dns_ovh`
-------------------------------
-
-.. automodule:: certbot_dns_ovh.dns_ovh
-   :members:

--- a/certbot-dns-rfc2136/docs/api.rst
+++ b/certbot-dns-rfc2136/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-rfc2136/docs/api/dns_rfc2136.rst
+++ b/certbot-dns-rfc2136/docs/api/dns_rfc2136.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_rfc2136.dns_rfc2136`
---------------------------------------
-
-.. automodule:: certbot_dns_rfc2136.dns_rfc2136
-   :members:

--- a/certbot-dns-route53/docs/api.rst
+++ b/certbot-dns-route53/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-route53/docs/api/authenticator.rst
+++ b/certbot-dns-route53/docs/api/authenticator.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_route53.authenticator`
-----------------------------------------
-
-.. automodule:: certbot_dns_route53.authenticator
-   :members:

--- a/certbot-dns-route53/docs/api/dns_route53.rst
+++ b/certbot-dns-route53/docs/api/dns_route53.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_route53.dns_route53`
---------------------------------------
-
-.. automodule:: certbot_dns_route53.dns_route53
-   :members:

--- a/certbot-dns-sakuracloud/docs/api.rst
+++ b/certbot-dns-sakuracloud/docs/api.rst
@@ -2,7 +2,4 @@
 API Documentation
 =================
 
-.. toctree::
-   :glob:
-
-   api/**
+Certbot plugins implement the Certbot plugins API, and do not otherwise have an external API.

--- a/certbot-dns-sakuracloud/docs/api/dns_sakuracloud.rst
+++ b/certbot-dns-sakuracloud/docs/api/dns_sakuracloud.rst
@@ -1,5 +1,0 @@
-:mod:`certbot_dns_sakuracloud.dns_sakuracloud`
-----------------------------------------------
-
-.. automodule:: certbot_dns_sakuracloud.dns_sakuracloud
-   :members:


### PR DESCRIPTION
Part of #5775. Replace DNS plugins' API documentation with a note that plugins adhere to certbot's plugin interface.

API pages now look like this:

![Screenshot 2019-11-21 at 3 40 24 PM](https://user-images.githubusercontent.com/1227205/69385767-52ea1180-0c75-11ea-94cc-7896e7d0e783.png)
