### PR TITLE
dns-cloudflare: Allow config-file overriding of Zone IDs

### DIFF
--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -51,7 +51,8 @@ including for renewal, and cannot be silenced except by addressing the issue
 Easy setup
 ^^^^^^^^^^
 
-Create a Token in your `Cloudflare dashboard <https://dash.cloudflare.com/profile/api-tokens>`_
+Create a Token in your
+`Cloudflare dashboard <https://dash.cloudflare.com/?to=/:account/profile/api-tokens>`_
 with ``Zone:Zone:Read`` and ``Zone:DNS:Edit`` permissions for **all** zones in your account.
 If you wish to restrict token access on a per-zone level, follow the `advanced setup`_.
 
@@ -68,7 +69,8 @@ Copy and save the token in a file like so:
 Advanced setup
 ^^^^^^^^^^^^^^
 
-Create a Token in your `Cloudflare dashboard <https://dash.cloudflare.com/profile/api-tokens>`_
+Create a Token in your
+`Cloudflare dashboard <https://dash.cloudflare.com/?to=/:account/profile/api-tokens>`_
 with ``Zone:DNS:Edit`` permissions for the specific zones for which you need certificates.
 
 You will also need to add the Zone ID for each zone(from the bottom right of each zone page in
@@ -94,8 +96,8 @@ the entire Cloudflare API for all domains in your account, meaning it could caus
 damage if leaked. **If possible, you should use a Cloudflare Token.**
 
 Copy your Global Key from your
-`Cloudflare dashboard <https://dash.cloudflare.com/profile/api-tokens>`_ and save it with your
-Cloudflare account's email address in the configuration file:
+`Cloudflare dashboard <https://dash.cloudflare.com/?to=/:account/profile/api-tokens>`_
+and save it with your Cloudflare account's email address in the configuration file:
 
 .. code-block:: ini
    :name: certbot_cloudflare_key.ini

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -93,8 +93,9 @@ A Global Key was previously used by Cloudflare for authentication, however this 
 the entire Cloudflare API for all domains in your account, meaning it could cause a lot of
 damage if leaked. **If possible, you should use a Cloudflare Token.**
 
-Copy your Global Key from your `Cloudflare dashboard <https://dash.cloudflare.com/profile/api-tokens>`_
-and save it with your Cloudflare account's email address in the configuration file:
+Copy your Global Key from your
+`Cloudflare dashboard <https://dash.cloudflare.com/profile/api-tokens>`_ and save it with your
+Cloudflare account's email address in the configuration file:
 
 .. code-block:: ini
    :name: certbot_cloudflare_key.ini

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/__init__.py
@@ -21,43 +21,14 @@ Credentials
 -----------
 
 Use of this plugin requires a configuration file containing Cloudflare API
-credentials, obtained from your Cloudflare
-`account page <https://dash.cloudflare.com/profile/api-tokens>`_.
+credentials.
 
-Previously, Cloudflare's "Global API Key" was used for authentication, however
-this key can access the entire Cloudflare API for all domains in your account,
-meaning it could cause a lot of damage if leaked.
+There are three ways to accomplish this. Using the `easy setup`_ or `advanced setup`_ is
+recommended, however requires at least version 2.3.1 of the ``cloudflare`` python module.
+If the version that automatically installed with this plugin is older than that,
+and you can't upgrade it on your system, you'll have to stick to the `legacy setup`_.
 
-Cloudflare's newer API Tokens can be restricted to specific domains and
-operations, and are therefore now the recommended authentication option.
-
-However, due to some shortcomings in Cloudflare's implementation of Tokens,
-Tokens created for Certbot currently require ``Zone:Zone:Read`` and ``Zone:DNS:Edit``
-permissions for **all** zones in your account. While this is not ideal, your Token
-will still have fewer permission than the Global key, so it's still worth doing.
-Hopefully Cloudflare will improve this in the future.
-
-Using Cloudflare Tokens also requires at least version 2.3.1 of the ``cloudflare``
-python module. If the version that automatically installed with this plugin is
-older than that, and you can't upgrade it on your system, you'll have to stick to
-the Global key.
-
-.. code-block:: ini
-   :name: certbot_cloudflare_token.ini
-   :caption: Example credentials file using restricted API Token (recommended):
-
-   # Cloudflare API token used by Certbot
-   dns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567
-
-.. code-block:: ini
-   :name: certbot_cloudflare_key.ini
-   :caption: Example credentials file using Global API Key (not recommended):
-
-   # Cloudflare API credentials used by Certbot
-   dns_cloudflare_email = cloudflare@example.com
-   dns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234
-
-The path to this file can be provided interactively or using the
+The path to the configuration file can be provided interactively or using the
 ``--dns-cloudflare-credentials`` command-line argument. Certbot records the path
 to this file for use during renewal, but does not store the file's contents.
 
@@ -69,16 +40,73 @@ to this file for use during renewal, but does not store the file's contents.
    new certificates or revoke existing certificates for associated domains,
    even if those domains aren't being managed by this server.
 
-Certbot will emit a warning if it detects that the credentials file can be
+Certbot will emit a warning if it detects that the configuration file can be
 accessed by other users on your system. The warning reads "Unsafe permissions
-on credentials configuration file", followed by the path to the credentials
-file. This warning will be emitted each time Certbot uses the credentials file,
+on credentials configuration file", followed by the path to the file.
+This warning will be emitted each time Certbot uses the credentials file,
 including for renewal, and cannot be silenced except by addressing the issue
 (e.g., by using a command like ``chmod 600`` to restrict access to the file).
 
 
-Examples
---------
+Easy setup
+^^^^^^^^^^
+
+Create a Token in your `Cloudflare dashboard <https://dash.cloudflare.com/profile/api-tokens>`_
+with ``Zone:Zone:Read`` and ``Zone:DNS:Edit`` permissions for **all** zones in your account.
+If you wish to restrict token access on a per-zone level, follow the `advanced setup`_.
+
+Copy and save the token in a file like so:
+
+.. code-block:: ini
+   :name: certbot_cloudflare_token.ini
+   :caption: Example credentials file using API Token:
+
+   # Cloudflare API token used by Certbot
+   dns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567
+
+
+Advanced setup
+^^^^^^^^^^^^^^
+
+Create a Token in your `Cloudflare dashboard <https://dash.cloudflare.com/profile/api-tokens>`_
+with ``Zone:DNS:Edit`` permissions for the specific zones for which you need certificates.
+
+You will also need to add the Zone ID for each zone(from the bottom right of each zone page in
+your dashboard) to the configuration file like so:
+
+.. code-block:: ini
+   :name: certbot_cloudflare_credentials.ini
+   :caption: Example credentials file using API Token with Zone IDs:
+
+   # Cloudflare API token used by Certbot
+   dns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567
+
+   [dns_cloudflare_zone_ids]
+   example.com = 0123456789abcdef0123456789abcdef
+   example.org = 0123456789abcdef0123456789abcdef
+
+
+Legacy setup
+^^^^^^^^^^^^
+
+A Global Key was previously used by Cloudflare for authentication, however this key can access
+the entire Cloudflare API for all domains in your account, meaning it could cause a lot of
+damage if leaked. **If possible, you should use a Cloudflare Token.**
+
+Copy your Global Key from your `Cloudflare dashboard <https://dash.cloudflare.com/profile/api-tokens>`_
+and save it with your Cloudflare account's email address in the configuration file:
+
+.. code-block:: ini
+   :name: certbot_cloudflare_key.ini
+   :caption: Example credentials file using Global API Key:
+
+   # Cloudflare API credentials used by Certbot
+   dns_cloudflare_email = cloudflare@example.com
+   dns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234
+
+
+Usage
+-----
 
 .. code-block:: bash
    :caption: To acquire a certificate for ``example.com``

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/dns_cloudflare.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/dns_cloudflare.py
@@ -14,7 +14,7 @@ from certbot.plugins import dns_common
 
 logger = logging.getLogger(__name__)
 
-ACCOUNT_URL = 'https://dash.cloudflare.com/profile/api-tokens'
+ACCOUNT_URL = 'https://dash.cloudflare.com/?to=/:account/profile/api-tokens'
 
 
 @zope.interface.implementer(interfaces.IAuthenticator)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,6 +14,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+* Add ability to override Cloudflare zone ID lookups in config file to allow greater
+  restriction of API Token permissions.
+
 * Add support for OCSP responses which use a public key hash ResponderID, fixing
   interoperability with Sectigo CAs.
 


### PR DESCRIPTION
Since the introduction of support for Cloudflare's limited-scope API Tokens in #7583, API Tokens for use with certbot have required access to all zones in a user's Cloudflare account due to a quirk of how Cloudflare's API works. This is obviously not ideal from a security perspective.

Since then, myself and @bmw have spoken with people at Cloudflare about fixing the bug in their API, however it is apparently not an easy fix, and they don't have a timeline. This PR implements an (optional) workaround with a slight cost to usability, meaning the three ways to authenticate to the Cloudflare API will now be:

- (existing) Using a Cloudflare API Token with the config option `dns_cloudflare_api_token`. This Token must have DNS Edit access to all zones in a user's Cloudflare account, and so is not ideal, but is easy to setup and is more restrictive than the global key.

- (new) Using a Cloudflare API Token with the config option `dns_cloudflare_api_token` **and providing the Cloudflare zone IDs for the zone(s) for which certs are required with `dns_cloudflare_zone_ids`.** With this option, the Token will only need DNS Edit access to the zone(s) which you need certs for.

- (existing) Using Cloudflare's global API key with the config options `dns_cloudflare_email` and `dns_cloudflare_api_key`. The Global Key grants full access to a user's entire Cloudflare account, and hence it is recommended against in the docs.

These three methods are documented as "Easy setup", "Advanced setup" and "Legacy setup" respectively.

This PR hence closes #7893, however I will keep a tab on Cloudflare's API so that the workaround can be removed from the docs once it's no longer needed. Depending on the way that Cloudflare fixes their bug, removing the actual functionality of this workaround will most likely require any users utilising it to modify their Token permissions, and so probably won't be possible without breaking things.

There's only one thing I feel might need some work: When using the new authentication method, if a zone ID is missing from the config file, the code ends up in the same state as it would when using a Token which is missing zone listing abilities in the first mode listed above. The error is:

certbot.errors.PluginError: Unable to determine zone_id for example.com using zone names: ['example.com', 'com']. Please confirm that the domain name has been entered correctly and is already associated with the supplied Cloudflare account. The error from Cloudflare was: 0 Actor 'com.cloudflare.api.token.<tokenID>' requires permission 'com.cloudflare.api.account.zone.list' to list zones

I feel like this needs reworking to be clearer, as there are probably about 3 cases that will result in the same error(some exclude the "The error from Cloudflare was:..." part).