### PR TITLE
Add missing spaces to manual plugin help

### DIFF
--- a/certbot/certbot/_internal/plugins/manual.py
+++ b/certbot/certbot/_internal/plugins/manual.py
@@ -37,8 +37,8 @@ class Authenticator(common.Plugin):
         'is the validation string, and $CERTBOT_TOKEN is the filename of the '
         'resource requested when performing an HTTP-01 challenge. An additional '
         'cleanup script can also be provided and can use the additional variable '
-        '$CERTBOT_AUTH_OUTPUT which contains the stdout output from the auth script.'
-        'For both authenticator and cleanup script, on HTTP-01 and DNS-01 challenges,'
+        '$CERTBOT_AUTH_OUTPUT which contains the stdout output from the auth script. '
+        'For both authenticator and cleanup script, on HTTP-01 and DNS-01 challenges, '
         '$CERTBOT_REMAINING_CHALLENGES will be equal to the number of challenges that '
         'remain after the current one, and $CERTBOT_ALL_DOMAINS contains a comma-separated '
         'list of all domains that are challenged for the current certificate.')


### PR DESCRIPTION
`certbot --help manual` output currently looks like:
```
...
  requested when performing an HTTP-01 challenge. An additional cleanup
  script can also be provided and can use the additional variable
  $CERTBOT_AUTH_OUTPUT which contains the stdout output from the auth
  script.For both authenticator and cleanup script, on HTTP-01 and DNS-01
  challenges,$CERTBOT_REMAINING_CHALLENGES will be equal to the number of
  challenges that remain after the current one, and $CERTBOT_ALL_DOMAINS
  contains a comma-separated list of all domains that are challenged for the
  current certificate.
...
```
With this PR it looks like:
```
...
  requested when performing an HTTP-01 challenge. An additional cleanup
  script can also be provided and can use the additional variable
  $CERTBOT_AUTH_OUTPUT which contains the stdout output from the auth
  script. For both authenticator and cleanup script, on HTTP-01 and DNS-01
  challenges, $CERTBOT_REMAINING_CHALLENGES will be equal to the number of
  challenges that remain after the current one, and $CERTBOT_ALL_DOMAINS
  contains a comma-separated list of all domains that are challenged for the
  current certificate.
...
```