### PR TITLE
Add a '--renew-before-expiry' CLI flag which overrides the default

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -247,6 +247,7 @@ Authors
 * [Thom Wiggers](https://github.com/thomwiggers)
 * [Till Maas](https://github.com/tyll)
 * [Timothy Guan-tin Chien](https://github.com/timdream)
+* [Tom Anthony](https://github.com/tomanthony)
 * [Torsten Bögershausen](https://github.com/tboegi)
 * [Travis Raines](https://github.com/rainest)
 * [Trung Ngo](https://github.com/Ngo-The-Trung)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Added `--renew-before-expiry` CLI flag, which allows overriding the default (currently 30 day) expiry interval, allowing easy renewal of certs at an earlier time. It can be used in conjunction with the `renew_before_expiry` renewal config file setting, in which case the the longer interval (i.e. earlier renewal date) will be accepted (provided it is different to the default value).
 
 ### Changed
 

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -204,6 +204,14 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         version="%(prog)s {0}".format(certbot.__version__),
         help="show program's version number and exit")
     helpful.add(
+        ["automation", "renew"], "--renew-before-expiry",
+        metavar="EXPIRY_TIME_INTERVAL", type=str, dest="renew_before_expiry",
+        default=flag_default("renew_before_expiry"),
+        help="If a certificate "
+             "already exists for the requested domains, renew it if "
+             "it is within the specified time period. (Provide "
+             "a value such as '40 days', or '3 weeks').")
+    helpful.add(
         ["automation", "renew"],
         "--force-renewal", "--renew-by-default", dest="renew_by_default",
         action="store_true", default=flag_default("renew_by_default"),

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -13,6 +13,15 @@ SETUPTOOLS_PLUGINS_ENTRY_POINT = "certbot.plugins"
 OLD_SETUPTOOLS_PLUGINS_ENTRY_POINT = "letsencrypt.plugins"
 """Plugins Setuptools entry point before rename."""
 
+RENEWER_DEFAULTS = dict(
+    renewer_enabled="yes",
+    renew_before_expiry="30 days",
+    # This value should ensure that there is never a deployment delay by
+    # default.
+    deploy_before_expiry="99 years",
+)
+"""Defaults for renewer script."""
+
 CLI_DEFAULTS = dict(
     config_files=[
         os.path.join(misc.get_default_folder('config'), 'cli.ini'),
@@ -36,6 +45,7 @@ CLI_DEFAULTS = dict(
     reinstall=False,
     expand=False,
     renew_by_default=False,
+    renew_before_expiry=RENEWER_DEFAULTS['renew_before_expiry'],
     renew_with_new_domains=False,
     autorenew=True,
     allow_subset_of_names=False,
@@ -135,15 +145,6 @@ REVOCATION_REASONS = {
 
 QUIET_LOGGING_LEVEL = logging.WARNING
 """Logging level to use in quiet mode."""
-
-RENEWER_DEFAULTS = dict(
-    renewer_enabled="yes",
-    renew_before_expiry="30 days",
-    # This value should ensure that there is never a deployment delay by
-    # default.
-    deploy_before_expiry="99 years",
-)
-"""Defaults for renewer script."""
 
 ARCHIVE_DIR = "archive"
 """Archive directory, relative to `IConfig.config_dir`."""

--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -100,6 +100,40 @@ def add_time_interval(base_time, interval, textparser=parsedatetime.Calendar()):
     return textparser.parseDT(interval, base_time, tzinfo=tzinfo)[0]
 
 
+def get_longest_time_interval(intervals, textparser=parsedatetime.Calendar()):
+    """Parse the time intervals, and return the longest (time-wise) interval
+
+    The interval can be in the English-language format understood by
+    parsedatetime, e.g., '10 days', '3 weeks', '6 months', '9 hours', or
+    a sequence of such intervals like '6 months 1 week' or '3 days 12
+    hours'. If an integer is found with no associated unit, it is
+    interpreted by default as a number of days.
+
+    :param list intervals: List of time intervals to select from.
+
+    :returns: A str interval, from intervals, that represents longest period.
+    :rtype: :class:`str`"""
+
+    now = datetime.datetime.utcnow()
+    now = now.replace(tzinfo=pytz.utc)
+
+    furthest_date = now
+    furthest_interval = intervals[0]
+
+    for interval in intervals:
+
+        if interval.strip().isdigit():
+            interval += " days"
+
+        interval_date = textparser.parseDT(interval, now, tzinfo=pytz.UTC)[0]
+
+        if furthest_date < interval_date:
+            furthest_date = interval_date
+            furthest_interval = interval
+
+    return furthest_interval
+
+
 def write_renewal_config(o_filename, n_filename, archive_dir, target, relevant_data):
     """Writes a renewal config file with the specified name and values.
 
@@ -948,8 +982,31 @@ class RenewableCert(interfaces.RenewableCert):
                 return True
 
             # Renews some period before expiry time
+            # There are three sources for the expiry setting:
             default_interval = constants.RENEWER_DEFAULTS["renew_before_expiry"]
-            interval = self.configuration.get("renew_before_expiry", default_interval)
+            cli_interval = self.cli_config.renew_before_expiry
+            config_interval = self.configuration.get("renew_before_expiry", default_interval)
+
+            # `config` and `cli` will both have picked up the `default`
+            # if they were not explicitly set. Those that are `default`
+            # are ignored. `default` is only used if neither `config`
+            # or `cli` are set.
+
+            candidate_intervals = []
+
+            if cli_interval != default_interval:
+                candidate_intervals.append(cli_interval)
+
+            if config_interval != default_interval:
+                candidate_intervals.append(config_interval)
+
+            if not candidate_intervals:
+                candidate_intervals.append(default_interval)
+
+            # Tend towards renewal, so select the longest interval,
+            # meaning that which will renew the soonest.
+            interval = get_longest_time_interval(candidate_intervals)
+
             expiry = crypto_util.notAfter(self.version(
                 "cert", self.latest_common_version()))
             now = pytz.UTC.fromutc(datetime.datetime.utcnow())

--- a/certbot/docs/cli-help.txt
+++ b/certbot/docs/cli-help.txt
@@ -138,6 +138,11 @@ automation:
                         requested names, always expand and replace it with the
                         additional names. (default: Ask)
   --version             show program's version number and exit
+  --renew-before-expiry EXPIRY_TIME_INTERVAL
+                        If a certificate already exists for the requested
+                        domains, renew it if it is within the specified time
+                        period. (Provide a value such as '40 days', or '3
+                        weeks'). (default: 30 days)
   --force-renewal, --renew-by-default
                         If a certificate already exists for the requested
                         domains, renew it now, regardless of whether it is

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -455,6 +455,66 @@ class RenewableCertTests(BaseRenewableCertTest):
             self.test_rc.configuration["renew_before_expiry"] = interval
             self.assertEqual(self.test_rc.should_autorenew(), result)
 
+
+    @mock.patch("certbot._internal.storage.cli")
+    @mock.patch("certbot._internal.storage.datetime")
+    def test_time_interval_selection(self, mock_datetime, mock_cli):
+        """Test should_autorenew() on the basis of various different
+        expiry time intervals via config/cli."""
+        test_cert = test_util.load_vector("cert_512.pem")
+
+        self._write_out_ex_kinds()
+
+        self.test_rc.update_all_links_to(12)
+        with open(self.test_rc.cert, "wb") as f:
+            f.write(test_cert)
+        self.test_rc.update_all_links_to(11)
+        with open(self.test_rc.cert, "wb") as f:
+            f.write(test_cert)
+
+        mock_datetime.timedelta = datetime.timedelta
+        mock_cli.set_by_cli.return_value = False
+        self.test_rc.configuration["renewalparams"] = {}
+
+        for (current_time, cli_rbe, config_rbe, result) in [
+                # 2014-12-13 12:00:00+00:00 (about 5 days prior to expiry)
+                # Config that should result in autorenewal/autodeployment
+                (1418472000, "1 day", "2 months", True),
+                (1418472000, "1 week", "1 day", True),
+                # Times that should not
+                (1418472000, "1 day", "1 day", False),
+                # 2014-11-13 12:00:00+00:00 (about 35 days prior to expiry)
+                # Config that should result in autorenewal/autodeployment
+                (1415880000, "30 days", "40 days", True),
+                # Times that should not
+                (1415880000, "30 days", "30 days", False),
+                # 2009-05-01 12:00:00+00:00 (about 5 years prior to expiry)
+                # Config that should result in autorenewal/autodeployment
+                (1241179200, "7 years", "7 years", True),
+                (1241179200, "30 days", "7 years", True),
+                (1241179200, "2200 days", "30 days", True),
+                # Config that should not
+                (1241179200, "8 hours", "30 days", False),
+                (1241179200, "2 days", "2 days", False),
+                (1241179200, "30 days", "40 days", False),
+                (1241179200, "9 months", "9 months", False),
+                # 2015-01-01 (after expiry has already happened, so all
+                #            intervals should cause autorenewal/autodeployment)
+                (1420070400, "0 seconds", "0 seconds", True),
+                (1420070400, "10 seconds", "10 seconds", True),
+                (1420070400, "10 minutes", "10 minutes", True),
+                (1420070400, "10 weeks", "10 weeks", True),
+                (1420070400, "10 months", "10 months", True),
+                (1420070400, "10 years", "10 years", True),
+                (1420070400, "99 months", "99 months", True),
+        ]:
+            sometime = datetime.datetime.utcfromtimestamp(current_time)
+            mock_datetime.datetime.utcnow.return_value = sometime
+            self.test_rc.cli_config.renew_before_expiry = cli_rbe
+            self.test_rc.configuration["deploy_before_expiry"] = config_rbe
+            self.test_rc.configuration["renew_before_expiry"] = config_rbe
+            self.assertEqual(self.test_rc.should_autorenew(), result)
+
     def test_autorenewal_is_enabled(self):
         self.test_rc.configuration["renewalparams"] = {}
         self.assertTrue(self.test_rc.autorenewal_is_enabled())


### PR DESCRIPTION
This is an attempt at adding a new flag `--renew-before-expiry` which works in the same way as the `renew_before_expiry` renewal config file option. It is often easier to supply a flag rather than find and update a config file, especially in scripted systems.

Notable is how this behaves when both the new CLI flag and config file option are present for a certificate. In that case the longer interval (i.e. earlier renewal date) is selected. If either option is set the same as the default then it is ignored.

This is motivated by the default 30 day period causing difficulty for customers of a project I work on, as they often have alarms that fire at the 30 day mark for vendor certs, so we wanted to renew at 35 days, but disliked the relative complexity of having scripts update renewal config files.

This is my first PR on the project, so hopefully I haven't missed anything! :)

## Pull Request Checklist

- [x ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.
