### PR TITLE
Don't run Python 3.5 tests twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,9 +160,6 @@ matrix:
       sudo: required
       services: docker
       <<: *extended-test-suite
-    - python: "3.5"
-      env: TOXENV=py35
-      <<: *extended-test-suite
     - python: "3.6"
       env: TOXENV=py36
       <<: *extended-test-suite


### PR DESCRIPTION
We currently run Python 3.5 tests twice when running the "extended-test-suite". This PR fixes that.