### PR TITLE
Clean up --register-unsafely-without-email docs

### DIFF
--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -173,7 +173,8 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         help="Specifying this flag enables registering an account with no "
              "email address. This is strongly discouraged, because you will be "
              "unable to receive notice about impending expiration or "
-             "revocation of your certificates.")
+             "revocation of your certificates or problems with your Certbot "
+             "installation that will lead to failure to renew.")
     helpful.add(
         ["register", "update_account", "unregister", "automation"], "-m", "--email",
         default=flag_default("email"),

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -171,13 +171,9 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         ["register", "automation"], "--register-unsafely-without-email", action="store_true",
         default=flag_default("register_unsafely_without_email"),
         help="Specifying this flag enables registering an account with no "
-             "email address. This is strongly discouraged, because in the "
-             "event of key loss or account compromise you will irrevocably "
-             "lose access to your account. You will also be unable to receive "
-             "notice about impending expiration or revocation of your "
-             "certificates. Updates to the Subscriber Agreement will still "
-             "affect you, and will be effective 14 days after posting an "
-             "update to the web site.")
+             "email address. This is strongly discouraged, because you will be "
+             "unable to receive notice about impending expiration or "
+             "revocation of your certificates.")
     helpful.add(
         ["register", "update_account", "unregister", "automation"], "-m", "--email",
         default=flag_default("email"),

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -6,7 +6,6 @@ import zope.component
 from certbot import errors
 from certbot import interfaces
 from certbot import util
-from certbot.compat import misc
 from certbot.compat import os
 from certbot.display import util as display_util
 

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -33,9 +33,9 @@ def get_email(invalid=False, optional=True):
     msg = "Enter email address (used for urgent renewal and security notices)\n"
     unsafe_suggestion = ("\n\nIf you really want to skip this, you can run "
                          "the client with --register-unsafely-without-email "
-                         "but make sure you then backup your account key from "
-                         "{0}\n\n".format(os.path.join(
-                             misc.get_default_folder('config'), 'accounts')))
+                         "but you will then be unable to receive notice about "
+                         "impending expiration or revocation of your "
+                         "certificates.\n\n")
     if optional:
         if invalid:
             msg += unsafe_suggestion

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -34,7 +34,8 @@ def get_email(invalid=False, optional=True):
                          "the client with --register-unsafely-without-email "
                          "but you will then be unable to receive notice about "
                          "impending expiration or revocation of your "
-                         "certificates.\n\n")
+                         "certificates or problems with your Certbot "
+                         "installation that will lead to failure to renew.\n\n")
     if optional:
         if invalid:
             msg += unsafe_suggestion


### PR DESCRIPTION
Account backups used to be really important in early versions of the ACME spec, but they're not anymore.

Also, the subscriber agreement being updated in 14 days is LE specific and shouldn't be hard coded in Certbot.