### PR TITLE
Use snapcraft upload, not snapcraft push

### DIFF
--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -39,5 +39,5 @@ stages:
           - bash: |
               mkdir -p .snapcraft
               ln -s $(snapcraftCfg.secureFilePath) .snapcraft/snapcraft.cfg
-              snapcraft push --release=edge snap/*.snap
+              snapcraft upload --release=edge snap/*.snap
             displayName: Publish to Snap store


### PR DESCRIPTION
I've noticed [snapcraft complaining about our use of `snapcraft push` instead of `snapcraft upload`](https://dev.azure.com/certbot/certbot/_build/results?buildId=2279&view=logs&j=699632ed-b021-590a-8a14-17dad7b1e5b1&t=ec46547f-7bb2-52f7-2cfc-3246f328135f&l=12). This PR switches things to the new subcommand.

You can see this working at https://dev.azure.com/certbot/certbot/_build/results?buildId=2286&view=results.