### PR TITLE
Fix test farm tests on macOS and update macOS images

### DIFF
--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -68,7 +68,7 @@ jobs:
           TOXENV: le_auto_oraclelinux6
         docker-dev:
           TOXENV: docker_dev
-        farmtest-apache2:
+        macos-farmtest-apache2:
           # We run one of these test farm tests on macOS to help ensure the
           # tests continue to work on the platform.
           IMAGE_NAME: macOS-10.14

--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -69,6 +69,8 @@ jobs:
         docker-dev:
           TOXENV: docker_dev
         farmtest-apache2:
+          # We run one of these test farm tests on macOS to help ensure the
+          # tests continue to work on the platform.
           IMAGE_NAME: macOS-10.14
           PYTHON_VERSION: 3.8
           TOXENV: test-farm-apache2

--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -71,7 +71,7 @@ jobs:
         macos-farmtest-apache2:
           # We run one of these test farm tests on macOS to help ensure the
           # tests continue to work on the platform.
-          IMAGE_NAME: macOS-10.14
+          IMAGE_NAME: macOS-10.15
           PYTHON_VERSION: 3.8
           TOXENV: test-farm-apache2
         farmtest-leauto-upgrades:

--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -69,6 +69,7 @@ jobs:
         docker-dev:
           TOXENV: docker_dev
         farmtest-apache2:
+          IMAGE_NAME: macOS-10.14
           PYTHON_VERSION: 3.7
           TOXENV: test-farm-apache2
         farmtest-leauto-upgrades:

--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -70,7 +70,7 @@ jobs:
           TOXENV: docker_dev
         farmtest-apache2:
           IMAGE_NAME: macOS-10.14
-          PYTHON_VERSION: 3.7
+          PYTHON_VERSION: 3.8
           TOXENV: test-farm-apache2
         farmtest-leauto-upgrades:
           PYTHON_VERSION: 3.7

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -3,11 +3,11 @@ jobs:
     strategy:
       matrix:
         macos-py27:
-          IMAGE_NAME: macOS-10.14
+          IMAGE_NAME: macOS-10.15
           PYTHON_VERSION: 2.7
           TOXENV: py27
         macos-py38:
-          IMAGE_NAME: macOS-10.14
+          IMAGE_NAME: macOS-10.15
           PYTHON_VERSION: 3.8
           TOXENV: py38
         windows-py36:


### PR DESCRIPTION
I don't entirely understand why this happened, but the test farm tests do not currently work with Python 3.8 on macOS. You can see the failure [here](https://dev.azure.com/certbot/certbot/_build/results?buildId=2519&view=logs&j=9d9056dd-6d3a-5ab9-4437-796135c21b43&t=b7b5de09-bf79-583a-8b7d-ab998b2e2a8b). Notice that [the log directory the test creates](https://dev.azure.com/certbot/certbot/_build/results?buildId=2519&view=logs&j=9d9056dd-6d3a-5ab9-4437-796135c21b43&t=b7b5de09-bf79-583a-8b7d-ab998b2e2a8b&l=180) is different from [the one the client processes try to use](https://dev.azure.com/certbot/certbot/_build/results?buildId=2519&view=logs&j=9d9056dd-6d3a-5ab9-4437-796135c21b43&t=b7b5de09-bf79-583a-8b7d-ab998b2e2a8b&l=322).

I think what's going on here is an implementation detail of the `multiprocessing` module on macOS. I think when the client processes are run, it reruns `multitester.py` causing the `LOGDIR` global variable which contains a timestamp to change in value.

I fixed this by making a local `log_dir` variable and passing it around as needed.

To help ensure the tests don't suddenly break for me on macOS in the future, I set up one of the test farm tests to run on macOS with Python 3. You can see the full test farm tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2527&view=results.

~~I also updated the macOS images used in the tests because some of the tests were breaking on the old image, even in [tests unmodified by this PR](https://dev.azure.com/certbot/certbot/_build/results?buildId=2524&view=logs&j=4176f179-b5cd-575a-19e5-e77b2911e842&t=cfcb0001-a4fd-5fbc-b41e-9da8650df2d4). I think the problem is that the Homebrew installation is old causing Homebrew to remove a bunch of packages it thinks are no longer needed such as `openssl`. See [this](https://dev.azure.com/certbot/certbot/_build/results?buildId=2524&view=logs&j=4176f179-b5cd-575a-19e5-e77b2911e842&t=3fedc703-decf-5b4d-51a5-e0c1b150427d&l=39). I think this results in the "SSL module is not available." errors.~~

I also updated the macOS images used in the tests because some of the tests were breaking on the old image. This appears to be fixed, but since there is a newer macOS image available and [it's even the default macOS image in Azure now](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml), let's switch to it.