### PR TITLE
Add support for NetBSD

### DIFF
--- a/certbot-nginx/certbot_nginx/_internal/constants.py
+++ b/certbot-nginx/certbot_nginx/_internal/constants.py
@@ -3,9 +3,12 @@ import platform
 
 FREEBSD_DARWIN_SERVER_ROOT = "/usr/local/etc/nginx"
 LINUX_SERVER_ROOT = "/etc/nginx"
+PKGSRC_SERVER_ROOT = "/usr/pkg/etc/nginx"
 
 if platform.system() in ('FreeBSD', 'Darwin'):
     server_root_tmp = FREEBSD_DARWIN_SERVER_ROOT
+elif platform.system() in ('NetBSD'):
+    server_root_tmp = PKGSRC_SERVER_ROOT
 else:
     server_root_tmp = LINUX_SERVER_ROOT
 

--- a/certbot-nginx/certbot_nginx/_internal/constants.py
+++ b/certbot-nginx/certbot_nginx/_internal/constants.py
@@ -7,7 +7,7 @@ PKGSRC_SERVER_ROOT = "/usr/pkg/etc/nginx"
 
 if platform.system() in ('FreeBSD', 'Darwin'):
     server_root_tmp = FREEBSD_DARWIN_SERVER_ROOT
-elif platform.system() in ('NetBSD'):
+elif platform.system() in ('NetBSD',):
     server_root_tmp = PKGSRC_SERVER_ROOT
 else:
     server_root_tmp = LINUX_SERVER_ROOT

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Add minimal code to run Nginx plugin on NetBSD.
 
 ### Changed
 
@@ -23,7 +23,6 @@ More details about these changes can be found on our GitHub repo.
 ### Added
 
 * Require explicit confirmation of snap plugin permissions before connecting.
-* Support for NetBSD.
 
 ### Changed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -23,6 +23,7 @@ More details about these changes can be found on our GitHub repo.
 ### Added
 
 * Require explicit confirmation of snap plugin permissions before connecting.
+* Support for NetBSD.
 
 ### Changed
 


### PR DESCRIPTION
 Add support for NetBSD by telling certbot-nginx where the nginx configuration directory is.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.
