### PR TITLE
add support for CNAME challenge alias with route53

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,6 +33,7 @@ Authors
 * [Ben Wolfe](https://github.com/bwolfe)
 * [Bigfish](https://github.com/bwolfe)
 * [Blake Griffith](https://github.com/cowlicks)
+* [Bob Carroll](https://github.com/rcarz)
 * [Brad Warren](https://github.com/bmw)
 * [Brandon Kraft](https://github.com/kraftbj)
 * [Brandon Kreisel](https://github.com/kraftbj)

--- a/certbot-dns-route53/certbot_dns_route53/__init__.py
+++ b/certbot-dns-route53/certbot_dns_route53/__init__.py
@@ -60,6 +60,45 @@ the required permissions <https://docs.aws.amazon.com/Route53/latest
        ]
    }
 
+.. code-block:: json
+   :name: sample-aws-delegated-policy.json
+   :caption: Example AWS policy file for a delegated zone:
+
+   {
+       "Version": "2012-10-17",
+       "Id": "certbot-dns-route53 sample policy",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Action": [
+                   "route53:ListHostedZones",
+                   "route53:GetChange"
+               ],
+               "Resource": [
+                   "*"
+               ]
+           },
+           {
+               "Effect" : "Allow",
+               "Action" : [
+                   "route53:ListResourceRecordSets"
+               ],
+               "Resource" : [
+                   "arn:aws:route53:::hostedzone/YOURHOSTEDZONEID"
+               ]
+           },
+           {
+               "Effect" : "Allow",
+               "Action" : [
+                   "route53:ChangeResourceRecordSets"
+               ],
+               "Resource" : [
+                   "arn:aws:route53:::hostedzone/YOURDELEGATEDZONEID"
+               ]
+           }
+       ]
+   }
+
 The `access keys <https://docs.aws.amazon.com/general/latest/gr
 /aws-sec-cred-types.html#access-keys-and-secret-access-keys>`_ for an account
 with these permissions must be supplied in one of the following ways, which are

--- a/certbot-dns-route53/examples/sample-aws-delegated-policy.json
+++ b/certbot-dns-route53/examples/sample-aws-delegated-policy.json
@@ -1,0 +1,34 @@
+{
+    "Version": "2012-10-17",
+    "Id": "certbot-dns-route53 sample policy",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ListHostedZones",
+                "route53:GetChange"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect" : "Allow",
+            "Action" : [
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource" : [
+                "arn:aws:route53:::hostedzone/YOURHOSTEDZONEID"
+            ]
+        },
+        {
+            "Effect" : "Allow",
+            "Action" : [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource" : [
+                "arn:aws:route53:::hostedzone/YOURDELEGATEDZONEID"
+            ]
+        }
+    ]
+}

--- a/certbot-dns-route53/tests/dns_route53_test.py
+++ b/certbot-dns-route53/tests/dns_route53_test.py
@@ -122,6 +122,22 @@ class ClientTest(unittest.TestCase):
                                 }
                             }
 
+    FOO_EXAMPLE_COM_A_RR = {
+                                "Name": "foo.example.com.",
+                                "Type": "A",
+                                "TTL": 300,
+                                "ResourceRecords": [{
+                                    "Value": "10.10.10.10" }]
+                            }
+
+    FOO_EXAMPLE_COM_CNAME_RR = {
+                                "Name": "foo.example.com.",
+                                "Type": "CNAME",
+                                "TTL": 300,
+                                "ResourceRecords": [{
+                                    "Value": "example.net" }]
+                            }
+
     def setUp(self):
         from certbot_dns_route53._internal.dns_route53 import Authenticator
 
@@ -196,6 +212,51 @@ class ClientTest(unittest.TestCase):
 
         self.assertRaises(errors.PluginError,
                           self.client._find_zone_id_for_domain,
+                          "foo.example.com")
+
+    def test_find_zone_id_for_domain_or_alias(self):
+        self.client._find_zone_id_for_domain = mock.MagicMock(side_effect=[1, 2])
+        self.client.r53.get_paginator = mock.MagicMock()
+        self.client.r53.get_paginator().paginate.return_value = [
+            {
+                "ResourceRecordSets": [
+                    self.FOO_EXAMPLE_COM_A_RR,
+                    self.FOO_EXAMPLE_COM_CNAME_RR
+                ]
+            }
+        ]
+
+        result = self.client._find_zone_id_for_domain_or_alias("foo.example.com")
+        self.assertEqual(result, (2, "example.net"))
+
+    def test_find_zone_id_for_domain_or_alias_no_results(self):
+        self.client._find_zone_id_for_domain = mock.MagicMock(side_effect=[1, 2])
+        self.client.r53.get_paginator = mock.MagicMock()
+        self.client.r53.get_paginator().paginate.return_value = [
+            {
+                "ResourceRecordSets": [
+                    self.FOO_EXAMPLE_COM_A_RR
+                ]
+            }
+        ]
+
+        result = self.client._find_zone_id_for_domain_or_alias("foo.example.com")
+        self.assertEqual(result, (1, "foo.example.com"))
+
+    def test_find_zone_id_for_domain_or_alias_with_bad_delegated_zone(self):
+        self.client._find_zone_id_for_domain = mock.MagicMock(
+            side_effect=[1, errors.PluginError])
+        self.client.r53.get_paginator = mock.MagicMock()
+        self.client.r53.get_paginator().paginate.return_value = [
+            {
+                "ResourceRecordSets": [
+                    self.FOO_EXAMPLE_COM_CNAME_RR
+                ]
+            }
+        ]
+
+        self.assertRaises(errors.PluginError,
+                          self.client._find_zone_id_for_domain_or_alias,
                           "foo.example.com")
 
     def test_change_txt_record(self):


### PR DESCRIPTION
This PR adds support for [challenge aliases](https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode) to the dns-route53 plugin. These changes are a lot more narrow in scope than #6644 and were meant to service an immediate need while a more [generalized solution](https://github.com/certbot/certbot/pull/7244) is discussed.

## Pull Request Checklist

- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.

Fixes #6566 