### PR TITLE
tests: remove Ubuntu 19.10

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -8,11 +8,6 @@ targets:
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-0545f7036167eb3aa
-    name: ubuntu19.10
-    type: ubuntu
-    virt: hvm
-    user: ubuntu
   - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu

--- a/tests/letstest/auto_targets.yaml
+++ b/tests/letstest/auto_targets.yaml
@@ -3,11 +3,6 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
-  - ami: ami-0545f7036167eb3aa
-    name: ubuntu19.10
-    type: ubuntu
-    virt: hvm
-    user: ubuntu
   - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -8,11 +8,6 @@ targets:
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-0545f7036167eb3aa
-    name: ubuntu19.10
-    type: ubuntu
-    virt: hvm
-    user: ubuntu
   - ami: ami-095192256fe1477ad
     name: ubuntu18.04LTS
     type: ubuntu


### PR DESCRIPTION
EOL since July 2020.


