### PR TITLE
Do not build pushes to master

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -1,5 +1,4 @@
-trigger:
-  - master
+trigger: none
 pr:
   - master
   - '*.x'


### PR DESCRIPTION
We previously were running on commits to `master` for test coverage, however, we don't need this anymore since we disabled codecov. Now that all of our tests are running in Azure, there is a greater demand for resources there, so let's skip the builds on pushes to `master` and rely on PR builds + nightly tests like we did in Travis.