### PR TITLE
Add minimal proxy support for OCSP verification

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -103,6 +103,7 @@ Authors
 * [Henry Chen](https://github.com/henrychen95)
 * [Hugo van Kemenade](https://github.com/hugovk)
 * [Ingolf Becker](https://github.com/watercrossing)
+* [Ivan Nejgebauer](https://github.com/inejge)
 * [Jaap Eldering](https://github.com/eldering)
 * [Jacob Hoffman-Andrews](https://github.com/jsha)
 * [Jacob Sachs](https://github.com/jsachs)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,6 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   of all domains challenged for the current certificate.
 * Added TLS-ALPN-01 challenge support in the `acme` library. Support of this
   challenge in the Certbot client is planned to be added in a future release.
+* Added minimal proxy support for OCSP verification.
 
 ### Changed
 

--- a/certbot/certbot/ocsp.py
+++ b/certbot/certbot/ocsp.py
@@ -21,6 +21,7 @@ from acme.magic_typing import Tuple
 from certbot import crypto_util
 from certbot import errors
 from certbot import util
+from certbot.compat.os import getenv
 from certbot.interfaces import RenewableCert  # pylint: disable=unused-import
 
 try:
@@ -102,17 +103,32 @@ class RevocationChecker(object):
 
     def _check_ocsp_openssl_bin(self, cert_path, chain_path, host, url, timeout):
         # type: (str, str, str, str, int) -> bool
+        # Minimal implementation of proxy selection logic as seen in, e.g., cURL
+        # Some things that won't work, but may well be in use somewhere:
+        # - username and password for proxy authentication
+        # - proxies accepting TLS connections
+        # - proxy exclusion through NO_PROXY
+        env_http_proxy = getenv('http_proxy')
+        env_HTTP_PROXY = getenv('HTTP_PROXY')
+        proxy_host = None
+        if env_http_proxy is not None or env_HTTP_PROXY is not None:
+            proxy_host = env_http_proxy if env_http_proxy is not None else env_HTTP_PROXY
+        if proxy_host is None:
+            url_opts = ["-url", url]
+        else:
+            if proxy_host.startswith('http://'):
+                proxy_host = proxy_host[len('http://'):]
+            url_opts = ["-host", proxy_host, "-path", url]
         # jdkasten thanks "Bulletproof SSL and TLS - Ivan Ristic" for documenting this!
         cmd = ["openssl", "ocsp",
                "-no_nonce",
                "-issuer", chain_path,
                "-cert", cert_path,
-               "-url", url,
                "-CAfile", chain_path,
                "-verify_other", chain_path,
                "-trust_other",
                "-timeout", str(timeout),
-               "-header"] + self.host_args(host)
+               "-header"] + self.host_args(host) + url_opts
         logger.debug("Querying OCSP for %s", cert_path)
         logger.debug(" ".join(cmd))
         try:


### PR DESCRIPTION
This PR adds code to recognize a subset of proxy configuration in the environment and translate it into options that are passed to `openssl ocsp`. Basic HTTP proxies without user authentication should work.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.
