### PR TITLE
Stop running snapcraft with sudo

### DIFF
--- a/snap/local/build_and_install.sh
+++ b/snap/local/build_and_install.sh
@@ -14,5 +14,7 @@ sudo /snap/bin/lxd.migrate -yes
 sudo /snap/bin/lxd waitready
 sudo /snap/bin/lxd init --auto
 tools/strip_hashes.py letsencrypt-auto-source/pieces/dependency-requirements.txt > constraints.txt
-snapcraft --use-lxd
+# Run snapcraft with the lxd group since it has not been added to the current
+# shell.
+sg lxd -c 'snapcraft --use-lxd'
 sudo snap install --dangerous --classic *.snap

--- a/snap/local/build_and_install.sh
+++ b/snap/local/build_and_install.sh
@@ -10,5 +10,5 @@ sudo /snap/bin/lxd.migrate -yes
 sudo /snap/bin/lxd waitready
 sudo /snap/bin/lxd init --auto
 tools/strip_hashes.py letsencrypt-auto-source/pieces/dependency-requirements.txt > constraints.txt
-sudo snapcraft --use-lxd
+snapcraft --use-lxd
 sudo snap install --dangerous --classic *.snap

--- a/snap/local/build_and_install.sh
+++ b/snap/local/build_and_install.sh
@@ -6,6 +6,10 @@ if [[ -z "$TRAVIS" ]]; then
     exit 1
 fi
 
+# Add the current user to the lxd group so they can run `snapcraft --use-lxd`
+# without sudo since running the command without sudo is required by newer
+# versions of snapcraft.
+sudo usermod -aG lxd "$USER"
 sudo /snap/bin/lxd.migrate -yes
 sudo /snap/bin/lxd waitready
 sudo /snap/bin/lxd init --auto


### PR DESCRIPTION
It looks like `snapcraft` 4.0 has been pushed to the stable channel which broke our current set up. Test failures can be seen at https://travis-ci.com/github/certbot/certbot/builds/170443208.

This PR fixes the problem and you can see tests passing with this change at https://travis-ci.com/github/certbot/certbot/builds/170565797.

@adferrand or @ohemorange, if you're able to provide a quick review on this, I'd appreciate it!