### PR TITLE
snap: use snap REST API in certbot.wrapper

### DIFF
--- a/certbot.wrapper
+++ b/certbot.wrapper
@@ -29,7 +29,7 @@ esac
 
 export CERTBOT_AUGEAS_PATH="${SNAP}/usr/lib/${ARCH_TRIPLET}/libaugeas.so.0"
 
-CERTBOT_PLUGIN_PATH="$(snap connections certbot | gawk 'BEGIN {ORS=""} NR>1 { if ($1 == "content[certbot-1]") { split($3,a,":"); PLUGINS=PLUGINS":/snap/"a[1]"/current/lib/python3.8/site-packages/"; next; } } END { print substr(PLUGINS, 2) }')"
+CERTBOT_PLUGIN_PATH="$(curl -s --unix-socket /run/snapd.socket "http://localhost/v2/connections?snap=certbot&interface=content" | jq -r  '.result.established | map(select(.plug.plug == "plugin" and ."plug-attrs".content == "certbot-1") | "/snap/"+.slot.snap+"/current/lib/python3.8/site-packages/" ) | join(":")')"
 export CERTBOT_PLUGIN_PATH
 
 exec certbot "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,7 +72,8 @@ parts:
       - python3-pkg-resources
       - python3.8-minimal
       # added for certbot.wrapper script:
-      - gawk
+      - curl
+      - jq
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, git, libaugeas-dev, python3-dev]
     build-environment:


### PR DESCRIPTION
In order to avoid potentially breaking changes in the snap CLI on the
host, this commit changes certbot.wrapper to use the snap REST API (via
curl and jq) to list connected Certbot plugins.

----

Fixes #8250