### PR TITLE
Remove link to letsencrypt readthedocs

### DIFF
--- a/certbot/README.rst
+++ b/certbot/README.rst
@@ -81,10 +81,6 @@ ACME working area in github: https://github.com/ietf-wg-acme/acme
    :target: https://codecov.io/gh/certbot/certbot
    :alt: Coverage status
 
-.. |docs| image:: https://readthedocs.org/projects/letsencrypt/badge/
-   :target: https://readthedocs.org/projects/letsencrypt/
-   :alt: Documentation status
-
 .. |container| image:: https://quay.io/repository/letsencrypt/letsencrypt/status
    :target: https://quay.io/repository/letsencrypt/letsencrypt
    :alt: Docker Repository on Quay.io


### PR DESCRIPTION
After a brief discussion in Mattermost, I shut down letsencrypt.readthedocs.io. Turns out we were linking to it in our README here so let's remove the broken link.

I didn't update the link to point to one of the readthedocs projects we still have because are main Certbot docs are self-hosted rather than being on readthedocs.