### PR TITLE
[Apache v2] Ensure gating

### DIFF
--- a/certbot-apache/certbot_apache/tests/augeasnode_test.py
+++ b/certbot-apache/certbot_apache/tests/augeasnode_test.py
@@ -16,7 +16,7 @@ class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-
         super(AugeasParserNodeTest, self).setUp()
 
         self.config = util.get_apache_configurator(
-            self.config_path, self.vhost_path, self.config_dir, self.work_dir)
+            self.config_path, self.vhost_path, self.config_dir, self.work_dir, use_parsernode=True)
         self.vh_truth = util.get_vh_truth(
             self.temp_dir, "debian_apache_2_4/multiple_vhosts")
 

--- a/certbot-apache/certbot_apache/tests/parsernode_configurator_test.py
+++ b/certbot-apache/certbot_apache/tests/parsernode_configurator_test.py
@@ -13,7 +13,8 @@ class ConfiguratorParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-p
         super(ConfiguratorParserNodeTest, self).setUp()
 
         self.config = util.get_apache_configurator(
-            self.config_path, self.vhost_path, self.config_dir, self.work_dir)
+            self.config_path, self.vhost_path, self.config_dir,
+            self.work_dir, use_parsernode=True)
         self.vh_truth = util.get_vh_truth(
             self.temp_dir, "debian_apache_2_4/multiple_vhosts")
 

--- a/certbot-apache/certbot_apache/tests/util.py
+++ b/certbot-apache/certbot_apache/tests/util.py
@@ -85,7 +85,8 @@ def get_apache_configurator(  # pylint: disable=too-many-arguments, too-many-loc
         config_path, vhost_path,
         config_dir, work_dir, version=(2, 4, 7),
         os_info="generic",
-        conf_vhost_path=None):
+        conf_vhost_path=None,
+        use_parsernode=False):
     """Create an Apache Configurator with the specified options.
 
     :param conf: Function that returns binary paths. self.conf in Configurator
@@ -118,7 +119,7 @@ def get_apache_configurator(  # pylint: disable=too-many-arguments, too-many-loc
                     except KeyError:
                         config_class = configurator.ApacheConfigurator
                     config = config_class(config=mock_le_config, name="apache",
-                                          version=version)
+                                          version=version, use_parsernode=use_parsernode)
                     if not conf_vhost_path:
                         config_class.OS_DEFAULTS["vhost_root"] = vhost_path
                     else:


### PR DESCRIPTION
`ApacheConfigurator` now has a new boolean kwarg `use_parsernode`, which if `True`, will enable the ParserNode functionality alongside of assertions against legacy implementation.