### PR TITLE
Read acmev1 Let's Encrypt server URL from renewal config as acmev2 URL

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -11,6 +11,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 * Allow session tickets to be disabled in Apache when mod_ssl is statically linked.
+* Read acmev1 Let's Encrypt server URL from renewal config as acmev2 URL to prepare
+  for impending acmev1 deprecation.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -120,6 +120,8 @@ CLI_DEFAULTS = dict(
 )
 STAGING_URI = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
+V1_URI = "https://acme-v01.api.letsencrypt.org/directory"
+
 # The set of reasons for revoking a certificate is defined in RFC 5280 in
 # section 5.3.1. The reasons that users are allowed to submit are restricted to
 # those accepted by the ACME server implementation. They are listed in

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -110,6 +110,14 @@ class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
         self.assertRaises(
             errors.Error, self._call, self.config, renewalparams)
 
+    @mock.patch('certbot._internal.renewal.cli.set_by_cli')
+    def test_ancient_server_renewal_conf(self, mock_set_by_cli):
+        from certbot._internal import constants
+        self.config.server = None
+        mock_set_by_cli.return_value = False
+        self._call(self.config, {'server': constants.V1_URI})
+        self.assertEqual(self.config.server, constants.CLI_DEFAULTS['server'])
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
This PR contains @alexzorin's commit to fix #7979.

I tested this manually by editing a renewal conf file to set the server to `acme-v01` and it successfully got a cert using the `acme-v02` server.