### PR TITLE
Fix unpinned tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,8 +263,10 @@ addons:
 # except in tests where the environment variable CERTBOT_NO_PIN is set.
 # virtualenv is listed here explicitly to make sure it is upgraded when
 # CERTBOT_NO_PIN is set to work around failures we've seen when using an older
-# version of virtualenv.
-install: 'tools/pip_install.py -U codecov tox virtualenv'
+# version of virtualenv. The option "-I" is set so when CERTBOT_NO_PIN is also
+# set, pip updates dependencies it thinks are already satisfied to avoid some
+# problems with its lack of real dependency resolution.
+install: 'tools/pip_install.py -I codecov tox virtualenv'
 # Most of the time TRAVIS_RETRY is an empty string, and has no effect on the
 # script command. It is set only to `travis_retry` during farm tests, in
 # order to trigger the Travis retry feature, and compensate the inherent


### PR DESCRIPTION
Our nightly tests failed last night due to a new release of `virtualenv` and `pip`'s lack of dependency resolution: https://travis-ci.com/certbot/certbot/jobs/285797857#L280. It looks like we were not the only ones affected by this problem: https://github.com/pypa/virtualenv/issues/1551

This fixes the problem by using `-I` to skip the logic where `pip` decides a dependency is already satisfied and has it reinstall/update the packages passed to `pip` and all of their dependencies.

You can see our nightly tests passing with this change at https://github.com/certbot/certbot/runs/439231061.