### PR TITLE
Don't list adding type annotations as a PR requirement

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,4 @@
 ## Pull Request Checklist
 
 - [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
-- [ ] Add [mypy type annotations](https://certbot.eff.org/docs/contributing.html#mypy-type-annotations) for any functions that were added or modified.
 - [ ] Include your name in `AUTHORS.md` if you like.


### PR DESCRIPTION
This came out of some discussion we had internally where we think we shouldn't list this as a requirement because most of us haven't been doing it ourselves and we think setting aside the time to get the majority of the codebase annotated will work better than trying to do it as we go.