### PR TITLE
Avoid deleting the workspace twice

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -86,7 +86,8 @@ class ACMEServer(object):
                                                 'alpine', 'rm', '-rf', '/workspace/boulder'])
                 process.wait()
         finally:
-            shutil.rmtree(self._workspace)
+            if os.path.exists(self._workspace):
+                shutil.rmtree(self._workspace)
         if self._stdout != sys.stdout:
             self._stdout.close()
         print('=> Test infrastructure stopped and cleaned up.')


### PR DESCRIPTION
As you can see at https://travis-ci.org/github/basak/certbot-snap-build/jobs/677762465, if we fail to set up the ACME server when running integration tests, we call `certbot_integration_tests.utils.acme_server.ACMEServer.stop` twice. Doing this causes an exception to occur on the second call to `stop` which masks the initial error.

This happens because of the code: https://github.com/certbot/certbot/blob/6693e87500344f0bff19f14beb2121f66a19d143/certbot-ci/certbot_integration_tests/conftest.py#L92-L94

We could alternatively change code there, but I personally think I like the approach in this PR best.

@adferrand, if you have the time and interest to review this trivial PR, I'd appreciate it!