### PR TITLE
Correct AutoHSTS docs

### DIFF
--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -2471,7 +2471,7 @@ class ApacheConfigurator(common.Installer):
         :type _unused_lineage: certbot._internal.storage.RenewableCert
 
         :param domains: List of domains in certificate to enhance
-        :type domains: str
+        :type domains: `list` of `str`
         """
 
         self._autohsts_fetch_state()

--- a/certbot/certbot/plugins/enhancements.py
+++ b/certbot/certbot/plugins/enhancements.py
@@ -153,7 +153,7 @@ class AutoHSTSEnhancement(object):
         :type lineage: certbot.interfaces.RenewableCert
 
         :param domains: List of domains in certificate to enhance
-        :type domains: str
+        :type domains: `list` of `str`
         """
 
 # This is used to configure internal new style enhancements in Certbot. These


### PR DESCRIPTION
`domains` is a list of strings, not a single string.