### PR TITLE
Fix renewal config not found error message

### DIFF
--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -50,7 +50,7 @@ def renewal_file_for_certname(config, certname):
     """Return /path/to/certname.conf in the renewal conf directory"""
     path = os.path.join(config.renewal_configs_dir, "{0}.conf".format(certname))
     if not os.path.exists(path):
-        raise errors.CertStorageError("No certificate found with name {0} (expected "
+        raise errors.CertStorageError("No renewal config found with name {0} (expected "
             "{1}).".format(certname, path))
     return path
 


### PR DESCRIPTION
It's the renewal config that was not found, not certificate.

## Pull Request Checklist

- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Include your name in `AUTHORS.md` if you like.
