### PR TITLE
Remove unnecessary symlink

### DIFF
--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -38,9 +38,6 @@ steps:
       secureFile: azure-test-farm.pem
     condition: contains(variables['TOXENV'], 'test-farm')
   - bash: |
-      ln -s $(testFarmPem.secureFilePath) tests/letstest/test-farm.pem
-    condition: contains(variables['TOXENV'], 'test-farm')
-  - bash: |
       export TARGET_BRANCH="`echo "${BUILD_SOURCEBRANCH}" | sed -E 's!refs/(heads|tags)/!!g'`"
       [ -z "${SYSTEM_PULLREQUEST_TARGETBRANCH}" ] || export TARGET_BRANCH="${SYSTEM_PULLREQUEST_TARGETBRANCH}"
       env


### PR DESCRIPTION
This isn't needed anymore thanks to the line:
```
AWS_EC2_PEM_FILE: $(testFarmPem.secureFilePath)
```