### PR TITLE
Add triggers for only a single CI system

### DIFF
--- a/.azure-pipelines/advanced.yml
+++ b/.azure-pipelines/advanced.yml
@@ -1,5 +1,6 @@
 # Advanced pipeline for isolated checks and release purpose
 trigger:
+  - azure-test-*
   - test-*
   - '*.x'
 pr:

--- a/.azure-pipelines/advanced.yml
+++ b/.azure-pipelines/advanced.yml
@@ -1,5 +1,7 @@
 # Advanced pipeline for isolated checks and release purpose
 trigger:
+  # When changing these triggers, please ensure the documentation under
+  # "Running tests in CI" is still correct.
   - azure-test-*
   - test-*
   - '*.x'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_script:
 # the number of simultaneous Travis runs, which speeds turnaround time on
 # review since there is a cap of on the number of simultaneous runs.
 branches:
+  # When changing these branches, please ensure the documentation under
+  # "Running tests in CI" is still correct.
   only:
     # apache-parser-v2 is a temporary branch for doing work related to
     # rewriting the parser in the Apache plugin.

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_script:
   - export TOX_TESTENV_PASSENV=TRAVIS
 
 # Only build pushes to the master branch, PRs, and branches beginning with
-# `test-` or of the form `digit(s).digit(s).x`. This reduces the number of
-# simultaneous Travis runs, which speeds turnaround time on review since there
-# is a cap of on the number of simultaneous runs.
+# `test-`, `travis-test-`, or of the form `digit(s).digit(s).x`. This reduces
+# the number of simultaneous Travis runs, which speeds turnaround time on
+# review since there is a cap of on the number of simultaneous runs.
 branches:
   only:
     # apache-parser-v2 is a temporary branch for doing work related to
@@ -24,7 +24,7 @@ branches:
     - apache-parser-v2
     - master
     - /^\d+\.\d+\.x$/
-    - /^test-.*$/
+    - /^(travis-)?test-.*$/
 
 # Jobs for the main test suite are always executed (including on PRs) except for pushes on master.
 not-on-master: &not-on-master
@@ -274,7 +274,7 @@ after_success: '[ "$TOXENV" == "py27-cover" ] && codecov -F linux'
 notifications:
   email: false
   irc:
-    if: NOT branch =~ ^test-.*$
+    if: NOT branch =~ ^(travis-)?test-.*$
     channels:
       # This is set to a secure variable to prevent forks from sending
       # notifications. This value was created by installing

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -201,6 +201,16 @@ using an HTTP-01 challenge on a machine with Python 3:
     certbot_test certonly --standalone -d test.example.com
     # To stop Pebble, launch `fg` to get back the background job, then press CTRL+C
 
+Running tests in CI
+~~~~~~~~~~~~~~~~~~~
+
+Certbot uses both Azure Pipelines and Travis to run continuous integration
+tests. If you are using our Azure and Travis setup, a branch whose name starts
+with `test-` will run all Azure and Travis tests on that branch. If the branch
+name starts with `azure-test-`, it will run all of our Azure tests and none of
+our Travis tests. If the branch stats with `travis-test-`, only our Travis
+tests will be run.
+
 Code components and layout
 ==========================
 


### PR DESCRIPTION
This is a quality of life improvement similar to https://github.com/certbot/certbot/pull/7733.

I regularly just want to run tests in one of our CI systems to do something like test our Windows installer, but I don't have a way to do that without manually modifying config files. This PR changes that.