### PR TITLE
Run at 4:30 UTC to have Azure reparse YAML file

### DIFF
--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -2,7 +2,7 @@
 trigger: none
 pr: none
 schedules:
-  - cron: "0 4 * * *"
+  - cron: "30 4 * * *"
     displayName: Nightly build
     branches:
       include:


### PR DESCRIPTION
Our nightly builds aren't running for some reason.

Testing on my fork, I've consistently noticed:

1. The scheduled builds are never set up for this file when it is first added to Azure Pipelines.
2. Making a change to the YAML file such as changing the time or adding or removing stages seems to cause the file to be reparsed and scheduled builds are properly created.

To hope this fixes the problem here, let's try running the scheduled builds a half hour later.