### PR TITLE
[Apache] Traverse the include path to the root where relevant

### DIFF
--- a/certbot-apache/certbot_apache/_internal/apache_util.py
+++ b/certbot-apache/certbot_apache/_internal/apache_util.py
@@ -52,6 +52,23 @@ def get_internal_aug_path(vhost_path):
     """
     return _split_aug_path(vhost_path)[1]
 
+def normalize_filepath(path, root):
+    """Attempts to normalize path to absolute path.
+
+    :param str path: The file path
+    :param str root: The working directory root
+
+    :returns: Normalized absolute path to a file
+    :rtype: str
+    """
+
+    # Expands references to user home
+    path = os.path.expanduser(path)
+    # Removes ../ etc.
+    path = os.path.normpath(path)
+    if not os.path.isabs(path):
+        path = os.path.join(root, path)
+    return path
 
 def _split_aug_path(vhost_path):
     """Splits an Augeas path into a file path and an internal path.

--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -857,7 +857,7 @@ class ApacheConfigurator(common.Installer):
             return None
 
         macro = False
-        if "/macro/" in path.lower():
+        if self.parser.find_blocks_from_include_tree("macro", path):
             macro = True
 
         vhost_enabled = self.parser.parsed_in_original(filename)

--- a/certbot-apache/certbot_apache/_internal/parser.py
+++ b/certbot-apache/certbot_apache/_internal/parser.py
@@ -628,7 +628,8 @@ class ApacheParser(object):
         found = re.search(block, path[startidx:], flags=re.IGNORECASE)
         while found:
             if found:
-                block_paths.append(path[:found.end()])
+                # Don't include the trailing slash
+                block_paths.append(path[:found.end()-1])
                 startidx = found.end()
             found = re.search(block, path[startidx:], flags=re.IGNORECASE)
         # We want the list to be from the leaf to the root

--- a/certbot-apache/certbot_apache/_internal/parser.py
+++ b/certbot-apache/certbot_apache/_internal/parser.py
@@ -677,7 +677,6 @@ class ApacheParser(object):
             and their values.
         """
 
-
         includes = self.find_dir("Include", start="/files")
         includes += self.find_dir("IncludeOptional", start="/files")
         inc_dict = dict()

--- a/certbot-apache/certbot_apache/_internal/parser.py
+++ b/certbot-apache/certbot_apache/_internal/parser.py
@@ -617,12 +617,13 @@ class ApacheParser(object):
         """
 
         block_paths = []  # type: List[str]
-        # Find blocks in the middle of path as well as in the end
-        block = "/{}(/|$)".format(block)
-
         # Not found
         if block.lower() not in path.lower():
             return block_paths
+
+        # Find blocks in the middle of path as well as in the end
+        block = "/{}(/|$)".format(block)
+
         startidx = 0
         found = re.search(block, path[startidx:], flags=re.IGNORECASE)
         while found:

--- a/certbot-apache/certbot_apache/_internal/parser.py
+++ b/certbot-apache/certbot_apache/_internal/parser.py
@@ -451,7 +451,7 @@ class ApacheParser(object):
         # Catch include and includeoptional
         if directive.lower().startswith("include"):
             # Refresh the list of includes
-            self.includes = self._find_all_includes()
+            self.includes = self._find_all_includes()  # pragma: no cover
 
     def get_ifmod(self, aug_conf_path, mod, beginning=False):
         """Returns the path to <IfMod mod> and creates one if it doesn't exist.

--- a/certbot-apache/tests/parser_test.py
+++ b/certbot-apache/tests/parser_test.py
@@ -335,6 +335,7 @@ class BasicParserTest(util.ParserTest):
         assert default_ssl is not None
         # Need to add this manually as apache2ctl cannot be run for tests
         self.parser.modules.add("mod_ssl.c")
+        self.parser.modules.add("mod_somethingcustom.c")
         blocks = self.parser.find_blocks_from_include_tree("ifmodule",
                                                            default_ssl.path)
         self.assertEqual(len(blocks), 2)
@@ -348,6 +349,20 @@ class BasicParserTest(util.ParserTest):
         notfound = self.parser.find_blocks_from_include_tree("nonexistent",
                                                            default_ssl.path)
         self.assertEqual(notfound, [])
+
+    def test_if_specific_ancestor_conditional(self):
+        default_ssl = None
+        for vh in self.config.vhosts:
+            if vh.path.endswith("default-ssl.conf/IfModule/VirtualHost"):
+                default_ssl = vh
+                break
+        assert default_ssl is not None
+        # Need to add this manually as apache2ctl cannot be run for tests
+        self.parser.modules.add("mod_ssl.c")
+        self.parser.modules.add("mod_somethingcustom.c")
+        blocks = self.parser.find_blocks_from_include_tree("ifmodule",
+                                                           default_ssl.path)
+        self.assertEqual('mod_somethingcustom.c', self.parser.get_arg(blocks[1]+"/arg[1]"))
 
 
 class ParserInitTest(util.ApacheTest):

--- a/certbot-apache/tests/testdata/debian_apache_2_4/multiple_vhosts/apache2/apache2.conf
+++ b/certbot-apache/tests/testdata/debian_apache_2_4/multiple_vhosts/apache2/apache2.conf
@@ -204,4 +204,9 @@ IncludeOptional sites-enabled/*.conf
 
 </VirtualHost>
 
+# Custom re-include of a single file to test multiple ancestor searches
+<IfModule mod_ssl.c>
+    IncludeOptional sites-enabled/default-ssl.conf
+</IfModule>
+
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/certbot-apache/tests/testdata/debian_apache_2_4/multiple_vhosts/apache2/apache2.conf
+++ b/certbot-apache/tests/testdata/debian_apache_2_4/multiple_vhosts/apache2/apache2.conf
@@ -205,7 +205,7 @@ IncludeOptional sites-enabled/*.conf
 </VirtualHost>
 
 # Custom re-include of a single file to test multiple ancestor searches
-<IfModule mod_ssl.c>
+<IfModule mod_somethingcustom.c>
     IncludeOptional sites-enabled/default-ssl.conf
 </IfModule>
 


### PR DESCRIPTION
This PR allows Certbot to utilize full include tree for searches that need to know about the ancestors. Search for `mod_macro` block is included in this PR. The functionality also takes the possibility of multiple includes into account.

Because of the limitations of the current parsing engine, we have to search includes from the root up. This also introduces quite big performance penalty, especially if done dynamically. This is why a dictionary of `Include`, `IncludeOptions` and their values are saved to the parser object, and refreshed when new includes are added.