### PR TITLE
Remove documentation for configuring ciphersuites (#8027)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -202,6 +202,7 @@ Authors
 * [Pierre Jaury](https://github.com/kaiyou)
 * [Piotr Kasprzyk](https://github.com/kwadrat)
 * [Prayag Verma](https://github.com/pra85)
+* [Rasesh Patel](https://github.com/raspat1)
 * [Reinaldo de Souza Jr](https://github.com/juniorz)
 * [Remi Rampin](https://github.com/remram44)
 * [Rémy HUBSCHER](https://github.com/Natim)

--- a/certbot/docs/ciphers.rst
+++ b/certbot/docs/ciphers.rst
@@ -114,9 +114,6 @@ the Qualys SSL Labs site, which Certbot will suggest
 when installing a certificate, to test your server and see whether it
 will be compatible with particular software versions.
 
-It will be possible to ask Certbot to instead apply (and track) Modern
-or Old configurations.
-
 The Let's Encrypt project expects to follow the Mozilla recommendations
 in the future as those recommendations are updated. (For example, some
 users have proposed prioritizing a new ciphersuite known as ``0xcc13``
@@ -158,51 +155,6 @@ better inform their own cryptographic parameter choices. We also
 welcome suggestions of other resources to add to this list. Please keep
 in mind that different recommendations may reflect different priorities
 or evaluations of trade-offs, especially related to compatibility!
-
-
-Changing your settings
-----------------------
-
-This will probably look something like
-
-.. code-block:: shell
-
-  certbot --cipher-recommendations mozilla-secure
-  certbot --cipher-recommendations mozilla-intermediate
-  certbot --cipher-recommendations mozilla-old
-
-to track Mozilla's *Secure*, *Intermediate*, or *Old* recommendations,
-and
-
-.. code-block:: shell
-
-  certbot --update-ciphers on
-
-to enable updating ciphers with each new Certbot release, or
-
-.. code-block:: shell
-
-  certbot --update-ciphers off
-
-to disable automatic configuration updates. These features have not yet
-been implemented and this syntax may change when they are implemented.
-
-
-TODO
-----
-
-The status of this feature is tracked as part of issue #1123 in our
-bug tracker.
-
-https://github.com/certbot/certbot/issues/1123
-
-Prior to implementation of #1123, the client does not actually modify
-ciphersuites (this is intended to be implemented as a "configuration
-enhancement", but the only configuration enhancement implemented
-so far is redirecting HTTP requests to HTTPS in web servers, the
-"redirect" enhancement). The changes here would probably be either a new
-"ciphersuite" enhancement in each plugin that provides an installer,
-or a family of enhancements, one per selectable ciphersuite configuration.
 
 Feedback
 ========


### PR DESCRIPTION
Issue #1123 discusses a feature that allows users to set the cipher
security level. That feature wasn't built. It didn't provide enough
user value to justify the corresponding increase in complexity. The
feature request and the associated discussion threads were closed.
However, the proposed API spec and the TODO section remained in the
cipher docs. They're a vestige of that issue from olden days and this PR
removes those last living traces...

Fixes #8027.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.
