### PR TITLE
Document how to revoke snapcraft credentials

### DIFF
--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -27,6 +27,11 @@ stages:
       # https://github.com/certbot/certbot/issues/7931. The file will
       # need to be updated before then to prevent automated deploys
       # from breaking.
+      #
+      # Revoking these credentials can be done by changing the password of the
+      # account used to generate the credentials. See
+      # https://forum.snapcraft.io/t/revoking-exported-credentials/19031 for
+      # more info.
       - job: publish_snap
         pool:
           vmImage: ubuntu-18.04


### PR DESCRIPTION
Hopefully this will never come up, but I wanted to figure out how to do this and document it just in case.

You can see deployment using my snapcraft account working at https://dev.azure.com/bmw0523/bmw/_build/results?buildId=318&view=logs&j=d150120f-6634-5552-7a3b-78014609a3b1&t=2d30e1b7-c9fe-5ba3-0bfd-8fc22bc0dee6 and then failing at https://dev.azure.com/bmw0523/bmw/_build/results?buildId=319&view=logs&j=d150120f-6634-5552-7a3b-78014609a3b1&t=2d30e1b7-c9fe-5ba3-0bfd-8fc22bc0dee6&l=16 after I changed my password.