### PR TITLE
Upgrade to pywin32>=227

### DIFF
--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -59,7 +59,7 @@ install_requires = [
 # However environment markers are supported only with setuptools >= 36.2.
 # So this dependency is not added for old Linux distributions with old setuptools,
 # in order to allow these systems to build certbot from sources.
-pywin32_req = 'pywin32>=225'  # do not forget to edit pywin32 dependency accordingly in windows-installer/construct.py
+pywin32_req = 'pywin32>=227'  # do not forget to edit pywin32 dependency accordingly in windows-installer/construct.py
 if StrictVersion(setuptools_version) >= StrictVersion('36.2'):
     install_requires.append(pywin32_req + " ; sys_platform == 'win32'")
 elif 'bdist_wheel' in sys.argv[1:]:

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -70,7 +70,7 @@ pytest-sugar==0.9.2
 pytest-rerunfailures==4.2
 python-dateutil==2.6.1
 python-digitalocean==1.11
-pywin32==225
+pywin32==227
 PyYAML==3.13
 repoze.sphinx.autointerface==0.8
 requests-file==1.4.2

--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -11,7 +11,7 @@ import time
 
 PYTHON_VERSION = (3, 7, 4)
 PYTHON_BITNESS = 32
-PYWIN32_VERSION = 225  # do not forget to edit pywin32 dependency accordingly in setup.py
+PYWIN32_VERSION = 227  # do not forget to edit pywin32 dependency accordingly in setup.py
 NSIS_VERSION = '3.04'
 
 


### PR DESCRIPTION
Current version of pywin32 used in certbot (225) does not have wheels available for Python 3.8. Installing certbot for development in this case requires to build from source. On Windows, this implies a Visual Studio C++ environment up and ready, which is absolutely not fun.

Let's upgrade to pywin32 227, that provides these wheels for all Python versions from 3.5 up to current dev status of 3.9.