### PR TITLE
Update order finalization to work in pebble strict mode.

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -744,7 +744,7 @@ class ClientV2(ClientBase):
         """
         csr = OpenSSL.crypto.load_certificate_request(
             OpenSSL.crypto.FILETYPE_PEM, orderr.csr_pem)
-        wrapped_csr = messages.CertificateRequest(csr=jose.ComparableX509(csr))
+        wrapped_csr = messages.Finalize(csr=jose.ComparableX509(csr))
         self._post(orderr.body.finalize, wrapped_csr)
         while datetime.datetime.now() < deadline:
             time.sleep(1)

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -525,12 +525,26 @@ class AuthorizationResource(ResourceWithURI):
 class CertificateRequest(jose.JSONObjectWithFields):
     """ACME new-cert request.
 
+    Deprecated. Use `.Finalize`.
+
     :ivar josepy.util.ComparableX509 csr:
         `OpenSSL.crypto.X509Req` wrapped in `.ComparableX509`
 
     """
     resource_type = 'new-cert'
     resource = fields.Resource(resource_type)
+    csr = jose.Field('csr', decoder=jose.decode_csr, encoder=jose.encode_csr)
+
+
+@Directory.register
+class Finalize(jose.JSONObjectWithFields):
+    """ACME order finalize request.
+
+    :ivar josepy.util.ComparableX509 csr:
+        `OpenSSL.crypto.X509Req` wrapped in `.ComparableX509`
+
+    """
+    resource_type = 'finalize'
     csr = jose.Field('csr', decoder=jose.decode_csr, encoder=jose.encode_csr)
 
 

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -410,6 +410,20 @@ class CertificateRequestTest(unittest.TestCase):
             self.req, CertificateRequest.from_json(self.req.to_json()))
 
 
+class FinalizeTest(unittest.TestCase):
+    """Tests for acme.messages.Finalize."""
+
+    def setUp(self):
+        from acme.messages import Finalize
+        self.req = Finalize(csr=CSR)
+
+    def test_json_de_serializable(self):
+        self.assertTrue(isinstance(self.req, jose.JSONDeSerializable))
+        from acme.messages import Finalize
+        self.assertEqual(
+            self.req, Finalize.from_json(self.req.to_json()))
+
+
 class CertificateResourceTest(unittest.TestCase):
     """Tests for acme.messages.CertificateResourceTest."""
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Fix acme module warnings when response Content-Type includes params (e.g. charset).
 * Fixed issue where webroot plugin would incorrectly raise `Read-only file system` 
   error when creating challenge directories (issue #7165).
+* Fix order finalization to work with pebble implementation in strict mode.
 
 ### Fixed
 


### PR DESCRIPTION
# Scope

This updates the finalize request body to work with pebble in --strict mode.

The error from pebble is

```
JWS body included JSON with a deprecated ACME v1 "resource" field ("new-cert")'
```

# Changes

I left the old CertificateRequest as it is for v1 compatibilty.

I have created a new Finalize message and use that for the v2 certbot implementation

# How to test

Start pebble with `--strict`` mode and check that certbot works.

Feel free to suggest another name for the new `Finalize` message... maybe OrderFinalize .

Thanks!!


