### PR TITLE
Improve log dump in snaps remote builds when an unexpected behavior is detected.

### DIFF
--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -2,7 +2,7 @@
 import argparse
 import glob
 import datetime
-from multiprocessing import Pool, Process, Manager, Event, Lock
+from multiprocessing import Pool, Process, Manager, Event
 import re
 import subprocess
 import sys
@@ -168,7 +168,7 @@ def main():
 
     with Manager() as manager, Pool(processes=len(targets)) as pool:
         status = manager.dict()
-        lock = Lock()
+        lock = manager.Lock()
 
         stop_event = Event()
         state_process = Process(target=_dump_status, args=(archs, status, stop_event))

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -16,7 +16,7 @@ PLUGINS = [basename(path) for path in glob.glob(join(CERTBOT_DIR, 'certbot-dns-*
 def _execute_build(target, archs, status, workspace):
     process = subprocess.Popen([
         'snapcraft', 'remote-build', '--launchpad-accept-public-upload', '--recover', '--build-on', ','.join(archs)
-    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, cwd=workspace)
+    ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True, cwd=workspace)
 
     process_output = []
     for line in process.stdout:

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -61,7 +61,7 @@ def _build_snap(target, archs, status, lock):
                 # We expect for each failed builds to have a build output, or something bad happened.
                 missing_outputs = False
                 for arch in failed_archs:
-                    if not exists(join(workspace, f'{target}_{failed_archs}.txt')):
+                    if not exists(join(workspace, f'{target}_{arch}.txt')):
                         missing_outputs = True
                         print(f'Missing output on a failed build {target} for {arch}.')
                 if missing_outputs:

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -58,7 +58,7 @@ def _build_snap(target, archs, status, lock):
                     break
 
             if failed_archs:
-                # We expect for each failed builds to have a build output, or something bad happened.
+                # We expect each failed build to have a log file, or something bad happened.
                 missing_outputs = False
                 for arch in failed_archs:
                     if not exists(join(workspace, f'{target}_{arch}.txt')):

--- a/tools/snap/generate_dnsplugins_postrefreshhook.sh
+++ b/tools/snap/generate_dnsplugins_postrefreshhook.sh
@@ -6,7 +6,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CERTBOT_DIR="$(dirname "$(dirname "${DIR}")")"
 
 for PLUGIN_PATH in "${CERTBOT_DIR}"/certbot-dns-*; do
-  PLUGIN=$(basename "${PLUGIN_PATH}")
   mkdir -p "${PLUGIN_PATH}/snap/hooks"
   cat <<EOF > "${PLUGIN_PATH}/snap/hooks/post-refresh"
 #!/bin/sh -e


### PR DESCRIPTION
Fixes #8169

This PR improves snaps remote builds script by dumping the output of `snapcraft remote-build` when unexpected behavior is detected:
* when all builds for a project finish with a zero status code, and none of them are marked as failed, we expect to have all the associated snap files available locally.
* when some builds are marked as failed, we expect to have a build output for each of them available locally.

In these two situations, if the expectation are not matched, then the script will display the output of `snapcraft remote-build` itself. I added also a control error to handle nicely the absence of an expected build output on the local machine.
