### PR TITLE
Fix finding Augeas in the ARM snaps

### DIFF
--- a/certbot.wrapper
+++ b/certbot.wrapper
@@ -1,5 +1,32 @@
 #!/bin/bash
 set -e
+
+# This code is based on snapcraft's own patch to work around this problem at
+# https://github.com/snapcore/snapcraft/blob/a97fb5c7ea553a1bd20f4887a7c3393e75761890/patches/ctypes_init.diff.
+case "${SNAP_ARCH}" in
+    'arm64')
+        ARCH_TRIPLET='aarch64-linux-gnu';;
+    'armhf')
+        ARCH_TRIPLET='arm-linux-gnueabihf';;
+    'i386')
+        ARCH_TRIPLET='i386-linux-gnu';;
+    'ppc64el')
+        ARCH_TRIPLET='powerpc64le-linux-gnu';;
+    'powerpc')
+        ARCH_TRIPLET='powerpc-linux-gnu';;
+    'amd64')
+        ARCH_TRIPLET='x86_64-linux-gnu';;
+    's390x')
+        ARCH_TRIPLET='s390x-linux-gnu';;
+    *)
+        echo "Unrecongized value of SNAP_ARCH: ${SNAP_ARCH}" >&2
+        exit 1
+esac
+
+PARTIAL_LIBRARY_PATH="${SNAP}/usr/lib/${ARCH_TRIPLET}/"
+export LD_LIBRARY_PATH="${PARTIAL_LIBRARY_PATH}:${LD_LIBRARY_PATH}"
+export CERTBOT_AUGEAS_PATH="${PARTIAL_LIBRARY_PATH}libaugeas.so.0"
+
 join() {
     sep=$1
     first=$2

--- a/certbot.wrapper
+++ b/certbot.wrapper
@@ -3,6 +3,10 @@ set -e
 
 # This code is based on snapcraft's own patch to work around this problem at
 # https://github.com/snapcore/snapcraft/blob/a97fb5c7ea553a1bd20f4887a7c3393e75761890/patches/ctypes_init.diff.
+# We may not build the Certbot snap for all of these architectures (and as of
+# writing this we do not), but we keep the code for them to avoid having to
+# solve this problem again in the future if we add support for new
+# architectures.
 case "${SNAP_ARCH}" in
     'arm64')
         ARCH_TRIPLET='aarch64-linux-gnu';;

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* The problem causing the Apache plugin in the Certbot snap on ARM systems to
+  fail to load the Augeas library it depends on has been fixed.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,6 @@ apps:
     environment:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
-      LD_LIBRARY_PATH: "$SNAP/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
       CERTBOT_SNAPPED: "True"
   renew:
     command: certbot.wrapper -q renew
@@ -32,7 +31,6 @@ apps:
     environment:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: $SNAP/usr/share/augeas/lenses/dist
-      LD_LIBRARY_PATH: "$SNAP/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
       CERTBOT_SNAPPED: "True"
     # Run approximately twice a day with randomization
     timer: 00:00~24:00/2
@@ -44,7 +42,7 @@ parts:
     source: .
     constraints: [$SNAPCRAFT_PART_SRC/snap-constraints.txt]
     python-packages:
-      - git+https://github.com/basak/python-augeas.git@snap
+      - git+https://github.com/certbot/python-augeas.git@certbot-patched
       - ./acme
       - ./certbot
       - ./certbot-apache
@@ -54,7 +52,7 @@ parts:
       # Old versions of this file used to unstage
       # lib/python3.8/site-packages/augeas.py to avoid conflicts between
       # python-augeas 0.5.0 which was pinned in snap-constraints.txt and
-      # Robie's python-augeas fork which creates an auto-generated cffi file at
+      # our python-augeas fork which creates an auto-generated cffi file at
       # the same path. Since we've combined things in one part and removed the
       # python-augeas pinning, unstaging this file had a different, unintended
       # effect so we now stage the file to keep the auto-generated cffi file.


### PR DESCRIPTION
Fixes #8216 and fixes #7943 (at least well enough to close in favor of https://github.com/certbot/certbot/issues/8229 in my opinion).

I created https://github.com/certbot/certbot/issues/8229 to track fixing this problem without patches/forks which should hopefully explain why we still need a patch/fork here especially if we want to fix #8216 soon which I think we do.

I took the `python-augeas` fork over from Robie though and created https://github.com/certbot/python-augeas. On that repo I rebased Robie's patch on the latest python-augeas release and added two of my own commits. You can see the diff from the most recently released version of python-augeas at https://github.com/certbot/python-augeas/compare/v1.1.0...certbot-patched.

I tested the snaps built with these changes on all 3 supported architectures and it worked. I also played with Certbot seeing if there were any other calls to the problematic function `ctypes.util.find_library` and I couldn't find any.

You can see the full test suite passing ~~except for the reoccuring Ubuntu 20.04 ARM failure~~ at https://dev.azure.com/certbot/certbot/_build/results?buildId=2554&view=results