### PR TITLE
Do not require mock in Python 3 in apache module

### DIFF
--- a/certbot-apache/local-oldest-requirements.txt
+++ b/certbot-apache/local-oldest-requirements.txt
@@ -1,3 +1,3 @@
 # Remember to update setup.py to match the package versions below.
 acme[dev]==0.29.0
--e certbot[dev]
+certbot[dev]==1.1.0

--- a/certbot-apache/local-oldest-requirements.txt
+++ b/certbot-apache/local-oldest-requirements.txt
@@ -1,3 +1,3 @@
 # Remember to update setup.py to match the package versions below.
 acme[dev]==0.29.0
-certbot[dev]==1.1.0
+-e certbot[dev]

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -22,11 +22,11 @@ install_requires = [
 setuptools_known_environment_markers = (StrictVersion(setuptools_version) >= StrictVersion('36.2'))
 if setuptools_known_environment_markers:
     install_requires.append('mock ; python_version < "3.3"')
-elif sys.version_info < (3,3):
-    install_requires.append('mock')
-else:
+elif 'bdist_wheel' in sys.argv[1:]:
     raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
                        'of setuptools. Version 36.2+ of setuptools is required.')
+elif sys.version_info < (3,3):
+    install_requires.append('mock')
 
 dev_extras = [
     'apacheconfig>=0.3.2',

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -12,7 +12,7 @@ version = '1.4.0.dev0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.29.0',
-    'certbot>=1.4.0.dev0',
+    'certbot>=1.1.0',
     'python-augeas',
     'setuptools',
     'zope.component',

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -12,7 +12,7 @@ version = '1.4.0.dev0'
 # acme/certbot version.
 install_requires = [
     'acme>=0.29.0',
-    'certbot>=1.1.0',
+    'certbot>=1.4.0.dev0',
     'python-augeas',
     'setuptools',
     'zope.component',

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -1,5 +1,7 @@
+from distutils.version import StrictVersion
 import sys
 
+from setuptools import __version__ as setuptools_version
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
@@ -11,12 +13,17 @@ version = '1.4.0.dev0'
 install_requires = [
     'acme>=0.29.0',
     'certbot>=1.1.0',
-    'mock',
     'python-augeas',
     'setuptools',
     'zope.component',
     'zope.interface',
 ]
+
+setuptools_known_environment_markers = (StrictVersion(setuptools_version) >= StrictVersion('36.2'))
+if setuptools_known_environment_markers:
+    install_requires.append('mock ; python_version < "3.3"')
+elif sys.version_info < (3,3):
+    install_requires.append('mock')
 
 dev_extras = [
     'apacheconfig>=0.3.2',

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -24,6 +24,9 @@ if setuptools_known_environment_markers:
     install_requires.append('mock ; python_version < "3.3"')
 elif sys.version_info < (3,3):
     install_requires.append('mock')
+else:
+    raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
+                       'of setuptools. Version 36.2+ of setuptools is required.')
 
 dev_extras = [
     'apacheconfig>=0.3.2',

--- a/certbot-apache/tests/augeasnode_test.py
+++ b/certbot-apache/tests/augeasnode_test.py
@@ -1,8 +1,5 @@
 """Tests for AugeasParserNode classes"""
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 import os
 import unittest

--- a/certbot-apache/tests/augeasnode_test.py
+++ b/certbot-apache/tests/augeasnode_test.py
@@ -1,5 +1,8 @@
 """Tests for AugeasParserNode classes"""
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 import os
 import unittest

--- a/certbot-apache/tests/augeasnode_test.py
+++ b/certbot-apache/tests/augeasnode_test.py
@@ -1,5 +1,8 @@
 """Tests for AugeasParserNode classes"""
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 import os
 import unittest

--- a/certbot-apache/tests/autohsts_test.py
+++ b/certbot-apache/tests/autohsts_test.py
@@ -3,10 +3,7 @@
 import re
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 import six  # pylint: disable=unused-import  # six is used in mock.patch()
 
 from certbot import errors

--- a/certbot-apache/tests/autohsts_test.py
+++ b/certbot-apache/tests/autohsts_test.py
@@ -3,7 +3,10 @@
 import re
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six  # pylint: disable=unused-import  # six is used in mock.patch()
 
 from certbot import errors

--- a/certbot-apache/tests/autohsts_test.py
+++ b/certbot-apache/tests/autohsts_test.py
@@ -3,7 +3,10 @@
 import re
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 import six  # pylint: disable=unused-import  # six is used in mock.patch()
 
 from certbot import errors

--- a/certbot-apache/tests/centos_test.py
+++ b/certbot-apache/tests/centos_test.py
@@ -1,10 +1,7 @@
 """Test for certbot_apache._internal.configurator for Centos overrides"""
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/centos_test.py
+++ b/certbot-apache/tests/centos_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.configurator for Centos overrides"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/centos_test.py
+++ b/certbot-apache/tests/centos_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.configurator for Centos overrides"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/configurator_reverter_test.py
+++ b/certbot-apache/tests/configurator_reverter_test.py
@@ -2,7 +2,10 @@
 import shutil
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot import errors
 import util

--- a/certbot-apache/tests/configurator_reverter_test.py
+++ b/certbot-apache/tests/configurator_reverter_test.py
@@ -2,10 +2,7 @@
 import shutil
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot import errors
 import util

--- a/certbot-apache/tests/configurator_reverter_test.py
+++ b/certbot-apache/tests/configurator_reverter_test.py
@@ -2,7 +2,10 @@
 import shutil
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 import util

--- a/certbot-apache/tests/configurator_test.py
+++ b/certbot-apache/tests/configurator_test.py
@@ -6,7 +6,10 @@ import socket
 import tempfile
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six  # pylint: disable=unused-import  # six is used in mock.patch()
 
 from acme import challenges

--- a/certbot-apache/tests/configurator_test.py
+++ b/certbot-apache/tests/configurator_test.py
@@ -6,7 +6,10 @@ import socket
 import tempfile
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 import six  # pylint: disable=unused-import  # six is used in mock.patch()
 
 from acme import challenges

--- a/certbot-apache/tests/configurator_test.py
+++ b/certbot-apache/tests/configurator_test.py
@@ -6,10 +6,7 @@ import socket
 import tempfile
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 import six  # pylint: disable=unused-import  # six is used in mock.patch()
 
 from acme import challenges

--- a/certbot-apache/tests/debian_test.py
+++ b/certbot-apache/tests/debian_test.py
@@ -2,10 +2,7 @@
 import shutil
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot import errors
 from certbot.compat import os

--- a/certbot-apache/tests/debian_test.py
+++ b/certbot-apache/tests/debian_test.py
@@ -2,7 +2,10 @@
 import shutil
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot.compat import os

--- a/certbot-apache/tests/debian_test.py
+++ b/certbot-apache/tests/debian_test.py
@@ -2,7 +2,10 @@
 import shutil
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot import errors
 from certbot.compat import os

--- a/certbot-apache/tests/display_ops_test.py
+++ b/certbot-apache/tests/display_ops_test.py
@@ -1,7 +1,10 @@
 """Test certbot_apache._internal.display_ops."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot.display import util as display_util

--- a/certbot-apache/tests/display_ops_test.py
+++ b/certbot-apache/tests/display_ops_test.py
@@ -1,7 +1,10 @@
 """Test certbot_apache._internal.display_ops."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot import errors
 from certbot.display import util as display_util

--- a/certbot-apache/tests/display_ops_test.py
+++ b/certbot-apache/tests/display_ops_test.py
@@ -1,10 +1,7 @@
 """Test certbot_apache._internal.display_ops."""
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot import errors
 from certbot.display import util as display_util

--- a/certbot-apache/tests/dualnode_test.py
+++ b/certbot-apache/tests/dualnode_test.py
@@ -1,7 +1,10 @@
 """Tests for DualParserNode implementation"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot_apache._internal import assertions
 from certbot_apache._internal import augeasparser

--- a/certbot-apache/tests/dualnode_test.py
+++ b/certbot-apache/tests/dualnode_test.py
@@ -1,7 +1,10 @@
 """Tests for DualParserNode implementation"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot_apache._internal import assertions
 from certbot_apache._internal import augeasparser

--- a/certbot-apache/tests/dualnode_test.py
+++ b/certbot-apache/tests/dualnode_test.py
@@ -1,10 +1,7 @@
 """Tests for DualParserNode implementation"""
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot_apache._internal import assertions
 from certbot_apache._internal import augeasparser

--- a/certbot-apache/tests/entrypoint_test.py
+++ b/certbot-apache/tests/entrypoint_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.entrypoint for override class resolution"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot_apache._internal import configurator
 from certbot_apache._internal import entrypoint

--- a/certbot-apache/tests/entrypoint_test.py
+++ b/certbot-apache/tests/entrypoint_test.py
@@ -1,10 +1,7 @@
 """Test for certbot_apache._internal.entrypoint for override class resolution"""
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot_apache._internal import configurator
 from certbot_apache._internal import entrypoint

--- a/certbot-apache/tests/entrypoint_test.py
+++ b/certbot-apache/tests/entrypoint_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.entrypoint for override class resolution"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot_apache._internal import configurator
 from certbot_apache._internal import entrypoint

--- a/certbot-apache/tests/fedora_test.py
+++ b/certbot-apache/tests/fedora_test.py
@@ -1,10 +1,7 @@
 """Test for certbot_apache._internal.configurator for Fedora 29+ overrides"""
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/fedora_test.py
+++ b/certbot-apache/tests/fedora_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.configurator for Fedora 29+ overrides"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/fedora_test.py
+++ b/certbot-apache/tests/fedora_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.configurator for Fedora 29+ overrides"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/gentoo_test.py
+++ b/certbot-apache/tests/gentoo_test.py
@@ -1,10 +1,7 @@
 """Test for certbot_apache._internal.configurator for Gentoo overrides"""
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/gentoo_test.py
+++ b/certbot-apache/tests/gentoo_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.configurator for Gentoo overrides"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/gentoo_test.py
+++ b/certbot-apache/tests/gentoo_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.configurator for Gentoo overrides"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -2,7 +2,10 @@
 import unittest
 import errno
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from acme import challenges
 from certbot import achallenges

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -2,10 +2,7 @@
 import unittest
 import errno
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from acme import challenges
 from certbot import achallenges

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -2,7 +2,10 @@
 import unittest
 import errno
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from acme import challenges
 from certbot import achallenges

--- a/certbot-apache/tests/parser_test.py
+++ b/certbot-apache/tests/parser_test.py
@@ -2,10 +2,7 @@
 import shutil
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 from certbot import errors
 from certbot.compat import os

--- a/certbot-apache/tests/parser_test.py
+++ b/certbot-apache/tests/parser_test.py
@@ -2,7 +2,10 @@
 import shutil
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot.compat import os

--- a/certbot-apache/tests/parser_test.py
+++ b/certbot-apache/tests/parser_test.py
@@ -2,7 +2,10 @@
 import shutil
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 from certbot import errors
 from certbot.compat import os

--- a/certbot-apache/tests/parsernode_configurator_test.py
+++ b/certbot-apache/tests/parsernode_configurator_test.py
@@ -1,10 +1,7 @@
 """Tests for ApacheConfigurator for AugeasParserNode classes"""
 import unittest
 
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 
 import util
 

--- a/certbot-apache/tests/parsernode_configurator_test.py
+++ b/certbot-apache/tests/parsernode_configurator_test.py
@@ -1,7 +1,10 @@
 """Tests for ApacheConfigurator for AugeasParserNode classes"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 import util
 

--- a/certbot-apache/tests/parsernode_configurator_test.py
+++ b/certbot-apache/tests/parsernode_configurator_test.py
@@ -1,7 +1,10 @@
 """Tests for ApacheConfigurator for AugeasParserNode classes"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 
 import util
 

--- a/certbot-apache/tests/util.py
+++ b/certbot-apache/tests/util.py
@@ -5,7 +5,10 @@ import unittest
 
 import augeas
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import zope.component
 
 from certbot.compat import os

--- a/certbot-apache/tests/util.py
+++ b/certbot-apache/tests/util.py
@@ -5,7 +5,10 @@ import unittest
 
 import augeas
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock # type: ignore
 import zope.component
 
 from certbot.compat import os

--- a/certbot-apache/tests/util.py
+++ b/certbot-apache/tests/util.py
@@ -5,10 +5,7 @@ import unittest
 
 import augeas
 import josepy as jose
-try:
-    import mock
-except ImportError: # pragma: no cover
-    from unittest import mock
+import mock
 import zope.component
 
 from certbot.compat import os


### PR DESCRIPTION
Part of #7886.

This PR conditionally installs mock in `apache/setup.py` based on setuptools version and python version, when possible. It then updates `apache` tests to use `unittest.mock` when `mock` isn't available.