### PR TITLE
acme/setup.py: comment refers to "PyOpenSSL" not "mock"

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -14,8 +14,8 @@ install_requires = [
     # 1.1.0+ is required to avoid the warnings described at
     # https://github.com/certbot/josepy/issues/13.
     'josepy>=1.1.0',
-    # Connection.set_tlsext_host_name (>=0.13)
     'mock',
+    # Connection.set_tlsext_host_name (>=0.13)
     'PyOpenSSL>=0.13.1',
     'pyrfc3339',
     'pytz',


### PR DESCRIPTION
just what the title says and entirely trivial but the ordering confused me for a bit.