### PR TITLE
Simplify and document use by services without root privileges

### DIFF
--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -986,7 +986,7 @@ class RenewableCert(interfaces.RenewableCert):
         for i in (cli_config.renewal_configs_dir, cli_config.default_archive_dir,
                   cli_config.live_dir):
             if not os.path.exists(i):
-                filesystem.makedirs(i, 0o700)
+                filesystem.makedirs(i, 0o755)
                 logger.debug("Creating directory %s.", i)
         config_file, config_filename = util.unique_lineage_name(
             cli_config.renewal_configs_dir, lineagename)

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -686,6 +686,10 @@ your (web) server configuration directly to those files (or create
 symlinks). During the renewal_, ``/etc/letsencrypt/live`` is updated
 with the latest necessary files.
 
+For servers that drop root privileges before attempting to read the
+private key file, use ``chgrp`` and ``chmod 0640`` to allow the server
+to read ``/etc/letsencrypt/live/$domain/privkey.pem``.
+
 .. note:: ``/etc/letsencrypt/archive`` and ``/etc/letsencrypt/keys``
    contain all previous keys and certificates, while
    ``/etc/letsencrypt/live`` symlinks to the latest versions.


### PR DESCRIPTION
Certificates are public information by design: they are provided by
web servers without any prior authentication required.  In a public
key cryptographic system, only the private key is secret information.

The private key file is already created as accessible only to the root
user with mode 0600, and these file permissions are set before any key
content is written to the file.  There is no window within which an
attacker with access to the containing directory would be able to read
the private key content.

Set the relevant default directory permissions to 0755 rather than
0700.  This allows certificates to be read by non-root users without
requiring further manipulation of the directory permissions.

Leave the private key file permissions as 0600 by default, and add
documentation explaining how to use chgrp and chmod to make the
private key file readable by a non-root service user.

This provides guidance on the simplest way to solve the common problem
of making keys and certificates usable by services that run without
root privileges, with no requirement to create a custom (and hence
error-prone) executable hook.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>