### PR TITLE
Remove passthrough because its no longer needed

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,9 +32,8 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: $SNAP/usr/share/augeas/lenses/dist
       LD_LIBRARY_PATH: "$SNAP/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
-    passthrough:
-        # Run approximately twice a day with randomization
-        timer: 00:00~24:00/2
+    # Run approximately twice a day with randomization
+    timer: 00:00~24:00/2
 
 parts:
   python-augeas:


### PR DESCRIPTION
https://snapcraft.io/docs/using-in-development-features describes how `passthrough` can be used to skip some of the validation performed by `snapcraft` to allow you to use new features of snaps that snapcraft may not understand yet.

We were using `passthrough` here for support for automatically running `certbot renew`, but this is apparently no longer needed.

You can see the build succeeding with this change at https://travis-ci.com/github/certbot/certbot/builds/162511925 and I tested building the snap locally and installing it with this change and it still successfully sets up systemd timers to run Certbot.