### PR TITLE
Remove on_cancel which isn't recognized by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -323,6 +323,5 @@ notifications:
       # https://github.com/travis-ci/travis.rb and running
       # `travis encrypt "chat.freenode.net#certbot-devel"`.
       - secure: "EWW66E2+KVPZyIPR8ViENZwfcup4Gx3/dlimmAZE0WuLwxDCshBBOd3O8Rf6pBokEoZlXM5eDT6XdyJj8n0DLslgjO62pExdunXpbcMwdY7l1ELxX2/UbnDTE6UnPYa09qVBHNG7156Z6yE0x2lH4M9Ykvp0G0cubjPQHylAwo0="
-    on_cancel: never
     on_success: never
     on_failure: always


### PR DESCRIPTION
Over the weekend, it looks like our IRC notifications from Travis broke. It seems the culprit is this `on_cancel` value in our Travis config. If you look at https://travis-ci.com/github/certbot/certbot/jobs/349283874/config, you'll see a warning about the `on_cancel` value:

![Screen Shot 2020-06-15 at 10 03 47 AM](https://user-images.githubusercontent.com/6504915/84685778-ab258100-aeef-11ea-8903-7a95f8806122.png)

Travis did not send a notification about this build.

I removed the `on_cancel` value and tested it at https://travis-ci.com/github/certbot/certbot/builds/171438091 and Travis properly sent a notification.

This PR just makes the same change to `master` so we get notified about failing `master` builds again.