### PR TITLE
certbot_dns_linode: decrease the default propagation interval

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -237,6 +237,7 @@ Authors
 * [Spencer Bliven](https://github.com/sbliven)
 * [Stacey Sheldon](https://github.com/solidgoldbomb)
 * [Stavros Korokithakis](https://github.com/skorokithakis)
+* [Ștefan Talpalaru](https://github.com/stefantalpalaru)
 * [Stefan Weil](https://github.com/stweil)
 * [Steve Desmond](https://github.com/stevedesmond-ca)
 * [sydneyli](https://github.com/sydneyli)

--- a/certbot-dns-linode/certbot_dns_linode/__init__.py
+++ b/certbot-dns-linode/certbot_dns_linode/__init__.py
@@ -14,10 +14,10 @@ Named Arguments
                                             DNS to propagate before asking the
                                             ACME server to verify the DNS
                                             record.
-                                            (Default: 1200 because Linode
-                                            updates its first DNS every 15
-                                            minutes and we allow 5 more minutes
-                                            for the update to reach the other 5
+                                            (Default: 120 because Linode
+                                            updates its first DNS every 60
+                                            seconds and we allow 60 more seconds
+                                            for the update to reach other 5
                                             servers)
 ==========================================  ===================================
 
@@ -80,15 +80,15 @@ Examples
      -d www.example.com
 
 .. code-block:: bash
-   :caption: To acquire a certificate for ``example.com``, waiting 1000 seconds
-             for DNS propagation (Linode updates its first DNS every 15 minutes
-             and we allow some extra time for the update to reach the other 5
+   :caption: To acquire a certificate for ``example.com``, waiting 120 seconds
+             for DNS propagation (Linode updates its first DNS every minute
+             and we allow some extra time for the update to reach other 5
              servers)
 
    certbot certonly \\
      --dns-linode \\
      --dns-linode-credentials ~/.secrets/certbot/linode.ini \\
-     --dns-linode-propagation-seconds 1000 \\
+     --dns-linode-propagation-seconds 120 \\
      -d example.com
 
 """

--- a/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
@@ -32,7 +32,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
     @classmethod
     def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
-        super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=1200)
+        super(Authenticator, cls).add_parser_arguments(add, default_propagation_seconds=120)
         add('credentials', help='Linode credentials INI file.')
 
     def more_info(self):  # pylint: disable=missing-function-docstring

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -12,7 +12,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* The Linode DNS plugin now waits 120 seconds for DNS propagation, instead of 1200,
+  due to https://www.linode.com/blog/linode/linode-turns-17/
 
 ### Fixed
 


### PR DESCRIPTION
«When you add or change DNS zones or records, your changes will now be reflected at our authoritative nameservers in under 60 seconds. This is down from the previous “every quarter hour” approach that we had for so long.» - https://www.linode.com/blog/linode/linode-turns-17/

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.
