### PR TITLE
Some improvements on snap builds

### DIFF
--- a/snap/local/build.sh
+++ b/snap/local/build.sh
@@ -39,4 +39,4 @@ docker run \
   -w "/certbot" \
   -e "PIP_EXTRA_INDEX_URL=http://localhost:8080" \
   "adferrand/snapcraft:${DOCKER_ARCH}-stable" \
-  snapcraft
+  bash -c "snapcraft clean && snapcraft"

--- a/tools/simple_http_server.py
+++ b/tools/simple_http_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A version of Python's SimpleHTTPServer that flushes its output."""
 import sys
 
@@ -7,6 +7,7 @@ try:
 except ImportError:
     from BaseHTTPServer import HTTPServer
     from SimpleHTTPServer import SimpleHTTPRequestHandler
+
 
 def serve_forever(port=0):
     """Spins up an HTTP server on all interfaces and the given port.


### PR DESCRIPTION
Short PR to improve some things during snap builds:
* cleanup snapcraft assets before a build, in order to avoid some weird errors when two builds are executed consecutively without cleanup
* use python3 explicitly in `tools/simple_http_server.py` because on several recent distributions, `python` binary is not exposed anymore, only `python2` or `python3`.
