### PR TITLE
Automatically publish snaps to the beta channel

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -9,4 +9,6 @@ stages:
   - template: templates/stages/test-and-package-stage.yml
   - template: templates/stages/changelog-stage.yml
   - template: templates/stages/deploy-stage.yml
+    parameters:
+      snapReleaseChannel: beta
   - template: templates/stages/notify-failure-stage.yml

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -1,4 +1,5 @@
-# Release pipeline to build and deploy Certbot for Windows for GitHub release tags
+# Release pipeline to run our full test suite, build artifacts, and deploy them
+# for GitHub release tags.
 trigger:
   tags:
     include:

--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -1,13 +1,24 @@
 stages:
   - stage: Deploy
     jobs:
-      # This job relies on a snapcraft.cfg preconfigured with credential,
-      # stored as a secure file in Azure Pipeline.
-      # This credential has a maximum lifetime of 1 year and the current
-      # credential will expire on 6/25/2021. The content of snapcraft.cfg
-      # will need to be updated to use a new credential before then to
-      # prevent automated deploys from breaking. Remembering to do this is
-      # also tracked by https://github.com/certbot/certbot/issues/7931.
+      # This job relies on credentials used to publish the Certbot snaps. This
+      # credential file was created by running:
+      #
+      #   snapcraft logout
+      #   snapcraft login (provide the shared snapcraft credentials when prompted)
+      #   snapcraft export-login --channels=beta,edge snapcraft.cfg
+      #
+      # Then the file was added as a secure file in Azure pipelines
+      # with the name snapcraft.cfg by following the instructions at
+      # https://docs.microsoft.com/en-us/azure/devops/pipelines/library/secure-files?view=azure-devops
+      # including authorizing the file in all pipelines as described at
+      # https://docs.microsoft.com/en-us/azure/devops/pipelines/library/secure-files?view=azure-devops#how-do-i-authorize-a-secure-file-for-use-in-all-pipelines.
+      #
+      # This file has a maximum lifetime of one year and the current
+      # file will expire on 2021-07-28 which is also tracked by
+      # https://github.com/certbot/certbot/issues/7931. The file will
+      # need to be updated before then to prevent automated deploys
+      # from breaking.
       - job: publish_snap
         pool:
           vmImage: ubuntu-18.04

--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -51,6 +51,6 @@ stages:
               mkdir -p .snapcraft
               ln -s $(snapcraftCfg.secureFilePath) .snapcraft/snapcraft.cfg
               for SNAP_FILE in snap/*.snap; do
-                snapcraft upload --release=${{ snapReleaseChannel }} "${SNAP_FILE}"
+                snapcraft upload --release=${{ parameters.snapReleaseChannel }} "${SNAP_FILE}"
               done
             displayName: Publish to Snap store

--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -1,3 +1,11 @@
+parameters:
+- name: snapReleaseChannel
+  type: string
+  default: edge
+  values:
+  - edge
+  - beta
+
 stages:
   - stage: Deploy
     jobs:
@@ -43,6 +51,6 @@ stages:
               mkdir -p .snapcraft
               ln -s $(snapcraftCfg.secureFilePath) .snapcraft/snapcraft.cfg
               for SNAP_FILE in snap/*.snap; do
-                snapcraft upload --release=edge "${SNAP_FILE}"
+                snapcraft upload --release=${{ snapReleaseChannel }} "${SNAP_FILE}"
               done
             displayName: Publish to Snap store


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8170.

Azure's documentation about this is at https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops and in particular the [Job, stage, and step templates with parameters section](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#job-stage-and-step-templates-with-parameters).

I tested this on my fork using different snap store credentials and pushing to a different snap. You can see the release pipeline uploading to the beta channel [here](https://dev.azure.com/bmw0523/bmw/_build/results?buildId=313&view=logs&j=d150120f-6634-5552-7a3b-78014609a3b1&t=2d30e1b7-c9fe-5ba3-0bfd-8fc22bc0dee6&l=13) and the nightly pipeline continuing to upload to the edge channel [here](https://dev.azure.com/bmw0523/bmw/_build/results?buildId=318&view=logs&j=d150120f-6634-5552-7a3b-78014609a3b1&t=2d30e1b7-c9fe-5ba3-0bfd-8fc22bc0dee6&l=13).

After this lands, we need to update the release instructions to reflect this change.