### PR TITLE
Removed unnecessary unittest.TestCase.setUp/tearDown calls.

### DIFF
--- a/certbot-apache/tests/util.py
+++ b/certbot-apache/tests/util.py
@@ -26,8 +26,6 @@ class ApacheTest(unittest.TestCase):
               config_root="debian_apache_2_4/multiple_vhosts/apache2",
               vhost_root="debian_apache_2_4/multiple_vhosts/apache2/sites-available"):
         # pylint: disable=arguments-differ
-        super(ApacheTest, self).setUp()
-
         self.temp_dir, self.config_dir, self.work_dir = common.dir_setup(
             test_dir=test_dir,
             pkg=__name__)

--- a/certbot-dns-route53/tests/dns_route53_test.py
+++ b/certbot-dns-route53/tests/dns_route53_test.py
@@ -35,7 +35,6 @@ class AuthenticatorTest(unittest.TestCase, dns_test_common.BaseAuthenticatorTest
         # Remove the dummy credentials from env vars
         del os.environ["AWS_ACCESS_KEY_ID"]
         del os.environ["AWS_SECRET_ACCESS_KEY"]
-        super(AuthenticatorTest, self).tearDown()
 
     def test_perform(self):
         self.auth._change_txt_record = mock.MagicMock()
@@ -128,8 +127,6 @@ class ClientTest(unittest.TestCase):
     def setUp(self):
         from certbot_dns_route53._internal.dns_route53 import Authenticator
 
-        super(ClientTest, self).setUp()
-
         self.config = mock.MagicMock()
 
         # Set up dummy credentials for testing
@@ -142,7 +139,6 @@ class ClientTest(unittest.TestCase):
         # Remove the dummy credentials from env vars
         del os.environ["AWS_ACCESS_KEY_ID"]
         del os.environ["AWS_SECRET_ACCESS_KEY"]
-        super(ClientTest, self).tearDown()
 
     def test_find_zone_id_for_domain(self):
         self.client.r53.get_paginator = mock.MagicMock()

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -185,8 +185,6 @@ class VerifyCertSetup(unittest.TestCase):
     """Refactoring for verification tests."""
 
     def setUp(self):
-        super(VerifyCertSetup, self).setUp()
-
         self.renewable_cert = mock.MagicMock()
         self.renewable_cert.cert_path = SS_CERT_PATH
         self.renewable_cert.chain_path = SS_CERT_PATH

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -326,7 +326,6 @@ class FileOutputDisplayTest(unittest.TestCase):
 class NoninteractiveDisplayTest(unittest.TestCase):
     """Test non-interactive display. These tests are pretty easy!"""
     def setUp(self):
-        super(NoninteractiveDisplayTest, self).setUp()
         self.mock_stdout = mock.MagicMock()
         self.displayer = display_util.NoninteractiveDisplay(self.mock_stdout)
 


### PR DESCRIPTION
This seems wrong. `unittest.TestCase.setUp()` and `unittest.TestCase.tearDown()` are merely hooks with `pass`.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.
