### PR TITLE
Add TODO to certbot.wrapper

### DIFF
--- a/certbot.wrapper
+++ b/certbot.wrapper
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# TODO: We may want to consider rewriting this script in Python. See
+# https://github.com/certbot/certbot/issues/8251 for more info.
 set -e
 
 # This code is based on snapcraft's own patch to work around this problem at


### PR DESCRIPTION
I'm adding this comment as part of the resolution of https://github.com/certbot/certbot/issues/8251. I think rewriting the script in Python is something we really should only worry about if we're working on the script in the future. Because of this, I personally prefer a code comment rather than an issue here.