### PR TITLE
Remove unrecognised argument passed to virtualenv

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1044,7 +1044,7 @@ def create_venv(venv_path, pyver, verbose):
         # Use virtualenv binary
         environ = os.environ.copy()
         environ['VIRTUALENV_NO_DOWNLOAD'] = '1'
-        command = ['virtualenv', '--no-site-packages', '--python', sys.executable, venv_path]
+        command = ['virtualenv', '--python', sys.executable, venv_path]
         subprocess.check_call(command, stdout=stdout, env=environ)
     else:
         # Use embedded venv module in Python 3


### PR DESCRIPTION
This is a patch to remove the unrecognised argument `--no-site-packages`.

```
virtualenv: error: unrecognized arguments: --no-site-packages
Traceback (most recent call last):
  File "<stdin>", line 27, in <module>
  File "<stdin>", line 19, in create_venv
  File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['virtualenv', '--no-site-packages', '--python', '/usr/bin/python2.7', '/opt/eff.org/certbot/venv']' returned non-zero exit status 2
```
