### PR TITLE
Add a step to check powershell version in vs2017-win2016

### DIFF
--- a/.azure-pipelines/templates/installer-tests.yml
+++ b/.azure-pipelines/templates/installer-tests.yml
@@ -31,6 +31,13 @@ jobs:
     pool:
       vmImage: $(imageName)
     steps:
+      - powershell: |
+          $currentVersion = (Get-Host | Select-Object Version).Version
+          if ($currentVersion.Major -ne 5) {
+              throw "Powershell version is not 5.x"
+          }
+        condition: eq(variables['imageName'], 'vs2017-win2016')
+        displayName: Check Powershell 5.x is used in vs2017-win2016
       - task: UsePythonVersion@0
         inputs:
           versionSpec: 3.8

--- a/.azure-pipelines/templates/installer-tests.yml
+++ b/.azure-pipelines/templates/installer-tests.yml
@@ -32,7 +32,7 @@ jobs:
       vmImage: $(imageName)
     steps:
       - powershell: |
-          $currentVersion = (Get-Host | Select-Object Version).Version
+          $currentVersion = $PSVersionTable.PSVersion
           if ($currentVersion.Major -ne 5) {
               throw "Powershell version is not 5.x"
           }


### PR DESCRIPTION
Following discussion at https://github.com/certbot/certbot/pull/7539#issuecomment-572318805, this PR adds a check for Powershell version: we expect that the `vs2017-win2016` node that will test the installer has Powershell 5.x, and nothing else.

This ensure that at least one node of the pipeline is testing the installer with the lowest Powershell version supported by Certbot.

One full pipeline success can be seen here: https://dev.azure.com/adferrand/certbot/_build/results?buildId=713

I also create on purpose a failing pipeline, that would check that Powershell 6.x is installed. Its result can be seen here: https://dev.azure.com/adferrand/certbot/_build/results?buildId=714
