### PR TITLE
Build the constraints file insided snapcraft

### DIFF
--- a/snap/local/build_and_install.sh
+++ b/snap/local/build_and_install.sh
@@ -21,9 +21,6 @@ source "${DIR}/common.sh"
 RegisterQemuHandlers
 ResolveArch "${SNAP_ARCH}"
 
-tools/strip_hashes.py letsencrypt-auto-source/pieces/dependency-requirements.txt \
-  | grep -v python-augeas > snap-constraints.txt
-
 pushd "${DIR}/packages"
 "${CERTBOT_DIR}/tools/simple_http_server.py" 8080 >/dev/null 2>&1 &
 HTTP_SERVER_PID="$!"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,9 @@ parts:
     build-packages: [libffi-dev, libssl-dev, git, libaugeas-dev, python3-dev]
     override-pull: |
         snapcraftctl pull
-        snapcraftctl set-version `cd $SNAPCRAFT_PART_SRC/certbot && git describe|sed s/^v//`
+        cd $SNAPCRAFT_PART_SRC
+        python3 tools/strip_hashes.py letsencrypt-auto-source/pieces/dependency-requirements.txt | grep -v python-augeas > snap-constraints.txt
+        snapcraftctl set-version `git describe|sed s/^v//`
 
   wrappers:
     plugin: dump


### PR DESCRIPTION
Fixes #7957

This PR makes snapcraft generate itself the dependencies constraints file during the snap build, instead of having an external script that does it before calling snapcraft.
