### PR TITLE
acme: no mock dependency at runtime

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -1,5 +1,7 @@
+from distutils.version import StrictVersion
 import sys
 
+from setuptools import __version__ as setuptools_version
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
@@ -26,9 +28,13 @@ install_requires = [
 ]
 
 tests_require = [
-    'mock',
     'pytest',
 ]
+setuptools_known_environemnt_markers = (StrictVersion(setuptools_version) >= StrictVersion('36.2'))
+if setuptools_known_environemnt_markers:
+    tests_require.append('mock ; python_version < "3.3"')
+elif sys.version_info  < (3,3):
+    tests_require.append('mock')
 
 dev_extras = [
     'pytest',

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -15,7 +15,6 @@ install_requires = [
     # 1.1.0+ is required to avoid the warnings described at
     # https://github.com/certbot/josepy/issues/13.
     'josepy>=1.1.0',
-    'mock',
     # Connection.set_tlsext_host_name (>=0.13)
     'PyOpenSSL>=0.13.1',
     'pyrfc3339',
@@ -24,6 +23,11 @@ install_requires = [
     'requests-toolbelt>=0.3.0',
     'setuptools',
     'six>=1.9.0',  # needed for python_2_unicode_compatible
+]
+
+tests_require = [
+    'mock',
+    'pytest',
 ]
 
 dev_extras = [
@@ -86,6 +90,6 @@ setup(
         'docs': docs_extras,
     },
     test_suite='acme',
-    tests_require=["pytest"],
+    tests_require=tests_require,
     cmdclass={"test": PyTest},
 )

--- a/acme/tests/challenges_test.py
+++ b/acme/tests/challenges_test.py
@@ -2,7 +2,10 @@
 import unittest
 
 import josepy as jose
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import requests
 from six.moves.urllib import parse as urllib_parse
 

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -6,7 +6,10 @@ import json
 import unittest
 
 import josepy as jose
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import OpenSSL
 import requests
 from six.moves import http_client  # pylint: disable=import-error

--- a/acme/tests/errors_test.py
+++ b/acme/tests/errors_test.py
@@ -1,7 +1,10 @@
 """Tests for acme.errors."""
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class BadNonceTest(unittest.TestCase):

--- a/acme/tests/magic_typing_test.py
+++ b/acme/tests/magic_typing_test.py
@@ -2,7 +2,10 @@
 import sys
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class MagicTypingTest(unittest.TestCase):

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -2,7 +2,10 @@
 import unittest
 
 import josepy as jose
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from acme import challenges
 from acme.magic_typing import Dict  # pylint: disable=unused-import, no-name-in-module

--- a/acme/tests/standalone_test.py
+++ b/acme/tests/standalone_test.py
@@ -4,7 +4,10 @@ import threading
 import unittest
 
 import josepy as jose
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import requests
 from six.moves import http_client  # pylint: disable=import-error
 from six.moves import socketserver  # type: ignore  # pylint: disable=import-error


### PR DESCRIPTION
The first commit moves the `mock` dependency to `test_requires` (`acme` component only). This is basically a template for removing the `mock` runtime dependency in other parts of the code (see also #6604).

The second commit removes the dependency on `mock` altogether for Python >= 3.3. Once Python 2 support is dropped we can also remove the `try/except`. Doing so tree-wide might be bit controversial as `certbot.tests` imports `mock` and is part of certbot's public api (so just switching it with `unittest.mock`might not be desirable).

