### PR TITLE
Wait 5 minutes instead of 4 for boulder to start

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -170,7 +170,7 @@ class ACMEServer(object):
 
         # Wait for the ACME CA server to be up.
         print('=> Waiting for boulder instance to respond...')
-        misc.check_until_timeout(self.acme_xdist['directory_url'], attempts=240)
+        misc.check_until_timeout(self.acme_xdist['directory_url'], attempts=300)
 
         # Configure challtestsrv to answer any A record request with ip of the docker host.
         response = requests.post('http://localhost:{0}/set-default-ipv4'.format(CHALLTESTSRV_PORT),


### PR DESCRIPTION
Last night, about a quarter of our tests using boulder timed out waiting for boulder to start. See https://travis-ci.com/certbot/certbot/builds/155045380. Some people told me they've seen Travis be exceptionally slow lately and [bumping the timeout to 5 minutes seems to have fixed the problem](https://travis-ci.com/github/certbot/certbot/builds/155218109) so let's do that.