### PR TITLE
Downgrade NSIS and upgrade Python

### DIFF
--- a/.azure-pipelines/templates/installer-tests.yml
+++ b/.azure-pipelines/templates/installer-tests.yml
@@ -40,7 +40,7 @@ jobs:
         displayName: Retrieve Windows installer
       - script: $(Build.SourcesDirectory)\bin\certbot-beta-installer-win32.exe /S
         displayName: Install Certbot
-      - powershell: Invoke-WebRequest https://www.python.org/ftp/python/3.8.0/python-3.8.0-amd64-webinstall.exe -OutFile C:\py3-setup.exe
+      - powershell: Invoke-WebRequest https://www.python.org/ftp/python/3.8.1/python-3.8.1-amd64-webinstall.exe -OutFile C:\py3-setup.exe
         displayName: Get Python
       - script: C:\py3-setup.exe /quiet PrependPath=1 InstallAllUsers=1 Include_launcher=1 InstallLauncherAllUsers=1 Include_test=0 Include_doc=0 Include_dev=1 Include_debug=0 Include_tcltk=0 TargetDir=C:\py3
         displayName: Install Python

--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -56,7 +56,7 @@ def _prepare_build_tools(venv_path, venv_python, repo_path):
     subprocess.check_call([sys.executable, '-m', 'venv', venv_path])
     subprocess.check_call([venv_python, os.path.join(repo_path, 'letsencrypt-auto-source', 'pieces', 'pipstrap.py')])
     subprocess.check_call([venv_python, os.path.join(repo_path, 'tools', 'pip_install.py'), 'pynsist'])
-    subprocess.check_call(['choco', 'upgrade', '-y', 'nsis', '--version', NSIS_VERSION])
+    subprocess.check_call(['choco', 'upgrade', '--allow-downgrade', '-y', 'nsis', '--version', NSIS_VERSION])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Windows installer tests started failing last night because Chocolatey was refusing to downgrade NSIS. See https://dev.azure.com/certbot/certbot/_build/results?buildId=951.

I fixed that problem by passing `--allow-downgrade` to chocolatey, but the Python installation for `certbot-ci` started failing. This happened even if we do not run the Certbot installer until after Python is installed which should mean that these failures were unrelated. See https://dev.azure.com/certbot/certbot/_build/results?buildId=957&view=results. I fixed this by upgrading Python used for testing to 3.8.1.

You can see the tests for the combination of these changes passing at https://dev.azure.com/certbot/certbot/_build/results?buildId=956&view=results.