### PR TITLE
Test on fedora 31

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -36,6 +36,11 @@ targets:
     user: admin
   #-----------------------------------------------------------------------------
   # Fedora
+  - ami: ami-0fcbe88944a53b4c8
+    name: fedora31
+    type: centos
+    virt: hvm
+    user: fedora
   - ami: ami-00bbc6858140f19ed
     name: fedora30
     type: centos

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -50,6 +50,11 @@ targets:
     type: centos
     virt: hvm
     user: ec2-user
+  - ami: ami-0fcbe88944a53b4c8
+    name: fedora31
+    type: centos
+    virt: hvm
+    user: fedora
   - ami: ami-00bbc6858140f19ed
     name: fedora30
     type: centos


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/7852.

The AMI ID comes from https://alt.fedoraproject.org/cloud/ where it is listed as their standard HVM AMI for the region we use us-east-1 (US East (N. Virginia)).

You can see test farm tests passing with this change at https://travis-ci.com/github/certbot/certbot/builds/160641585.
