### PR TITLE
Fix refactor

### DIFF
--- a/.azure-pipelines/templates/changelog.yml
+++ b/.azure-pipelines/templates/changelog.yml
@@ -4,7 +4,7 @@ jobs:
       vmImage: vs2017-win2016
     steps:
       - bash: |
-          CERTBOT_VERSION="$(python -c "import certbot; print(certbot.__version__)")"
+          CERTBOT_VERSION="$(cd certbot && python -c "import certbot; print(certbot.__version__)" && cd ~-)"
           "${BUILD_REPOSITORY_LOCALPATH}\tools\extract_changelog.py" "${CERTBOT_VERSION}" >> "${BUILD_ARTIFACTSTAGINGDIRECTORY}/release_notes.md"
         displayName: Prepare changelog
       - task: PublishPipelineArtifact@1

--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -14,7 +14,7 @@ RUN /opt/certbot/src/letsencrypt-auto-source/letsencrypt-auto --os-packages-only
 # the above is not likely to change, so by putting it further up the
 # Dockerfile we make sure we cache as much as possible
 
-COPY certbot/setup.py certbot/README.rst CHANGELOG.md certbot/MANIFEST.in linter_plugin.py tox.cover.py tox.ini .pylintrc /opt/certbot/src/
+COPY certbot/setup.py certbot/README.rst certbot/CHANGELOG.md certbot/MANIFEST.in linter_plugin.py tox.cover.py tox.ini .pylintrc /opt/certbot/src/
 
 # all above files are necessary for setup.py, however, package source
 # code directory has to be copied separately to a subdirectory...

--- a/certbot/README.rst
+++ b/certbot/README.rst
@@ -16,7 +16,7 @@ configuring webservers to use them. This client runs on Unix-based operating
 systems.
 
 To see the changes made to Certbot between versions please refer to our
-`changelog <https://github.com/certbot/certbot/blob/master/CHANGELOG.md>`_.
+`changelog <https://github.com/certbot/certbot/blob/master/certbot/CHANGELOG.md>`_.
 
 Until May 2016, Certbot was named simply ``letsencrypt`` or ``letsencrypt-auto``,
 depending on install method. Instructions on the Internet, and some pieces of the

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -65,8 +65,8 @@ fi
 git checkout "$RELEASE_BRANCH"
 
 # Update changelog
-sed -i "s/master/$(date +'%Y-%m-%d')/" CHANGELOG.md
-git add CHANGELOG.md
+sed -i "s/master/$(date +'%Y-%m-%d')/" certbot/CHANGELOG.md
+git add certbot/CHANGELOG.md
 git diff --cached
 git commit -m "Update changelog for $version release"
 
@@ -249,17 +249,17 @@ echo gpg2 -U $RELEASE_GPG_KEY --detach-sign --armor $name.$rev.tar.xz
 cd ~-
 
 # Add master section to CHANGELOG.md
-header=$(head -n 4 CHANGELOG.md)
+header=$(head -n 4 certbot/CHANGELOG.md)
 body=$(sed s/nextversion/$nextversion/ tools/_changelog_top.txt)
-footer=$(tail -n +5 CHANGELOG.md)
+footer=$(tail -n +5 certbot/CHANGELOG.md)
 echo "$header
 
 $body
 
-$footer" > CHANGELOG.md
-git add CHANGELOG.md
+$footer" > certbot/CHANGELOG.md
+git add certbot/CHANGELOG.md
 git diff --cached
-git commit -m "Add contents to CHANGELOG.md for next version"
+git commit -m "Add contents to certbot/CHANGELOG.md for next version"
 
 echo "New root: $root"
 echo "Test commands (in the letstest repo):"

--- a/tools/extract_changelog.py
+++ b/tools/extract_changelog.py
@@ -16,7 +16,7 @@ def main():
     section_pattern = re.compile(r'^##\s*{0}\s*-\s*[\d-]+$'
                                  .format(version.replace('.', '\\.')))
 
-    with open(os.path.join(CERTBOT_ROOT, 'CHANGELOG.md')) as file_h:
+    with open(os.path.join(CERTBOT_ROOT, 'certbot', 'CHANGELOG.md')) as file_h:
         lines = file_h.read().splitlines()
 
     changelog = []

--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -119,8 +119,9 @@ imp.load_dynamic('pythoncom', pcom)
 
     installer_cfg_path = os.path.join(build_path, 'installer.cfg')
 
+    certbot_pkg_path = os.path.join(repo_path, 'certbot')
     certbot_version = subprocess.check_output([sys.executable, '-c', 'import certbot; print(certbot.__version__)'],
-                                              universal_newlines=True, cwd=repo_path).strip()
+                                              universal_newlines=True, cwd=certbot_pkg_path).strip()
 
     with open(installer_cfg_path, 'w') as file_h:
         file_h.write('''\

--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -40,7 +40,7 @@ def _compile_wheels(repo_path, build_path, venv_python):
     wheels_path = os.path.join(build_path, 'wheels')
     os.makedirs(wheels_path)
 
-    certbot_packages = ['acme', '.']
+    certbot_packages = ['acme', 'certbot']
     # Uncomment following line to include all DNS plugins in the installer
     # certbot_packages.extend([name for name in os.listdir(repo_path) if name.startswith('certbot-dns-')])
     wheels_project = [os.path.join(repo_path, package) for package in certbot_packages]


### PR DESCRIPTION
Clean up some places missed by #7544.

Found this when running test farm tests. They were working as of `5d90544`, and I will truly shocked if subsequent changes (all to the windows installer) made them stop working.