### PR TITLE
remove _internal docs

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -13,7 +13,6 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-* certbot._internal.cli is now a package split in submodules instead of a whole module.
 * Fix acme module warnings when response Content-Type includes params (e.g. charset).
 * Fixed issue where webroot plugin would incorrectly raise `Read-only file system` 
   error when creating challenge directories (issue #7165).


### PR DESCRIPTION
Since this is an entirely internal code change, I personally don't think we should document it in our changelog.