### PR TITLE
Test on Ubuntu 19.10

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -1,6 +1,11 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
+  - ami: ami-0545f7036167eb3aa
+    name: ubuntu19.10
+    type: ubuntu
+    virt: hvm
+    user: ubuntu
   - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -1,6 +1,11 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
+  - ami: ami-0545f7036167eb3aa
+    name: ubuntu19.10
+    type: ubuntu
+    virt: hvm
+    user: ubuntu
   - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/7851.

You can see tests successfully running with this change at https://travis-ci.com/github/certbot/certbot/builds/160641256.

The AMI-ID was taken from https://cloud-images.ubuntu.com/locator/ec2/. As of writing this, it is the only Ubuntu 19.10 AMI on that page in `us-east-1` using EBS for storage that isn't running on ARM. The instance store AMI cannot be used because that storage type is not available for the instance size we use. See https://aws.amazon.com/ec2/pricing/on-demand/ and https://travis-ci.com/certbot/certbot/builds/113021661 for proof of that.