### PR TITLE
Fix --archs default

### DIFF
--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -146,7 +146,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('targets', nargs='+', choices=['ALL', 'DNS_PLUGINS', 'certbot', *PLUGINS],
                         help='the list of snaps to build')
-    parser.add_argument('--archs', nargs='+', choices=['amd64', 'arm64', 'armhf'], default='amd64',
+    parser.add_argument('--archs', nargs='+', choices=['amd64', 'arm64', 'armhf'], default=['amd64'],
                         help='the architectures for which snaps are built')
     args = parser.parse_args()
 


### PR DESCRIPTION
Per https://docs.python.org/3/library/argparse.html#nargs, the use of `nargs='+'` causes the argument's value to be a list but we have a default value of a string. Because of this, when I tried running this script locally without setting this argument, it tried to build the snap on the architectures `a,m,4,d,6` which didn't go well.

This PR fixes the default value.