### PR TITLE
Do not require mock in Python 3 in certbot module

### DIFF
--- a/certbot/certbot/plugins/dns_test_common.py
+++ b/certbot/certbot/plugins/dns_test_common.py
@@ -5,7 +5,7 @@ import josepy as jose
 try:
     import mock
 except ImportError: # pragma: no cover
-    from unittest import mock
+    from unittest import mock # type: ignore
 import six
 
 from acme import challenges

--- a/certbot/certbot/plugins/dns_test_common.py
+++ b/certbot/certbot/plugins/dns_test_common.py
@@ -2,7 +2,10 @@
 
 import configobj
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 
 from acme import challenges

--- a/certbot/certbot/plugins/dns_test_common_lexicon.py
+++ b/certbot/certbot/plugins/dns_test_common_lexicon.py
@@ -4,7 +4,7 @@ import josepy as jose
 try:
     import mock
 except ImportError: # pragma: no cover
-    from unittest import mock
+    from unittest import mock # type: ignore
 from requests.exceptions import HTTPError
 from requests.exceptions import RequestException
 

--- a/certbot/certbot/plugins/dns_test_common_lexicon.py
+++ b/certbot/certbot/plugins/dns_test_common_lexicon.py
@@ -1,7 +1,10 @@
 """Base test class for DNS authenticators built on Lexicon."""
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 from requests.exceptions import HTTPError
 from requests.exceptions import RequestException
 

--- a/certbot/certbot/tests/util.py
+++ b/certbot/certbot/tests/util.py
@@ -10,7 +10,10 @@ import unittest
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import OpenSSL
 import pkg_resources
 import six

--- a/certbot/certbot/tests/util.py
+++ b/certbot/certbot/tests/util.py
@@ -13,7 +13,7 @@ import josepy as jose
 try:
     import mock
 except ImportError: # pragma: no cover
-    from unittest import mock
+    from unittest import mock # type: ignore
 import OpenSSL
 import pkg_resources
 import six

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -47,7 +47,6 @@ install_requires = [
     # 1.1.0+ is required to avoid the warnings described at
     # https://github.com/certbot/josepy/issues/13.
     'josepy>=1.1.0',
-    'mock',
     'parsedatetime>=1.3',  # Calendar.parseDT
     'pyrfc3339',
     'pytz',
@@ -62,7 +61,8 @@ install_requires = [
 # So this dependency is not added for old Linux distributions with old setuptools,
 # in order to allow these systems to build certbot from sources.
 pywin32_req = 'pywin32>=227'  # do not forget to edit pywin32 dependency accordingly in windows-installer/construct.py
-if StrictVersion(setuptools_version) >= StrictVersion('36.2'):
+setuptools_known_environment_markers = (StrictVersion(setuptools_version) >= StrictVersion('36.2'))
+if setuptools_known_environment_markers:
     install_requires.append(pywin32_req + " ; sys_platform == 'win32'")
 elif 'bdist_wheel' in sys.argv[1:]:
     raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
@@ -72,6 +72,11 @@ elif os.name == 'nt':
     # it, if the sdist is installed on Windows with an old version of
     # setuptools, pywin32 will not be specified as a dependency.
     install_requires.append(pywin32_req)
+
+if setuptools_known_environment_markers:
+    install_requires.append('mock ; python_version < "3.3"')
+elif sys.version_info < (3,3):
+    install_requires.append('mock')
 
 dev_extras = [
     'coverage',

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -77,6 +77,9 @@ if setuptools_known_environment_markers:
     install_requires.append('mock ; python_version < "3.3"')
 elif sys.version_info < (3,3):
     install_requires.append('mock')
+else:
+    raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
+                       'of setuptools. Version 36.2+ of setuptools is required.')
 
 dev_extras = [
     'coverage',

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -75,11 +75,11 @@ elif os.name == 'nt':
 
 if setuptools_known_environment_markers:
     install_requires.append('mock ; python_version < "3.3"')
-elif sys.version_info < (3,3):
-    install_requires.append('mock')
-else:
+elif 'bdist_wheel' in sys.argv[1:]:
     raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
                        'of setuptools. Version 36.2+ of setuptools is required.')
+elif sys.version_info < (3,3):
+    install_requires.append('mock')
 
 dev_extras = [
     'coverage',

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -4,7 +4,10 @@ import json
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import pytz
 
 from acme import messages

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -3,7 +3,10 @@ import functools
 import logging
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import zope.component
 
 from acme import challenges

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -7,7 +7,10 @@ import tempfile
 import unittest
 
 import configobj
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot._internal import configuration

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -4,7 +4,10 @@ import copy
 import tempfile
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 from six.moves import reload_module  # pylint: disable=import-error
 

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -5,7 +5,10 @@ import tempfile
 import unittest
 
 from josepy import interfaces
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot import util

--- a/certbot/tests/compat/filesystem_test.py
+++ b/certbot/tests/compat/filesystem_test.py
@@ -3,7 +3,10 @@ import contextlib
 import errno
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import util
 from certbot._internal import lock

--- a/certbot/tests/configuration_test.py
+++ b/certbot/tests/configuration_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot._internal.configuration."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot._internal import constants

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -2,7 +2,10 @@
 import logging
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import OpenSSL
 import zope.component
 

--- a/certbot/tests/display/completer_test.py
+++ b/certbot/tests/display/completer_test.py
@@ -7,7 +7,10 @@ import string
 import sys
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 from six.moves import reload_module  # pylint: disable=import-error
 
 from certbot.compat import filesystem  # pylint: disable=ungrouped-imports

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -4,7 +4,10 @@ import sys
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import zope.component
 
 from acme import messages

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -4,7 +4,10 @@ import socket
 import tempfile
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 
 from certbot import errors

--- a/certbot/tests/eff_test.py
+++ b/certbot/tests/eff_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot._internal.eff."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import requests
 
 from certbot._internal import constants

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -4,7 +4,10 @@ import signal
 import sys
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot.compat import os
 

--- a/certbot/tests/errors_test.py
+++ b/certbot/tests/errors_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot.errors."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from acme import messages
 from certbot import achallenges

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot._internal.hooks."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot import util

--- a/certbot/tests/lock_test.py
+++ b/certbot/tests/lock_test.py
@@ -3,7 +3,10 @@ import functools
 import multiprocessing
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot.compat import os

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -5,7 +5,10 @@ import sys
 import time
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 
 from acme import messages

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -13,7 +13,10 @@ import traceback
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import pytz
 import six
 from six.moves import reload_module  # pylint: disable=import-error

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -10,7 +10,10 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes  # type: ignore
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import pytz
 
 from certbot import errors

--- a/certbot/tests/plugins/common_test.py
+++ b/certbot/tests/plugins/common_test.py
@@ -4,7 +4,10 @@ import shutil
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from acme import challenges
 from certbot import achallenges

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -3,7 +3,10 @@ import functools
 import string
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import pkg_resources
 import six
 import zope.interface

--- a/certbot/tests/plugins/dns_common_lexicon_test.py
+++ b/certbot/tests/plugins/dns_common_lexicon_test.py
@@ -2,7 +2,10 @@
 
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot.plugins import dns_common_lexicon
 from certbot.plugins import dns_test_common_lexicon

--- a/certbot/tests/plugins/dns_common_test.py
+++ b/certbot/tests/plugins/dns_common_test.py
@@ -4,7 +4,10 @@ import collections
 import logging
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot import util

--- a/certbot/tests/plugins/enhancements_test.py
+++ b/certbot/tests/plugins/enhancements_test.py
@@ -1,7 +1,10 @@
 """Tests for new style enhancements"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot._internal.plugins import null
 from certbot.plugins import enhancements

--- a/certbot/tests/plugins/manual_test.py
+++ b/certbot/tests/plugins/manual_test.py
@@ -2,7 +2,10 @@
 import sys
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 
 from acme import challenges

--- a/certbot/tests/plugins/null_test.py
+++ b/certbot/tests/plugins/null_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot._internal.plugins.null."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 
 

--- a/certbot/tests/plugins/selection_test.py
+++ b/certbot/tests/plugins/selection_test.py
@@ -2,7 +2,10 @@
 import sys
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import zope.component
 
 from certbot import errors

--- a/certbot/tests/plugins/standalone_test.py
+++ b/certbot/tests/plugins/standalone_test.py
@@ -5,7 +5,10 @@ from socket import errno as socket_errors  # type: ignore
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import OpenSSL.crypto  # pylint: disable=unused-import
 import six
 

--- a/certbot/tests/plugins/storage_test.py
+++ b/certbot/tests/plugins/storage_test.py
@@ -2,7 +2,10 @@
 import json
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import errors
 from certbot.compat import filesystem

--- a/certbot/tests/plugins/util_test.py
+++ b/certbot/tests/plugins/util_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot.plugins.util."""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot.compat import os
 

--- a/certbot/tests/plugins/webroot_test.py
+++ b/certbot/tests/plugins/webroot_test.py
@@ -10,7 +10,10 @@ import tempfile
 import unittest
 
 import josepy as jose
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 
 from acme import challenges

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot._internal.renewal"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from acme import challenges
 from certbot import errors

--- a/certbot/tests/renewupdater_test.py
+++ b/certbot/tests/renewupdater_test.py
@@ -1,7 +1,10 @@
 """Tests for renewal updater interfaces"""
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 
 from certbot import interfaces
 from certbot._internal import main

--- a/certbot/tests/reporter_test.py
+++ b/certbot/tests/reporter_test.py
@@ -2,7 +2,10 @@
 import sys
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 
 

--- a/certbot/tests/reverter_test.py
+++ b/certbot/tests/reverter_test.py
@@ -5,7 +5,10 @@ import shutil
 import tempfile
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 
 from certbot import errors

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -6,7 +6,10 @@ import stat
 import unittest
 
 import configobj
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import pytz
 import six
 

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -4,7 +4,10 @@ import errno
 import sys
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError: # pragma: no cover
+    from unittest import mock
 import six
 from six.moves import reload_module  # pylint: disable=import-error
 


### PR DESCRIPTION
This PR is exactly the same as #7895, but know we know a little bit more about what was going on with `mypy`.

Part of #7886.

This PR conditionally installs mock in `certbot/setup.py` based on setuptools version and python version, when possible. It then updates `certbot` tests to use `unittest.mock` when `mock` isn't available.