### PR TITLE
fix for issue #7933 (dns-google plugin fails to use instance authentication)

### DIFF
--- a/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
@@ -90,7 +90,13 @@ class _GoogleClient(object):
             with open(account_json) as account:
                 self.project_id = json.load(account)['project_id']
         else:
-            credentials = AppAssertionCredentials()
+            try:
+                # try it infer credentials from Google Compute Engine.
+                # support for other GCP environments is restricted due to the
+                # limitations of the deprecated oauth2client library
+                credentials = AppAssertionCredentials()
+            except:
+                credentials = None
             self.project_id = self.get_project_id()
 
         if not dns_api:

--- a/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
@@ -6,6 +6,7 @@ from googleapiclient import discovery
 from googleapiclient import errors as googleapiclient_errors
 import httplib2
 from oauth2client.service_account import ServiceAccountCredentials
+from oauth2client.contrib.gce import AppAssertionCredentials
 import zope.interface
 
 from certbot import errors
@@ -89,7 +90,7 @@ class _GoogleClient(object):
             with open(account_json) as account:
                 self.project_id = json.load(account)['project_id']
         else:
-            credentials = None
+            credentials = AppAssertionCredentials()
             self.project_id = self.get_project_id()
 
         if not dns_api:


### PR DESCRIPTION
Fix updates the google-api-python-client to a current version, which uses an updated backend for creating an api service with googleapiclient.discovery.

Examples from Google Documentation:
https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually
https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions

