### PR TITLE
Specify the Certbot snap grade

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ description: |
    - Help you revoke the certificate if that ever becomes necessary.
 confinement: classic
 base: core20
+grade: stable
 adopt-info: certbot
 
 apps:


### PR DESCRIPTION
https://snapcraft.io/docs/snapcraft-yaml-reference says the `grade` of the snap is optional, but `snapcraft` is printing warnings about the lack of a grade at build time. See https://dev.azure.com/certbot/certbot/_build/results?buildId=2315&view=logs&j=e78c2f43-1184-58fa-5e93-7c8c4cc4e785&t=71747431-87e6-53d4-e265-fbdbb66a0a32&l=1618.

I don't like warnings so lets specify a grade. You can see our snap builds and tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2316&view=results.