### PR TITLE
Remove Ubuntu 19.04 tests

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -1,11 +1,6 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
-  - ami: ami-08ab45c4343f5f5c6
-    name: ubuntu19.04
-    type: ubuntu
-    virt: hvm
-    user: ubuntu
   - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -1,11 +1,6 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
-  - ami: ami-08ab45c4343f5f5c6
-    name: ubuntu19.04
-    type: ubuntu
-    virt: hvm
-    user: ubuntu
   - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu


### PR DESCRIPTION
This PR fixes the Travis failures that can be seen https://travis-ci.com/certbot/certbot/builds/160258644. Running the tests locally, it looks like Ubuntu has started shutting down the 19.04 repos which makes sense as this release has been EOL'd. See https://wiki.ubuntu.com/Releases.

I have the full suite including the test farm tests running at https://travis-ci.com/github/certbot/certbot/builds/160269969 with this change.

The issue of adding 19.10 to our test farm tests is tracked by https://github.com/certbot/certbot/issues/7851. I think that issue is important and it's in our current milestone, but I'd personally rather get our tests passing for now and try to expand them to run on other systems later.