### PR TITLE
dns-route53: Add option for using a base domain

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -161,6 +161,7 @@ Authors
 * [Mathieu Leduc-Hamel](https://github.com/mlhamel)
 * [Matt Bostock](https://github.com/mattbostock)
 * [Matthew Ames](https://github.com/SuperMatt)
+* [Michael Hartle](https://github.com/mhartle)
 * [Michael Schumacher](https://github.com/schumaml)
 * [Michael Strache](https://github.com/Jarodiv)
 * [Michael Sverdlin](https://github.com/sveder)

--- a/certbot-dns-route53/certbot_dns_route53/_internal/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/_internal/dns_route53.py
@@ -38,6 +38,11 @@ class Authenticator(dns_common.DNSAuthenticator):
         self.r53 = boto3.client("route53")
         self._resource_records = collections.defaultdict(list) # type: DefaultDict[str, List[Dict[str, str]]]
 
+    @classmethod
+    def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
+        super(Authenticator, cls).add_parser_arguments(add)
+        add('base-domain', default=None, help='Base domain containing the DNS TXT records, defaults to none.')
+
     def more_info(self):  # pylint: disable=missing-docstring,no-self-use
         return "Solve a DNS01 challenge using AWS Route53"
 
@@ -53,7 +58,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         try:
             change_ids = [
                 self._change_txt_record("UPSERT",
-                  achall.validation_domain_name(achall.domain),
+                  self._domain_to_update(achall.validation_domain_name(achall.domain)),
                   achall.validation(achall.account_key))
                 for achall in achalls
             ]
@@ -65,9 +70,14 @@ class Authenticator(dns_common.DNSAuthenticator):
             raise errors.PluginError("\n".join([str(e), INSTRUCTIONS]))
         return [achall.response(achall.account_key) for achall in achalls]
 
+    def _domain_to_update(self, domain):
+        if self.conf('base-domain'):
+            return domain + '.' + self.conf('base-domain') + '.'
+        return domain
+
     def _cleanup(self, domain, validation_name, validation):
         try:
-            self._change_txt_record("DELETE", validation_name, validation)
+            self._change_txt_record("DELETE", self._domain_to_update(validation_name), validation)
         except (NoCredentialsError, ClientError) as e:
             logger.debug('Encountered error during cleanup: %s', e, exc_info=True)
 

--- a/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
+++ b/certbot-dns-route53/certbot_dns_route53/dns_route53_test.py
@@ -19,7 +19,7 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
 
         super(AuthenticatorTest, self).setUp()
 
-        self.config = mock.MagicMock()
+        self.config = mock.MagicMock(route53_base_domain=None)
 
         # Set up dummy credentials for testing
         os.environ["AWS_ACCESS_KEY_ID"] = "dummy_access_key"
@@ -41,6 +41,19 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
 
         self.auth._change_txt_record.assert_called_once_with("UPSERT",
                                                              '_acme-challenge.' + DOMAIN,
+                                                             mock.ANY)
+        self.assertEqual(self.auth._wait_for_change.call_count, 1)
+
+    def test_perform_base_domain(self):
+	self.config.route53_base_domain = "base.com"
+
+        self.auth._change_txt_record = mock.MagicMock()
+        self.auth._wait_for_change = mock.MagicMock()
+
+        self.auth.perform([self.achall])
+
+        self.auth._change_txt_record.assert_called_once_with("UPSERT",
+                                                             '_acme-challenge.'+DOMAIN+".base.com.",
                                                              mock.ANY)
         self.assertEqual(self.auth._wait_for_change.call_count, 1)
 
@@ -68,6 +81,19 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
 
         self.auth._change_txt_record.assert_called_once_with("DELETE",
                                                              '_acme-challenge.'+DOMAIN,
+                                                             mock.ANY)
+
+    def test_cleanup_base_domain(self):
+	self.config.route53_base_domain = "base.com"
+
+        self.auth._attempt_cleanup = True
+
+        self.auth._change_txt_record = mock.MagicMock()
+
+        self.auth.cleanup([self.achall])
+
+        self.auth._change_txt_record.assert_called_once_with("DELETE",
+                                                             '_acme-challenge.'+DOMAIN+".base.com.",
                                                              mock.ANY)
 
     def test_cleanup_no_credentials_error(self):


### PR DESCRIPTION
This small PR implements the option of updating / deleting domains under a base domain in dns-route53. If --route53-base-domain base.com is given as option, the DNS records for "_acme-challenge.example.com" are updated / deleted under "_acme-challenge.example.com.base.com". By default, --route-base-domain defaults to None and has no effect.

This comes in handy for automatically DNS challenges for wildcard certificates for domains that are hosted with provides that do not provide an API to dynamic update DNS records, but still allow DNS records like CNAME or NS to be configured through a web application. It also helps for just using a single zone in Route 53 when you need to handle multiple domains.

The basic approach is to delegate a subdomain like "certbot.example.com" from your hosting provider to AWS Route 53, adding NS records at your hosting provider to point to a zone defined by a SOA record at AWS Route 53. You can then add a static CNAME record for "_acme-challenges.example.com" at your hosting provider which points to a (not yet existing) "_acme-challenges.example.com.certbot.example.com" at Route 53, and finally use certbot configured for Route 53 with the option "--route53-base-domain certbot.example.com" to handle the dynamic part. For multiple domains, just reuse a "management" subdomain and add CNAMEs as required.