### PR TITLE
Turn off Travis notifications in test branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -274,6 +274,7 @@ after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'
 notifications:
   email: false
   irc:
+    if: NOT branch =~ ^test-.*$
     channels:
       # This is set to a secure variable to prevent forks from sending
       # notifications. This value was created by installing


### PR DESCRIPTION
When I want to manually run the full test suite to test something, I've been manually deleting our notification setup from `.travis.yml` to avoid spamming IRC with my personal test failures.

This PR sets this behavior up to happen automatically by turning off IRC notifications in test branches. You can see this working by noticing the IRC notification section in the bottom of the config for this PR at https://travis-ci.com/certbot/certbot/builds/146827907/config and the fact that it is absent from a `test-` branch based on this one at https://travis-ci.com/certbot/certbot/jobs/282059094/config.