### PR TITLE
Allow existing but empty archive and live dir to be used when creating new lineage

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -21,6 +21,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Stop asking interactively if the user would like to add a redirect.
 * `mock` dependency is now conditional on Python 2 in all of our packages.
 * Deprecate certbot-auto on Gentoo, macOS, and FreeBSD.
+* Allow existing but empty archive and live dir to be used when creating new lineage.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -1007,18 +1007,18 @@ class RenewableCert(interfaces.RenewableCert):
         lineagename = lineagename_for_filename(config_filename)
         archive = full_archive_path(None, cli_config, lineagename)
         live_dir = _full_live_path(cli_config, lineagename)
-        if os.path.exists(archive):
+        if os.path.exists(archive) and (not os.path.isdir(archive) or os.listdir(archive)):
             config_file.close()
             raise errors.CertStorageError(
                 "archive directory exists for " + lineagename)
-        if os.path.exists(live_dir):
+        if os.path.exists(live_dir) and (not os.path.isdir(live_dir) or os.listdir(live_dir)):
             config_file.close()
             raise errors.CertStorageError(
                 "live directory exists for " + lineagename)
-        filesystem.mkdir(archive)
-        filesystem.mkdir(live_dir)
-        logger.debug("Archive directory %s and live "
-                     "directory %s created.", archive, live_dir)
+        for i in (archive, live_dir):
+            if not os.path.exists(i):
+                filesystem.makedirs(i)
+                logger.debug("Creating directory %s.", i)
 
         # Put the data into the appropriate files on disk
         target = {kind: os.path.join(live_dir, kind + ".pem") for kind in ALL_FOUR}

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -610,17 +610,25 @@ class RenewableCertTests(BaseRenewableCertTest):
             self.config.renewal_configs_dir, "the-lineage.com-0001.conf")))
         self.assertTrue(os.path.exists(os.path.join(
             self.config.live_dir, "the-lineage.com-0001", "README")))
+        # Allow write to existing but empty dir
+        filesystem.mkdir(os.path.join(self.config.default_archive_dir, "the-lineage.com-0002"))
+        result = storage.RenewableCert.new_lineage(
+            "the-lineage.com", b"cert3", b"privkey3", b"chain3", self.config)
+        self.assertTrue(os.path.exists(os.path.join(
+            self.config.live_dir, "the-lineage.com-0002", "README")))
+        self.assertTrue(filesystem.check_mode(result.key_path, 0o600))
         # Now trigger the detection of already existing files
-        filesystem.mkdir(os.path.join(
-            self.config.live_dir, "the-lineage.com-0002"))
+        shutil.copytree(os.path.join(self.config.live_dir, "the-lineage.com"),
+                        os.path.join(self.config.live_dir, "the-lineage.com-0003"))
         self.assertRaises(errors.CertStorageError,
                           storage.RenewableCert.new_lineage, "the-lineage.com",
-                          b"cert3", b"privkey3", b"chain3", self.config)
-        filesystem.mkdir(os.path.join(self.config.default_archive_dir, "other-example.com"))
+                          b"cert4", b"privkey4", b"chain4", self.config)
+        shutil.copytree(os.path.join(self.config.live_dir, "the-lineage.com"),
+                        os.path.join(self.config.live_dir, "other-example.com"))
         self.assertRaises(errors.CertStorageError,
                           storage.RenewableCert.new_lineage,
-                          "other-example.com", b"cert4",
-                          b"privkey4", b"chain4", self.config)
+                          "other-example.com", b"cert5",
+                          b"privkey5", b"chain5", self.config)
         # Make sure it can accept renewal parameters
         result = storage.RenewableCert.new_lineage(
             "the-lineage.com", b"cert2", b"privkey2", b"chain2", self.config)


### PR DESCRIPTION
## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.

---

The motivation behind this change is to allow a docker container running a tls service to bind mount the archive dir & live dir of a single lineage. For example:

``` yaml
    volumes:
      - "/etc/letsencrypt/archive/www.example.com:/etc/letsencrypt/archive/www.example.com:ro"
      - "/etc/letsencrypt/live/www.example.com:/etc/letsencrypt/live/www.example.com:ro"
```

This way, this tls service container would not have access to other lineages for other containers. For this to work, archive directory and live directory for a lineage have to be created first to be bind mounted. However, certbot currently would not work with existing but empty archive or live directory. Thus result in certificates successfully being issued, but failed to be written to disk. I learned this the hard way with setting docker auto restart on my certbot container, and it resulted hitting limit rate in just a few seconds by keeping failing and restarting.

This PR would allow writing into existing archive or live dir, as long as they are both empty.

---

Alternative ideas for docker use case:

1. Have each tls service container bind mount the certbot deploy hook dir and install a deploy hook. This means that certbot container would also need to mount the deploy location, which is definitely not ideal. Also, this still have a race condition that, if deploy hook is installed by tls service container after certificate was generated, the tls service container would have no certificate because the deploy hook was installed to late.
2. Pre-install a single deploy hook in certbot container which copy the lineage files to a different shared directory. E.g. Deploy hook would resolve symlinks and then copy files from `/etc/letsencrypt/live/www.example.com` to `/var/ssl/www.example.com`. Certbot container would need to mount `/var/ssl` and the tls service container would mount `/var/ssl/www.example.com`. This works but I don't like the complexity.
3. Simply mount the whole `/etc/letsencrypt` directory on the tls service container. This works as well, but expose unnecessary access of certbot credential as well as private key of other certificates to tls service container, thus not ideal.