### PR TITLE
Split docker job

### DIFF
--- a/.azure-pipelines/advanced-test.yml
+++ b/.azure-pipelines/advanced-test.yml
@@ -5,5 +5,10 @@ trigger:
   - test-*
 pr: none
 
+variables:
+  # We don't publish our Docker images in this pipeline, but when building them
+  # for testing, let's use the nightly tag.
+  dockerTag: nightly
+
 stages:
   - template: templates/stages/test-and-package-stage.yml

--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -9,6 +9,9 @@ schedules:
       - master
     always: true
 
+variables:
+  dockerTag: nightly
+
 stages:
   - template: templates/stages/test-and-package-stage.yml
   - template: templates/stages/deploy-stage.yml

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -6,11 +6,13 @@ trigger:
       - v*
 pr: none
 
+variables:
+  dockerTag: ${{variables['Build.SourceBranchName']}}
+
 stages:
   - template: templates/stages/test-and-package-stage.yml
   - template: templates/stages/changelog-stage.yml
   - template: templates/stages/deploy-stage.yml
     parameters:
       snapReleaseChannel: beta
-      dockerTag: ${{variables['Build.SourceBranchName']}}
   - template: templates/stages/notify-failure-stage.yml

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -1,4 +1,13 @@
 jobs:
+  - job: docker_build
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+      - bash: |
+          docker images
+          tools/docker/build.sh nightly
+          docker images
+        displayName: Build the Docker images
   - job: installer_build
     pool:
       vmImage: vs2017-win2016

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -3,10 +3,21 @@ jobs:
     pool:
       vmImage: ubuntu-18.04
     steps:
-      - bash: |
-          tools/docker/build.sh $(dockerTag)
-          docker images --filter reference='*/dns-*' --filter reference='*/certbot'
+      - bash: tools/docker/build.sh ${{ variables.dockerTag }}
         displayName: Build the Docker images
+      # We don't filter for the Docker Hub organization to continue to allow
+      # easy testing of these scripts on forks.
+      - bash: |
+          DOCKER_IMAGES=$(docker images --quiet --filter reference='*/dns-*' --filter reference='*/certbot')
+          docker save --output docker_images.tar $DOCKER_IMAGES
+        displayName: Save the Docker images
+      - bash: mv docker_images.tar $(Build.ArtifactStagingDirectory)
+        displayName: Prepare Docker artifact
+      - task: PublishPipelineArtifact@1
+        inputs:
+          path: $(Build.ArtifactStagingDirectory)
+          artifact: docker_images
+        displayName: Store Docker artifact
   - job: installer_build
     pool:
       vmImage: vs2017-win2016

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -4,9 +4,8 @@ jobs:
       vmImage: ubuntu-18.04
     steps:
       - bash: |
-          docker images
-          tools/docker/build.sh nightly
-          docker images
+          tools/docker/build.sh $(dockerTag)
+          docker images --filter reference='*/dns-*' --filter reference='*/certbot'
         displayName: Build the Docker images
   - job: installer_build
     pool:

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -8,7 +8,7 @@ jobs:
       # We don't filter for the Docker Hub organization to continue to allow
       # easy testing of these scripts on forks.
       - bash: |
-          DOCKER_IMAGES=$(docker images --quiet --filter reference='*/dns-*' --filter reference='*/certbot')
+          DOCKER_IMAGES=$(docker images --filter reference='*/certbot' --filter reference='*/dns-*' --format '{{.Repository}}')
           docker save --output docker_images.tar $DOCKER_IMAGES
         displayName: Save the Docker images
       # If the name of the tar file or artifact changes, the deploy stage will

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -3,7 +3,7 @@ jobs:
     pool:
       vmImage: ubuntu-18.04
     steps:
-      - bash: tools/docker/build.sh ${{ variables.dockerTag }}
+      - bash: tools/docker/build.sh $(dockerTag)
         displayName: Build the Docker images
       # We don't filter for the Docker Hub organization to continue to allow
       # easy testing of these scripts on forks.

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -11,6 +11,8 @@ jobs:
           DOCKER_IMAGES=$(docker images --quiet --filter reference='*/dns-*' --filter reference='*/certbot')
           docker save --output docker_images.tar $DOCKER_IMAGES
         displayName: Save the Docker images
+      # If the name of the tar file or artifact changes, the deploy stage will
+      # also need to be updated.
       - bash: mv docker_images.tar $(Build.ArtifactStagingDirectory)
         displayName: Prepare Docker artifact
       - task: PublishPipelineArtifact@1

--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -5,9 +5,6 @@ parameters:
   values:
   - edge
   - beta
-- name: dockerTag
-  type: string
-  default: nightly
 
 stages:
   - stage: Deploy

--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -69,6 +69,7 @@ stages:
               path: $(Build.SourcesDirectory)
             displayName: Retrieve Docker images
           - bash: docker load --input $(Build.SourcesDirectory)/docker_images.tar
+            displayName: Load Docker images
           - task: Docker@2
             inputs:
               command: login

--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -66,6 +66,12 @@ stages:
         pool:
           vmImage: ubuntu-18.04
         steps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: docker_images
+              path: $(Build.SourcesDirectory)
+            displayName: Retrieve Docker images
+          - bash: docker load --input $(Build.SourcesDirectory)/docker_images.tar
           - task: Docker@2
             inputs:
               command: login
@@ -81,7 +87,5 @@ stages:
               # Certbot organization on Docker Hub.
               containerRegistry: docker-hub
             displayName: Login to Docker Hub
-          - bash: tools/docker/build.sh  ${{ parameters.dockerTag }}
-            displayName: Build the Docker images
-          - bash: tools/docker/deploy.sh ${{ parameters.dockerTag }}
+          - bash: tools/docker/deploy.sh $(dockerTag)
             displayName: Deploy the Docker images

--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -51,6 +51,10 @@ Build() {
 }
 
 TAG_BASE="$1"
+if [ -z "$TAG_BASE" ]; then
+    echo "We cannot tag Docker images with an empty string!" >&2
+    exit 1
+fi
 
 # Step 1: Certbot core Docker
 Build "$DOCKER_HUB_ORG/certbot" "$TAG_BASE" "$REPO_ROOT" "$WORK_DIR/core"

--- a/tools/docker/deploy.sh
+++ b/tools/docker/deploy.sh
@@ -24,6 +24,10 @@ Deploy() {
 }
 
 TAG_BASE="$1"  # Eg. v0.35.0 or nightly
+if [ -z "$TAG_BASE" ]; then
+    echo "We cannot tag Docker images with an empty string!" >&2
+    exit 1
+fi
 source "$WORK_DIR/lib/common"
 
 # Step 1: Certbot core Docker


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8198.

You can see this working at:

* https://dev.azure.com/bmw0523/bmw/_build/results?buildId=361&view=results
* https://dev.azure.com/certbot/certbot/_build/results?buildId=2468&view=results
* https://dev.azure.com/certbot/certbot/_build/results?buildId=2470&view=results

The last build is still going and I expect it'll pass, but just in case, I'll leave this as a draft PR for now.

The overall time of release builds should go down with this PR. This is because we can do the long Docker build in parallel with the long snap build rather than doing them sequentially.