### PR TITLE
Delete conflicting server_names for random28524

### DIFF
--- a/certbot-compatibility-test/nginx/nginx-roundtrip-testdata/79-configs/site-10571
+++ b/certbot-compatibility-test/nginx/nginx-roundtrip-testdata/79-configs/site-10571
@@ -61,7 +61,6 @@ server {
 server {
     listen 80;
     server_name random1413.example.org www.random1413.example.org;
-    server_name random28524.example.org www.random28524.example.org;
     server_name random25266.example.org www.random25266.example.org;
     server_name random26791.example.org www.random26791.example.org;
 

--- a/certbot-compatibility-test/nginx/nginx-roundtrip-testdata/79-configs/site-19791
+++ b/certbot-compatibility-test/nginx/nginx-roundtrip-testdata/79-configs/site-19791
@@ -29,6 +29,5 @@ server {
 
 server {
     server_name www.random1413.example.org;
-    server_name random28524.example.org www.random28524.example.org;
     rewrite ^ http://random1413.example.org$request_uri permanent;
 }


### PR DESCRIPTION
This fixes the same problem in the config under `nginx-roundtrip-testdata` as the one I fixed in https://github.com/certbot/certbot/pull/8248 for the nginx compatibility test.