### PR TITLE
Do not unstage generated cffi augeas

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,8 +49,6 @@ parts:
       - ./certbot-nginx
     stage:
       - -usr/lib/python3.8/sitecustomize.py # maybe unnecessary
-      # Prefer cffi
-      - -lib/python3.8/site-packages/augeas.py
     stage-packages:
       - libaugeas0
       # added to stage python:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,6 +49,13 @@ parts:
       - ./certbot-nginx
     stage:
       - -usr/lib/python3.8/sitecustomize.py # maybe unnecessary
+      # Old versions of this file used to unstage
+      # lib/python3.8/site-packages/augeas.py to avoid conflicts between
+      # python-augeas 0.5.0 which was pinned in snap-constraints.txt and
+      # Robie's python-augeas fork which creates an auto-generated cffi file at
+      # the same path. Since we've combined things in one part and removed the
+      # python-augeas pinning, unstaging this file had a different, unintended
+      # effect so we now stage the file to keep the auto-generated cffi file.
     stage-packages:
       - libaugeas0
       # added to stage python:


### PR DESCRIPTION
This line seems to refer to [augeas.py](https://github.com/hercules-team/python-augeas/blob/v0.5.0/augeas.py) from the version of Augeas we normally have pinned. This was necessary when we were installing each Certbot component in separate parts and only combining them later to ensure that the Augeas fork (which uses cffi) was used instead of the unmodified pinned version of Augeas.

Since everything is installed in one part and we're removing the Augeas pinning now though, this line is no longer necessary. You can see the snap being built and tested successfully with this change at https://travis-ci.com/github/certbot/certbot/builds/172134518.