### PR TITLE
Update Hash for FIPS-140

### DIFF
--- a/certbot/certbot/_internal/account.py
+++ b/certbot/certbot/_internal/account.py
@@ -56,7 +56,7 @@ class Account(object):
                 tz=pytz.UTC).replace(microsecond=0),
             creation_host=socket.getfqdn()) if meta is None else meta
 
-        self.id = hashlib.md5(
+        self.id = hashlib.sha256(
             self.key.key.public_key().public_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo)


### PR DESCRIPTION
The current mechanisms don't work for a machine with FIPS in enforcing mode. This patch fixes this issue. MD5 is not an allowed hashing mechanism.

## Pull Request Checklist

- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Include your name in `AUTHORS.md` if you like.
