### PR TITLE
Fix mypy on macOS

### DIFF
--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -25,11 +25,9 @@ from certbot._internal import lock
 from certbot.compat import filesystem
 from certbot.compat import os
 
-if sys.platform.startswith('linux'):
+_USE_DISTRO = sys.platform.startswith('linux')
+if _USE_DISTRO:
     import distro
-    _USE_DISTRO = True
-else:
-    _USE_DISTRO = False
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
If you run `mypy --platform darwin certbot/certbot/util.py` you'll get:
```
certbot/certbot/util.py:303: error: Name 'distro' is not defined
certbot/certbot/util.py:319: error: Name 'distro' is not defined
certbot/certbot/util.py:369: error: Name 'distro' is not defined
```
This is because mypy's logic for handling platform specific code is pretty simple and can't figure out what we're doing with `_USE_DISTRO` here. See https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks for more info.

Setting `_USE_DISTRO` to the result of `sys.platform.startswith('linux')` solves the problem without changing the overall behavior of our code here though.

This fixes part of https://github.com/certbot/certbot/issues/7803, but there's more work to be done on Windows.