### PR TITLE
Add --dry-run-deploy-hooks to run the deploy-hooks on dry runs

### DIFF
--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -168,6 +168,12 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
              " if they are defined because they may be necessary to accurately simulate"
              " renewal. --deploy-hook commands are not called.")
     helpful.add(
+        ["renew"],
+        "--dry-run-deploy-hooks", action="store_true", dest="dry_run_deploy_hooks",
+        default=flag_default("dry_run_deploy_hooks"),
+        help="If used together with --dry-run, then deploy-hooks are"
+             " run.")
+    helpful.add(
         ["register", "automation"], "--register-unsafely-without-email", action="store_true",
         default=flag_default("register_unsafely_without_email"),
         help="Specifying this flag enables registering an account with no "

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -261,6 +261,11 @@ class HelpfulArgumentParser(object):
                 parsed_args.tos = True
                 parsed_args.register_unsafely_without_email = True
 
+        if parsed_args.dry_run_deploy_hooks:
+            if self.verb not in ["renew"]:
+                raise errors.Error("--dry-run-deploy-hooks currently only works with the "
+                                   "'renew' subcommand (%r)" % self.verb)
+
     def handle_csr(self, parsed_args):
         """Process a --csr flag."""
         if parsed_args.verb != "certonly":

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -30,6 +30,7 @@ CLI_DEFAULTS = dict(
     domains=[],
     certname=None,
     dry_run=False,
+    dry_run_deploy_hooks=False,
     register_unsafely_without_email=False,
     email=None,
     eff_email=None,

--- a/certbot/certbot/_internal/hooks.py
+++ b/certbot/certbot/_internal/hooks.py
@@ -160,8 +160,9 @@ def deploy_hook(config, domains, lineage_path):
 
     """
     if config.deploy_hook:
+        deploy_hooks_disabled = config.dry_run and not config.dry_run_deploy_hooks
         _run_deploy_hook(config.deploy_hook, domains,
-                         lineage_path, config.dry_run)
+                         lineage_path, deploy_hooks_disabled)
 
 
 def renew_hook(config, domains, lineage_path):
@@ -182,9 +183,11 @@ def renew_hook(config, domains, lineage_path):
 
     """
     executed_dir_hooks = set()
+    deploy_hooks_disabled = config.dry_run and not config.dry_run_deploy_hooks
+
     if config.directory_hooks:
         for hook in list_hooks(config.renewal_deploy_hooks_dir):
-            _run_deploy_hook(hook, domains, lineage_path, config.dry_run)
+            _run_deploy_hook(hook, domains, lineage_path, deploy_hooks_disabled)
             executed_dir_hooks.add(hook)
 
     if config.renew_hook:
@@ -193,7 +196,7 @@ def renew_hook(config, domains, lineage_path):
                         config.renew_hook)
         else:
             _run_deploy_hook(config.renew_hook, domains,
-                             lineage_path, config.dry_run)
+                             lineage_path, deploy_hooks_disabled)
 
 
 def _run_deploy_hook(command, domains, lineage_path, dry_run):


### PR DESCRIPTION
Now "certbot renew --dry-run --dry-run-deploy-hooks" can be used to
run the deploy-hooks without certbot actually contacting the
LetsEncrypt API. This can be useful when developing/modifying
deploy-hooks, in order to prevent running into LE's rate limiting.

Fixes #5658.