### PR TITLE
Remove --no-site-packages outside of certbot-auto.

### DIFF
--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -31,7 +31,7 @@ COPY certbot-nginx /opt/certbot/src/certbot-nginx/
 COPY certbot-compatibility-test /opt/certbot/src/certbot-compatibility-test/
 COPY tools /opt/certbot/src/tools
 
-RUN VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages -p python2 /opt/certbot/venv && \
+RUN VIRTUALENV_NO_DOWNLOAD=1 virtualenv -p python2 /opt/certbot/venv && \
     /opt/certbot/venv/bin/pip install -U setuptools && \
     /opt/certbot/venv/bin/pip install -U pip
 ENV PATH /opt/certbot/venv/bin:$PATH

--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -59,7 +59,7 @@ mv "dist.$version" "dist.$version.$(date +%s).bak" || true
 git tag --delete "$tag" || true
 
 tmpvenv=$(mktemp -d)
-VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages -p python2 $tmpvenv
+VIRTUALENV_NO_DOWNLOAD=1 virtualenv -p python2 $tmpvenv
 . $tmpvenv/bin/activate
 # update setuptools/pip just like in other places in the repo
 pip install -U setuptools
@@ -160,7 +160,7 @@ cd "dist.$version"
 python -m SimpleHTTPServer $PORT &
 # cd .. is NOT done on purpose: we make sure that all subpackages are
 # installed from local PyPI rather than current directory (repo root)
-VIRTUALENV_NO_DOWNLOAD=1 virtualenv --no-site-packages ../venv
+VIRTUALENV_NO_DOWNLOAD=1 virtualenv ../venv
 . ../venv/bin/activate
 pip install -U setuptools
 pip install -U pip


### PR DESCRIPTION
In a recent release, `virtualenv` stopped accepting the flag `--no-site-packages`. See https://github.com/pypa/virtualenv/issues/1681.

This flag has been deprecated and been the default behavior since 2011. See https://virtualenv.pypa.io/en/legacy/changes.html#v1-7-2011-11-30.

The virtualenv package in all of Debian 8+, EPEL 6, RHEL 7+, and Ubuntu 12.04+ all have this change so I personally think checking that `virtualenv` is new enough that it has same behavior as old versions with `--no-site-packages` is unnecessary.

Since we update `virtualenv` to the latest version in the release script, you need this change in order to successfully do new releases. After this lands, I think we should cherry pick this change to the 1.3.x branch so it's ready in case we need it.

While doing so is almost certainly fine, I didn't change certbot-auto to avoid angering that soon to be deprecated monster.