### PR TITLE
Add CloudDNS to third-party plugins

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -280,6 +280,7 @@ pritunl_           N    Y    Install certificates in pritunl distributed OpenVPN
 proxmox_           N    Y    Install certificates in Proxmox Virtualization servers
 dns-standalone_    Y    N    Obtain certificates via an integrated DNS server
 dns-ispconfig_     Y    N    DNS Authentication using ISPConfig as DNS server
+dns-clouddns_      Y    N    DNS Authentication using CloudDNS API
 ================== ==== ==== ===============================================================
 
 .. _haproxy: https://github.com/greenhost/certbot-haproxy
@@ -291,6 +292,7 @@ dns-ispconfig_     Y    N    DNS Authentication using ISPConfig as DNS server
 .. _external-auth: https://github.com/EnigmaBridge/certbot-external-auth
 .. _dns-standalone: https://github.com/siilike/certbot-dns-standalone
 .. _dns-ispconfig: https://github.com/m42e/certbot-dns-ispconfig
+.. _dns-clouddns: https://github.com/vshosting/certbot-dns-clouddns
 
 If you're interested, you can also :ref:`write your own plugin <dev-plugin>`.
 


### PR DESCRIPTION
As the title says, just updates the documentation to include CloudDNS certbot plugin.
