### PR TITLE
Set Certbot snap version from __init__.py

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
         snapcraftctl pull
         cd $SNAPCRAFT_PART_SRC
         python3 tools/strip_hashes.py letsencrypt-auto-source/pieces/dependency-requirements.txt | grep -v python-augeas > snap-constraints.txt
-        snapcraftctl set-version `git describe|sed s/^v//`
+        snapcraftctl set-version `grep -oP "__version__ = '\K.*(?=')" $SNAPCRAFT_PART_SRC/certbot/certbot/__init__.py`
   shared-metadata:
     plugin: dump
     source: .


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8166 following the feedback in https://github.com/certbot/certbot/pull/8337.

I took the command to get Certbot's version from: https://github.com/certbot/certbot/blob/ef8c481634b642489c20b29d2a8c30526d5b5adf/snap/snapcraft.yaml#L90

You can see the snap tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2785&view=results.