### PR TITLE
log: Don't print backtrace on ^c/KeyboardInterrupt

### DIFF
--- a/certbot/certbot/_internal/log.py
+++ b/certbot/certbot/_internal/log.py
@@ -319,6 +319,9 @@ def post_arg_parse_except_hook(exc_type, exc_value, trace, debug, log_path):
     # logger.DEBUG should be used
     if debug or not issubclass(exc_type, Exception):
         assert constants.QUIET_LOGGING_LEVEL <= logging.ERROR
+        if exc_type is KeyboardInterrupt:
+            logger.error('Exiting due to user request.')
+            sys.exit(1)
         logger.error('Exiting abnormally:', exc_info=exc_info)
     else:
         logger.debug('Exiting abnormally:', exc_info=exc_info)

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -306,7 +306,7 @@ class PostArgParseExceptHookTest(unittest.TestCase):
         self.log_path = 'foo.log'
 
     def test_base_exception(self):
-        exc_type = KeyboardInterrupt
+        exc_type = BaseException
         mock_logger, output = self._test_common(exc_type, debug=False)
         self._assert_exception_logged(mock_logger.error, exc_type)
         self._assert_logfile_output(output)
@@ -341,6 +341,11 @@ class PostArgParseExceptHookTest(unittest.TestCase):
         mock_logger, output = self._test_common(exc_type, debug=False)
         self._assert_exception_logged(mock_logger.debug, exc_type)
         self._assert_quiet_output(mock_logger, output)
+
+    def test_keyboardinterrupt(self):
+        exc_type = KeyboardInterrupt
+        mock_logger, output = self._test_common(exc_type, debug=False)
+        mock_logger.error.assert_called_once_with('Exiting due to user request.')
 
     def _test_common(self, error_type, debug):
         """Returns the mocked logger and stderr output."""


### PR DESCRIPTION
In the spirit of the terminal output revamp, I think it would be helpful to avoid printing potentially 50+ lines of stack when a user is trying to interrupt Certbot.

I am wary that there might be undocumented reason why this wasn't done before, but as writing this was very quick, why not?

Fixes #8257.