### PR TITLE
Fix Travis extended/full test suite logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ not-on-master: &not-on-master
 # Jobs for the extended test suite are executed for cron jobs and pushes to
 # non-development branches.
 extended-test-suite: &extended-test-suite
-  if: type = cron OR (type = push AND branch = master)
+  if: type = cron OR (type = push AND branch != master)
 
 matrix:
   include:


### PR DESCRIPTION
In https://github.com/certbot/certbot/pull/7925 we accidently changed the logic here. Before it was:
```
type = cron OR (type = push AND branch NOT IN (apache-parser-v2, master))
```
now it's
```
type = cron OR (type = push AND branch = master)
```
We want to be able to run our full test suite on things like `test-*` branches. The reason we had been excluding `master` is it has the full test suite run on it (through what Travis calls `cron`) nightly and not running on every commit helps prevent us on waiting on CI since our nightly tests spin up so many jobs.

This PR changes things back to the intended behavior.

(We could talk about changing the condition to just `type = cron OR type = push` if we want, but I'd rather do that in a separate PR once things like `test-` branches are fixed.)