### PR TITLE
Update to IPython with Python 3.8 support

### DIFF
--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -83,7 +83,6 @@ elif sys.version_info < (3,3):
 
 dev_extras = [
     'coverage',
-    'ipdb',
     'pytest',
     'pytest-cov',
     'pytest-xdist',
@@ -94,6 +93,7 @@ dev_extras = [
 
 dev3_extras = [
     'astroid',
+    'ipdb',
     'mypy',
     'pylint',
 ]

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -10,6 +10,7 @@ asn1crypto==0.22.0
 astroid==2.3.3
 attrs==17.3.0
 Babel==2.5.1
+backcall==0.2.0
 backports.functools-lru-cache==1.5
 backports.shutil-get-terminal-size==1.0.0
 backports.ssl-match-hostname==3.7.0.1
@@ -40,9 +41,10 @@ httplib2==0.10.3
 imagesize==0.7.1
 importlib-metadata==0.23
 ipdb==0.12.3
-ipython==5.8.0
+ipython==7.9.0
 ipython-genutils==0.2.0
 isort==4.3.21
+jedi==0.17.1
 Jinja2==2.9.6
 jmespath==0.9.4
 josepy==1.1.0
@@ -59,13 +61,14 @@ ndg-httpsclient==0.3.2
 oauth2client==4.0.0
 packaging==19.2
 paramiko==2.4.2
+parso==0.7.0
 pathlib2==2.3.5
 pexpect==4.7.0
 pickleshare==0.7.5
 pkginfo==1.4.2
 pluggy==0.13.0
 ply==3.4
-prompt-toolkit==1.0.18
+prompt-toolkit==2.0.10
 ptyprocess==0.6.0
 py==1.8.0
 pyasn1==0.1.9

--- a/tools/oldest_constraints.txt
+++ b/tools/oldest_constraints.txt
@@ -63,3 +63,10 @@ dns-lexicon==2.2.1
 # Tracking at https://github.com/certbot/certbot/issues/6473
 boto3==1.4.7
 botocore==1.7.41
+
+# Old certbot[dev] constraints
+# Old versions of certbot[dev] required ipdb and our normally pinned version of
+# ipython which ipdb depends on doesn't support Python 2 so we pin an older
+# version here to keep tests working while we have Python 2 support.
+ipython==5.8.0
+prompt-toolkit==1.0.18


### PR DESCRIPTION
As discussed on the Certbot call, IPython 5.x which is the last major version that supports Python 2 doesn't work with Python 3.8. You can see failures on a system with Python 3.8 like Ubuntu 20.04 by creating a dev environment, activating it, running `ipython`, and trying to import a module which will fail with:
```
$ ipython
Python 3.8.2 (default, Apr 27 2020, 15:53:34) 
Type "copyright", "credits" or "license" for more information.

IPython 5.8.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import os
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/usr/lib/python3.8/codeop.py in __call__(self, source, filename, symbol)
    134 
    135     def __call__(self, source, filename, symbol):
--> 136         codeob = compile(source, filename, symbol, self.flags, 1)
    137         for feature in _features:
    138             if codeob.co_flags & feature.compiler_flag:

TypeError: required field "type_ignores" missing from Module

```
You can find more info about IPython versions and which versions of Python are supported at https://github.com/ipython/ipython/tree/632449800023922a60ca4a39fc2ff0ebf3be358d#overview. I opened an issue to ask about fixing IPython in the 5.x branch at https://github.com/ipython/ipython/issues/12432 and received no response so to fix this, I moved `ipdb` to our `dev3` extras and updated IPython to the latest version that supports Python 3.5+. 

To keep our oldest tests working which will try to install `ipdb` on Python 2 because it is in the `dev` requirements for old versions of Certbot, I kept `ipython` pinned to an old version in our oldest tests. Alternatively, we could update all of our plugins to say they require the latest version of Certbot, but pinning back IPython seemed easier and more helpful to me.

You can see the full test suite running with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2318&view=results.