### PR TITLE
Disable build isolation during snap dns plugins build

### DIFF
--- a/certbot-dns-cloudflare/snap/snapcraft.yaml
+++ b/certbot-dns-cloudflare/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-cloudxns/snap/snapcraft.yaml
+++ b/certbot-dns-cloudxns/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-digitalocean/snap/snapcraft.yaml
+++ b/certbot-dns-digitalocean/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-dnsimple/snap/snapcraft.yaml
+++ b/certbot-dns-dnsimple/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-dnsmadeeasy/snap/snapcraft.yaml
+++ b/certbot-dns-dnsmadeeasy/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-gehirn/snap/snapcraft.yaml
+++ b/certbot-dns-gehirn/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-google/snap/snapcraft.yaml
+++ b/certbot-dns-google/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-linode/snap/snapcraft.yaml
+++ b/certbot-dns-linode/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-luadns/snap/snapcraft.yaml
+++ b/certbot-dns-luadns/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-nsone/snap/snapcraft.yaml
+++ b/certbot-dns-nsone/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-ovh/snap/snapcraft.yaml
+++ b/certbot-dns-ovh/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-rfc2136/snap/snapcraft.yaml
+++ b/certbot-dns-rfc2136/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-route53/snap/snapcraft.yaml
+++ b/certbot-dns-route53/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/certbot-dns-sakuracloud/snap/snapcraft.yaml
+++ b/certbot-dns-sakuracloud/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ parts:
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:

--- a/tools/snap/generate_dnsplugins_snapcraft.sh
+++ b/tools/snap/generate_dnsplugins_snapcraft.sh
@@ -29,6 +29,7 @@ parts:
         snapcraftctl set-version \`grep ^version \$SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"\`
     build-environment:
       - SNAP_BUILD: "True"
+      - PIP_NO_BUILD_ISOLATION: "no"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]
   certbot-metadata:


### PR DESCRIPTION
Partial fix for #8256

This PR disable the build isolation for snap dns plugins similarly to what is done for the certbot snap.
