### PR TITLE
Do not require mock in Python 3 in acme module

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -30,11 +30,11 @@ install_requires = [
 setuptools_known_environment_markers = (StrictVersion(setuptools_version) >= StrictVersion('36.2'))
 if setuptools_known_environment_markers:
     install_requires.append('mock ; python_version < "3.3"')
-elif sys.version_info < (3,3):
-    install_requires.append('mock')
-else:
+elif 'bdist_wheel' in sys.argv[1:]:
     raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
                        'of setuptools. Version 36.2+ of setuptools is required.')
+elif sys.version_info < (3,3):
+    install_requires.append('mock')
 
 dev_extras = [
     'pytest',

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -1,5 +1,7 @@
+from distutils.version import StrictVersion
 import sys
 
+from setuptools import __version__ as setuptools_version
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
@@ -15,7 +17,6 @@ install_requires = [
     # 1.1.0+ is required to avoid the warnings described at
     # https://github.com/certbot/josepy/issues/13.
     'josepy>=1.1.0',
-    'mock',
     # Connection.set_tlsext_host_name (>=0.13)
     'PyOpenSSL>=0.13.1',
     'pyrfc3339',
@@ -25,6 +26,12 @@ install_requires = [
     'setuptools',
     'six>=1.9.0',  # needed for python_2_unicode_compatible
 ]
+
+setuptools_known_environment_markers = (StrictVersion(setuptools_version) >= StrictVersion('36.2'))
+if setuptools_known_environment_markers:
+    install_requires.append('mock ; python_version < "3.3"')
+elif sys.version_info < (3,3):
+    install_requires.append('mock')
 
 dev_extras = [
     'pytest',

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -32,6 +32,9 @@ if setuptools_known_environment_markers:
     install_requires.append('mock ; python_version < "3.3"')
 elif sys.version_info < (3,3):
     install_requires.append('mock')
+else:
+    raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
+                       'of setuptools. Version 36.2+ of setuptools is required.')
 
 dev_extras = [
     'pytest',

--- a/acme/tests/challenges_test.py
+++ b/acme/tests/challenges_test.py
@@ -3,7 +3,10 @@ import unittest
 
 import josepy as jose
 import OpenSSL
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import requests
 from six.moves.urllib import parse as urllib_parse
 

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -6,7 +6,10 @@ import json
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import OpenSSL
 import requests
 from six.moves import http_client  # pylint: disable=import-error

--- a/acme/tests/errors_test.py
+++ b/acme/tests/errors_test.py
@@ -1,7 +1,10 @@
 """Tests for acme.errors."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 
 class BadNonceTest(unittest.TestCase):

--- a/acme/tests/magic_typing_test.py
+++ b/acme/tests/magic_typing_test.py
@@ -2,7 +2,10 @@
 import sys
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 
 class MagicTypingTest(unittest.TestCase):

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -2,7 +2,10 @@
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from acme import challenges
 import test_util

--- a/acme/tests/standalone_test.py
+++ b/acme/tests/standalone_test.py
@@ -4,7 +4,10 @@ import threading
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import requests
 from six.moves import http_client  # pylint: disable=import-error
 from six.moves import socketserver  # type: ignore  # pylint: disable=import-error


### PR DESCRIPTION
Part of #7886.

This PR conditionally installs mock in `acme/setup.py` based on setuptools version and python version, when possible. It then updates `acme` tests to use `unittest.mock` when `mock` isn't available.