### PR TITLE
Don't display todo comments in docs

### DIFF
--- a/acme/docs/conf.py
+++ b/acme/docs/conf.py
@@ -113,7 +113,7 @@ pygments_style = 'sphinx'
 #keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-cloudflare/docs/conf.py
+++ b/certbot-dns-cloudflare/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-cloudxns/docs/conf.py
+++ b/certbot-dns-cloudxns/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-digitalocean/docs/conf.py
+++ b/certbot-dns-digitalocean/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-dnsimple/docs/conf.py
+++ b/certbot-dns-dnsimple/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-dnsmadeeasy/docs/conf.py
+++ b/certbot-dns-dnsmadeeasy/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-gehirn/docs/conf.py
+++ b/certbot-dns-gehirn/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-google/docs/conf.py
+++ b/certbot-dns-google/docs/conf.py
@@ -85,7 +85,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-linode/docs/conf.py
+++ b/certbot-dns-linode/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-luadns/docs/conf.py
+++ b/certbot-dns-luadns/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-nsone/docs/conf.py
+++ b/certbot-dns-nsone/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-ovh/docs/conf.py
+++ b/certbot-dns-ovh/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-rfc2136/docs/conf.py
+++ b/certbot-dns-rfc2136/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-route53/docs/conf.py
+++ b/certbot-dns-route53/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot-dns-sakuracloud/docs/conf.py
+++ b/certbot-dns-sakuracloud/docs/conf.py
@@ -84,7 +84,7 @@ default_role = 'py:obj'
 pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -122,7 +122,7 @@ pygments_style = 'sphinx'
 #keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 suppress_warnings = ['image.nonlocal_uri']
 

--- a/letshelp-certbot/docs/conf.py
+++ b/letshelp-certbot/docs/conf.py
@@ -112,7 +112,7 @@ pygments_style = 'sphinx'
 #keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+todo_include_todos = False
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/tools/sphinx-quickstart.sh
+++ b/tools/sphinx-quickstart.sh
@@ -16,6 +16,8 @@ sed -i -e "s|intersphinx_mapping = {'https://docs.python.org/': None}|intersphin
 sed -i -e "s|html_theme = 'alabaster'|\n# http://docs.readthedocs.org/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs\n# on_rtd is whether we are on readthedocs.org\non_rtd = os.environ.get('READTHEDOCS', None) == 'True'\nif not on_rtd:  # only import and set the theme if we're building docs locally\n    import sphinx_rtd_theme\n    html_theme = 'sphinx_rtd_theme'\n    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]\n# otherwise, readthedocs.org uses their theme by default, so no need to specify it|" conf.py
 sed -i -e "s|# Add any paths that contain templates here, relative to this directory.|autodoc_member_order = 'bysource'\nautodoc_default_flags = ['show-inheritance']\n\n# Add any paths that contain templates here, relative to this directory.|" conf.py
 sed -i -e "s|# The name of the Pygments (syntax highlighting) style to use.|default_role = 'py:obj'\n\n# The name of the Pygments (syntax highlighting) style to use.|" conf.py
+# If the --ext-todo flag is removed from sphinx-quickstart, the line below can be removed.
+sed -i -e "s|todo_include_todos = True|todo_include_todos = False|" conf.py
 echo "/_build/" >> .gitignore
 echo "=================
 API Documentation


### PR DESCRIPTION
Currently if you go to https://certbot.eff.org/docs/api/certbot.crypto_util.html, there is a todo comment displayed at the top of the page. These todos were written for developers, not users, so I do not think they should be shown from our documentation.

This PR makes the quick and easy fix of configuring Sphinx not to show these todo items. I created https://github.com/certbot/certbot/issues/7752 to track removing all of these todos from our docstrings and disabling the Sphinx todo extension.