### PR TITLE
Use Python 3 in the release script

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -59,7 +59,7 @@ mv "dist.$version" "dist.$version.$(date +%s).bak" || true
 git tag --delete "$tag" || true
 
 tmpvenv=$(mktemp -d)
-VIRTUALENV_NO_DOWNLOAD=1 virtualenv -p python2 $tmpvenv
+python3 -m venv "$tmpvenv"
 . $tmpvenv/bin/activate
 # update setuptools/pip just like in other places in the repo
 pip install -U setuptools
@@ -157,7 +157,7 @@ done
 echo "Testing packages"
 cd "dist.$version"
 # start local PyPI
-python -m SimpleHTTPServer $PORT &
+python -m http.server $PORT &
 # cd .. is NOT done on purpose: we make sure that all subpackages are
 # installed from local PyPI rather than current directory (repo root)
 VIRTUALENV_NO_DOWNLOAD=1 virtualenv ../venv
@@ -202,7 +202,7 @@ done
 # pin pip hashes of the things we just built
 for pkg in $SUBPKGS_IN_AUTO ; do
     echo $pkg==$version \\
-    pip hash dist."$version/$pkg"/*.{whl,gz} | grep "^--hash" | python2 -c 'from sys import stdin; input = stdin.read(); print "   ", input.replace("\n--hash", " \\\n    --hash"),'
+    pip hash dist."$version/$pkg"/*.{whl,gz} | grep "^--hash" | python -c 'from sys import stdin; input = stdin.read(); print("   ", input.replace("\n--hash", " \\\n    --hash"), end="")'
 done > letsencrypt-auto-source/pieces/certbot-requirements.txt
 deactivate
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/7902.

@ohemorange, if you have the time to review this PR too, that'd be great!

I did a mock release with the offline signature code commented out and everything worked fine.