### PR TITLE
Switch to the Debian Buster ARM image

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -8,12 +8,6 @@ targets:
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-008680ee60f23c94b
-    name: ubuntu20.04_arm64
-    type: ubuntu
-    virt: hvm
-    user: ubuntu
-    machine_type: a1.medium
   - ami: ami-0545f7036167eb3aa
     name: ubuntu19.10
     type: ubuntu
@@ -36,6 +30,12 @@ targets:
     type: ubuntu
     virt: hvm
     user: admin
+  - ami: ami-0dcd54b7d2fff584f
+    name: debian10_arm64
+    type: ubuntu
+    virt: hvm
+    user: admin
+    machine_type: a1.medium
   - ami: ami-003f19e0e687de1cd
     name: debian9
     type: ubuntu

--- a/tests/letstest/scripts/test_apache2.sh
+++ b/tests/letstest/scripts/test_apache2.sh
@@ -12,7 +12,7 @@ then
     # For apache 2.4, set up ServerName
     sudo sed -i '/ServerName/ s/#ServerName/ServerName/' $CONFFILE
     sudo sed -i '/ServerName/ s/www.example.com/'$PUBLIC_HOSTNAME'/' $CONFFILE
-    if [ $(python3 -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -ne 38 ]
+    if [ $(python3 -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -lt 36 ]
     then
         # Upgrade python version using pyenv because py3.5 is deprecated
         # Don't upgrade if it's already 3.8 because pyenv doesn't work great on arm, and

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -8,12 +8,6 @@ targets:
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-008680ee60f23c94b
-    name: ubuntu20.04_arm64
-    type: ubuntu
-    virt: hvm
-    user: ubuntu
-    machine_type: a1.medium
   - ami: ami-0545f7036167eb3aa
     name: ubuntu19.10
     type: ubuntu
@@ -31,6 +25,12 @@ targets:
     type: ubuntu
     virt: hvm
     user: admin
+  - ami: ami-0dcd54b7d2fff584f
+    name: debian10_arm64
+    type: ubuntu
+    virt: hvm
+    user: admin
+    machine_type: a1.medium
   #-----------------------------------------------------------------------------
   # Other Redhat Distros
   - ami: ami-0916c408cb02e310b


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8220.

I took the AMI from https://wiki.debian.org/Cloud/AmazonEC2Image/Buster.

You can see the affected test farm tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2560&view=results.