### PR TITLE
Update CHANGELOG.md regarding #6994

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Removed the fallback introduced with 0.34.0 in `acme` to retry a POST-as-GET
+  request as a GET request when the targeted ACME CA server seems to not support
+  POST-as-GET requests.
 
 ### Fixed
 


### PR DESCRIPTION
This PR adds a changelog entry about the POST-as-GET to GET fallback removed in #6994.
