### PR TITLE
Split advanced pipeline

### DIFF
--- a/.azure-pipelines/advanced-test.yml
+++ b/.azure-pipelines/advanced-test.yml
@@ -1,0 +1,12 @@
+# Advanced pipeline for running our full test suite on demand.
+trigger:
+  # When changing these triggers, please ensure the documentation under
+  # "Running tests in CI" is still correct.
+  - azure-test-*
+  - test-*
+
+jobs:
+  # Any addition here should be reflected in the advanced and release pipelines.
+  # It is advised to declare all jobs here as templates to improve maintainability.
+  - template: templates/tests-suite.yml
+  - template: templates/installer-tests.yml

--- a/.azure-pipelines/advanced.yml
+++ b/.azure-pipelines/advanced.yml
@@ -1,12 +1,6 @@
-# Advanced pipeline for isolated checks and release purpose
+# Advanced pipeline for running our full test suite on protected branches.
 trigger:
-  # When changing these triggers, please ensure the documentation under
-  # "Running tests in CI" is still correct.
-  - azure-test-*
-  - test-*
   - '*.x'
-pr:
-  - test-*
 # This pipeline is also nightly run on master
 schedules:
   - cron: "0 4 * * *"
@@ -17,7 +11,7 @@ schedules:
     always: true
 
 jobs:
-  # Any addition here should be reflected in the release pipeline.
+  # Any addition here should be reflected in the advanced-test and release pipelines.
   # It is advised to declare all jobs here as templates to improve maintainability.
   - template: templates/tests-suite.yml
   - template: templates/installer-tests.yml

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -6,7 +6,7 @@ trigger:
 pr: none
 
 jobs:
-  # Any addition here should be reflected in the advanced pipeline.
+  # Any addition here should be reflected in the advanced and advanced-test pipelines.
   # It is advised to declare all jobs here as templates to improve maintainability.
   - template: templates/tests-suite.yml
   - template: templates/installer-tests.yml


### PR DESCRIPTION
I want to do what I did in https://github.com/certbot/certbot/pull/7733 to our Azure Pipelines setup, but unfortunately this isn't currently possible. The only filters available for service hooks for the "build completed" trigger are the pipeline and build status. See 
![Screen Shot 2020-02-26 at 3 04 56 PM](https://user-images.githubusercontent.com/6504915/75396464-64ad0780-58a9-11ea-97a1-3454a9754675.png)

To accomplish this, I propose splitting the "advanced" pipeline into two cases. One is for builds on protected branches where we want to be notified if they fail while the other is just used to manually run tests on certain branches.
