### PR TITLE
Print cause of exit in red text

### DIFF
--- a/certbot/certbot/_internal/log.py
+++ b/certbot/certbot/_internal/log.py
@@ -322,10 +322,10 @@ def post_arg_parse_except_hook(exc_type, exc_value, trace, debug, log_path):
         logger.error('Exiting abnormally:', exc_info=exc_info)
     else:
         logger.debug('Exiting abnormally:', exc_info=exc_info)
+        # Use logger to print the error message to take advantage of
+        # our logger printing warnings and errors in red text.
         if issubclass(exc_type, errors.Error):
-            # Use logger to print the error message to take advantage of
-            # our logger printing warnings and errors in red text.
-            logger.error(exc_value)
+            logger.error(str(exc_value))
             sys.exit(1)
         logger.error('An unexpected error occurred:')
         if messages.is_acme_error(exc_value):
@@ -333,7 +333,12 @@ def post_arg_parse_except_hook(exc_type, exc_value, trace, debug, log_path):
             _, _, exc_str = str(exc_value).partition(':: ')
             logger.error(exc_str)
         else:
-            traceback.print_exception(exc_type, exc_value, None)
+            output = traceback.format_exception_only(exc_type, exc_value)
+            # format_exception_only returns a list of strings each
+            # terminated by a newline. We combine them into one string
+            # and remove the final newline before passing it to
+            # logger.error.
+            logger.error(''.join(output).rstrip())
     exit_with_log_path(log_path)
 
 

--- a/certbot/certbot/_internal/log.py
+++ b/certbot/certbot/_internal/log.py
@@ -323,7 +323,10 @@ def post_arg_parse_except_hook(exc_type, exc_value, trace, debug, log_path):
     else:
         logger.debug('Exiting abnormally:', exc_info=exc_info)
         if issubclass(exc_type, errors.Error):
-            sys.exit(exc_value)
+            # Use logger to print the error message to take advantage of
+            # our logger printing warnings and errors in red text.
+            logger.error(exc_value)
+            sys.exit(1)
         logger.error('An unexpected error occurred:')
         if messages.is_acme_error(exc_value):
             # Remove the ACME error prefix from the exception


### PR DESCRIPTION
Certbot writes logging messages at the warning level or higher to the terminal in red text. It turns out fatal errors aren't always printed in red though.

I noticed this when testing https://github.com/certbot/certbot/pull/7984. Relevant output looks like:
![Screen Shot 2020-05-18 at 10 22 11 AM](https://user-images.githubusercontent.com/6504915/82241751-8ab6d680-98f1-11ea-8f7d-da725874ac95.png)

The fatal error message here is "Could not find ssl_module; not installing certificate." but it's not given any special significance and I think it's harder to see because of the other red text and the important notes section.

While we have plans to remove the important notes section in the future, I personally think another thing we should do here is to display the fatal error in red as well which is done in this PR.

I started to add tests here, but I think we're pretty well covered by the existing tests checking that `SystemExit` is raised and that the error message is written to the terminal in all cases. I'm happy to add more if there's something in particular the reviewer of this PR thinks should be tested.