### PR TITLE
Converted dict comprehensions to use literals.

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -448,7 +448,7 @@ class Client(ClientBase):
         heapq.heapify(waiting)
         # mapping between original Authorization Resource and the most
         # recently updated one
-        updated = dict((authzr, authzr) for authzr in authzrs)
+        updated = {authzr: authzr for authzr in authzrs}
 
         while waiting:
             # find the smallest Retry-After, and sleep if necessary

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -206,7 +206,7 @@ class Directory(jose.JSONDeSerializable):
         external_account_required = jose.Field('externalAccountRequired', omitempty=True)
 
         def __init__(self, **kwargs):
-            kwargs = dict((self._internal_name(k), v) for k, v in kwargs.items())
+            kwargs = {self._internal_name(k): v for k, v in kwargs.items()}
             super(Directory.Meta, self).__init__(**kwargs)
 
         @property
@@ -465,7 +465,7 @@ class ChallengeBody(ResourceBody):
                        omitempty=True, default=None)
 
     def __init__(self, **kwargs):
-        kwargs = dict((self._internal_name(k), v) for k, v in kwargs.items())
+        kwargs = {self._internal_name(k): v for k, v in kwargs.items()}
         super(ChallengeBody, self).__init__(**kwargs)
 
     def encode(self, name):

--- a/acme/acme/util.py
+++ b/acme/acme/util.py
@@ -4,4 +4,4 @@ import six
 
 def map_keys(dikt, func):
     """Map dictionary keys."""
-    return dict((func(key), value) for key, value in six.iteritems(dikt))
+    return {func(key): value for key, value in six.iteritems(dikt)}

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -192,8 +192,8 @@ class HelpfulArgumentParser(object):
         if self.detect_defaults:
             return parsed_args
 
-        self.defaults = dict((key, copy.deepcopy(self.parser.get_default(key)))
-                             for key in vars(parsed_args))
+        self.defaults = {key: copy.deepcopy(self.parser.get_default(key))
+                             for key in vars(parsed_args)}
 
         # Do any post-parsing homework here
 

--- a/certbot/certbot/_internal/plugins/disco.py
+++ b/certbot/certbot/_internal/plugins/disco.py
@@ -277,8 +277,8 @@ class PluginsRegistry(Mapping):
 
     def filter(self, pred):
         """Filter plugins based on predicate."""
-        return type(self)(dict((name, plugin_ep) for name, plugin_ep
-                               in six.iteritems(self._plugins) if pred(plugin_ep)))
+        return type(self)({name: plugin_ep for name, plugin_ep
+                               in six.iteritems(self._plugins) if pred(plugin_ep)})
 
     def visible(self):
         """Filter plugins based on visibility."""

--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -1126,7 +1126,7 @@ class RenewableCert(interfaces.RenewableCert):
             logger.debug("Writing full chain to %s.", target["fullchain"])
             f.write(new_cert + new_chain)
 
-        symlinks = dict((kind, self.configuration[kind]) for kind in ALL_FOUR)
+        symlinks = {kind: self.configuration[kind] for kind in ALL_FOUR}
         # Update renewal config file
         self.configfile = update_configuration(
             self.lineagename, self.archive_dir, symlinks, cli_config)

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -35,8 +35,8 @@ class BaseCertManagerTest(test_util.ConfigTestCase):
             "example.org": None,
             "other.com": os.path.join(self.config.config_dir, "specialarchive")
         }
-        self.config_files = dict((domain, self._set_up_config(domain, self.domains[domain]))
-            for domain in self.domains)
+        self.config_files = {domain: self._set_up_config(domain, self.domains[domain])
+            for domain in self.domains}
 
         # We also create a file that isn't a renewal config in the same
         # location to test that logic that reads in all-and-only renewal
@@ -80,8 +80,8 @@ class UpdateLiveSymlinksTest(BaseCertManagerTest):
                 archive_dir_path = custom_archive
             else:
                 archive_dir_path = os.path.join(self.config.default_archive_dir, domain)
-            archive_paths[domain] = dict((kind,
-                os.path.join(archive_dir_path, kind + "1.pem")) for kind in ALL_FOUR)
+            archive_paths[domain] = {kind:
+                os.path.join(archive_dir_path, kind + "1.pem") for kind in ALL_FOUR}
             for kind in ALL_FOUR:
                 live_path = self.config_files[domain][kind]
                 archive_path = archive_paths[domain][kind]

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -14,7 +14,7 @@ from certbot.compat import os
 
 def get_signals(signums):
     """Get the handlers for an iterable of signums."""
-    return dict((s, signal.getsignal(s)) for s in signums)
+    return {s: signal.getsignal(s) for s in signums}
 
 
 def set_signals(sig_handler_dict):
@@ -28,7 +28,7 @@ def signal_receiver(signums):
     """Context manager to catch signals"""
     signals = []
     prev_handlers = get_signals(signums)  # type: Dict[int, Union[int, None, Callable]]
-    set_signals(dict((s, lambda s, _: signals.append(s)) for s in signums))
+    set_signals({s: lambda s, _: signals.append(s) for s in signums})
     yield signals
     set_signals(prev_handlers)
 

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1492,7 +1492,7 @@ class UnregisterTest(unittest.TestCase):
             'account': mock.patch('certbot._internal.main.account'),
             'client': mock.patch('certbot._internal.main.client'),
             'get_utility': test_util.patch_get_utility()}
-        self.mocks = dict((k, v.start()) for k, v in self.patchers.items())
+        self.mocks = {k: v.start() for k, v in self.patchers.items()}
 
     def tearDown(self):
         for patch in self.patchers.values():

--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -177,7 +177,7 @@ def _prepare_environment():
 
 
 if __name__ == '__main__':
-    if not os.name == 'nt':
+    if os.name != 'nt':
         raise RuntimeError('This script must be run under Windows.')
 
     if ctypes.windll.shell32.IsUserAnAdmin() == 0:


### PR DESCRIPTION
## Pull Request Checklist

Literals for comprehensions are much faster, and probably also more Pythonic. The `dict` adds a few more instructions compared to the literals; it can be checked with `dis.dis(...)`. This is the same for both `list`, `tuple`, `dict` and `set`. I think it'd be a lot of work changing this consistently in the code base, and I'm not sure if it'd be merged.

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.
