### PR TITLE
Don't run advanced tests on PRs

### DIFF
--- a/.azure-pipelines/advanced-test.yml
+++ b/.azure-pipelines/advanced-test.yml
@@ -4,6 +4,7 @@ trigger:
   # "Running tests in CI" is still correct.
   - azure-test-*
   - test-*
+pr: none
 
 jobs:
   # Any addition here should be reflected in the advanced and release pipelines.

--- a/.azure-pipelines/advanced.yml
+++ b/.azure-pipelines/advanced.yml
@@ -1,6 +1,7 @@
 # Advanced pipeline for running our full test suite on protected branches.
 trigger:
   - '*.x'
+pr: none
 # This pipeline is also nightly run on master
 schedules:
   - cron: "0 4 * * *"


### PR DESCRIPTION
When I wrote https://github.com/certbot/certbot/pull/7813, I didn't understand the default behavior for pull requests if you don't specify `pr` in the yaml file. According to https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#pr-triggers:

> If no pr triggers appear in your YAML file, pull request builds are automatically enabled for all branches...

This is not the behavior we want. This PR fixes the problem by disabling builds on PRs.

You should be able to see this working because the advanced tests should not run on this PR but they did run on https://github.com/certbot/certbot/pull/7811.