### PR TITLE
Remove SSL Labs From Certbot Output

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -27,6 +27,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Don't use `StrictVersion`, but `LooseVersion` to check version requirements with setuptools,
   to fix some packaging issues with libraries respecting PEP404 for version string,
   with doesn't match `StrictVersion` requirements.
+* Certbot output doesn't refer to SSL Labs due to confusing scoring behavior.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -281,6 +281,7 @@ def _gen_ssl_lab_urls(domains):
     """
     return ["https://www.ssllabs.com/ssltest/analyze.html?d=%s" % dom for dom in domains]
 
+
 def _gen_https_names(domains):
     """Returns a string of the https domains.
 

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -242,8 +242,8 @@ def success_installation(domains):
     """
     z_util(interfaces.IDisplay).notification(
         "Congratulations! You have successfully enabled {0}".format(
-            _gen_https_names(domains),
-            pause=False))
+            _gen_https_names(domains)),
+        pause=False)
 
 
 def success_renewal(domains):
@@ -257,8 +257,8 @@ def success_renewal(domains):
         "new certificate has been installed.{1}{1}"
         "The new certificate covers the following domains: {0}".format(
             _gen_https_names(domains),
-            os.linesep,
-            pause=False))
+            os.linesep),
+        pause=False)
 
 
 def success_revocation(cert_path):

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -275,6 +275,12 @@ def success_revocation(cert_path):
         pause=False)
 
 
+def _gen_ssl_lab_urls(domains):
+    """Returns a list of urls.
+    :param list domains: Each domain is a 'str'
+    """
+    return ["https://www.ssllabs.com/ssltest/analyze.html?d=%s" % dom for dom in domains]
+
 def _gen_https_names(domains):
     """Returns a string of the https domains.
 

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -277,7 +277,9 @@ def success_revocation(cert_path):
 
 def _gen_ssl_lab_urls(domains):
     """Returns a list of urls.
+
     :param list domains: Each domain is a 'str'
+
     """
     return ["https://www.ssllabs.com/ssltest/analyze.html?d=%s" % dom for dom in domains]
 

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -241,12 +241,9 @@ def success_installation(domains):
 
     """
     z_util(interfaces.IDisplay).notification(
-        "Congratulations! You have successfully enabled {0}{1}{1}"
-        "You should test your configuration at:{1}{2}".format(
+        "Congratulations! You have successfully enabled {0}".format(
             _gen_https_names(domains),
-            os.linesep,
-            os.linesep.join(_gen_ssl_lab_urls(domains))),
-        pause=False)
+            pause=False))
 
 
 def success_renewal(domains):
@@ -258,12 +255,11 @@ def success_renewal(domains):
     z_util(interfaces.IDisplay).notification(
         "Your existing certificate has been successfully renewed, and the "
         "new certificate has been installed.{1}{1}"
-        "The new certificate covers the following domains: {0}{1}{1}"
-        "You should test your configuration at:{1}{2}".format(
+        "The new certificate covers the following domains: {0}{1}{1}".format(
             _gen_https_names(domains),
             os.linesep,
-            os.linesep.join(_gen_ssl_lab_urls(domains))),
-        pause=False)
+            pause=False))
+
 
 def success_revocation(cert_path):
     """Display a box confirming a certificate has been revoked.
@@ -277,15 +273,6 @@ def success_revocation(cert_path):
             cert_path,
             os.linesep),
         pause=False)
-
-
-def _gen_ssl_lab_urls(domains):
-    """Returns a list of urls.
-
-    :param list domains: Each domain is a 'str'
-
-    """
-    return ["https://www.ssllabs.com/ssltest/analyze.html?d=%s" % dom for dom in domains]
 
 
 def _gen_https_names(domains):

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -255,7 +255,7 @@ def success_renewal(domains):
     z_util(interfaces.IDisplay).notification(
         "Your existing certificate has been successfully renewed, and the "
         "new certificate has been installed.{1}{1}"
-        "The new certificate covers the following domains: {0}{1}{1}".format(
+        "The new certificate covers the following domains: {0}".format(
             _gen_https_names(domains),
             os.linesep,
             pause=False))

--- a/certbot/docs/ciphers.rst
+++ b/certbot/docs/ciphers.rst
@@ -110,8 +110,7 @@ to most-backwards compatible). The client will follow the Mozilla defaults
 for the *Intermediate* configuration by default, at least with regards to
 ciphersuites and TLS versions. Mozilla's web site describes which client
 software will be compatible with each configuration. You can also use
-the Qualys SSL Labs site, which Certbot will suggest
-when installing a certificate, to test your server and see whether it
+the Qualys SSL Labs site to test your server and see whether it
 will be compatible with particular software versions.
 
 The Let's Encrypt project expects to follow the Mozilla recommendations


### PR DESCRIPTION
The Apache plugin expects clients to support SNI, but
SSL Labs tries without SNI and includes the results
in their score.

Closes certbot/certbot#7728

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.

