### PR TITLE
Update 3rd party external plugin info

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -275,7 +275,7 @@ haproxy_           Y    Y    Integration with the HAProxy load balancer
 s3front_           Y    Y    Integration with Amazon CloudFront distribution of S3 buckets
 gandi_             Y    N    Obtain certificates via the Gandi LiveDNS API
 varnish_           Y    N    Obtain certificates via a Varnish server
-external_          Y    N    A plugin for convenient scripting (See also ticket 2782_)
+external-auth_     Y    Y    A plugin for convenient scripting
 pritunl_           N    Y    Install certificates in pritunl distributed OpenVPN servers
 proxmox_           N    Y    Install certificates in Proxmox Virtualization servers
 dns-standalone_    Y    N    Obtain certificates via an integrated DNS server
@@ -286,10 +286,9 @@ dns-ispconfig_     Y    N    DNS Authentication using ISPConfig as DNS server
 .. _s3front: https://github.com/dlapiduz/letsencrypt-s3front
 .. _gandi: https://github.com/obynio/certbot-plugin-gandi
 .. _varnish: http://git.sesse.net/?p=letsencrypt-varnish-plugin
-.. _2782: https://github.com/certbot/certbot/issues/2782
 .. _pritunl: https://github.com/kharkevich/letsencrypt-pritunl
 .. _proxmox: https://github.com/kharkevich/letsencrypt-proxmox
-.. _external: https://github.com/marcan/letsencrypt-external
+.. _external: https://github.com/EnigmaBridge/certbot-external-auth
 .. _dns-standalone: https://github.com/siilike/certbot-dns-standalone
 .. _dns-ispconfig: https://github.com/m42e/certbot-dns-ispconfig
 


### PR DESCRIPTION
The old plugin at https://github.com/marcan/certbot-external says it's obsolete and points people to https://github.com/EnigmaBridge/certbot-external-auth. The new plugin is also an installer.

I also removed the reference to #2782 about us adding similar functionality since that's been done for a long time. We could reference our manual plugin instead, but I think that devalues their plugin a bit which I don't think is necessary or correct as it has different features.