### PR TITLE
Do not list the field name twice

### DIFF
--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -245,7 +245,7 @@ class Directory(jose.JSONDeSerializable):
         try:
             return self[name.replace('_', '-')]
         except KeyError as error:
-            raise AttributeError(str(error) + ': ' + name)
+            raise AttributeError(str(error))
 
     def __getitem__(self, name):
         try:


### PR DESCRIPTION
https://github.com/certbot/certbot/pull/7687 improved our `acme` module by adding the name of the missing field to the error message raised from `messages.Directory.__getitem__`.

One slight downside is `messages.Directory.__getattr__` uses `__getitem__` and was previously adding the missing field to the error message so now it is listed twice in this case. This PR fixes that problem.