### PR TITLE
Add the content interface to Certbot

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,3 +85,9 @@ parts:
     # After certbot-apache to not rebuild duplicates (essentially sharing what was already staged,
     # like zope)
     after: [certbot-apache]
+
+plugs:
+  plugin:
+    interface: content
+    content: certbot-1
+    target: $SNAP/certbot-plugin


### PR DESCRIPTION
This PR moves the setup of the content interface which we plan to use to support external plugins from the [snap-plugin branch](https://github.com/certbot/certbot/tree/snap-plugin) to `master`. This being in `master` might make it easier to make progress on issues like https://github.com/certbot/certbot/issues/7667.

I think it's OK to land this in `master` now because:

1. Certbot isn't configured to consume anything shared over the interface yet. That work is tracked in https://github.com/certbot/certbot/issues/7945.
2. While I don't think we currently have any plans to change anything here, since the Certbot snap is still in its beta phase, I think we can change whatever we want here whenever we want.