### PR TITLE
Exclude pycache and .py[cod] from certbot package

### DIFF
--- a/certbot/MANIFEST.in
+++ b/certbot/MANIFEST.in
@@ -6,3 +6,5 @@ recursive-include examples *
 recursive-include certbot/tests/testdata *
 recursive-include tests *.py
 include certbot/ssl-dhparams.pem
+global-exclude __pycache__
+global-exclude *.py[cod]


### PR DESCRIPTION
See discussion at https://github.com/certbot/certbot/pull/7599#issuecomment-558857381