### PR TITLE
letsencrypt-auto OL8 support

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-* letsencryot-auto: Added support for use of Oracle Linux 8's preferred Python 3.
+* letsencrypt-auto: Added support for use of Oracle Linux 8's preferred Python 3.
 
 ### Fixed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* letsencryot-auto: Added support for use of Oracle Linux 8's preferred Python 3.
 
 ### Fixed
 

--- a/letsencrypt-auto
+++ b/letsencrypt-auto
@@ -862,6 +862,8 @@ elif [ -f /etc/redhat-release ]; then
       RPM_USE_PYTHON_3=1
     elif [ "$RPM_DIST_NAME" = "centos" -a "$RPM_DIST_VERSION" -ge 8 ]; then
       RPM_USE_PYTHON_3=1
+    elif [ "$RPM_DIST_NAME" = "ol" -a "$RPM_DIST_VERSION" -ge 8 ]; then
+      RPM_USE_PYTHON_3=1
     else
       RPM_USE_PYTHON_3=0
     fi


### PR DESCRIPTION
letsencrypt-auto: Added support for use of Oracle Linux 8's preferred Python 3