### PR TITLE
Improve main documentation

### DIFF
--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1304,12 +1304,13 @@ def set_displayer(config):
 
 
 def main(cli_args=None):
-    """Command line argument parsing and main script execution.
+    """Run Certbot.
 
-    :returns: result of requested command
+    :param cli_args: command line to Certbot, defaults to ``sys.argv[1:]``
+    :type cli_args: `list` of `str`
 
-    :raises errors.Error: OS errors triggered by wrong permissions
-    :raises errors.Error: error if plugin command is not supported
+    :returns: value for `sys.exit` about the exit status of Certbot
+    :rtype: `str` or `int` or `None`
 
     """
     if not cli_args:

--- a/certbot/certbot/main.py
+++ b/certbot/certbot/main.py
@@ -3,12 +3,13 @@ from certbot._internal import main as internal_main
 
 
 def main(cli_args=None):
-    """Command line argument parsing and main script execution.
+    """Run Certbot.
 
-    :returns: result of requested command
+    :param cli_args: command line to Certbot, defaults to ``sys.argv[1:]``
+    :type cli_args: `list` of `str`
 
-    :raises errors.Error: OS errors triggered by wrong permissions
-    :raises errors.Error: error if plugin command is not supported
+    :returns: value for `sys.exit` about the exit status of Certbot
+    :rtype: `str` or `int` or `None`
 
     """
     return internal_main.main(cli_args)


### PR DESCRIPTION
The resulting docs look like:
![Screen Shot 2019-11-27 at 2 38 27 PM](https://user-images.githubusercontent.com/6504915/69763933-989a5480-1123-11ea-8538-76a3a354b2bd.png)

I deleted the exceptions because I think it's not feasible to document the possible exceptions raised by all of Certbot.