### PR TITLE
suppress tracebacks in ErrorHandler recovery

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,6 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Update the packaging instructions to promote usage of `python -m pytest` to test Certbot
   instead of the deprecated `python setup.py test` setuptools approach.
 * Reduced CLI logging when reloading nginx, if it is not running.
+* Reduced CLI logging when handling some kinds of errors.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/error_handler.py
+++ b/certbot/certbot/_internal/error_handler.py
@@ -123,8 +123,10 @@ class ErrorHandler(object):
         while self.funcs:
             try:
                 self.funcs[-1]()
-            except Exception:  # pylint: disable=broad-except
-                logger.error("Encountered exception during recovery: ", exc_info=True)
+            except Exception as exc:  # pylint: disable=broad-except
+                output = traceback.format_exception_only(type(exc), exc)
+                logger.error("Encountered exception during recovery: %s",
+                             ''.join(output).rstrip())
             self.funcs.pop()
 
     def _set_signal_handlers(self):


### PR DESCRIPTION
The ErrorHandler context manager could produce very verbose CLI output
when handling long exception chains (PIP 3134 enhanced reporting).

Rather than logging every exception with its traceback to the CLI, this
commit changes ErrorHandler so that only the final exception in the
chain, without traceback, is logged to the CLI.

This is consistent with a previous change made in the global except
hook (#8000).

Fixes #8288. 

[Output before and after](https://gist.github.com/alexzorin/a0ce1781ee6aa5f3bd8ba0595008cf05).