### PR TITLE
Add --chain-path to --help install output.

### DIFF
--- a/certbot/certbot/_internal/cli/paths_parser.py
+++ b/certbot/certbot/_internal/cli/paths_parser.py
@@ -38,7 +38,7 @@ def _paths_parser(helpful):
         default_cp = flag_default("auth_chain_path")
     add(["paths", "install"], "--fullchain-path", default=default_cp, type=os.path.abspath,
         help="Accompanying path to a full certificate chain (certificate plus chain).")
-    add("paths", "--chain-path", default=default_cp, type=os.path.abspath,
+    add(["paths", "install"], "--chain-path", default=default_cp, type=os.path.abspath,
         help="Accompanying path to a certificate chain.")
     add("paths", "--config-dir", default=flag_default("config_dir"),
         help=config_help("config_dir"))


### PR DESCRIPTION
Currently `certbot --help install` looks like:
```
% certbot --help install
usage: 

  certbot install --cert-path /path/to/fullchain.pem  --key-path /path/to/private-key [options]

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG_FILE, --config CONFIG_FILE
                        path to config file (default: /etc/letsencrypt/cli.ini
                        and ~/.config/letsencrypt/cli.ini)

install:
  Options for modifying how a certificate is deployed

  --cert-path CERT_PATH
                        Path to where certificate is saved (with auth --csr),
                        installed from, or revoked. (default: None)
  --key-path KEY_PATH   Path to private key for certificate installation or
                        revocation (if account key is missing) (default: None)
  --fullchain-path FULLCHAIN_PATH
                        Accompanying path to a full certificate chain
                        (certificate plus chain). (default: None)
  --apache              Obtain and install certificates using Apache (default:
                        False)
  --nginx               Obtain and install certificates using Nginx (default:
                        False)
```
`--chain-path` is one of the 4 common paths that may need to be provided here and its missing from the output. Let's add it.
