### PR TITLE
Apache module check fix

### DIFF
--- a/certbot-apache/certbot_apache/_internal/http_01.py
+++ b/certbot-apache/certbot_apache/_internal/http_01.py
@@ -81,15 +81,14 @@ class ApacheHttp01(common.ChallengePerformer):
     def prepare_http01_modules(self):
         """Make sure that we have the needed modules available for http01"""
 
-        if self.configurator.conf("handle-modules"):
-            needed_modules = ["rewrite"]
-            if self.configurator.version < (2, 4):
-                needed_modules.append("authz_host")
-            else:
-                needed_modules.append("authz_core")
-            for mod in needed_modules:
-                if mod + "_module" not in self.configurator.parser.modules:
-                    self.configurator.enable_mod(mod, temp=True)
+        needed_modules = ["rewrite"]
+        if self.configurator.version < (2, 4):
+            needed_modules.append("authz_host")
+        else:
+            needed_modules.append("authz_core")
+        for mod in needed_modules:
+            if mod + "_module" not in self.configurator.parser.modules:
+                self.configurator.enable_mod(mod, temp=True)
 
     def _mod_config(self):
         selected_vhosts = []  # type: List[VirtualHost]

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,10 +16,11 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Fix acme module warnings when response Content-Type includes params (e.g. charset).
 * Fixed issue where webroot plugin would incorrectly raise `Read-only file system` 
   error when creating challenge directories (issue #7165).
+* Always check for required Apache modules when performing http-01 challenge
 
 ### Fixed
 
-*
+* 
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/7795

In https://github.com/certbot/certbot/pull/5202 @joohoi added distribution specific override functionality based on class inheritance to the Apache module. This includes distro-specific `enable_mod()` functions. The [current `enable_mod()` function only raises an error](https://github.com/certbot/certbot/blob/42dda35/certbot-apache/certbot_apache/_internal/configurator.py#L2295-L2314) with the specific overrides providing a functioning enable_mod, if possible.

Therefore, my argument is that checking for the `handle-modules` variable is superfluous with the functionality of the current `enable_mod` function**s**. Removing the check for `handle-modules` fixes situations where required modules aren't loaded and `handle-modules` equals False.

One might even argue the [using of `handle-modules` in configurator.py`](https://github.com/certbot/certbot/blob/42dda35/certbot-apache/certbot_apache/_internal/configurator.py#L1238) is also superfluous with the same argument.