### PR TITLE
nginx: fix server_name case-sensitivity in parser

### DIFF
--- a/certbot-nginx/certbot_nginx/_internal/parser.py
+++ b/certbot-nginx/certbot_nginx/_internal/parser.py
@@ -496,7 +496,8 @@ def get_best_match(target_name, names):
 
 
 def _exact_match(target_name, name):
-    return name in (target_name, '.' + target_name)
+    target_lower = target_name.lower()
+    return name.lower() in (target_lower, '.' + target_lower)
 
 
 def _wildcard_match(target_name, name, start):
@@ -517,11 +518,11 @@ def _wildcard_match(target_name, name, start):
     if first not in ('*', ''):
         return False
 
-    target_name = '.'.join(parts)
-    name = '.'.join(match_parts)
+    target_name_lower = '.'.join(parts).lower()
+    name_lower = '.'.join(match_parts).lower()
 
     # Ex: www.eff.org matches *.eff.org, eff.org does not match *.eff.org
-    return target_name.endswith('.' + name)
+    return target_name_lower.endswith('.' + name_lower)
 
 
 def _regex_match(target_name, name):

--- a/certbot-nginx/tests/parser_test.py
+++ b/certbot-nginx/tests/parser_test.py
@@ -340,7 +340,9 @@ class NginxParserTest(util.NginxTest):
                  {'*.www.eff.org', 'www.*'},
                  {'*.org'},
                  set(),
-                 {'example.com'}]
+                 {'example.com'},
+                 {'www.Eff.org'},
+                 {'.efF.org'}]
         winners = [('exact', 'www.eff.org'),
                    (None, None),
                    ('exact', '.www.eff.org'),
@@ -353,7 +355,9 @@ class NginxParserTest(util.NginxTest):
                    ('wildcard_end', 'www.*'),
                    ('wildcard_start', '*.org'),
                    (None, None),
-                   (None, None)]
+                   (None, None),
+                   ('exact', 'www.Eff.org'),
+                   ('wildcard_start', '.efF.org')]
 
         for i, winner in enumerate(winners):
             self.assertEqual(winner,

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -20,6 +20,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * The `acme` library can now tell the ACME server to clear contact information by passing an empty
   `tuple` to the `contact` field of a `Registration` message. 
 * Fixed the `*** stack smashing detected ***` error in the Certbot snap on some systems.
+* Fixed `server_name` case-sensitivity in the nginx plugin.
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
This commit fixes an issue with the nginx parser where it would perform
case-sensitive matching against server_name.

This would cause the authenticator and installer to ignore existing
virtualhosts containing uppercase characters, resulting in duplicate
virtualhosts and broken configurations.

"Exact" and "wildcard" matching is now case-insensitive. Regex-based
matching will continue to respect the case mode of the pattern.

Fixes #6776.

