### PR TITLE
Remove update_symlinks

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -74,6 +74,7 @@ Authors
 * [Eric Rescorla](https://github.com/ekr)
 * [Eric Wustrow](https://github.com/ewust)
 * [Erik Rose](https://github.com/erikrose)
+* [Erik Hansen](https://github.com/suckatrash)
 * [Eugene Kazakov](https://github.com/xgin)
 * [Fabian](https://github.com/faerbit)
 * [Faidon Liambotis](https://github.com/paravoid)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Removed the `update_symlinks` subcommand
 
 ### Fixed
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -23,21 +23,6 @@ logger = logging.getLogger(__name__)
 # Commands
 ###################
 
-def update_live_symlinks(config):
-    """Update the certificate file family symlinks to use archive_dir.
-
-    Use the information in the config file to make symlinks point to
-    the correct archive directory.
-
-    .. note:: This assumes that the installation is using a Reverter object.
-
-    :param config: Configuration.
-    :type config: :class:`certbot._internal.configuration.NamespaceConfig`
-
-    """
-    for renewal_file in storage.renewal_conf_files(config):
-        storage.RenewableCert(renewal_file, config, update_symlinks=True)
-
 def rename_lineage(config):
     """Rename the specified lineage to the new name.
 

--- a/certbot/certbot/_internal/cli.py
+++ b/certbot/certbot/_internal/cli.py
@@ -406,13 +406,6 @@ VERB_HELP = [
         "opts": 'Options for the "plugins" subcommand',
         "usage": "\n\n  certbot plugins [options]\n\n"
     }),
-    ("update_symlinks", {
-        "short": "Recreate symlinks in your /etc/letsencrypt/live/ directory",
-        "opts": ("Recreates certificate and key symlinks in {0}, if you changed them by hand "
-                 "or edited a renewal configuration file".format(
-                  os.path.join(flag_default("config_dir"), "live"))),
-        "usage": "\n\n  certbot update_symlinks [options]\n\n"
-    }),
     ("enhance", {
         "short": "Add security enhancements to your existing configuration",
         "opts": ("Helps to harden the TLS configuration by adding security enhancements "
@@ -450,7 +443,6 @@ class HelpfulArgumentParser(object):
             "revoke": main.revoke,
             "rollback": main.rollback,
             "everything": main.run,
-            "update_symlinks": main.update_symlinks,
             "certificates": main.certificates,
             "delete": main.delete,
             "enhance": main.enhance,
@@ -860,7 +852,7 @@ def _add_all_groups(helpful):
     helpful.add_group("paths", description="Flags for changing execution paths & servers")
     helpful.add_group("manage",
         description="Various subcommands and flags are available for managing your certificates:",
-        verbs=["certificates", "delete", "renew", "revoke", "update_symlinks"])
+        verbs=["certificates", "delete", "renew", "revoke"])
 
     # VERBS
     for verb, docs in VERB_HELP:

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -949,24 +949,6 @@ def rollback(config, plugins):
     """
     client.rollback(config.installer, config.checkpoints, config, plugins)
 
-def update_symlinks(config, unused_plugins):
-    """Update the certificate file family symlinks
-
-    Use the information in the config file to make symlinks point to
-    the correct archive directory.
-
-    :param config: Configuration object
-    :type config: interfaces.IConfig
-
-    :param unused_plugins: List of plugins (deprecated)
-    :type unused_plugins: `list` of `str`
-
-    :returns: `None`
-    :rtype: None
-
-    """
-    cert_manager.update_live_symlinks(config)
-
 def rename(config, unused_plugins):
     """Rename a certificate
 

--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -412,7 +412,7 @@ class RenewableCert(interfaces.RenewableCert):
         renewal configuration file and/or systemwide defaults.
 
     """
-    def __init__(self, config_filename, cli_config, update_symlinks=False):
+    def __init__(self, config_filename, cli_config):
         """Instantiate a RenewableCert object from an existing lineage.
 
         :param str config_filename: the path to the renewal config file
@@ -460,8 +460,6 @@ class RenewableCert(interfaces.RenewableCert):
         self.live_dir = os.path.dirname(self.cert)
 
         self._fix_symlinks()
-        if update_symlinks:
-            self._update_symlinks()
         self._check_symlinks()
 
     @property
@@ -534,17 +532,6 @@ class RenewableCert(interfaces.RenewableCert):
             if not os.path.exists(target):
                 raise errors.CertStorageError("target {0} of symlink {1} does "
                                               "not exist".format(target, link))
-
-    def _update_symlinks(self):
-        """Updates symlinks to use archive_dir"""
-        for kind in ALL_FOUR:
-            link = getattr(self, kind)
-            previous_link = get_link_target(link)
-            new_link = os.path.join(self.relative_archive_dir(link),
-                os.path.basename(previous_link))
-
-            os.unlink(link)
-            os.symlink(new_link, link)
 
     def _consistent(self):
         """Are the files associated with this lineage self-consistent?

--- a/certbot/docs/cli-help.txt
+++ b/certbot/docs/cli-help.txt
@@ -268,8 +268,6 @@ manage:
                         name)
   revoke                Revoke a certificate specified with --cert-path or
                         --cert-name
-  update_symlinks       Recreate symlinks in your /etc/letsencrypt/live/
-                        directory
 
 run:
   Options for obtaining & installing certificates
@@ -405,10 +403,6 @@ plugins:
   --prepare             Initialize and prepare plugins. (default: False)
   --authenticators      Limit to authenticator plugins only. (default: None)
   --installers          Limit to installer plugins only. (default: None)
-
-update_symlinks:
-  Recreates certificate and key symlinks in /etc/letsencrypt/live, if you
-  changed them by hand or edited a renewal configuration file
 
 enhance:
   Helps to harden the TLS configuration by adding security enhancements to

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -621,32 +621,6 @@ For most tasks, it is safest to limit yourself to pointing symlinks at the files
 (for instance, combining certificates and keys in different way, or having copies of things with different
 specific permissions that are demanded by other programs).
 
-If the contents of ``/etc/letsencrypt/archive/CERTNAME`` are moved to a new folder, first specify
-the new folder's name in the renewal configuration file, then run ``certbot update_symlinks`` to
-point the symlinks in ``/etc/letsencrypt/live/CERTNAME`` to the new folder.
-
-If you would like the live certificate files whose symlink location Certbot updates on each run to
-reside in a different location, first move them to that location, then specify the full path of
-each of the four files in the renewal configuration file. Since the symlinks are relative links,
-you must follow this with an invocation of ``certbot update_symlinks``.
-
-For example, say that a certificate's renewal configuration file previously contained the following
-directives::
-
-  archive_dir = /etc/letsencrypt/archive/example.com
-  cert = /etc/letsencrypt/live/example.com/cert.pem
-  privkey = /etc/letsencrypt/live/example.com/privkey.pem
-  chain = /etc/letsencrypt/live/example.com/chain.pem
-  fullchain = /etc/letsencrypt/live/example.com/fullchain.pem
-
-The following commands could be used to specify where these files are located::
-
-  mv /etc/letsencrypt/archive/example.com /home/user/me/certbot/example_archive
-  sed -i 's,/etc/letsencrypt/archive/example.com,/home/user/me/certbot/example_archive,' /etc/letsencrypt/renewal/example.com.conf
-  mv /etc/letsencrypt/live/example.com/*.pem /home/user/me/certbot/
-  sed -i 's,/etc/letsencrypt/live/example.com,/home/user/me/certbot,g' /etc/letsencrypt/renewal/example.com.conf
-  certbot update_symlinks
-
 Automated Renewals
 ------------------
 

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -62,46 +62,6 @@ class BaseCertManagerTest(test_util.ConfigTestCase):
         config_file.write()
         return config_file
 
-
-class UpdateLiveSymlinksTest(BaseCertManagerTest):
-    """Tests for certbot._internal.cert_manager.update_live_symlinks
-    """
-    def test_update_live_symlinks(self):
-        """Test update_live_symlinks"""
-        # create files with incorrect symlinks
-        from certbot._internal import cert_manager
-        archive_paths = {}
-        for domain in self.domains:
-            custom_archive = self.domains[domain]
-            if custom_archive is not None:
-                archive_dir_path = custom_archive
-            else:
-                archive_dir_path = os.path.join(self.config.default_archive_dir, domain)
-            archive_paths[domain] = dict((kind,
-                os.path.join(archive_dir_path, kind + "1.pem")) for kind in ALL_FOUR)
-            for kind in ALL_FOUR:
-                live_path = self.config_files[domain][kind]
-                archive_path = archive_paths[domain][kind]
-                open(archive_path, 'a').close()
-                # path is incorrect but base must be correct
-                os.symlink(os.path.join(self.config.config_dir, kind + "1.pem"), live_path)
-
-        # run update symlinks
-        cert_manager.update_live_symlinks(self.config)
-
-        # check that symlinks go where they should
-        prev_dir = os.getcwd()
-        try:
-            for domain in self.domains:
-                for kind in ALL_FOUR:
-                    os.chdir(os.path.dirname(self.config_files[domain][kind]))
-                    self.assertEqual(
-                        filesystem.realpath(os.readlink(self.config_files[domain][kind])),
-                        filesystem.realpath(archive_paths[domain][kind]))
-        finally:
-            os.chdir(prev_dir)
-
-
 class DeleteTest(storage_test.BaseRenewableCertTest):
     """Tests for certbot._internal.cert_manager.delete
     """

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -748,11 +748,6 @@ class MainTest(test_util.ConfigTestCase):
         client.rollback.assert_called_once_with(
             mock.ANY, 123, mock.ANY, mock.ANY)
 
-    @mock.patch('certbot._internal.cert_manager.update_live_symlinks')
-    def test_update_symlinks(self, mock_cert_manager):
-        self._call_no_clientmock(['update_symlinks'])
-        self.assertEqual(1, mock_cert_manager.call_count)
-
     @mock.patch('certbot._internal.cert_manager.certificates')
     def test_certificates(self, mock_cert_manager):
         self._call_no_clientmock(['certificates'])

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -775,21 +775,6 @@ class RenewableCertTests(BaseRenewableCertTest):
         self.assertEqual(stat.S_IMODE(os.lstat(temp).st_mode),
                          stat.S_IMODE(os.lstat(temp2).st_mode))
 
-    def test_update_symlinks(self):
-        from certbot._internal import storage
-        archive_dir_path = os.path.join(self.config.config_dir, "archive", "example.org")
-        for kind in ALL_FOUR:
-            live_path = self.config_file[kind]
-            basename = kind + "1.pem"
-            archive_path = os.path.join(archive_dir_path, basename)
-            open(archive_path, 'a').close()
-            os.symlink(os.path.join(self.config.config_dir, basename), live_path)
-        self.assertRaises(errors.CertStorageError,
-                          storage.RenewableCert, self.config_file.filename,
-                          self.config)
-        storage.RenewableCert(self.config_file.filename, self.config,
-            update_symlinks=True)
-
 class DeleteFilesTest(BaseRenewableCertTest):
     """Tests for certbot._internal.storage.delete_files"""
     def setUp(self):


### PR DESCRIPTION
This PR should resolve #6284.  The `update_symlinks` subcommand is removed as well as related documentation and tests.
