### PR TITLE
Remove text that certbot.tests.utils isn't public

### DIFF
--- a/certbot/certbot/tests/util.py
+++ b/certbot/certbot/tests/util.py
@@ -1,8 +1,4 @@
-"""Test utilities.
-
-.. warning:: This module is not part of the public API.
-
-"""
+"""Test utilities."""
 import logging
 from multiprocessing import Event
 from multiprocessing import Process


### PR DESCRIPTION
This module is part of our public API for the purposes of making it easier for plugins to write tests.