### PR TITLE
Fix minimum certbot version in plugins in 1.1.x

### DIFF
--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.29.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'mock',
     'python-augeas',
     'setuptools',

--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.29.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'cloudflare>=1.5.1',
     'mock',
     'setuptools',

--- a/certbot-dns-cloudxns/setup.py
+++ b/certbot-dns-cloudxns/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
     'mock',
     'setuptools',

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.29.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'mock',
     'python-digitalocean>=1.11',
     'setuptools',

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -11,7 +11,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'mock',
     'setuptools',
     'zope.interface',

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
     'mock',
     'setuptools',

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -9,7 +9,7 @@ version = '1.1.0'
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dns-lexicon>=2.1.22',
     'mock',
     'setuptools',

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.29.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'google-api-python-client>=1.5.5',
     'mock',
     'oauth2client>=4.0',

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -9,7 +9,7 @@ version = '1.1.0'
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dns-lexicon>=2.2.3',
     'mock',
     'setuptools',

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
     'mock',
     'setuptools',

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
     'mock',
     'setuptools',

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dns-lexicon>=2.7.14',  # Correct proxy use on OVH provider
     'mock',
     'setuptools',

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.29.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dnspython',
     'mock',
     'setuptools',

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.29.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'boto3',
     'mock',
     'setuptools',

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -9,7 +9,7 @@ version = '1.1.0'
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
     'acme>=0.31.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'dns-lexicon>=2.1.23',
     'mock',
     'setuptools',

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -10,7 +10,7 @@ version = '1.1.0'
 # acme/certbot version.
 install_requires = [
     'acme>=1.0.0',
-    'certbot>=1.0.0',
+    'certbot>=1.1.0',
     'mock',
     'PyOpenSSL',
     'pyparsing>=1.5.5',  # Python3 support; perhaps unnecessary?


### PR DESCRIPTION
This is probably overkill, but this cherry picks #7684 to the `1.1.x` branch to properly specify the minimum Certbot version in case of a point release.