### PR TITLE
Improve error message for prepare-plug-plugin hook when certbot isn't installed

### DIFF
--- a/snap/hooks/prepare-plug-plugin
+++ b/snap/hooks/prepare-plug-plugin
@@ -5,7 +5,8 @@ if [ "$(snapctl get trust-plugin-with-root)" = "ok" ]; then
     snapctl unset trust-plugin-with-root
     exit 0
 else
-    echo "Only connect this interface if you trust the plugin author to have root on the system"
-    echo "Run \`snap set $SNAP_NAME trust-plugin-with-root=ok\` to acknowledge this and then run this command again to perform the connection"
+    echo "Only connect this interface if you trust the plugin author to have root on the system."
+    echo "Run \`snap set $SNAP_NAME trust-plugin-with-root=ok\` to acknowledge this and then run this command again to perform the connection."
+    echo "If that doesn't work, you may need to remove all certbot-dns-* plugins from the system, then try installing the certbot snap again."
     exit 1
 fi


### PR DESCRIPTION
Provides a partial fix for #8182 by improving the error message.