### PR TITLE
Include header files for compilation

### DIFF
--- a/.azure-pipelines/templates/installer-tests.yml
+++ b/.azure-pipelines/templates/installer-tests.yml
@@ -42,7 +42,7 @@ jobs:
         displayName: Install Certbot
       - powershell: Invoke-WebRequest https://www.python.org/ftp/python/3.8.0/python-3.8.0-amd64-webinstall.exe -OutFile C:\py3-setup.exe
         displayName: Get Python
-      - script: C:\py3-setup.exe /quiet PrependPath=1 InstallAllUsers=1 Include_launcher=1 InstallLauncherAllUsers=1 Include_test=0 Include_doc=0 Include_dev=0 Include_debug=0 Include_tcltk=0 TargetDir=C:\py3
+      - script: C:\py3-setup.exe /quiet PrependPath=1 InstallAllUsers=1 Include_launcher=1 InstallLauncherAllUsers=1 Include_test=0 Include_doc=0 Include_dev=1 Include_debug=0 Include_tcltk=0 TargetDir=C:\py3
         displayName: Install Python
       - script: |
           py -3 -m venv venv


### PR DESCRIPTION
https://github.com/certbot/certbot/pull/7120 broke our Windows installer tests (see https://dev.azure.com/certbot/certbot/_build/results?buildId=764&view=results) because `pip` tries to install and compile `bcrypt` when installing `certbot-ci` which failed because we were installing Python without development headers. This PR adds development headers to the installation fixing the problem.

cc @adferrand 