### PR TITLE
Implement redirect by default

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -28,6 +28,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   `certbot.reverter.Reverter.view_config_changes`, and
   `certbot.util.get_systemd_os_info` have been removed
 * Certbot's `register --update-registration` subcommand has been removed
+* When possible, default to automatically configuring the webserver so all requests
+  redirect to secure HTTPS access. This is mostly relevant when running Certbot
+  in non-interactive mode. Previously, the default was to not redirect all requests.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/display/enhancements.py
+++ b/certbot/certbot/_internal/display/enhancements.py
@@ -50,7 +50,7 @@ def redirect_by_default():
 
     code, selection = util(interfaces.IDisplay).menu(
         "Please choose whether or not to redirect HTTP traffic to HTTPS, removing HTTP access.",
-        choices, default=0,
+        choices, default=1,
         cli_flag="--redirect / --no-redirect", force_interactive=True)
 
     if code != display_util.OK:


### PR DESCRIPTION
Change redirect default to yes so that it happens automatically in noninteractive mode and remove error message.

As a follow-up, we should remove the interactive ask, controlling this feature only by a flag. Issue for this has been created [here](https://github.com/certbot/certbot/issues/7594), but doesn't need to be done for 1.0.