### PR TITLE
Create umask Context Manager

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* certbot.util.umask Context Manager.
 
 ### Changed
 

--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -5,6 +5,7 @@ import argparse
 import atexit
 import collections
 from collections import OrderedDict
+from contextlib import contextmanager
 import distutils.version
 import errno
 import logging
@@ -14,12 +15,10 @@ import socket
 import subprocess
 import sys
 
-from contextlib import contextmanager
-from typing import Iterator
-
 import configargparse
 import six
 
+from acme.magic_typing import Iterator
 from acme.magic_typing import Tuple
 from acme.magic_typing import Union
 from certbot import errors

--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -14,6 +14,9 @@ import socket
 import subprocess
 import sys
 
+from contextlib import contextmanager
+from typing import Iterator
+
 import configargparse
 import six
 
@@ -205,6 +208,21 @@ def make_or_verify_dir(directory, mode=0o755, strict=False):
                     " permissions %s" % (directory, oct(mode)))
         else:
             raise
+
+
+@contextmanager
+def umask(temp_mask):
+    # type: (int) -> Iterator[None]
+    """Context manager to set umask and restore previous value
+
+    :param int temp_mask: Same as `mask` for `filesystem.umask`.
+
+    """
+    perm_mask = filesystem.umask(temp_mask)
+    try:
+        yield
+    finally:
+        filesystem.umask(perm_mask)
 
 
 def safe_open(path, mode="w", chmod=None):

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -207,7 +207,7 @@ class UmaskTest(test_util.TempDirTestCase):
 
     def test_umask(self):
         self._call(0o0)
-        self.assertTrue(filesystem.check_mode(self.default_name, 0o666))
+        self.assertFalse(filesystem.check_mode(self.default_name, 0o0))
         self.assertEqual(filesystem.umask(self.perm_mask), 0o777)
 
     def tearDown(self):

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -196,7 +196,8 @@ class UmaskTest(test_util.TempDirTestCase):
 
     def setUp(self):
         super(UmaskTest, self).setUp()
-        self.default_name = os.path.join(self.tempdir, "foo.txt")
+        self.default_name = os.path.join(self.tempdir, "UmaskTest.txt")
+        self.perm_mask = filesystem.umask(0o777)
 
     def _call(self, temp_mask):
         from certbot.util import umask
@@ -205,10 +206,12 @@ class UmaskTest(test_util.TempDirTestCase):
                 pass
 
     def test_umask(self):
-        perm_mask = filesystem.umask(0o777)
         self._call(0o0)
         self.assertTrue(filesystem.check_mode(self.default_name, 0o666))
-        self.assertEqual(filesystem.umask(perm_mask), 0o777)
+        self.assertEqual(filesystem.umask(self.perm_mask), 0o777)
+
+    def tearDown(self):
+        filesystem.umask(self.perm_mask)
 
 
 class UniqueFileTest(test_util.TempDirTestCase):

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -191,6 +191,26 @@ class MakeOrVerifyDirTest(test_util.TempDirTestCase):
             self.assertRaises(OSError, self._call, "bar", 12312312)
 
 
+class UmaskTest(test_util.TempDirTestCase):
+    """Tests for certbot.util.umask."""
+
+    def setUp(self):
+        super(UmaskTest, self).setUp()
+        self.default_name = os.path.join(self.tempdir, "foo.txt")
+
+    def _call(self, temp_mask):
+        from certbot.util import umask
+        with umask(temp_mask):
+            with open(self.default_name, 'w'):
+                pass
+
+    def test_umask(self):
+        perm_mask = filesystem.umask(0o777)
+        self._call(0o0)
+        self.assertTrue(filesystem.check_mode(self.default_name, 0o666))
+        self.assertEqual(filesystem.umask(perm_mask), 0o777)
+
+
 class UniqueFileTest(test_util.TempDirTestCase):
     """Tests for certbot.util.unique_file."""
 


### PR DESCRIPTION
cerbot.util.umask is a context manager to set umask
to a value and restore it to its previous value when
exiting the `with` block.

Closes certbot/certbot#7992

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.