### PR TITLE
Fixes #6972 by updating lexicon to latest version

### DIFF
--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -9,7 +9,7 @@ version = '1.1.0.dev0'
 install_requires = [
     'acme>=0.31.0',
     'certbot>=0.39.0',
-    'dns-lexicon>=2.2.3',
+    'dns-lexicon>=3.3.11',
     'mock',
     'setuptools',
     'zope.interface',

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fixed #6972 by updating lexicon dependency.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -19,7 +19,7 @@ configparser==3.7.4
 contextlib2==0.6.0.post1
 coverage==4.5.4
 decorator==4.1.2
-dns-lexicon==3.2.1
+dns-lexicon==3.3.11
 dnspython==1.15.0
 docutils==0.12
 execnet==1.5.0


### PR DESCRIPTION
This PR updates the lexicon dependency to v3.3.11 which has the fix for #6972 .