### PR TITLE
Do not create the symlink for test assets on Windows if the asset pat…

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -279,16 +279,17 @@ def load_sample_data_path(workspace):
     shutil.copytree(original, copied, symlinks=True)
 
     if os.name == 'nt':
-        # Fix the symlinks on Windows since GIT is not creating them upon checkout
+        # Fix the symlinks on Windows if GIT is not configured to create them upon checkout
         for lineage in ['a.encryption-example.com', 'b.encryption-example.com']:
             current_live = os.path.join(copied, 'live', lineage)
             for name in os.listdir(current_live):
                 if name != 'README':
                     current_file = os.path.join(current_live, name)
-                    with open(current_file) as file_h:
-                        src = file_h.read()
-                    os.unlink(current_file)
-                    os.symlink(os.path.join(current_live, src), current_file)
+                    if not os.path.islink(current_file):
+                        with open(current_file) as file_h:
+                            src = file_h.read()
+                        os.unlink(current_file)
+                        os.symlink(os.path.join(current_live, src), current_file)
 
     return copied
 


### PR DESCRIPTION
On Windows, by default Git does not generate symlinks during a branch checkout. Indeed creation of symlinks requires special rights (typically administrators ones) that usually a user does not have.

So certbot-ci takes that into account, and dynamically generate these symlinks during the integration tests.

However, it is possible to configure your system and Git to actually create these symlinks on Windows. See https://github.com/git-for-windows/git/wiki/Symbolic-Links#creating-symbolic-links

It seems that the Azure Pipeline Windows agents have now this configuration applied. As a consequence, our Windows integration tests are now failing during the CI.

This PR fixes that, by generating the symlinks only if the tests assets are not already symlinks. This way, the two situations on Windows (Git with and without symlinks on checkout) are handled nicely, and the CI can work again.