### PR TITLE
Remove the need for TRAVIS to be set.

### DIFF
--- a/snap/local/build_and_install.sh
+++ b/snap/local/build_and_install.sh
@@ -5,11 +5,6 @@
 # Usage: build_and_install.sh [amd64,arm64,armhf]
 set -ex
 
-if [[ -z "${TRAVIS}" ]]; then
-    echo "This script makes global changes to the system it is run on so should only be run in CI."
-    exit 1
-fi
-
 SNAP_ARCH=$1
 
 if [[ -z "${SNAP_ARCH}" ]]; then


### PR DESCRIPTION
I initially added this when the script was doing things like migrating all LXD containers to the snap. I think the external side effects are now pretty minimal thought so I think we can remove the need for this environment variable which makes it easier to use outside of CI for manual testing.