### PR TITLE
Use in dict rather than "in dict.keys()". Fix linting warnings about "not in".

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -801,7 +801,7 @@ class ClientV2(ClientBase):
         """
         # Can't use response.links directly because it drops multiple links
         # of the same relation type, which is possible in RFC8555 responses.
-        if not 'Link' in response.headers:
+        if 'Link' not in response.headers:
             return []
         links = parse_header_links(response.headers['Link'])
         return [l['url'] for l in links

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -1342,7 +1342,7 @@ class ClientNetworkSourceAddressBindingTest(unittest.TestCase):
         # test should fail if the default adapter type is changed by requests
         net = ClientNetwork(key=None, alg=None)
         session = requests.Session()
-        for scheme in session.adapters.keys():
+        for scheme in session.adapters:
             client_network_adapter = net.session.adapters.get(scheme)
             default_adapter = session.adapters.get(scheme)
             self.assertEqual(client_network_adapter.__class__, default_adapter.__class__)

--- a/certbot-apache/certbot_apache/_internal/parser.py
+++ b/certbot-apache/certbot_apache/_internal/parser.py
@@ -799,7 +799,7 @@ class ApacheParser(object):
     def _parsed_by_parser_paths(self, filep, paths):
         """Helper function that searches through provided paths and returns
         True if file path is found in the set"""
-        for directory in paths.keys():
+        for directory in paths:
             for filename in paths[directory]:
                 if fnmatch.fnmatch(filep, os.path.join(directory, filename)):
                     return True

--- a/certbot-apache/tests/centos_test.py
+++ b/certbot-apache/tests/centos_test.py
@@ -140,7 +140,7 @@ class MultipleVhostsTestCentOS(util.ApacheTest):
         self.assertEqual(mock_get.call_count, 3)
         self.assertEqual(len(self.config.parser.modules), 4)
         self.assertEqual(len(self.config.parser.variables), 2)
-        self.assertTrue("TEST2" in self.config.parser.variables.keys())
+        self.assertTrue("TEST2" in self.config.parser.variables)
         self.assertTrue("mod_another.c" in self.config.parser.modules)
 
     def test_get_virtual_hosts(self):
@@ -172,11 +172,11 @@ class MultipleVhostsTestCentOS(util.ApacheTest):
             mock_osi.return_value = ("centos", "7")
             self.config.parser.update_runtime_variables()
 
-        self.assertTrue("mock_define" in self.config.parser.variables.keys())
-        self.assertTrue("mock_define_too" in self.config.parser.variables.keys())
-        self.assertTrue("mock_value" in self.config.parser.variables.keys())
+        self.assertTrue("mock_define" in self.config.parser.variables)
+        self.assertTrue("mock_define_too" in self.config.parser.variables)
+        self.assertTrue("mock_value" in self.config.parser.variables)
         self.assertEqual("TRUE", self.config.parser.variables["mock_value"])
-        self.assertTrue("MOCK_NOSEP" in self.config.parser.variables.keys())
+        self.assertTrue("MOCK_NOSEP" in self.config.parser.variables)
         self.assertEqual("NOSEP_VAL", self.config.parser.variables["NOSEP_TWO"])
 
     @mock.patch("certbot_apache._internal.configurator.util.run_script")

--- a/certbot-apache/tests/fedora_test.py
+++ b/certbot-apache/tests/fedora_test.py
@@ -134,7 +134,7 @@ class MultipleVhostsTestFedora(util.ApacheTest):
         self.assertEqual(mock_get.call_count, 3)
         self.assertEqual(len(self.config.parser.modules), 4)
         self.assertEqual(len(self.config.parser.variables), 2)
-        self.assertTrue("TEST2" in self.config.parser.variables.keys())
+        self.assertTrue("TEST2" in self.config.parser.variables)
         self.assertTrue("mod_another.c" in self.config.parser.modules)
 
     @mock.patch("certbot_apache._internal.configurator.util.run_script")
@@ -172,11 +172,11 @@ class MultipleVhostsTestFedora(util.ApacheTest):
             mock_osi.return_value = ("fedora", "29")
             self.config.parser.update_runtime_variables()
 
-        self.assertTrue("mock_define" in self.config.parser.variables.keys())
-        self.assertTrue("mock_define_too" in self.config.parser.variables.keys())
-        self.assertTrue("mock_value" in self.config.parser.variables.keys())
+        self.assertTrue("mock_define" in self.config.parser.variables)
+        self.assertTrue("mock_define_too" in self.config.parser.variables)
+        self.assertTrue("mock_value" in self.config.parser.variables)
         self.assertEqual("TRUE", self.config.parser.variables["mock_value"])
-        self.assertTrue("MOCK_NOSEP" in self.config.parser.variables.keys())
+        self.assertTrue("MOCK_NOSEP" in self.config.parser.variables)
         self.assertEqual("NOSEP_VAL", self.config.parser.variables["NOSEP_TWO"])
 
     @mock.patch("certbot_apache._internal.configurator.util.run_script")

--- a/certbot-apache/tests/gentoo_test.py
+++ b/certbot-apache/tests/gentoo_test.py
@@ -91,7 +91,7 @@ class MultipleVhostsTestGentoo(util.ApacheTest):
         with mock.patch("certbot_apache._internal.override_gentoo.GentooParser.update_modules"):
             self.config.parser.update_runtime_variables()
         for define in defines:
-            self.assertTrue(define in self.config.parser.variables.keys())
+            self.assertTrue(define in self.config.parser.variables)
 
     @mock.patch("certbot_apache._internal.apache_util.parse_from_subprocess")
     def test_no_binary_configdump(self, mock_subprocess):

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
@@ -57,7 +57,7 @@ class Proxy(configurators_common.Proxy):
 
     def _prepare_configurator(self):
         """Prepares the Apache plugin for testing"""
-        for k in entrypoint.ENTRYPOINT.OS_DEFAULTS.keys():
+        for k in entrypoint.ENTRYPOINT.OS_DEFAULTS:
             setattr(self.le_config, "apache_" + k,
                     entrypoint.ENTRYPOINT.OS_DEFAULTS[k])
 

--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -127,7 +127,7 @@ def write_renewal_config(o_filename, n_filename, archive_dir, target, relevant_d
 
     config["renewalparams"].update(relevant_data)
 
-    for k in config["renewalparams"].keys():
+    for k in config["renewalparams"]:
         if k not in relevant_data:
             del config["renewalparams"][k]
 

--- a/certbot/certbot/plugins/storage.py
+++ b/certbot/certbot/plugins/storage.py
@@ -106,7 +106,7 @@ class PluginStorage(object):
         if not self._initialized:
             self._initialize_storage()
 
-        if not self._classkey in self._data.keys():
+        if self._classkey not in self._data:
             self._data[self._classkey] = {}
         self._data[self._classkey][key] = value
 

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -322,7 +322,7 @@ def create_client_instance(ec2_client, target, security_group_id, subnet_id):
     else:
         # 32 bit systems
         machine_type = 'c1.medium'
-    if 'userdata' in target.keys():
+    if 'userdata' in target:
         userdata = target['userdata']
     else:
         userdata = ''


### PR DESCRIPTION
I found another obvious optimization to make while doing this. 

It's a rather simple example, but should emphasize that using `.keys()` to check if a certain key is in the dictionary is not good.
```
In [5]: x = {'a': 1, 'b': 2, 'c': 3}

In [6]: %timeit 'a' in x
10000000 loops, best of 3: 39 ns per loop

In [7]: %timeit 'a' in x.keys()
The slowest run took 19.87 times longer than the fastest. This could mean that an intermediate result is being cached.
10000000 loops, best of 3: 92.7 ns per loop
```

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.
