### PR TITLE
Print script output in case of a failure

### DIFF
--- a/letsencrypt-auto-source/tests/auto_test.py
+++ b/letsencrypt-auto-source/tests/auto_test.py
@@ -167,6 +167,10 @@ def out_and_err(command, input=None, shell=False, env=None):
     if status:
         error = CalledProcessError(status, command)
         error.output = out
+        print('stdout output was:')
+        print(out)
+        print('stderr output was:')
+        print(err)
         raise error
     return out, err
 


### PR DESCRIPTION
These tests failed at https://travis-ci.com/certbot/certbot/jobs/285202481 but do not include any output from the script about what went wrong because the string created from `subprocess.CalledProcessError` does not include value of output.

This PR fixes that by printing these values which `pytest` will include in the output if the test fails.