### PR TITLE
[nginx] Parse $hostname in `server_name`

### DIFF
--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -601,7 +601,6 @@ class NginxConfigurator(common.Installer):
             try:
                 vhost.names.remove("$hostname")
                 vhost.names.add(socket.gethostname())
-                breakpoint()
             except KeyError:
                 pass
 

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -598,6 +598,13 @@ class NginxConfigurator(common.Installer):
         all_names = set()  # type: Set[str]
 
         for vhost in self.parser.get_vhosts():
+            try:
+                vhost.names.remove("$hostname")
+                vhost.names.add(socket.gethostname())
+                breakpoint()
+            except KeyError:
+                pass
+
             all_names.update(vhost.names)
 
             for addr in vhost.addrs:

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -313,9 +313,6 @@ class NginxConfigurator(common.Installer):
         .. todo:: This should maybe return list if no obvious answer
             is presented.
 
-        .. todo:: The special name "$hostname" corresponds to the machine's
-            hostname. Currently we just ignore this.
-
         :param str target_name: domain name
         :param bool create_if_no_match: If we should create a new vhost from default
             when there is no match found. If we can't choose a default, raise a

--- a/certbot-nginx/tests/configurator_test.py
+++ b/certbot-nginx/tests/configurator_test.py
@@ -36,7 +36,7 @@ class NginxConfiguratorTest(util.NginxTest):
 
     def test_prepare(self):
         self.assertEqual((1, 6, 2), self.config.version)
-        self.assertEqual(11, len(self.config.parser.parsed))
+        self.assertEqual(12, len(self.config.parser.parsed))
 
     @mock.patch("certbot_nginx._internal.configurator.util.exe_exists")
     @mock.patch("certbot_nginx._internal.configurator.subprocess.Popen")
@@ -926,7 +926,7 @@ class NginxConfiguratorTest(util.NginxTest):
                                                 prefer_ssl=False,
                                                 no_ssl_filter_port='80')
             # Check that the dialog was called with only port 80 vhosts
-            self.assertEqual(len(mock_select_vhs.call_args[0][0]), 5)
+            self.assertEqual(len(mock_select_vhs.call_args[0][0]), 6)
 
 
 class InstallSslOptionsConfTest(util.NginxTest):

--- a/certbot-nginx/tests/configurator_test.py
+++ b/certbot-nginx/tests/configurator_test.py
@@ -76,15 +76,17 @@ class NginxConfiguratorTest(util.NginxTest):
         else:  # pragma: no cover
             self.fail("Exception wasn't raised!")
 
+    @mock.patch("certbot_nginx._internal.configurator.socket.gethostname")
     @mock.patch("certbot_nginx._internal.configurator.socket.gethostbyaddr")
-    def test_get_all_names(self, mock_gethostbyaddr):
+    def test_get_all_names(self, mock_gethostbyaddr, mock_gethostname):
         mock_gethostbyaddr.return_value = ('155.225.50.69.nephoscale.net', [], [])
+        mock_gethostname.return_value = ('example.net')
         names = self.config.get_all_names()
         self.assertEqual(names, {
             "155.225.50.69.nephoscale.net", "www.example.org", "another.alias",
              "migration.com", "summer.com", "geese.com", "sslon.com",
              "globalssl.com", "globalsslsetssl.com", "ipv6.com", "ipv6ssl.com",
-             "headers.com"})
+             "headers.com", "example.net"})
 
     def test_supported_enhancements(self):
         self.assertEqual(['redirect', 'ensure-http-header', 'staple-ocsp'],

--- a/certbot-nginx/tests/parser_test.py
+++ b/certbot-nginx/tests/parser_test.py
@@ -58,7 +58,8 @@ class NginxParserTest(util.NginxTest):
                            'sites-enabled/sslon.com',
                            'sites-enabled/globalssl.com',
                            'sites-enabled/ipv6.com',
-                           'sites-enabled/ipv6ssl.com']},
+                           'sites-enabled/ipv6ssl.com',
+                           'sites-enabled/example.net']},
                          set(nparser.parsed.keys()))
         self.assertEqual([['server_name', 'somename', 'alias', 'another.alias']],
                          nparser.parsed[nparser.abs_path('server.conf')])
@@ -88,7 +89,7 @@ class NginxParserTest(util.NginxTest):
         parsed = nparser._parse_files(nparser.abs_path(
             'sites-enabled/example.com.test'))
         self.assertEqual(3, len(glob.glob(nparser.abs_path('*.test'))))
-        self.assertEqual(8, len(
+        self.assertEqual(9, len(
             glob.glob(nparser.abs_path('sites-enabled/*.test'))))
         self.assertEqual([[['server'], [['listen', '69.50.225.155:9000'],
                                         ['listen', '127.0.0.1'],
@@ -171,7 +172,7 @@ class NginxParserTest(util.NginxTest):
                                                   '*.www.example.com']),
                                  [], [2, 1, 0])
 
-        self.assertEqual(13, len(vhosts))
+        self.assertEqual(14, len(vhosts))
         example_com = [x for x in vhosts if 'example.com' in x.filep][0]
         self.assertEqual(vhost3, example_com)
         default = [x for x in vhosts if 'default' in x.filep][0]

--- a/certbot-nginx/tests/testdata/etc_nginx/sites-enabled/example.net
+++ b/certbot-nginx/tests/testdata/etc_nginx/sites-enabled/example.net
@@ -1,0 +1,5 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name $hostname;
+}

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -7,6 +7,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 * Added support for Cloudflare's limited-scope API Tokens
+* Added support for `$hostname` in nginx `server_name` directive
 
 ### Changed
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/7446.

I'm pretty sure I'm properly abusing the try/except statements, but in my mind it was way easier than comparing and ifs and elses when I saw the `remove()` operation :grin:. If there's any objection at all with this programming, please let me know.

Also, I was a little bit tempted to use `socket.getfqdn()`, but didn't change it, because [nginx uses gethostname() too](https://github.com/nginx/nginx/blob/9e07862d6e9d37041a42bbfa34dd1f56ed547505/src/core/ngx_cycle.c#L196). Perhaps that's because C doesn't have a `getfqdn()` function, but hey, if `gethostname()` is good enough for C, it's probably good enough for Python? :stuck_out_tongue: Also, it's a small change if `getfqdn()` is prefered.