### PR TITLE
WIP: Rough fix for vanishing renewal config.

### DIFF
--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -13,6 +13,7 @@ from certbot import errors
 from certbot import interfaces
 from certbot import ocsp
 from certbot import util
+from certbot._internal import renewal
 from certbot._internal import storage
 from certbot.compat import os
 from certbot.display import util as display_util
@@ -110,7 +111,8 @@ def lineage_for_certname(cli_config, certname):
     except errors.CertStorageError:
         return None
     try:
-        return storage.RenewableCert(renewal_file, cli_config)
+        # TODO(dmw) fix by making public/building into __init__ etc
+        return renewal._reconstitute(cli_config, renewal_file)
     except (errors.CertStorageError, IOError):
         logger.debug("Renewal conf file %s is broken.", renewal_file)
         logger.debug("Traceback was:\n%s", traceback.format_exc())
@@ -378,7 +380,8 @@ def _search_lineages(cli_config, func, initial_rv, *args):
     rv = initial_rv
     for renewal_file in storage.renewal_conf_files(cli_config):
         try:
-            candidate_lineage = storage.RenewableCert(renewal_file, cli_config)
+            # TODO(dmw) fix by making public/building into __init__ etc
+            candidate_lineage = renewal._reconstitute(cli_config, renewal_file)
         except (errors.CertStorageError, IOError):
             logger.debug("Renewal conf file %s is broken. Skipping.", renewal_file)
             logger.debug("Traceback was:\n%s", traceback.format_exc())

--- a/certbot/certbot/_internal/client.py
+++ b/certbot/certbot/_internal/client.py
@@ -390,6 +390,7 @@ class Client(object):
 
         authzr = self.auth_handler.handle_authorizations(orderr, best_effort)
         return orderr.update(authorizations=authzr)
+
     def obtain_and_enroll_certificate(self, domains, certname):
         """Obtain and enroll certificate.
 

--- a/certbot/certbot/_internal/configuration.py
+++ b/certbot/certbot/_internal/configuration.py
@@ -58,6 +58,15 @@ class NamespaceConfig(object):
     def __setattr__(self, name, value):
         setattr(self.namespace, name, value)
 
+    def __str__(self):
+        s = list()
+        for k, v in self.__dict__.items():
+            s.append("{}='{}'".format(k, v))
+        return "< NamespaceConfig {} >".format(" ".join(s))
+
+    def __repr__(self):
+        return self.__str__()
+
     @property
     def server_path(self):
         """File path based on ``server``."""

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1089,11 +1089,16 @@ def run(config, plugins):
         raise errors.NotSupportedError("One ore more of the requested enhancements "
                                        "are not supported by the selected installer")
 
-    # TODO: Handle errors from _init_le_client?
-    le_client = _init_le_client(config, authenticator, installer)
-
+    #TODO(dmw) clean-up post test, get lineage w/ merged config *before* creating le_client
     domains, certname = _find_domains_or_certname(config, installer)
     should_get_cert, lineage = _find_cert(config, domains, certname)
+    if lineage:
+        passconfig = lineage.cli_config
+    else:
+        passconfig = config
+
+    # TODO: Handle errors from _init_le_client?
+    le_client = _init_le_client(passconfig, authenticator, installer)
 
     new_lineage = lineage
     if should_get_cert:
@@ -1171,9 +1176,12 @@ def renew_cert(config, plugins, lineage):
     except errors.PluginSelectionError as e:
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
-    le_client = _init_le_client(config, auth, installer)
+    # TODO(dmw) quiet down
+    logger.debug("CLI Config: %s", config)
+    logger.debug("RenewableCertificate Config: %s", lineage.cli_config)
+    le_client = _init_le_client(lineage.cli_config, auth, installer)
 
-    renewed_lineage = _get_and_save_cert(le_client, config, lineage=lineage)
+    renewed_lineage = _get_and_save_cert(le_client, lineage.cli_config, lineage=lineage)
 
     notify = zope.component.getUtility(interfaces.IDisplay).notification
     if installer is None:
@@ -1214,16 +1222,24 @@ def certonly(config, plugins):
         logger.info("Could not choose appropriate plugin: %s", e)
         raise
 
-    le_client = _init_le_client(config, auth, installer)
+    # TODO(dmw) clean-up
+    # get config via lineage from cli + renewal *before* creating le_client
+    domains, certname = _find_domains_or_certname(config, installer)
+    should_get_cert, lineage = _find_cert(config, domains, certname)
+    logger.info("CLI Config: %s", config)
+    if lineage:
+        passconfig = lineage.cli_config
+        logger.info("RenewableCertificate Config: %s", lineage.cli_config)
+    else:
+        passconfig = config
+
+    le_client = _init_le_client(passconfig, auth, installer)
 
     if config.csr:
         cert_path, fullchain_path = _csr_get_and_save_cert(config, le_client)
         _report_new_cert(config, cert_path, fullchain_path)
         _suggest_donation_if_appropriate(config)
         return
-
-    domains, certname = _find_domains_or_certname(config, installer)
-    should_get_cert, lineage = _find_cert(config, domains, certname)
 
     if not should_get_cert:
         notify = zope.component.getUtility(interfaces.IDisplay).notification

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -79,6 +79,7 @@ def _reconstitute(config, full_path):
     # those elements are present.
     try:
         restore_required_config_elements(config, renewalparams)
+        logger.debug("Config after restoring renewal config: %s", config)
         _restore_plugin_configs(config, renewalparams)
     except (ValueError, errors.Error) as error:
         logger.warning(
@@ -96,6 +97,8 @@ def _reconstitute(config, full_path):
                        "was: %s. Skipping.", full_path, error)
         return None
 
+    # TODO(dmw) figure out cleaner way to do this test
+    renewal_candidate.cli_config = config
     return renewal_candidate
 
 
@@ -168,7 +171,6 @@ def restore_required_config_elements(config, renewalparams):
         configuration file that defines this lineage
 
     """
-
     required_items = itertools.chain(
         (("pref_challs", _restore_pref_challs),),
         six.moves.zip(BOOL_CONFIG_ITEMS, itertools.repeat(_restore_bool)),
@@ -177,6 +179,7 @@ def restore_required_config_elements(config, renewalparams):
     for item_name, restore_func in required_items:
         if item_name in renewalparams and not cli.set_by_cli(item_name):
             value = restore_func(item_name, renewalparams[item_name])
+            logger.debug("Restoring config setting '%s' to '%s'", item_name, value)
             setattr(config, item_name, value)
 
 


### PR DESCRIPTION
Addresses #7694 

Findings: Issue was caused by modifying config by reference and subsequently relying on reference in caller being passed to all subsequent users.  Issue did not manifest in 'renew' subcommand but was present in 'certonly' and 'run' code paths due to how object reference was passed.

Suggested permanent fix:  Collapse config object references, store it for each given domain in a canonical object attribute and always use it from there.

Still needs:
- a decision on making renewal.py:_reconstitute public _for real_ or wrapping it in a public function
- is RenewableCertificate a reasonable candidate for holding config object reference?
- tests -- I have some partially working ones but will seek advice in the EFF #certbot mattermost channel
