### PR TITLE
Use a specific tag of adferrand/snapcraft to build QEMU snaps and avoid failures

### DIFF
--- a/tools/snap/build.sh
+++ b/tools/snap/build.sh
@@ -32,7 +32,7 @@ function cleanup() {
 trap cleanup EXIT
 
 # NB: We use ARCH-stable-save tag instead of ARCH-stable, because recent versions of snapcraft images
-# behave badly on QEMU for armhf architecture. This should be fixed either by a new version of the
+# behave badly on QEMU for arm64 architecture. This should be fixed either by a new version of the
 # image that does not have this problem anymore, or the migration to snapcraft remote builds.
 docker run \
   --rm \

--- a/tools/snap/build.sh
+++ b/tools/snap/build.sh
@@ -31,11 +31,14 @@ function cleanup() {
 
 trap cleanup EXIT
 
+# NB: We use ARCH-stable-save tag instead of ARCH-stable, because recent versions of snapcraft images
+# behave badly on QEMU for armhf architecture. This should be fixed either by a new version of the
+# image that does not have this problem anymore, or the migration to snapcraft remote builds.
 docker run \
   --rm \
   --net=host \
   -v "${CERTBOT_DIR}:/certbot" \
   -w "/certbot" \
   -e "PIP_EXTRA_INDEX_URL=http://localhost:8080" \
-  "adferrand/snapcraft:${DOCKER_ARCH}-stable" \
+  "adferrand/snapcraft:${DOCKER_ARCH}-stable-save" \
   bash -c "snapcraft clean && snapcraft"

--- a/tools/snap/build_dns.sh
+++ b/tools/snap/build_dns.sh
@@ -60,6 +60,9 @@ for DNS_PLUGIN in ${DNS_PLUGINS}; do
 done
 EOF
 
+# NB: We use ARCH-stable-save tag instead of ARCH-stable, because recent versions of snapcraft images
+# behave badly on QEMU for armhf architecture. This should be fixed either by a new version of the
+# image that does not have this problem anymore, or the migration to snapcraft remote builds.
 docker run \
   --rm \
   --net=host \
@@ -69,5 +72,5 @@ docker run \
   -w "/certbot" \
   -e "DNS_PLUGINS=${DNS_PLUGINS}" \
   -e "PIP_EXTRA_INDEX_URL=http://localhost:8080" \
-  "adferrand/snapcraft:${DOCKER_ARCH}-stable" \
+  "adferrand/snapcraft:${DOCKER_ARCH}-stable-save" \
   /script.sh

--- a/tools/snap/build_dns.sh
+++ b/tools/snap/build_dns.sh
@@ -61,7 +61,7 @@ done
 EOF
 
 # NB: We use ARCH-stable-save tag instead of ARCH-stable, because recent versions of snapcraft images
-# behave badly on QEMU for armhf architecture. This should be fixed either by a new version of the
+# behave badly on QEMU for arm64 architecture. This should be fixed either by a new version of the
 # image that does not have this problem anymore, or the migration to snapcraft remote builds.
 docker run \
   --rm \


### PR DESCRIPTION
The latest builds of snapcraft introduced somehow several failures when snaps are built on QEMU for armhf. See https://dev.azure.com/certbot/certbot/_build/results?buildId=2326&view=logs&j=7c548e18-6053-5a42-b366-e6480da09a69&t=a7c7ca26-ae0c-54e6-0355-3bfcd7bab03c for instance.

This PR uses a specific tags from `adferrand/snapcraft`, extracted from the last known working `nightly` pipeline, to avoid these failures until a more permanent fix is done. Very likely the fix will be the move to snapcraft remote builds.