### PR TITLE
Give DNS plugin snaps grade stable

### DIFF
--- a/certbot-dns-cloudflare/snap/snapcraft.yaml
+++ b/certbot-dns-cloudflare/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-cloudflare
 summary: Cloudflare DNS Authenticator plugin for Certbot
 description: Cloudflare DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-cloudflare
 

--- a/certbot-dns-cloudxns/snap/snapcraft.yaml
+++ b/certbot-dns-cloudxns/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-cloudxns
 summary: CloudXNS DNS Authenticator plugin for Certbot
 description: CloudXNS DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-cloudxns
 

--- a/certbot-dns-digitalocean/snap/snapcraft.yaml
+++ b/certbot-dns-digitalocean/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-digitalocean
 summary: DigitalOcean DNS Authenticator plugin for Certbot
 description: DigitalOcean DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-digitalocean
 

--- a/certbot-dns-dnsimple/snap/snapcraft.yaml
+++ b/certbot-dns-dnsimple/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-dnsimple
 summary: DNSimple DNS Authenticator plugin for Certbot
 description: DNSimple DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-dnsimple
 

--- a/certbot-dns-dnsmadeeasy/snap/snapcraft.yaml
+++ b/certbot-dns-dnsmadeeasy/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-dnsmadeeasy
 summary: DNS Made Easy DNS Authenticator plugin for Certbot
 description: DNS Made Easy DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-dnsmadeeasy
 

--- a/certbot-dns-gehirn/snap/snapcraft.yaml
+++ b/certbot-dns-gehirn/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-gehirn
 summary: Gehirn Infrastructure Service DNS Authenticator plugin for Certbot
 description: Gehirn Infrastructure Service DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-gehirn
 

--- a/certbot-dns-google/snap/snapcraft.yaml
+++ b/certbot-dns-google/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-google
 summary: Google Cloud DNS Authenticator plugin for Certbot
 description: Google Cloud DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-google
 

--- a/certbot-dns-linode/snap/snapcraft.yaml
+++ b/certbot-dns-linode/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-linode
 summary: Linode DNS Authenticator plugin for Certbot
 description: Linode DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-linode
 

--- a/certbot-dns-luadns/snap/snapcraft.yaml
+++ b/certbot-dns-luadns/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-luadns
 summary: LuaDNS Authenticator plugin for Certbot
 description: LuaDNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-luadns
 

--- a/certbot-dns-nsone/snap/snapcraft.yaml
+++ b/certbot-dns-nsone/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-nsone
 summary: NS1 DNS Authenticator plugin for Certbot
 description: NS1 DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-nsone
 

--- a/certbot-dns-ovh/snap/snapcraft.yaml
+++ b/certbot-dns-ovh/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-ovh
 summary: OVH DNS Authenticator plugin for Certbot
 description: OVH DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-ovh
 

--- a/certbot-dns-rfc2136/snap/snapcraft.yaml
+++ b/certbot-dns-rfc2136/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-rfc2136
 summary: RFC 2136 DNS Authenticator plugin for Certbot
 description: RFC 2136 DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-rfc2136
 

--- a/certbot-dns-route53/snap/snapcraft.yaml
+++ b/certbot-dns-route53/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-route53
 summary: Route53 DNS Authenticator plugin for Certbot
 description: Route53 DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-route53
 

--- a/certbot-dns-sakuracloud/snap/snapcraft.yaml
+++ b/certbot-dns-sakuracloud/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ name: certbot-dns-sakuracloud
 summary: Sakura Cloud DNS Authenticator plugin for Certbot
 description: Sakura Cloud DNS Authenticator plugin for Certbot
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: certbot-dns-sakuracloud
 

--- a/tools/snap/generate_dnsplugins_snapcraft.sh
+++ b/tools/snap/generate_dnsplugins_snapcraft.sh
@@ -15,7 +15,7 @@ name: ${PLUGIN}
 summary: ${DESCRIPTION}
 description: ${DESCRIPTION}
 confinement: strict
-grade: devel
+grade: stable
 base: core20
 adopt-info: ${PLUGIN}
 


### PR DESCRIPTION
With more and more of our wildcard instructions on https://certbot.eff.org telling people to use these plugins, I think we should get ready to move our DNS plugins to the stable channel. This PR removes `grade: devel` so the snap store doesn't prevent us from doing that when we want to. See https://github.com/certbot/certbot/pull/8128 where we did this to the Certbot snap for more info.

You can see the snap tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2797&view=results.