### PR TITLE
Move our macOS tests to Azure Pipelines

### DIFF
--- a/.azure-pipelines/templates/tests-suite.yml
+++ b/.azure-pipelines/templates/tests-suite.yml
@@ -1,22 +1,35 @@
 jobs:
   - job: test
-    pool:
-      vmImage: vs2017-win2016
     strategy:
       matrix:
-        py35:
+        macos-py27:
+          IMAGE_NAME: macOS-10.15
+          PYTHON_VERSION: 2.7
+          TOXENV: py27
+        macos-py38:
+          IMAGE_NAME: macOS-10.15
+          PYTHON_VERSION: 3.8
+          TOXENV: py38
+        windows-py35:
+          IMAGE_NAME: vs2017-win2016
           PYTHON_VERSION: 3.5
           TOXENV: py35
-        py37-cover:
+        windows-py37-cover:
+          IMAGE_NAME: vs2017-win2016
           PYTHON_VERSION: 3.7
           TOXENV: py37-cover
-        integration-certbot:
+        windows-integration-certbot:
+          IMAGE_NAME: vs2017-win2016
           PYTHON_VERSION: 3.7
           TOXENV: integration-certbot
           PYTEST_ADDOPTS: --numprocesses 4
+    pool:
+      vmImage: $(IMAGE_NAME)
     variables:
     - group: certbot-common
     steps:
+    - bash: brew install augeas
+      condition: startswith(variables['IMAGE_NAME'], 'macOS')
     - task: UsePythonVersion@0
       inputs:
         versionSpec: $(PYTHON_VERSION)

--- a/.azure-pipelines/templates/tests-suite.yml
+++ b/.azure-pipelines/templates/tests-suite.yml
@@ -3,11 +3,11 @@ jobs:
     strategy:
       matrix:
         macos-py27:
-          IMAGE_NAME: macOS-10.15
+          IMAGE_NAME: macOS-10.14
           PYTHON_VERSION: 2.7
           TOXENV: py27
         macos-py38:
-          IMAGE_NAME: macOS-10.15
+          IMAGE_NAME: macOS-10.14
           PYTHON_VERSION: 3.8
           TOXENV: py38
         windows-py35:

--- a/.azure-pipelines/templates/tests-suite.yml
+++ b/.azure-pipelines/templates/tests-suite.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
     - bash: brew install augeas
       condition: startswith(variables['IMAGE_NAME'], 'macOS')
+      displayName: Install Augeas
     - task: UsePythonVersion@0
       inputs:
         versionSpec: $(PYTHON_VERSION)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
         - $HOME/.cache/pip
 
 before_script:
-  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ulimit -n 1024 ; fi'
   # On Travis, the fastest parallelization for integration tests has proved to be 4.
   - 'if [[ "$TOXENV" == *"integration"* ]]; then export PYTEST_ADDOPTS="--numprocesses 4"; fi'
   # Use Travis retry feature for farm tests since they are flaky
@@ -223,24 +222,6 @@ matrix:
         apt:
           packages:  # don't install nginx and apache
             - libaugeas0
-      <<: *extended-test-suite
-    - language: generic
-      env: TOXENV=py27
-      os: osx
-      addons:
-        homebrew:
-          packages:
-            - augeas
-            - python2
-      <<: *extended-test-suite
-    - language: generic
-      env: TOXENV=py3
-      os: osx
-      addons:
-        homebrew:
-          packages:
-            - augeas
-            - python3
       <<: *extended-test-suite
 
 # container-based infrastructure


### PR DESCRIPTION
[Our macOS tests are failing](https://travis-ci.com/certbot/certbot/builds/149965318) again this time due to the problem described at https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/14.

I tried adding `update: true` to the Homebrew config as described in that thread, but [it didn't work](https://travis-ci.com/certbot/certbot/builds/150070374). I also tried updating the macOS image we use which [didn't work](https://travis-ci.com/certbot/certbot/builds/150072389).

Since we continue to have problems with macOS on Travis, let try moving the tests to Azure Pipelines.