### PR TITLE
Fix certbot.compat.os docs

### DIFF
--- a/certbot/certbot/compat/os.py
+++ b/certbot/certbot/compat/os.py
@@ -3,6 +3,9 @@ This compat modules is a wrapper of the core os module that forbids usage of spe
 (e.g. chown, chmod, getuid) that would be harmful to the Windows file security model of Certbot.
 This module is intended to replace standard os module throughout certbot projects (except acme).
 
+This module has the same API as the os module in the Python standard library
+except for the functions defined below.
+
 isort:skip_file
 """
 # pylint: disable=function-redefined
@@ -21,12 +24,15 @@ import os as std_os  # pylint: disable=os-module-forbidden
 import sys as std_sys
 
 ourselves = std_sys.modules[__name__]
-for attribute in dir(std_os):
-    # Check if the attribute does not already exist in our module. It could be internal attributes
-    # of the module (__name__, __doc__), or attributes from standard os already imported with
-    # `from os import *`.
-    if not hasattr(ourselves, attribute):
-        setattr(ourselves, attribute, getattr(std_os, attribute))
+# Adding all of stdlib os to this module confuses Sphinx so we skip this when
+# building the documentation.
+if not os.environ.get("CERTBOT_DOCS") == "1":
+    for attribute in dir(std_os):
+        # Check if the attribute does not already exist in our module. It could be internal attributes
+        # of the module (__name__, __doc__), or attributes from standard os already imported with
+        # `from os import *`.
+        if not hasattr(ourselves, attribute):
+            setattr(ourselves, attribute, getattr(std_os, attribute))
 
 # Import our internal path module, then allow certbot.compat.os.path
 # to behave as a module (similarly to os.path).

--- a/certbot/certbot/compat/os.py
+++ b/certbot/certbot/compat/os.py
@@ -28,9 +28,9 @@ ourselves = std_sys.modules[__name__]
 # building the documentation.
 if not std_os.environ.get("CERTBOT_DOCS") == "1":
     for attribute in dir(std_os):
-        # Check if the attribute does not already exist in our module. It could be internal attributes
-        # of the module (__name__, __doc__), or attributes from standard os already imported with
-        # `from os import *`.
+        # Check if the attribute does not already exist in our module. It could
+        # be internal attributes of the module (__name__, __doc__), or
+        # attributes from standard os already imported with `from os import *`.
         if not hasattr(ourselves, attribute):
             setattr(ourselves, attribute, getattr(std_os, attribute))
 

--- a/certbot/certbot/compat/os.py
+++ b/certbot/certbot/compat/os.py
@@ -6,8 +6,8 @@ This module is intended to replace standard os module throughout certbot project
 This module has the same API as the os module in the Python standard library
 except for the functions defined below.
 
-isort:skip_file
 """
+# isort:skip_file
 # pylint: disable=function-redefined
 from __future__ import absolute_import
 

--- a/certbot/certbot/compat/os.py
+++ b/certbot/certbot/compat/os.py
@@ -26,7 +26,7 @@ import sys as std_sys
 ourselves = std_sys.modules[__name__]
 # Adding all of stdlib os to this module confuses Sphinx so we skip this when
 # building the documentation.
-if not os.environ.get("CERTBOT_DOCS") == "1":
+if not std_os.environ.get("CERTBOT_DOCS") == "1":
     for attribute in dir(std_os):
         # Check if the attribute does not already exist in our module. It could be internal attributes
         # of the module (__name__, __doc__), or attributes from standard os already imported with


### PR DESCRIPTION
While working on https://github.com/certbot/certbot/issues/8164, I noticed a ton of new errors about certbot.compat.os. Looking at the docs, it looks like https://certbot.eff.org/docs/api/certbot.compat.os.html. What's going on here is since we wrap stdlib `os`, Sphinx tries to document each member of `os` which goes somewhat poorly.

After this PR, the docs looks like:
![Screen Shot 2020-08-13 at 4 50 02 PM](https://user-images.githubusercontent.com/6504915/90198097-7ca81300-dd85-11ea-927c-b8923edffd32.png)
