### PR TITLE
Allow setting DNS TTL

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -70,6 +70,7 @@ Authors
 * [Dominic Cleal](https://github.com/domcleal)
 * [Dominic Lüchinger](https://github.com/dol)
 * [Douglas José](https://github.com/douglasjose)
+* [D. Scott Boggs](https://github.com/dscottboggs)
 * [Erica Portnoy](https://github.com/ohemorange)
 * [Eric Engestrom](https://github.com/1ace)
 * [Eric Rescorla](https://github.com/ekr)

--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
@@ -7,6 +7,7 @@ import zope.interface
 from certbot import errors
 from certbot import interfaces
 from certbot.plugins import dns_common
+from certbot.compat.os import environ
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,10 @@ class _DigitalOceanClient(object):
     Encapsulates all communication with the DigitalOcean API.
     """
 
+    # https://developers.digitalocean.com/documentation/changelog/api-v2/update-domain-record-ttl/
+    MINIUMUM_ALLOWED_TTL = 30
+    TTL = environ.get("DIGITALOCEAN_TTL", MINIUMUM_ALLOWED_TTL)
+
     def __init__(self, token):
         self.manager = digitalocean.Manager(token=token)
 
@@ -88,6 +93,7 @@ class _DigitalOceanClient(object):
             result = domain.create_new_domain_record(
                 type='TXT',
                 name=self._compute_record_name(domain, record_name),
+                ttl=self.TTL,
                 data=record_content)
 
             record_id = result['domain_record']['id']

--- a/certbot-dns-digitalocean/tests/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/tests/dns_digitalocean_test.py
@@ -78,6 +78,7 @@ class DigitalOceanClientTest(unittest.TestCase):
         self.digitalocean_client.add_txt_record(DOMAIN, self.record_name, self.record_content)
 
         domain_mock.create_new_domain_record.assert_called_with(type='TXT',
+                                                                ttl=30,
                                                                 name=self.record_prefix,
                                                                 data=self.record_content)
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -15,6 +15,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Disable old SSL versions and ciphersuites to follow Mozilla recommendations in Apache.
 * Remove ECDHE-RSA-AES128-SHA from NGINX ciphers list now that Windows 2008 R2 and Windows 7 are EOLed
 * Support for Python 3.4 has been removed.
+* Add an option to choose a TTL for the DNS-DigialOcean provider.
 
 ### Fixed
 


### PR DESCRIPTION
Fixes #7969.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.

# Purpose
This pull request is to allow setting a custom TTL when using DigitalOcean TXT records for authentication, as well as to lower the default to a more reasonable 60 seconds.

# Rationale
The default used by the dependent `python-digitalocean` library is 1800 seconds (one-half hour) which can cause frustrations when testing out configurations with `--dry-run`.