### PR TITLE
Add warning about ignoring our own warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,12 @@
 [pytest]
 # In general, all warnings are treated as errors. Here are the exceptions:
 #   1- decodestring: https://github.com/rthalley/dnspython/issues/338
+# Warnings being triggered by our plugins using deprecated features in
+# acme/certbot should be fixed by having our plugins no longer using the
+# deprecated code and not ignored here. Fixing things in this way prevents us
+# from shipping packages raising our own deprecation warnings and gives time
+# for plugins that don't use the deprecated API to propagate, especially for
+# plugins packaged as an external snap, before we release breaking changes.
 filterwarnings =
     error
     ignore:decodestring:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,10 +6,11 @@
 #   1- decodestring: https://github.com/rthalley/dnspython/issues/338
 # Warnings being triggered by our plugins using deprecated features in
 # acme/certbot should be fixed by having our plugins no longer using the
-# deprecated code and not ignored here. Fixing things in this way prevents us
-# from shipping packages raising our own deprecation warnings and gives time
-# for plugins that don't use the deprecated API to propagate, especially for
-# plugins packaged as an external snap, before we release breaking changes.
+# deprecated code rather than adding them to the list of ignored warnings here.
+# Fixing things in this way prevents us from shipping packages raising our own
+# deprecation warnings and gives time for plugins that don't use the deprecated
+# API to propagate, especially for plugins packaged as an external snap, before
+# we release breaking changes.
 filterwarnings =
     error
     ignore:decodestring:DeprecationWarning


### PR DESCRIPTION
Coming out of the conversation at https://github.com/certbot/certbot/issues/7863 in the linked Google Doc, we should always have at least 1 release between updating one of our plugins to stop using a deprecated acme/certbot API and removing it from acme/certbot. Doing this gives the plugin changes time to propagate rather than potentially having the plugin break because Certbot was updated before the plugin had made the necessary changes.

This comment here should help ensure this.