### PR TITLE
Add confirmation before certificate delete

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -8,6 +8,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * `--preconfigured-renewal` flag, for packager use only.
   See the [packaging guide](https://certbot.eff.org/docs/packaging.html).
+* Confirmation when deleting certificates
 
 ### Changed
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -315,7 +315,8 @@ def get_certnames(config, verb, allow_multiple=False, custom_prompt=None):
             raise errors.Error("No existing certificates found.")
         if allow_multiple:
             if not custom_prompt:
-                prompt = "Which certificate(s) would you like to {0}?".format(verb)
+                prompt = ("Which certificate or certificates would you like to "
+                    "{0}?".format(verb))
             else:
                 prompt = custom_prompt
             code, certnames = disp.checklist(

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -91,12 +91,7 @@ def delete(config):
     """Delete Certbot files associated with a certificate lineage."""
     certnames = get_certnames(config, "delete", allow_multiple=True)
     disp = zope.component.getUtility(interfaces.IDisplay)
-    if len(certnames) > 1:
-        suffix = "s"
-        verb = "are"
-    else:
-        suffix = ""
-        verb = "is"
+    suffix, verb = ("s", "are") if len(certnames) > 1 else ("", "is")
     msg = ["The following certificate{0} {1} selected for deletion:\n"
         .format(suffix, verb)]
     for certname in certnames:

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -91,7 +91,7 @@ def delete(config):
     """Delete Certbot files associated with a certificate lineage."""
     certnames = get_certnames(config, "delete", allow_multiple=True)
     disp = zope.component.getUtility(interfaces.IDisplay)
-    msg = ["The following certificate(s) is/are selected for deletion:\n"]
+    msg = ["The following certificate(s) are selected for deletion:\n"]
     for certname in certnames:
         msg.append("  * " + certname)
     msg.append("\nAre you sure you want to delete the above certificate(s)?")

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -103,7 +103,7 @@ def delete(config):
         logger.info("  * %s", certname)
     if not disp.yesno("Are you sure to delete the above certificate{0}?".
         format(suffix), default=True):
-        logger.info("Deleting of certificate%s canceled.", suffix)
+        logger.info("Deletion of certificate%s canceled.", suffix)
         return
     for certname in certnames:
         storage.delete_files(config, certname)

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -90,9 +90,23 @@ def certificates(config):
 def delete(config):
     """Delete Certbot files associated with a certificate lineage."""
     certnames = get_certnames(config, "delete", allow_multiple=True)
+    disp = zope.component.getUtility(interfaces.IDisplay)
+    if len(certnames) > 1:
+        suffix = "s"
+        verb = "are"
+    else:
+        suffix = ""
+        verb   = "is"
+    logger.info("\nThe following certificate{0} {1} selected for deletion:\n"
+        .format(suffix, verb))
+    for certname in certnames:
+        logger.info("  * " + certname)
+    if not disp.yesno("Are you sure to delete the above certificate{0}?".
+        format(suffix), force_interactive=True):
+        logger.info("Deleting of certificate{0} canceled.".format(suffix))
+        return
     for certname in certnames:
         storage.delete_files(config, certname)
-        disp = zope.component.getUtility(interfaces.IDisplay)
         disp.notification("Deleted all files relating to certificate {0}."
             .format(certname), pause=False)
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -96,14 +96,14 @@ def delete(config):
         verb = "are"
     else:
         suffix = ""
-        verb   = "is"
-    logger.info("\nThe following certificate{0} {1} selected for deletion:\n"
-        .format(suffix, verb))
+        verb = "is"
+    logger.info("\nThe following certificate%s %s selected for deletion:\n",
+        suffix, verb)
     for certname in certnames:
-        logger.info("  * " + certname)
+        logger.info("  * %s", certname)
     if not disp.yesno("Are you sure to delete the above certificate{0}?".
-        format(suffix), force_interactive=True):
-        logger.info("Deleting of certificate{0} canceled.".format(suffix))
+        format(suffix), default=True):
+        logger.info("Deleting of certificate%s canceled.", suffix)
         return
     for certname in certnames:
         storage.delete_files(config, certname)

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -97,12 +97,13 @@ def delete(config):
     else:
         suffix = ""
         verb = "is"
-    logger.info("\nThe following certificate%s %s selected for deletion:\n",
-        suffix, verb)
+    msg = ["The following certificate{0} {1} selected for deletion:\n"
+        .format(suffix, verb)]
     for certname in certnames:
-        logger.info("  * %s", certname)
-    if not disp.yesno("Are you sure to delete the above certificate{0}?".
-        format(suffix), default=True):
+        msg.append("  * " + certname)
+    msg.append("\nAre you sure to delete the above certificate{0}?".
+            format(suffix))
+    if not disp.yesno("\n".join(msg), default=True):
         logger.info("Deletion of certificate%s canceled.", suffix)
         return
     for certname in certnames:

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -91,15 +91,12 @@ def delete(config):
     """Delete Certbot files associated with a certificate lineage."""
     certnames = get_certnames(config, "delete", allow_multiple=True)
     disp = zope.component.getUtility(interfaces.IDisplay)
-    suffix, verb = ("s", "are") if len(certnames) > 1 else ("", "is")
-    msg = ["The following certificate{0} {1} selected for deletion:\n"
-        .format(suffix, verb)]
+    msg = ["The following certificate(s) is/are selected for deletion:\n"]
     for certname in certnames:
         msg.append("  * " + certname)
-    msg.append("\nAre you sure to delete the above certificate{0}?".
-            format(suffix))
+    msg.append("\nAre you sure you want to delete the above certificate(s)?")
     if not disp.yesno("\n".join(msg), default=True):
-        logger.info("Deletion of certificate%s canceled.", suffix)
+        logger.info("Deletion of certificate(s) canceled.")
         return
     for certname in certnames:
         storage.delete_files(config, certname)
@@ -315,8 +312,7 @@ def get_certnames(config, verb, allow_multiple=False, custom_prompt=None):
             raise errors.Error("No existing certificates found.")
         if allow_multiple:
             if not custom_prompt:
-                prompt = ("Which certificate or certificates would you like to "
-                    "{0}?".format(verb))
+                prompt = "Which certificate(s) would you like to {0}?".format(verb)
             else:
                 prompt = custom_prompt
             code, certnames = disp.checklist(

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -116,10 +116,11 @@ class DeleteTest(storage_test.BaseRenewableCertTest):
     @test_util.patch_get_utility()
     @mock.patch('certbot._internal.cert_manager.lineage_for_certname')
     @mock.patch('certbot._internal.storage.delete_files')
-    def test_delete_from_config(self, mock_delete_files, mock_lineage_for_certname,
-        unused_get_utility):
+    def test_delete_from_config_yes(self, mock_delete_files, mock_lineage_for_certname,
+        mock_util):
         """Test delete"""
         mock_lineage_for_certname.return_value = self.test_rc
+        mock_util().yesno.return_value = True
         self.config.certname = "example.org"
         self._call()
         mock_delete_files.assert_called_once_with(self.config, "example.org")
@@ -127,26 +128,64 @@ class DeleteTest(storage_test.BaseRenewableCertTest):
     @test_util.patch_get_utility()
     @mock.patch('certbot._internal.cert_manager.lineage_for_certname')
     @mock.patch('certbot._internal.storage.delete_files')
-    def test_delete_interactive_single(self, mock_delete_files, mock_lineage_for_certname,
+    def test_delete_from_config_no(self, mock_delete_files, mock_lineage_for_certname,
+        mock_util):
+        """Test delete"""
+        mock_lineage_for_certname.return_value = self.test_rc
+        mock_util().yesno.return_value = False
+        self.config.certname = "example.org"
+        self._call()
+        self.assertEqual(mock_delete_files.call_count, 0)
+
+    @test_util.patch_get_utility()
+    @mock.patch('certbot._internal.cert_manager.lineage_for_certname')
+    @mock.patch('certbot._internal.storage.delete_files')
+    def test_delete_interactive_single_yes(self, mock_delete_files, mock_lineage_for_certname,
         mock_util):
         """Test delete"""
         mock_lineage_for_certname.return_value = self.test_rc
         mock_util().checklist.return_value = (display_util.OK, ["example.org"])
+        mock_util().yesno.return_value = True
         self._call()
         mock_delete_files.assert_called_once_with(self.config, "example.org")
 
     @test_util.patch_get_utility()
     @mock.patch('certbot._internal.cert_manager.lineage_for_certname')
     @mock.patch('certbot._internal.storage.delete_files')
-    def test_delete_interactive_multiple(self, mock_delete_files, mock_lineage_for_certname,
+    def test_delete_interactive_single_no(self, mock_delete_files, mock_lineage_for_certname,
+        mock_util):
+        """Test delete"""
+        mock_lineage_for_certname.return_value = self.test_rc
+        mock_util().checklist.return_value = (display_util.OK, ["example.org"])
+        mock_util().yesno.return_value = False
+        self._call()
+        self.assertEqual(mock_delete_files.call_count, 0)
+
+    @test_util.patch_get_utility()
+    @mock.patch('certbot._internal.cert_manager.lineage_for_certname')
+    @mock.patch('certbot._internal.storage.delete_files')
+    def test_delete_interactive_multiple_yes(self, mock_delete_files, mock_lineage_for_certname,
         mock_util):
         """Test delete"""
         mock_lineage_for_certname.return_value = self.test_rc
         mock_util().checklist.return_value = (display_util.OK, ["example.org", "other.org"])
+        mock_util().yesno.return_value = True
         self._call()
         mock_delete_files.assert_any_call(self.config, "example.org")
         mock_delete_files.assert_any_call(self.config, "other.org")
         self.assertEqual(mock_delete_files.call_count, 2)
+
+    @test_util.patch_get_utility()
+    @mock.patch('certbot._internal.cert_manager.lineage_for_certname')
+    @mock.patch('certbot._internal.storage.delete_files')
+    def test_delete_interactive_multiple_no(self, mock_delete_files, mock_lineage_for_certname,
+        mock_util):
+        """Test delete"""
+        mock_lineage_for_certname.return_value = self.test_rc
+        mock_util().checklist.return_value = (display_util.OK, ["example.org", "other.org"])
+        mock_util().yesno.return_value = False
+        self._call()
+        self.assertEqual(mock_delete_files.call_count, 0)
 
 
 class CertificatesTest(BaseCertManagerTest):

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -661,7 +661,7 @@ class GetCertnameTest(unittest.TestCase):
         mock_files.return_value = ['example.com.conf']
         mock_name.return_value = 'example.com'
         from certbot._internal import cert_manager
-        prompt = "Which certificate(s) would you"
+        prompt = "Which certificate or certificates would you"
         self.mock_get_utility().checklist.return_value = (display_util.OK,
                                                           ['example.com'])
         self.assertEqual(

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -661,7 +661,7 @@ class GetCertnameTest(unittest.TestCase):
         mock_files.return_value = ['example.com.conf']
         mock_name.return_value = 'example.com'
         from certbot._internal import cert_manager
-        prompt = "Which certificate or certificates would you"
+        prompt = "Which certificate(s) would you"
         self.mock_get_utility().checklist.return_value = (display_util.OK,
                                                           ['example.com'])
         self.assertEqual(


### PR DESCRIPTION
Fixes #8347, #8348

Not sure about:

* The indenting and marking of the listing of the to be removed certificates. Two spaces with an asterisk seemed logical to *me* personally, but other opinions or established routines might prevail.
* The added tests keep the `cert_manager.py` coverage at the same level, but please, take a good look if I at least did a decent job with those things.. I am *not* a fan of writing, errr, hacking and copy/pasting together those things.