### PR TITLE
Print a message about obtaining a certificate.

### DIFF
--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -448,6 +448,8 @@ def _report_new_cert(config, cert_path, fullchain_path, key_path=None):
 
     assert cert_path and fullchain_path, "No certificates saved to report."
 
+    logger.info('You have successfully obtained a certificate!')
+
     expiry = crypto_util.notAfter(cert_path).date()
     reporter_util = zope.component.getUtility(interfaces.IReporter)
     # Print the path to fullchain.pem because that's what modern webservers


### PR DESCRIPTION
While #8076 does everything asked for in https://github.com/certbot/certbot/issues/7512 and functionally works great, the placement of this prompt feels strange to me in the context of Certbot's other output. It looks like:
```
$ sudo certbot -d example.org --standalone certonly
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator standalone, Installer None
Obtaining a new certificate
Performing the following challenges:
http-01 challenge for example.org
Waiting for verification...
Cleaning up challenges

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
Would you be willing to share your email address with the Electronic Frontier
Foundation, a founding partner of the Let's Encrypt project and the non-profit
organization that develops Certbot? We'd like to send you email about our work
encrypting the web, EFF news, campaigns, and ways to support digital freedom.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
(Y)es/(N)o:
```
This PR adds a new message in `_report_new_cert` which makes the flow a little nicer in my opinion. The new output looks like:
```
$ sudo certbot -d example.org --standalone certonly
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator standalone, Installer None
Obtaining a new certificate
Performing the following challenges:
http-01 challenge for example.org
Waiting for verification...
Cleaning up challenges
You have successfully obtained a certificate!

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
Would you be willing to share your email address with the Electronic Frontier
Foundation, a founding partner of the Let's Encrypt project and the non-profit
organization that develops Certbot? We'd like to send you email about our work
encrypting the web, EFF news, campaigns, and ways to support digital freedom.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
(Y)es/(N)o:
```