### PR TITLE
Remove useless before_install lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ matrix:
     - sudo: required
       env: TOXENV=apache_compat
       services: docker
-      before_install:
       addons:
       <<: *not-on-master
     - sudo: required
@@ -87,7 +86,6 @@ matrix:
     - sudo: required
       env: TOXENV=nginx_compat
       services: docker
-      before_install:
       addons:
       <<: *extended-test-suite
     - python: "3.7"


### PR DESCRIPTION
A long time ago when these lines were added (https://github.com/certbot/certbot/pull/3393) they were useful because they skipped a needless `before_install` step in some builds. Now we never have a `before_install` step so these lines are cruft and can be removed.