### PR TITLE
Make each DNS plugin respect EXCLUDE_CERTBOT_DEPS

### DIFF
--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -11,12 +11,19 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.29.0',
-    'certbot>=1.1.0',
     'cloudflare>=1.5.1',
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.29.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-cloudxns/setup.py
+++ b/certbot-dns-cloudxns/setup.py
@@ -11,12 +11,19 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.31.0',
-    'certbot>=1.1.0',
     'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.31.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-cloudxns/setup.py
+++ b/certbot-dns-cloudxns/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -11,13 +11,20 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.29.0',
-    'certbot>=1.1.0',
     'python-digitalocean>=1.11',
     'setuptools',
     'six',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.29.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -11,12 +11,19 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.31.0',
-    'certbot>=1.1.0',
     'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.31.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -10,12 +10,19 @@ version = '1.6.0.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'acme>=0.31.0',
-    'certbot>=1.1.0',
     'dns-lexicon>=2.1.22',
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.31.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -11,8 +11,6 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.29.0',
-    'certbot>=1.1.0',
     'google-api-python-client>=1.5.5',
     'oauth2client>=4.0',
     'setuptools',
@@ -20,6 +18,15 @@ install_requires = [
     # already a dependency of google-api-python-client, but added for consistency
     'httplib2'
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.29.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -10,12 +10,19 @@ version = '1.6.0.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'acme>=0.31.0',
-    'certbot>=1.1.0',
     'dns-lexicon>=2.2.3',
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.31.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -11,12 +11,19 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.31.0',
-    'certbot>=1.1.0',
     'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.31.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -11,12 +11,19 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.31.0',
-    'certbot>=1.1.0',
     'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.31.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -11,12 +11,19 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.31.0',
-    'certbot>=1.1.0',
     'dns-lexicon>=2.7.14',  # Correct proxy use on OVH provider
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.31.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -11,12 +11,19 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.29.0',
-    'certbot>=1.1.0',
     'dnspython',
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.29.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -11,12 +11,19 @@ version = '1.6.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.29.0',
-    'certbot>=1.1.0',
     'boto3',
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.29.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+import os
 import sys
 
 from setuptools import __version__ as setuptools_version

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -10,12 +10,19 @@ version = '1.6.0.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'acme>=0.31.0',
-    'certbot>=1.1.0',
     'dns-lexicon>=2.1.23',
     'setuptools',
     'zope.interface',
 ]
+
+if not os.environ.get('EXCLUDE_CERTBOT_DEPS'):
+    install_requires.extend([
+        'acme>=0.31.0',
+        'certbot>=1.1.0',
+    ])
+elif 'bdist_wheel' in sys.argv[1:]:
+    raise RuntimeError('Unset EXCLUDE_CERTBOT_DEPS when building wheels '
+                       'to include certbot dependencies.')
 
 setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
 if setuptools_known_environment_markers:


### PR DESCRIPTION
Fixes #8105.

- [ ] is it ok that we're importing os?
- [ ] a fun semi-related fact I've just noticed is that if *any* connected plugin fails, certbot fails to run at all

Manual testing as described in https://github.com/certbot/certbot/pull/8091 passed, using the `certbot-dns-digitalocean` snap, with the slight updated steps of "disconnect existing `dnsimple` plugin before starting tests" and "use `sudo snap revert certbot`" to replace the final two steps (revert/re-snap/reinstall).