### PR TITLE
[Apache v2] Implement find_* procedures for ApacheBlockNode

### DIFF
--- a/certbot-apache/certbot_apache/_internal/apacheparser.py
+++ b/certbot-apache/certbot_apache/_internal/apacheparser.py
@@ -1,8 +1,24 @@
 """ apacheconfig implementation of the ParserNode interfaces """
 
+import glob
+
+from certbot import errors
+from certbot.compat import os
+
 from certbot_apache._internal import assertions
 from certbot_apache._internal import interfaces
 from certbot_apache._internal import parsernode_util as util
+
+
+def _load_file(filename, metadata):
+    with open(filename) as f:
+        ast = metadata['loader'].loads(f.read())
+    metadata = metadata.copy()
+    metadata['ac_ast'] = ast
+    return ApacheBlockNode(name=assertions.PASS,
+                           ancestor=None,
+                           filepath=filename,
+                           metadata=metadata)
 
 
 class ApacheParserNode(interfaces.ParserNode):
@@ -62,6 +78,19 @@ class ApacheDirectiveNode(ApacheParserNode):
         self.enabled = enabled
         self.include = None
 
+        # Include processing
+        if self.name and self.name.lower() in ["include", "includeoptional"]:
+            value = self.parameters[0]
+            path = os.path.join(self.metadata['serverroot'], value)
+            if os.path.isdir(path):
+                path += "/*"                    # TODO (mona): test
+            filepaths = glob.glob(path)
+            for filepath in filepaths:
+                if filepath not in self.metadata['parsed_files']:
+                    node = _load_file(filepath, self.metadata)
+                    self.metadata['parsed_files'][filepath] = node
+            self.include = set(filepaths)
+
     def __eq__(self, other):  # pragma: no cover
         if isinstance(other, self.__class__):
             return (self.name == other.name and
@@ -75,7 +104,28 @@ class ApacheDirectiveNode(ApacheParserNode):
 
     def set_parameters(self, _parameters):
         """Sets the parameters for DirectiveNode"""
-        return
+        self.parameters = tuple(_parameters)
+        self._raw.value = tuple(" ".join(_parameters))
+
+
+def _recursive_generator(node, exclude=True, files_visited=None):
+    # iterator through children, and recursively expands through blocks and includes
+    if not files_visited:
+        files_visited = set([node.filepath])
+    for child in node.children:
+        if exclude and not isinstance(child, ApacheCommentNode) and not child.enabled:
+            continue
+        yield child
+        if isinstance(child, ApacheBlockNode):
+            for subchild in _recursive_generator(child, exclude, files_visited):
+                yield subchild
+        if isinstance(child, ApacheDirectiveNode) and child.include:
+            for filename in child.include:
+                if filename not in files_visited:
+                    files_visited.add(filename)
+                    file_ast = node.metadata['parsed_files'][filename]
+                    for subchild in _recursive_generator(file_ast, exclude, files_visited):
+                        yield subchild
 
 
 class ApacheBlockNode(ApacheDirectiveNode):
@@ -83,9 +133,32 @@ class ApacheBlockNode(ApacheDirectiveNode):
 
     def __init__(self, **kwargs):
         super(ApacheBlockNode, self).__init__(**kwargs)
-        self.children = ()
+        self._raw_children = self._raw
+        children = []
 
-    def __eq__(self, other):  # pragma: no cover
+        for raw_node in self._raw_children:
+            metadata = self.metadata.copy()
+            metadata['ac_ast'] = raw_node
+            if raw_node.typestring == "comment":
+                node = ApacheCommentNode(comment=raw_node.name[2:],
+                                         metadata=metadata, ancestor=self,
+                                         filepath=self.filepath)
+            elif raw_node.typestring == "block":  # TODO (mona) mypy annotations
+                parameters = util.parameters_from_string(raw_node.arguments)
+                node = ApacheBlockNode(name=raw_node.tag, parameters=parameters,
+                                       metadata=metadata, ancestor=self,
+                                       filepath=self.filepath, enabled=self.enabled)
+            else:
+                parameters = ()
+                if raw_node.value:  # TODO (mona) mypy annotations
+                    parameters = util.parameters_from_string(raw_node.value)
+                node = ApacheDirectiveNode(name=raw_node.name, parameters=parameters,
+                                           metadata=metadata, ancestor=self,
+                                           filepath=self.filepath, enabled=self.enabled)
+            children.append(node)
+        self.children = tuple(children)
+
+    def __eq__(self, other):  # TODO (mona): test
         if isinstance(other, self.__class__):
             return (self.name == other.name and
                     self.filepath == other.filepath and
@@ -128,28 +201,31 @@ class ApacheBlockNode(ApacheDirectiveNode):
         self.children += (new_comment,)
         return new_comment
 
-    def find_blocks(self, name, exclude=True): # pylint: disable=unused-argument
+    # TODO: Implement exclude
+    def find_blocks(self, name, exclude=False): # pylint: disable=unused-argument
         """Recursive search of BlockNodes from the sequence of children"""
-        return [ApacheBlockNode(name=assertions.PASS,
-                                parameters=assertions.PASS,
-                                ancestor=self,
-                                filepath=assertions.PASS,
-                                metadata=self.metadata)]
+        blocks = []
+        for child in _recursive_generator(self, exclude=exclude):
+            if isinstance(child, ApacheBlockNode) and child.name.lower() == name.lower():
+                blocks.append(child)
+        return blocks
 
     def find_directives(self, name, exclude=True): # pylint: disable=unused-argument
         """Recursive search of DirectiveNodes from the sequence of children"""
-        return [ApacheDirectiveNode(name=assertions.PASS,
-                                    parameters=assertions.PASS,
-                                    ancestor=self,
-                                    filepath=assertions.PASS,
-                                    metadata=self.metadata)]
+        directives = []
+        for child in _recursive_generator(self, exclude=exclude):
+            if isinstance(child, ApacheDirectiveNode) and child.name.lower() == name.lower():
+                directives.append(child)
+        return directives
 
     def find_comments(self, comment, exact=False): # pylint: disable=unused-argument
         """Recursive search of DirectiveNodes from the sequence of children"""
-        return [ApacheCommentNode(comment=assertions.PASS,
-                                  ancestor=self,
-                                  filepath=assertions.PASS,
-                                  metadata=self.metadata)]
+        comments = []
+        for child in _recursive_generator(self):
+            # TODO: Is this the correct metric for matching comments?
+            if isinstance(child, ApacheCommentNode) and comment in child.comment:
+                comments.append(child)
+        return comments
 
     def delete_child(self, child):  # pragma: no cover
         """Deletes a ParserNode from the sequence of children"""

--- a/certbot-apache/certbot_apache/_internal/augeasparser.py
+++ b/certbot-apache/certbot_apache/_internal/augeasparser.py
@@ -389,8 +389,8 @@ class AugeasBlockNode(AugeasDirectiveNode):
         exception if it's unable to do so.
         :param AugeasParserNode: child: A node to delete.
         """
-        if not self.parser.aug.remove(child.metadata["augeaspath"]):
 
+        if not self.parser.aug.remove(child.metadata["augeaspath"]):
             raise errors.PluginError(
                 ("Could not delete child node, the Augeas path: {} doesn't " +
                  "seem to exist.").format(child.metadata["augeaspath"])

--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -371,9 +371,9 @@ class ApacheConfigurator(common.Installer):
         """Initializes the ParserNode parser root instance."""
 
         apache_vars = dict()
-        apache_vars["defines"] = apache_util.parse_defines(self.option("ctl"))
-        apache_vars["includes"] = apache_util.parse_includes(self.option("ctl"))
-        apache_vars["modules"] = apache_util.parse_modules(self.option("ctl"))
+        apache_vars["defines"] = set(apache_util.parse_defines(self.option("ctl")))
+        apache_vars["includes"] = set(apache_util.parse_includes(self.option("ctl")))
+        apache_vars["modules"] = set(apache_util.parse_modules(self.option("ctl")))
         metadata["apache_vars"] = apache_vars
 
         with apacheconfig.make_loader(writable=True,

--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -265,7 +265,6 @@ class ApacheConfigurator(common.Installer):
         # Set up ParserNode root
         pn_meta = {"augeasparser": self.parser,
                    "augeaspath": self.parser.get_root_augpath(),
-                   # TODO (mona): audit the use of serverroot here
                    "serverroot": self.option("server_root"),
                    "ac_ast": None}
         if self.USE_PARSERNODE and HAS_APACHECONFIG:

--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -265,6 +265,8 @@ class ApacheConfigurator(common.Installer):
         # Set up ParserNode root
         pn_meta = {"augeasparser": self.parser,
                    "augeaspath": self.parser.get_root_augpath(),
+                   # TODO (mona): audit the use of serverroot here
+                   "serverroot": self.option("server_root"),
                    "ac_ast": None}
         if self.USE_PARSERNODE and HAS_APACHECONFIG:
             self.parser_root = self.get_parsernode_root(pn_meta)
@@ -374,17 +376,19 @@ class ApacheConfigurator(common.Installer):
         apache_vars["modules"] = apache_util.parse_modules(self.option("ctl"))
         metadata["apache_vars"] = apache_vars
 
-        with open(self.parser.loc["root"]) as f:
-            with apacheconfig.make_loader(writable=True,
-                  **apacheconfig.flavors.NATIVE_APACHE) as loader:
+        with apacheconfig.make_loader(writable=True,
+              **apacheconfig.flavors.NATIVE_APACHE) as loader:
+            with open(self.parser.loc["root"]) as f:
                 metadata["ac_ast"] = loader.loads(f.read())
+            metadata["loader"] = loader
+            metadata["parsed_files"] = {}
 
-        return dualparser.DualBlockNode(
-            name=assertions.PASS,
-            ancestor=None,
-            filepath=self.parser.loc["root"],
-            metadata=metadata
-        )
+            return dualparser.DualBlockNode(
+                name=assertions.PASS,
+                ancestor=None,
+                filepath=self.parser.loc["root"],
+                metadata=metadata
+            )
 
     def _wildcard_domain(self, domain):
         """

--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -12,6 +12,11 @@ import pkg_resources
 import six
 import zope.component
 import zope.interface
+try:
+    import apacheconfig
+    HAS_APACHECONFIG = True
+except ImportError:  # pragma: no cover
+    HAS_APACHECONFIG = False
 
 from acme import challenges
 from acme.magic_typing import DefaultDict
@@ -261,7 +266,7 @@ class ApacheConfigurator(common.Installer):
         pn_meta = {"augeasparser": self.parser,
                    "augeaspath": self.parser.get_root_augpath(),
                    "ac_ast": None}
-        if self.USE_PARSERNODE:
+        if self.USE_PARSERNODE and HAS_APACHECONFIG:
             self.parser_root = self.get_parsernode_root(pn_meta)
             self.parsed_paths = self.parser_root.parsed_paths()
 
@@ -368,6 +373,11 @@ class ApacheConfigurator(common.Installer):
         apache_vars["includes"] = apache_util.parse_includes(self.option("ctl"))
         apache_vars["modules"] = apache_util.parse_modules(self.option("ctl"))
         metadata["apache_vars"] = apache_vars
+
+        with open(self.parser.loc["root"]) as f:
+            with apacheconfig.make_loader(writable=True,
+                  **apacheconfig.flavors.NATIVE_APACHE) as loader:
+                metadata["ac_ast"] = loader.loads(f.read())
 
         return dualparser.DualBlockNode(
             name=assertions.PASS,
@@ -907,7 +917,7 @@ class ApacheConfigurator(common.Installer):
         """
 
         v1_vhosts = self.get_virtual_hosts_v1()
-        if self.USE_PARSERNODE:
+        if self.USE_PARSERNODE and HAS_APACHECONFIG:
             v2_vhosts = self.get_virtual_hosts_v2()
 
             for v1_vh in v1_vhosts:

--- a/certbot-apache/certbot_apache/_internal/parsernode_util.py
+++ b/certbot-apache/certbot_apache/_internal/parsernode_util.py
@@ -127,3 +127,27 @@ def directivenode_kwargs(kwargs):
     parameters = kwargs.pop("parameters")
     enabled = kwargs.pop("enabled")
     return name, parameters, enabled, kwargs
+
+
+def parameters_from_string(text):
+    # TODO (mona) document this function
+    text = text.strip()
+    words = []
+    word = ""
+    quote = None
+    for c in text:
+        if c.isspace() and not quote:
+            if word:
+                words.append(word)
+            word = ""
+        else:
+            word += c
+        if not quote and c in "\"\'":
+            quote = c
+        elif c == quote:
+            words.append(word[1:-1])
+            word = ""
+            quote = None
+    if word:
+        words.append(word)
+    return tuple(words)

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 ]
 
 dev_extras = [
-    'apacheconfig>=0.3.1',
+    'apacheconfig>=0.3.2',
 ]
 
 class PyTest(TestCommand):

--- a/certbot-apache/tests/augeasnode_test.py
+++ b/certbot-apache/tests/augeasnode_test.py
@@ -155,11 +155,11 @@ class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-
 
     def test_add_child_comment(self):
         newc = self.config.parser_root.primary.add_child_comment("The content")
-        comments = self.config.parser_root.find_comments("The content")
+        comments = self.config.parser_root.primary.find_comments("The content")
         self.assertEqual(len(comments), 1)
         self.assertEqual(
             newc.metadata["augeaspath"],
-            comments[0].primary.metadata["augeaspath"]
+            comments[0].metadata["augeaspath"]
         )
         self.assertEqual(newc.comment, comments[0].comment)
 
@@ -288,11 +288,11 @@ class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-
             ["with", "parameters"],
             position=0
         )
-        dirs = self.config.parser_root.find_directives("ThisWasAdded")
+        dirs = self.config.parser_root.primary.find_directives("ThisWasAdded")
         self.assertEqual(len(dirs), 1)
         self.assertEqual(dirs[0].parameters, ("with", "parameters"))
         # The new directive was added to the very first line of the config
-        self.assertTrue(dirs[0].primary.metadata["augeaspath"].endswith("[1]"))
+        self.assertTrue(dirs[0].metadata["augeaspath"].endswith("[1]"))
 
     def test_add_child_directive_exception(self):
         self.assertRaises(

--- a/certbot-apache/tests/augeasnode_test.py
+++ b/certbot-apache/tests/augeasnode_test.py
@@ -1,7 +1,14 @@
 """Tests for AugeasParserNode classes"""
 import mock
 
+import unittest
 import util
+
+try:
+    import apacheconfig  # pylint: disable=import-error,unused-import
+    HAS_APACHECONFIG = True
+except ImportError:  # pragma: no cover
+    HAS_APACHECONFIG = False
 
 from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot import errors
@@ -10,6 +17,7 @@ from certbot_apache._internal import assertions
 
 
 
+@unittest.skipIf(not HAS_APACHECONFIG, reason='Tests require apacheconfig dependency')
 class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-methods
     """Test AugeasParserNode using available test configurations"""
 

--- a/certbot-apache/tests/dualnode_test.py
+++ b/certbot-apache/tests/dualnode_test.py
@@ -15,7 +15,10 @@ class DualParserNodeTest(unittest.TestCase):  # pylint: disable=too-many-public-
         parser_mock = mock.MagicMock()
         parser_mock.aug.match.return_value = []
         parser_mock.get_arg.return_value = []
-        self.metadata = {"augeasparser": parser_mock, "augeaspath": "/invalid", "ac_ast": None}
+        ast_mock = mock.MagicMock()
+        ast_mock.__iter__.return_value = iter([])
+        self.metadata = {"augeasparser": parser_mock,
+                         "augeaspath": "/invalid", "ac_ast": ast_mock}
         self.block = dualparser.DualBlockNode(name="block",
                                               ancestor=None,
                                               filepath="/tmp/something",

--- a/certbot-apache/tests/dualnode_test.py
+++ b/certbot-apache/tests/dualnode_test.py
@@ -18,7 +18,8 @@ class DualParserNodeTest(unittest.TestCase):  # pylint: disable=too-many-public-
         ast_mock = mock.MagicMock()
         ast_mock.__iter__.return_value = iter([])
         self.metadata = {"augeasparser": parser_mock,
-                         "augeaspath": "/invalid", "ac_ast": ast_mock}
+                         "augeaspath": "/invalid", "ac_ast": ast_mock,
+                         "apache_vars": { "modules": set(), "defines": set(), "includes": set(), }}
         self.block = dualparser.DualBlockNode(name="block",
                                               ancestor=None,
                                               filepath="/tmp/something",

--- a/certbot-apache/tests/parsernode_configurator_test.py
+++ b/certbot-apache/tests/parsernode_configurator_test.py
@@ -5,7 +5,14 @@ import mock
 
 import util
 
+try:
+    import apacheconfig
+    HAS_APACHECONFIG = True
+except ImportError:  # pragma: no cover
+    HAS_APACHECONFIG = False
 
+
+@unittest.skipIf(not HAS_APACHECONFIG, reason='Tests require apacheconfig dependency')
 class ConfiguratorParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-methods
     """Test AugeasParserNode using available test configurations"""
 

--- a/certbot-apache/tests/parsernode_util_test.py
+++ b/certbot-apache/tests/parsernode_util_test.py
@@ -110,6 +110,31 @@ class ParserNodeUtilTest(unittest.TestCase):
         p_params.pop("filepath")
         self.assertRaises(TypeError, util.parsernode_kwargs, p_params)
 
+    def test_parameters_from_string(self):
+        test_cases = [
+            # Whitespace between tokens is usually ignored
+            ("one two", ("one", "two")),
+            ("\t\none \n\ntwo \t", ("one", "two")),
+            # Quotes preserve whitespace
+            ("one 'param\ttwo'", ("one", "param\ttwo")),
+            ("\t  one \t\n ' param\t2\t'\n", ("one", " param\t2\t")),
+            # Empty/edge cases
+            ("one '' ", ("one", "")),
+            ("one", ("one",)),
+            ("\t\n ", ()),
+            ("", ()),
+            # End-quote can be escaped
+            ("one ' \\'two'", ("one", " 'two")),
+            ("one \" \\\"two\"", ("one", " \"two")),
+            # Escapes are escaped within quotes
+            ("one 'two\\\\ '", ("one", "two\\ ")),
+            # Unmatched quotations
+            ("one 'two ", ("one", "'two ")),
+            ("one 'two\" ", ("one", "'two\" ")),
+        ]
+        for text, expected in test_cases:
+            self.assertEqual(util.parameters_from_string(text), expected)
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -3,7 +3,7 @@
 # Some dev package versions specified here may be overridden by higher level constraints
 # files during tests (eg. letsencrypt-auto-source/pieces/dependency-requirements.txt).
 alabaster==0.7.10
-apacheconfig==0.3.1
+apacheconfig==0.3.2
 apipkg==1.4
 appnope==0.1.0
 asn1crypto==0.22.0

--- a/tools/oldest_constraints.txt
+++ b/tools/oldest_constraints.txt
@@ -39,7 +39,7 @@ pytz==2012rc0
 google-api-python-client==1.5.5
 
 # Our setup.py constraints
-apacheconfig==0.3.1
+apacheconfig==0.3.2
 cloudflare==1.5.1
 cryptography==1.2.3
 parsedatetime==1.3

--- a/tox.ini
+++ b/tox.ini
@@ -120,12 +120,14 @@ setenv =
 basepython = python2.7
 commands =
     {[base]install_packages}
+    {[base]pip_install} certbot-apache[dev]
     python tox.cover.py
 
 [testenv:py37-cover]
 basepython = python3.7
 commands =
     {[base]install_packages}
+    {[base]pip_install} certbot-apache[dev]
     python tox.cover.py
 
 [testenv:lint]


### PR DESCRIPTION
Depends on #7710 -- will be a draft PR until upstream lands. Can view diff with 69bb92d to see full diff of this code.

Let me know if this looks like a manageable chunk of code to review at once.

To implements all find_* procedures for ApacheBlockNode:
 * Recursively creates ApacheParserNode tree on construction (expanding includes)
 * Inspects & adds to loaded modules while parsing

The code is currently being run and compared with the Augeas implementation in `ApacheConfigurator.get_virtual_hosts_v2()` to retrieve all the Virtual Host blocks.