### PR TITLE
Use certbot.wrapper during renewal.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ apps:
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       LD_LIBRARY_PATH: "$SNAP/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
   renew:
-    command: bin/certbot -q renew
+    command: certbot.wrapper -q renew
     daemon: oneshot
     environment:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"


### PR DESCRIPTION
Without this change, Certbot won't be able to find externally snapped plugins when renewing certificates. I tested the systemd service created by snapd with this change and it ran as expected.