### PR TITLE
Add snap log files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ stage
 *.snap
 snap-constraints.txt
 qemu-*
+certbot-dns*/certbot-dns*_amd64*.txt
+certbot-dns*/certbot-dns*_arm*.txt
+/certbot_amd64*.txt
+/certbot_arm*.txt


### PR DESCRIPTION
This PR adds the build logs that are created when you run `snapcraft remote-build` or `tools/snap/build_remote.py` to `.gitignore`. The names of these files on my system are:
```
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.1.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.10.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.11.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.2.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.3.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.4.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.5.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.6.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.7.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.8.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.9.txt
certbot-dns-cloudflare/certbot-dns-cloudflare_amd64.txt
certbot-dns-cloudxns/certbot-dns-cloudxns_amd64.txt
certbot-dns-linode/certbot-dns-linode_amd64.txt
certbot-dns-linode/certbot-dns-linode_arm64.txt
certbot-dns-linode/certbot-dns-linode_armhf.txt
certbot_amd64.txt
```
which are all properly ignored with this change.