### PR TITLE
Update instructions about how to build docs

### DIFF
--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -520,19 +520,21 @@ during the next release.
 Updating the documentation
 ==========================
 
-In order to generate the Sphinx documentation, run the following
-commands:
+Many of the packages in the Certbot repository have documentation in a
+``docs/`` directory in the top level directory for the package. For instance,
+Certbot's documentation is under ``certbot/docs``.
+
+To build this any of this documentation, make sure you have followed the
+instructions to set up a `local copy`_ of Certbot including activating the
+virtual environment and then ``cd`` to the docs directory you want to build and
+run the command:
 
 .. code-block:: shell
 
-   make -C docs clean html man
+   make clean html
 
-This should generate documentation in the ``docs/_build/html``
-directory.
-
-.. note:: If you skipped the "Getting Started" instructions above,
-  run ``pip install -e "certbot[docs]"`` to install Certbot's docs extras modules.
-
+This would generate the HTML documentation in ``_build/html`` in your current
+``docs/`` directory.
 
 .. _docker-dev:
 

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -521,13 +521,14 @@ Updating the documentation
 ==========================
 
 Many of the packages in the Certbot repository have documentation in a
-``docs/`` directory in the top level directory for the package. For instance,
-Certbot's documentation is under ``certbot/docs``.
+``docs/`` directory. This directory is located under the top level directory
+for the package. For instance, Certbot's documentation is under
+``certbot/docs``.
 
-To build this any of this documentation, make sure you have followed the
+To build the documentation of a package, make sure you have followed the
 instructions to set up a `local copy`_ of Certbot including activating the
-virtual environment and then ``cd`` to the docs directory you want to build and
-run the command:
+virtual environment. After that, ``cd`` to the docs directory you want to build
+and run the command:
 
 .. code-block:: shell
 


### PR DESCRIPTION
The resulting documentation looks like 
![Screen Shot 2019-11-26 at 12 16 54 PM](https://user-images.githubusercontent.com/6504915/69669451-bc3b9d00-1046-11ea-8d99-6b592425e0ce.png) where "local copy" links to https://certbot.eff.org/docs/contributing.html#running-a-local-copy-of-the-client.
