### PR TITLE
Invoke pipstrap in tox and during the CI

### DIFF
--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -3,6 +3,8 @@ jobs:
     variables:
       - name: IMAGE_NAME
         value: ubuntu-18.04
+      - name: PYTHON_VERSION
+        value: 3.8
       - group: certbot-common
     strategy:
       matrix:

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -71,7 +71,7 @@ jobs:
         displayName: Check Powershell 5.x is used in vs2017-win2016
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: 3.8
+          versionSpec: 3.7
           addToPath: true
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -71,18 +71,23 @@ jobs:
         displayName: Check Powershell 5.x is used in vs2017-win2016
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: 3.7
-          architecture: x86
+          versionSpec: 3.8
           addToPath: true
       - task: DownloadPipelineArtifact@2
         inputs:
           artifact: windows-installer
           path: $(Build.SourcesDirectory)/bin
         displayName: Retrieve Windows installer
+      # pip 9.0 provided by pipstrap is not able to resolve properly the pywin32 dependency
+      # required by certbot-ci: as a temporary workaround until pipstrap is updated, we install
+      # a recent version of pip, but we also to disable the isolated feature as described in
+      # https://github.com/certbot/certbot/issues/8256
       - script: |
           py -3 -m venv venv
-          venv\Scripts\python letsencrypt-auto-source\pieces\pipstrap.py
+          venv\Scripts\python -m pip install pip==20.2.3 setuptools==50.3.0 wheel==0.35.1
           venv\Scripts\python tools\pip_install.py -e certbot-ci
+        env:
+          PIP_NO_BUILD_ISOLATION: no
         displayName: Prepare Certbot-CI
       - script: |
           set PATH=%ProgramFiles(x86)%\Certbot\bin;%PATH%

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -136,6 +136,10 @@ jobs:
     pool:
       vmImage: ubuntu-18.04
     steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: 3.8
+          addToPath: true
       - script: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends nginx-light snapd

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -80,6 +80,7 @@ jobs:
         displayName: Retrieve Windows installer
       - script: |
           py -3 -m venv venv
+          venv\Scripts\python letsencrypt-auto-source\pieces\pipstrap.py
           venv\Scripts\python tools\pip_install.py -e certbot-ci
         displayName: Prepare Certbot-CI
       - script: |
@@ -138,7 +139,9 @@ jobs:
       - script: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends nginx-light snapd
-          python tools/pip_install.py -U tox
+          python3 -m venv venv
+          venv/bin/python letsencrypt-auto-source/pieces/pipstrap.py
+          venv/bin/python tools/pip_install.py -U tox
         displayName: Install dependencies
       - task: DownloadPipelineArtifact@2
         inputs:
@@ -149,7 +152,7 @@ jobs:
           sudo snap install --dangerous --classic snap/certbot_*_amd64.snap
         displayName: Install Certbot snap
       - script: |
-          python -m tox -e integration-external,apacheconftest-external-with-pebble
+          venv/bin/python -m tox -e integration-external,apacheconftest-external-with-pebble
         displayName: Run tox
   - job: snap_dns_run
     dependsOn: snaps_build
@@ -171,6 +174,7 @@ jobs:
         displayName: Retrieve Certbot snaps
       - script: |
           python3 -m venv venv
+          venv/bin/python letsencrypt-auto-source/pieces/pipstrap.py
           venv/bin/python tools/pip_install.py -e certbot-ci
         displayName: Prepare Certbot-CI
       - script: |

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -72,6 +72,7 @@ jobs:
       - task: UsePythonVersion@0
         inputs:
           versionSpec: 3.7
+          architecture: x86
           addToPath: true
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -1,5 +1,7 @@
 jobs:
   - job: test
+    variables:
+      PYTHON_VERSION: 3.8
     strategy:
       matrix:
         macos-py27:

--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -21,7 +21,6 @@ steps:
     inputs:
       versionSpec: $(PYTHON_VERSION)
       addToPath: true
-    condition: ne(variables['PYTHON_VERSION'], '')
     # tools/pip_install.py is used to pin packages to a known working version
     # except in tests where the environment variable CERTBOT_NO_PIN is set.
     # virtualenv is listed here explicitly to make sure it is upgraded when

--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -30,6 +30,7 @@ steps:
     # set, pip updates dependencies it thinks are already satisfied to avoid some
     # problems with its lack of real dependency resolution.
   - bash: |
+      python letsencrypt-auto-source/pieces/pipstrap.py
       python tools/pip_install.py -I tox virtualenv
     displayName: Install runtime dependencies
   - task: DownloadSecureFile@1

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1617,7 +1617,7 @@ maybe_argparse = (
 
 # Be careful when updating the pinned versions here, in particular for pip.
 # Indeed starting from 10.0, pip will build dependencies in isolation if the
-# related projects is compliant with PEP 517. This is not something we want
+# related projects are compliant with PEP 517. This is not something we want
 # as of now, so the isolation build will need to be disabled wherever
 # pipstrap is used (see https://github.com/certbot/certbot/issues/8256).
 PACKAGES = maybe_argparse + [

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1615,6 +1615,11 @@ maybe_argparse = (
     if sys.version_info < (2, 7, 0) else [])
 
 
+# Be careful when updating the pinned versions here, in particular for pip.
+# Indeed starting from 10.0, pip will build dependencies in isolation if the
+# related projects is compliant with PEP 517. This is not something we want
+# as of now, so the isolation build will need to be disabled wherever
+# pipstrap is used (see https://github.com/certbot/certbot/issues/8256).
 PACKAGES = maybe_argparse + [
     # Pip has no dependencies, as it vendors everything:
     ('11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/'

--- a/letsencrypt-auto-source/pieces/pipstrap.py
+++ b/letsencrypt-auto-source/pieces/pipstrap.py
@@ -67,6 +67,11 @@ maybe_argparse = (
     if sys.version_info < (2, 7, 0) else [])
 
 
+# Be careful when updating the pinned versions here, in particular for pip.
+# Indeed starting from 10.0, pip will build dependencies in isolation if the
+# related projects are compliant with PEP 517. This is not something we want
+# as of now, so the isolation build will need to be disabled wherever
+# pipstrap is used (see https://github.com/certbot/certbot/issues/8256).
 PACKAGES = maybe_argparse + [
     # Pip has no dependencies, as it vendors everything:
     ('11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/'

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,11 @@ skipsdist = true
 envlist = modification,py3-cover,lint,mypy
 
 [base]
-# pip installs the requested packages in editable mode
-pip_install = python {toxinidir}/tools/pip_install_editable.py
 # pip installs the requested packages in editable mode and runs unit tests on
 # them. Each package is installed and tested in the order they are provided
 # before the script moves on to the next package. All dependencies are pinned
 # to a specific version for increased stability for developers.
+pip_install = python {toxinidir}/tools/pip_install_editable.py
 install_and_test = python {toxinidir}/tools/install_and_test.py
 dns_packages =
     certbot-dns-cloudflare \
@@ -62,6 +61,7 @@ source_paths =
 [testenv]
 passenv =
     CERTBOT_NO_PIN
+commands_pre = python {toxinidir}/letsencrypt-auto-source/pieces/pipstrap.py
 commands =
     !cover: {[base]install_and_test} {[base]all_packages}
     !cover: python tests/lock_test.py

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,12 @@ skipsdist = true
 envlist = modification,py3-cover,lint,mypy
 
 [base]
+# pip installs the requested packages in editable mode
+pip_install = python {toxinidir}/tools/pip_install_editable.py
 # pip installs the requested packages in editable mode and runs unit tests on
 # them. Each package is installed and tested in the order they are provided
 # before the script moves on to the next package. All dependencies are pinned
 # to a specific version for increased stability for developers.
-pip_install = python {toxinidir}/tools/pip_install_editable.py
 install_and_test = python {toxinidir}/tools/install_and_test.py
 dns_packages =
     certbot-dns-cloudflare \


### PR DESCRIPTION
Partial fix for #8256

This PR makes tox calls pipstrap before any `commands` is executed, and Azure Pipelines calls pipstrap when appropriate (when an actual call to `pip` is done). Docker is already covered since `pipstrap` is called in the `certbot/certbot` docker on the Python system interpreter, and that interpreter is reused during the build of the relevant Docker images for DNS plugins.