### PR TITLE
Deprecate certbot-auto on Gentoo, macOS, and FreeBSD

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -20,6 +20,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Stop asking interactively if the user would like to add a redirect.
 * `mock` dependency is now conditional on Python 2 in all of our packages.
+* Deprecate certbot-auto on Gentoo, macOS, and FreeBSD.
 
 ### Fixed
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -656,38 +656,6 @@ BootstrapArchCommon() {
   fi
 }
 
-# If new packages are installed by BootstrapGentooCommon below, this version
-# number must be increased.
-BOOTSTRAP_GENTOO_COMMON_VERSION=1
-
-BootstrapGentooCommon() {
-  PACKAGES="
-    dev-lang/python:2.7
-    dev-python/virtualenv
-    app-admin/augeas
-    dev-libs/openssl
-    dev-libs/libffi
-    app-misc/ca-certificates
-    virtual/pkgconfig"
-
-  ASK_OPTION="--ask"
-  if [ "$ASSUME_YES" = 1 ]; then
-    ASK_OPTION=""
-  fi
-
-  case "$PACKAGE_MANAGER" in
-    (paludis)
-      cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
-      ;;
-    (pkgcore)
-      pmerge --noreplace --oneshot $ASK_OPTION $PACKAGES
-      ;;
-    (portage|*)
-      emerge --noreplace --oneshot $ASK_OPTION $PACKAGES
-      ;;
-  esac
-}
-
 # If new packages are installed by BootstrapFreeBsd below, this version number
 # must be increased.
 BOOTSTRAP_FREEBSD_VERSION=1
@@ -910,10 +878,7 @@ elif [ -f /etc/manjaro-release ]; then
   }
   BOOTSTRAP_VERSION="BootstrapArchCommon $BOOTSTRAP_ARCH_COMMON_VERSION"
 elif [ -f /etc/gentoo-release ]; then
-  Bootstrap() {
-    DeprecationBootstrap "Gentoo" BootstrapGentooCommon
-  }
-  BOOTSTRAP_VERSION="BootstrapGentooCommon $BOOTSTRAP_GENTOO_COMMON_VERSION"
+  DEPRECATED_OS=1
 elif uname | grep -iq FreeBSD ; then
   Bootstrap() {
     DeprecationBootstrap "FreeBSD" BootstrapFreeBsd
@@ -979,7 +944,6 @@ BootstrapMageiaCommon 1
 BootstrapRpmCommon 1
 BootstrapSuseCommon 1
 BootstrapArchCommon 1
-BootstrapGentooCommon 1
 BootstrapFreeBsd 1
 BootstrapMac 1
 BootstrapSmartOS 1

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -910,20 +910,11 @@ elif [ -f /etc/manjaro-release ]; then
   }
   BOOTSTRAP_VERSION="BootstrapArchCommon $BOOTSTRAP_ARCH_COMMON_VERSION"
 elif [ -f /etc/gentoo-release ]; then
-  Bootstrap() {
-    DeprecationBootstrap "Gentoo" BootstrapGentooCommon
-  }
-  BOOTSTRAP_VERSION="BootstrapGentooCommon $BOOTSTRAP_GENTOO_COMMON_VERSION"
+  DEPRECATED_OS=1
 elif uname | grep -iq FreeBSD ; then
-  Bootstrap() {
-    DeprecationBootstrap "FreeBSD" BootstrapFreeBsd
-  }
-  BOOTSTRAP_VERSION="BootstrapFreeBsd $BOOTSTRAP_FREEBSD_VERSION"
+  DEPRECATED_OS=1
 elif uname | grep -iq Darwin ; then
-  Bootstrap() {
-    DeprecationBootstrap "macOS" BootstrapMac
-  }
-  BOOTSTRAP_VERSION="BootstrapMac $BOOTSTRAP_MAC_VERSION"
+  DEPRECATED_OS=1
 elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
   Bootstrap() {
     ExperimentalBootstrap "Amazon Linux" BootstrapRpmCommon

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -672,55 +672,6 @@ BootstrapFreeBsd() {
     libffi
 }
 
-# If new packages are installed by BootstrapMac below, this version number must
-# be increased.
-BOOTSTRAP_MAC_VERSION=1
-
-BootstrapMac() {
-  if hash brew 2>/dev/null; then
-    say "Using Homebrew to install dependencies..."
-    pkgman=brew
-    pkgcmd="brew install"
-  elif hash port 2>/dev/null; then
-    say "Using MacPorts to install dependencies..."
-    pkgman=port
-    pkgcmd="port install"
-  else
-    say "No Homebrew/MacPorts; installing Homebrew..."
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    pkgman=brew
-    pkgcmd="brew install"
-  fi
-
-  $pkgcmd augeas
-  if [ "$(which python)" = "/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python" \
-      -o "$(which python)" = "/usr/bin/python" ]; then
-    # We want to avoid using the system Python because it requires root to use pip.
-    # python.org, MacPorts or HomeBrew Python installations should all be OK.
-    say "Installing python..."
-    $pkgcmd python
-  fi
-
-  # Workaround for _dlopen not finding augeas on macOS
-  if [ "$pkgman" = "port" ] && ! [ -e "/usr/local/lib/libaugeas.dylib" ] && [ -e "/opt/local/lib/libaugeas.dylib" ]; then
-    say "Applying augeas workaround"
-    mkdir -p /usr/local/lib/
-    ln -s /opt/local/lib/libaugeas.dylib /usr/local/lib/
-  fi
-
-  if ! hash pip 2>/dev/null; then
-    say "pip not installed"
-    say "Installing pip..."
-    curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
-  fi
-
-  if ! hash virtualenv 2>/dev/null; then
-    say "virtualenv not installed."
-    say "Installing with pip..."
-    pip install virtualenv
-  fi
-}
-
 # If new packages are installed by BootstrapSmartOS below, this version number
 # must be increased.
 BOOTSTRAP_SMARTOS_VERSION=1
@@ -885,10 +836,7 @@ elif uname | grep -iq FreeBSD ; then
   }
   BOOTSTRAP_VERSION="BootstrapFreeBsd $BOOTSTRAP_FREEBSD_VERSION"
 elif uname | grep -iq Darwin ; then
-  Bootstrap() {
-    DeprecationBootstrap "macOS" BootstrapMac
-  }
-  BOOTSTRAP_VERSION="BootstrapMac $BOOTSTRAP_MAC_VERSION"
+  DEPRECATED_OS=1
 elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
   Bootstrap() {
     ExperimentalBootstrap "Amazon Linux" BootstrapRpmCommon
@@ -945,7 +893,6 @@ BootstrapRpmCommon 1
 BootstrapSuseCommon 1
 BootstrapArchCommon 1
 BootstrapFreeBsd 1
-BootstrapMac 1
 BootstrapSmartOS 1
 UNLIKELY_EOF
   then

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -656,22 +656,6 @@ BootstrapArchCommon() {
   fi
 }
 
-# If new packages are installed by BootstrapFreeBsd below, this version number
-# must be increased.
-BOOTSTRAP_FREEBSD_VERSION=1
-
-BootstrapFreeBsd() {
-  if [ "$QUIET" = 1 ]; then
-    QUIET_FLAG="--quiet"
-  fi
-
-  pkg install -Ay $QUIET_FLAG \
-    python \
-    py27-virtualenv \
-    augeas \
-    libffi
-}
-
 # If new packages are installed by BootstrapSmartOS below, this version number
 # must be increased.
 BOOTSTRAP_SMARTOS_VERSION=1
@@ -831,10 +815,7 @@ elif [ -f /etc/manjaro-release ]; then
 elif [ -f /etc/gentoo-release ]; then
   DEPRECATED_OS=1
 elif uname | grep -iq FreeBSD ; then
-  Bootstrap() {
-    DeprecationBootstrap "FreeBSD" BootstrapFreeBsd
-  }
-  BOOTSTRAP_VERSION="BootstrapFreeBsd $BOOTSTRAP_FREEBSD_VERSION"
+  DEPRECATED_OS=1
 elif uname | grep -iq Darwin ; then
   DEPRECATED_OS=1
 elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
@@ -892,7 +873,6 @@ BootstrapMageiaCommon 1
 BootstrapRpmCommon 1
 BootstrapSuseCommon 1
 BootstrapArchCommon 1
-BootstrapFreeBsd 1
 BootstrapSmartOS 1
 UNLIKELY_EOF
   then

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -656,6 +656,103 @@ BootstrapArchCommon() {
   fi
 }
 
+# If new packages are installed by BootstrapGentooCommon below, this version
+# number must be increased.
+BOOTSTRAP_GENTOO_COMMON_VERSION=1
+
+BootstrapGentooCommon() {
+  PACKAGES="
+    dev-lang/python:2.7
+    dev-python/virtualenv
+    app-admin/augeas
+    dev-libs/openssl
+    dev-libs/libffi
+    app-misc/ca-certificates
+    virtual/pkgconfig"
+
+  ASK_OPTION="--ask"
+  if [ "$ASSUME_YES" = 1 ]; then
+    ASK_OPTION=""
+  fi
+
+  case "$PACKAGE_MANAGER" in
+    (paludis)
+      cave resolve --preserve-world --keep-targets if-possible $PACKAGES -x
+      ;;
+    (pkgcore)
+      pmerge --noreplace --oneshot $ASK_OPTION $PACKAGES
+      ;;
+    (portage|*)
+      emerge --noreplace --oneshot $ASK_OPTION $PACKAGES
+      ;;
+  esac
+}
+
+# If new packages are installed by BootstrapFreeBsd below, this version number
+# must be increased.
+BOOTSTRAP_FREEBSD_VERSION=1
+
+BootstrapFreeBsd() {
+  if [ "$QUIET" = 1 ]; then
+    QUIET_FLAG="--quiet"
+  fi
+
+  pkg install -Ay $QUIET_FLAG \
+    python \
+    py27-virtualenv \
+    augeas \
+    libffi
+}
+
+# If new packages are installed by BootstrapMac below, this version number must
+# be increased.
+BOOTSTRAP_MAC_VERSION=1
+
+BootstrapMac() {
+  if hash brew 2>/dev/null; then
+    say "Using Homebrew to install dependencies..."
+    pkgman=brew
+    pkgcmd="brew install"
+  elif hash port 2>/dev/null; then
+    say "Using MacPorts to install dependencies..."
+    pkgman=port
+    pkgcmd="port install"
+  else
+    say "No Homebrew/MacPorts; installing Homebrew..."
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    pkgman=brew
+    pkgcmd="brew install"
+  fi
+
+  $pkgcmd augeas
+  if [ "$(which python)" = "/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python" \
+      -o "$(which python)" = "/usr/bin/python" ]; then
+    # We want to avoid using the system Python because it requires root to use pip.
+    # python.org, MacPorts or HomeBrew Python installations should all be OK.
+    say "Installing python..."
+    $pkgcmd python
+  fi
+
+  # Workaround for _dlopen not finding augeas on macOS
+  if [ "$pkgman" = "port" ] && ! [ -e "/usr/local/lib/libaugeas.dylib" ] && [ -e "/opt/local/lib/libaugeas.dylib" ]; then
+    say "Applying augeas workaround"
+    mkdir -p /usr/local/lib/
+    ln -s /opt/local/lib/libaugeas.dylib /usr/local/lib/
+  fi
+
+  if ! hash pip 2>/dev/null; then
+    say "pip not installed"
+    say "Installing pip..."
+    curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
+  fi
+
+  if ! hash virtualenv 2>/dev/null; then
+    say "virtualenv not installed."
+    say "Installing with pip..."
+    pip install virtualenv
+  fi
+}
+
 # If new packages are installed by BootstrapSmartOS below, this version number
 # must be increased.
 BOOTSTRAP_SMARTOS_VERSION=1
@@ -813,11 +910,20 @@ elif [ -f /etc/manjaro-release ]; then
   }
   BOOTSTRAP_VERSION="BootstrapArchCommon $BOOTSTRAP_ARCH_COMMON_VERSION"
 elif [ -f /etc/gentoo-release ]; then
-  DEPRECATED_OS=1
+  Bootstrap() {
+    DeprecationBootstrap "Gentoo" BootstrapGentooCommon
+  }
+  BOOTSTRAP_VERSION="BootstrapGentooCommon $BOOTSTRAP_GENTOO_COMMON_VERSION"
 elif uname | grep -iq FreeBSD ; then
-  DEPRECATED_OS=1
+  Bootstrap() {
+    DeprecationBootstrap "FreeBSD" BootstrapFreeBsd
+  }
+  BOOTSTRAP_VERSION="BootstrapFreeBsd $BOOTSTRAP_FREEBSD_VERSION"
 elif uname | grep -iq Darwin ; then
-  DEPRECATED_OS=1
+  Bootstrap() {
+    DeprecationBootstrap "macOS" BootstrapMac
+  }
+  BOOTSTRAP_VERSION="BootstrapMac $BOOTSTRAP_MAC_VERSION"
 elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
   Bootstrap() {
     ExperimentalBootstrap "Amazon Linux" BootstrapRpmCommon
@@ -873,6 +979,9 @@ BootstrapMageiaCommon 1
 BootstrapRpmCommon 1
 BootstrapSuseCommon 1
 BootstrapArchCommon 1
+BootstrapGentooCommon 1
+BootstrapFreeBsd 1
+BootstrapMac 1
 BootstrapSmartOS 1
 UNLIKELY_EOF
   then

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -432,20 +432,11 @@ elif [ -f /etc/manjaro-release ]; then
   }
   BOOTSTRAP_VERSION="BootstrapArchCommon $BOOTSTRAP_ARCH_COMMON_VERSION"
 elif [ -f /etc/gentoo-release ]; then
-  Bootstrap() {
-    DeprecationBootstrap "Gentoo" BootstrapGentooCommon
-  }
-  BOOTSTRAP_VERSION="BootstrapGentooCommon $BOOTSTRAP_GENTOO_COMMON_VERSION"
+  DEPRECATED_OS=1
 elif uname | grep -iq FreeBSD ; then
-  Bootstrap() {
-    DeprecationBootstrap "FreeBSD" BootstrapFreeBsd
-  }
-  BOOTSTRAP_VERSION="BootstrapFreeBsd $BOOTSTRAP_FREEBSD_VERSION"
+  DEPRECATED_OS=1
 elif uname | grep -iq Darwin ; then
-  Bootstrap() {
-    DeprecationBootstrap "macOS" BootstrapMac
-  }
-  BOOTSTRAP_VERSION="BootstrapMac $BOOTSTRAP_MAC_VERSION"
+  DEPRECATED_OS=1
 elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
   Bootstrap() {
     ExperimentalBootstrap "Amazon Linux" BootstrapRpmCommon


### PR DESCRIPTION
Fixes #7747.

There are other references to macOS in the code but I see no reason to rip those out and take the risk. I'm also happy to put back most of the rest of the deleted code if we think there's a chance that'll be a problem.