### PR TITLE
Upgrade httplib2

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -23,6 +23,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   In the previous release, Certbot said it required `acme>=1.6.0` when it
   actually required `acme>=1.8.0` to properly support removing contact
   information from an ACME account.
+* Upgraded the version of httplib2 used in our snaps and Docker images to add
+  support for proxy environment variables and fix the plugin for Google Cloud
+  DNS.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -39,7 +39,7 @@ future==0.16.0
 futures==3.3.0
 filelock==3.0.12
 google-api-python-client==1.5.5
-httplib2==0.10.3
+httplib2==0.18.1
 imagesize==0.7.1
 importlib-metadata==0.23
 ipdb==0.12.3


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8204.

I also think this fixes https://community.letsencrypt.org/t/cannot-perform-dns-challenge-on-gce/133820. On Ubuntu 20.04 using our Python 3 developer environment, trying to use the certbot-dns-google plugin crashes with the same error before this change and works afterwards.

Mangled and revoked credentials if you would like to try and test this yourself can be found at https://gist.github.com/f65a37d8cd8d7e6ca8603eb60ac6ccd9. After `httplib2` is upgraded, it should crash with an error about your credentials rather than an SSL error. If you'd like trusted credentials to fully test it works after this change, let me know.

You can see the full test suite testing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2739&view=results.

Once this PR lands and has been pushed to the edge channel, I think we should update https://community.letsencrypt.org/t/cannot-perform-dns-challenge-on-gce/133820 with instructions on how to install the plugin from the edge channel to have people double check that it fixes the problem.