### PR TITLE
Clarify the minimum pyparsing version

### DIFF
--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'certbot>=1.1.0',
     'mock',
     'PyOpenSSL',
-    'pyparsing>=1.5.5',  # Python3 support; perhaps unnecessary?
+    'pyparsing>=1.5.5',  # Python3 support
     'setuptools',
     'zope.interface',
 ]

--- a/tools/oldest_constraints.txt
+++ b/tools/oldest_constraints.txt
@@ -13,7 +13,6 @@ ply==3.4
 pyasn1==0.1.9
 pycparser==2.14
 pyOpenSSL==0.13.1
-pyparsing==1.5.6
 pyRFC3339==1.0
 python-augeas==0.5.0
 oauth2client==4.0.0


### PR DESCRIPTION
Fixes #2106.

`tools/oldest_constraints.txt` had two versions of `pyparsing` pinned, but I removed the newer one and both our unit tests and integration tests passed with `pyparsing==1.5.5` at https://travis-ci.com/certbot/certbot/builds/148474009.

I also updated the comment in `certbot-nginx/setup.py` because `pyparsing>=1.5.5` is needed for Python 3 based on [their changelog](https://github.com/pyparsing/pyparsing/blob/8d9ab59a2b2767ad56c9b852c325075113718c0a/CHANGES#L1647).