### PR TITLE
Cleanup more pylint issues

### DIFF
--- a/acme/acme/magic_typing.py
+++ b/acme/acme/magic_typing.py
@@ -11,6 +11,5 @@ try:
     # mypy doesn't respect modifying sys.modules
     from typing import *  # pylint: disable=wildcard-import, unused-wildcard-import
     from typing import Collection, IO  # type: ignore
-    # pylint: enable=unused-import
 except ImportError:
     sys.modules[__name__] = TypingClass()

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -15,7 +15,6 @@ from acme import challenges
 from acme import errors
 from acme import jws as acme_jws
 from acme import messages
-from acme.magic_typing import Dict  # pylint: disable=unused-import, no-name-in-module
 from acme.mixins import VersionedLEACMEMixin
 import messages_test
 import test_util

--- a/acme/tests/crypto_util_test.py
+++ b/acme/tests/crypto_util_test.py
@@ -11,7 +11,6 @@ import six
 from six.moves import socketserver  # type: ignore  # pylint: disable=import-error
 
 from acme import errors
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 import test_util
 
 

--- a/acme/tests/magic_typing_test.py
+++ b/acme/tests/magic_typing_test.py
@@ -18,6 +18,7 @@ class MagicTypingTest(unittest.TestCase):
         sys.modules['typing'] = typing_class_mock
         if 'acme.magic_typing' in sys.modules:
             del sys.modules['acme.magic_typing'] # pragma: no cover
+        from acme.magic_typing import Text
         self.assertEqual(Text, text_mock)
         del sys.modules['acme.magic_typing']
         sys.modules['typing'] = temp_typing
@@ -30,6 +31,7 @@ class MagicTypingTest(unittest.TestCase):
         sys.modules['typing'] = None
         if 'acme.magic_typing' in sys.modules:
             del sys.modules['acme.magic_typing'] # pragma: no cover
+        from acme.magic_typing import Text
         self.assertTrue(Text is None)
         del sys.modules['acme.magic_typing']
         sys.modules['typing'] = temp_typing

--- a/acme/tests/magic_typing_test.py
+++ b/acme/tests/magic_typing_test.py
@@ -18,7 +18,6 @@ class MagicTypingTest(unittest.TestCase):
         sys.modules['typing'] = typing_class_mock
         if 'acme.magic_typing' in sys.modules:
             del sys.modules['acme.magic_typing'] # pragma: no cover
-        from acme.magic_typing import Text # pylint: disable=no-name-in-module
         self.assertEqual(Text, text_mock)
         del sys.modules['acme.magic_typing']
         sys.modules['typing'] = temp_typing
@@ -31,7 +30,6 @@ class MagicTypingTest(unittest.TestCase):
         sys.modules['typing'] = None
         if 'acme.magic_typing' in sys.modules:
             del sys.modules['acme.magic_typing'] # pragma: no cover
-        from acme.magic_typing import Text # pylint: disable=no-name-in-module
         self.assertTrue(Text is None)
         del sys.modules['acme.magic_typing']
         sys.modules['typing'] = temp_typing

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -5,7 +5,6 @@ import josepy as jose
 import mock
 
 from acme import challenges
-from acme.magic_typing import Dict  # pylint: disable=unused-import, no-name-in-module
 import test_util
 
 CERT = test_util.load_comparable_cert('cert.der')

--- a/acme/tests/standalone_test.py
+++ b/acme/tests/standalone_test.py
@@ -12,7 +12,6 @@ from six.moves import socketserver  # type: ignore  # pylint: disable=import-err
 from acme import challenges
 from acme import crypto_util
 from acme import errors
-from acme.magic_typing import Set  # pylint: disable=unused-import, no-name-in-module
 
 import test_util
 

--- a/certbot-apache/certbot_apache/_internal/augeasparser.py
+++ b/certbot-apache/certbot_apache/_internal/augeasparser.py
@@ -64,7 +64,7 @@ Translates over to:
     "/files/etc/apache2/apache2.conf/bLoCk[1]",
 ]
 """
-from acme.magic_typing import Set  # pylint: disable=unused-import, no-name-in-module
+from acme.magic_typing import Set
 from certbot import errors
 from certbot.compat import os
 

--- a/certbot-apache/certbot_apache/_internal/entrypoint.py
+++ b/certbot-apache/certbot_apache/_internal/entrypoint.py
@@ -1,6 +1,4 @@
 """ Entry point for Apache Plugin """
-# Pylint does not like disutils.version when running inside a venv.
-# See: https://github.com/PyCQA/pylint/issues/73
 from distutils.version import LooseVersion
 
 from certbot import util

--- a/certbot-apache/certbot_apache/_internal/interfaces.py
+++ b/certbot-apache/certbot_apache/_internal/interfaces.py
@@ -102,7 +102,6 @@ For this reason the internal representation of data should not ignore the case.
 import abc
 import six
 
-from acme.magic_typing import Any, Dict, Optional, Tuple  # pylint: disable=unused-import, no-name-in-module
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/certbot-apache/tests/augeasnode_test.py
+++ b/certbot-apache/tests/augeasnode_test.py
@@ -3,7 +3,6 @@ import mock
 
 import util
 
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot import errors
 
 from certbot_apache._internal import assertions

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -5,7 +5,6 @@ import errno
 import mock
 
 from acme import challenges
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot import achallenges
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -1,5 +1,4 @@
 """Nginx Configuration"""
-# https://github.com/PyCQA/pylint/issues/73
 from distutils.version import LooseVersion
 import logging
 import re

--- a/certbot-nginx/tests/parser_test.py
+++ b/certbot-nginx/tests/parser_test.py
@@ -4,7 +4,6 @@ import re
 import shutil
 import unittest
 
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot import errors
 from certbot.compat import os
 from certbot_nginx._internal import nginxparser

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -11,9 +11,7 @@ import zope.interface
 
 from zope.interface import interfaces as zope_interfaces
 
-# pylint: disable=unused-import, no-name-in-module
-from acme.magic_typing import Any, Dict, Optional
-# pylint: enable=unused-import, no-name-in-module
+from acme.magic_typing import Any, Dict
 
 from certbot import crypto_util
 from certbot import errors

--- a/certbot/certbot/_internal/plugins/disco.py
+++ b/certbot/certbot/_internal/plugins/disco.py
@@ -192,9 +192,6 @@ class PluginsRegistry(Mapping):
         # This prevents deadlock caused by plugins acquiring a lock
         # and ensures at least one concurrent Certbot instance will run
         # successfully.
-
-        # Pylint checks for super init, but also claims the super
-        # has no __init__member
         self._plugins = collections.OrderedDict(sorted(six.iteritems(plugins)))
 
     @classmethod

--- a/certbot/certbot/compat/filesystem.py
+++ b/certbot/certbot/compat/filesystem.py
@@ -15,7 +15,6 @@ try:
     import win32file
     import pywintypes
     import winerror
-    # pylint: enable=import-error
 except ImportError:
     POSIX_MODE = True
 else:

--- a/certbot/certbot/compat/filesystem.py
+++ b/certbot/certbot/compat/filesystem.py
@@ -6,8 +6,6 @@ import os  # pylint: disable=os-module-forbidden
 import stat
 
 from acme.magic_typing import List
-from acme.magic_typing import Tuple  # pylint: disable=unused-import
-from acme.magic_typing import Union  # pylint: disable=unused-import
 
 try:
     import ntsecuritycon

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -419,7 +419,6 @@ to start contributing to Certbot.
 To run mypy on Certbot, use ``tox -e mypy`` on a machine that has Python 3 installed.
 
 Note that instead of just importing ``typing``, due to packaging issues, in Certbot we import from
-``acme.magic_typing`` and have to add some comments for pylint like this:
 
 .. code-block:: python
 

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -419,6 +419,7 @@ to start contributing to Certbot.
 To run mypy on Certbot, use ``tox -e mypy`` on a machine that has Python 3 installed.
 
 Note that instead of just importing ``typing``, due to packaging issues, in Certbot we import from
+``acme.magic_typing`` and have to add some comments for pylint like this:
 
 .. code-block:: python
 

--- a/certbot/tests/compat/filesystem_test.py
+++ b/certbot/tests/compat/filesystem_test.py
@@ -13,11 +13,9 @@ import certbot.tests.util as test_util
 from certbot.tests.util import TempDirTestCase
 
 try:
-    # pylint: disable=import-error
     import win32api
     import win32security
     import ntsecuritycon
-    # pylint: enable=import-error
     POSIX_MODE = False
 except ImportError:
     POSIX_MODE = True

--- a/certbot/tests/display/completer_test.py
+++ b/certbot/tests/display/completer_test.py
@@ -10,7 +10,6 @@ import unittest
 import mock
 from six.moves import reload_module  # pylint: disable=import-error
 
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot.compat import filesystem  # pylint: disable=ungrouped-imports
 from certbot.compat import os  # pylint: disable=ungrouped-imports
 import certbot.tests.util as test_util  # pylint: disable=ungrouped-imports

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -6,9 +6,6 @@ import unittest
 
 import mock
 
-from acme.magic_typing import Callable  # pylint: disable=unused-import, no-name-in-module
-from acme.magic_typing import Dict  # pylint: disable=unused-import, no-name-in-module
-from acme.magic_typing import Union  # pylint: disable=unused-import, no-name-in-module
 from certbot.compat import os
 
 

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -3,7 +3,6 @@ import unittest
 
 import mock
 
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot import errors
 from certbot import util
 from certbot.compat import filesystem

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -9,7 +9,6 @@ import mock
 import six
 
 from acme import messages
-from acme.magic_typing import Optional  # pylint: disable=unused-import, no-name-in-module
 from certbot import errors
 from certbot import util
 from certbot._internal import constants

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -18,7 +18,6 @@ import pytz
 import six
 from six.moves import reload_module  # pylint: disable=import-error
 
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot import crypto_util
 from certbot import errors
 from certbot import interfaces  # pylint: disable=unused-import

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -8,7 +8,6 @@ import pkg_resources
 import six
 import zope.interface
 
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot import errors
 from certbot import interfaces
 from certbot._internal.plugins import standalone

--- a/certbot/tests/plugins/selection_test.py
+++ b/certbot/tests/plugins/selection_test.py
@@ -5,7 +5,6 @@ import unittest
 import mock
 import zope.component
 
-from acme.magic_typing import List  # pylint: disable=unused-import, no-name-in-module
 from certbot import errors
 from certbot import interfaces
 from certbot._internal.plugins.disco import PluginsRegistry

--- a/certbot/tests/plugins/standalone_test.py
+++ b/certbot/tests/plugins/standalone_test.py
@@ -11,9 +11,6 @@ import six
 
 from acme import challenges
 from acme import standalone as acme_standalone  # pylint: disable=unused-import
-from acme.magic_typing import Dict  # pylint: disable=unused-import, no-name-in-module
-from acme.magic_typing import Set  # pylint: disable=unused-import, no-name-in-module
-from acme.magic_typing import Tuple  # pylint: disable=unused-import, no-name-in-module
 from certbot import achallenges
 from certbot import errors
 from certbot.tests import acme_util


### PR DESCRIPTION
~~At https://github.com/certbot/certbot/pull/7657/files#diff-ac8047a9485d16a51354ebcc20feb288L3 we removed some `# pylint: disable` comments, but accidentally left a link to pylint's GitHub which was describing why these disables were needed.~~

~~Let's remove it.~~

Well, this started because I wanted to clean up one stray comment I noticed while working on other stuff but in looking into it, I got nerdsniped and noticed a bunch more.

This PR builds on #7657 and cleans up additional unnecessary `pylint` comments and some stray comments referring to `pylint: disable` comments that have been deleted that I didn't notice in my review of that PR. 