### PR TITLE
Make DNS plugin snaps use core20

### DIFF
--- a/certbot-dns-cloudflare/snap/snapcraft.yaml
+++ b/certbot-dns-cloudflare/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Cloudflare DNS Authenticator plugin for Certbot
 description: Cloudflare DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-cloudflare
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-cloudxns/snap/snapcraft.yaml
+++ b/certbot-dns-cloudxns/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: CloudXNS DNS Authenticator plugin for Certbot
 description: CloudXNS DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-cloudxns
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-digitalocean/snap/snapcraft.yaml
+++ b/certbot-dns-digitalocean/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: DigitalOcean DNS Authenticator plugin for Certbot
 description: DigitalOcean DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-digitalocean
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-dnsimple/snap/snapcraft.yaml
+++ b/certbot-dns-dnsimple/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: DNSimple DNS Authenticator plugin for Certbot
 description: DNSimple DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-dnsimple
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-dnsmadeeasy/snap/snapcraft.yaml
+++ b/certbot-dns-dnsmadeeasy/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: DNS Made Easy DNS Authenticator plugin for Certbot
 description: DNS Made Easy DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-dnsmadeeasy
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-gehirn/snap/snapcraft.yaml
+++ b/certbot-dns-gehirn/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Gehirn Infrastructure Service DNS Authenticator plugin for Certbot
 description: Gehirn Infrastructure Service DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-gehirn
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-google/snap/snapcraft.yaml
+++ b/certbot-dns-google/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Google Cloud DNS Authenticator plugin for Certbot
 description: Google Cloud DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-google
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-linode/snap/snapcraft.yaml
+++ b/certbot-dns-linode/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Linode DNS Authenticator plugin for Certbot
 description: Linode DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-linode
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-luadns/snap/snapcraft.yaml
+++ b/certbot-dns-luadns/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: LuaDNS Authenticator plugin for Certbot
 description: LuaDNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-luadns
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-nsone/snap/snapcraft.yaml
+++ b/certbot-dns-nsone/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: NS1 DNS Authenticator plugin for Certbot
 description: NS1 DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-nsone
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-ovh/snap/snapcraft.yaml
+++ b/certbot-dns-ovh/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: OVH DNS Authenticator plugin for Certbot
 description: OVH DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-ovh
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-rfc2136/snap/snapcraft.yaml
+++ b/certbot-dns-rfc2136/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: RFC 2136 DNS Authenticator plugin for Certbot
 description: RFC 2136 DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-rfc2136
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-route53/snap/snapcraft.yaml
+++ b/certbot-dns-route53/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Route53 DNS Authenticator plugin for Certbot
 description: Route53 DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-route53
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot-dns-sakuracloud/snap/snapcraft.yaml
+++ b/certbot-dns-sakuracloud/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: Sakura Cloud DNS Authenticator plugin for Certbot
 description: Sakura Cloud DNS Authenticator plugin for Certbot
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: certbot-dns-sakuracloud
 
 parts:
@@ -11,7 +11,6 @@ parts:
     plugin: python
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
@@ -23,4 +22,4 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.6/site-packages
+      - $SNAP/lib/python3.8/site-packages

--- a/certbot.wrapper
+++ b/certbot.wrapper
@@ -11,7 +11,7 @@ join() {
     fi
 }
 
-paths=$(for plugin_snap in $(snap connections certbot|sed -n '2,$p'|awk '$1=="content[certbot-1]"{print $3}'|cut -d: -f1); do echo /snap/$plugin_snap/current/lib/python3.6/site-packages; done)
+paths=$(for plugin_snap in $(snap connections certbot|sed -n '2,$p'|awk '$1=="content[certbot-1]"{print $3}'|cut -d: -f1); do echo /snap/$plugin_snap/current/lib/python3.8/site-packages; done)
 export PYTHONPATH=$(join : $PYTHONPATH $paths)
 if [ -z "$PYTHONPATH" ]; then
     unset PYTHONPATH

--- a/tools/generate_dnsplugins_snapcraft.sh
+++ b/tools/generate_dnsplugins_snapcraft.sh
@@ -15,7 +15,7 @@ summary: ${DESCRIPTION}
 description: ${DESCRIPTION}
 confinement: strict
 grade: devel
-base: core18
+base: core20
 adopt-info: ${PLUGIN}
 
 parts:
@@ -23,7 +23,6 @@ parts:
     plugin: python
     source: .
     constraints: [\$SNAPCRAFT_PART_SRC/snap-constraints.txt]
-    python-version: python3
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version \`grep ^version \$SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"\`
@@ -35,6 +34,6 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - \$SNAP/lib/python3.6/site-packages
+      - \$SNAP/lib/python3.8/site-packages
 EOF
 done


### PR DESCRIPTION
Fixes #8103.

This PR also modifies `certbot.wrapper` to look at the new path. This begs the question, how will we change the base for our plugins the next time we want to do it? Both snaps will need to be updated before the plugins can be found again. Are we ok with that?