### PR TITLE
Add dns-lightsail as third-party plugin

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -281,6 +281,7 @@ proxmox_           N    Y    Install certificates in Proxmox Virtualization serv
 dns-standalone_    Y    N    Obtain certificates via an integrated DNS server
 dns-ispconfig_     Y    N    DNS Authentication using ISPConfig as DNS server
 dns-clouddns_      Y    N    DNS Authentication using CloudDNS API
+dns-lightsail_     Y    N    DNS Authentication using Amazon Lightsail DNS API
 dns-inwx           Y    Y    DNS Authentication for INWX through the XML API
 ================== ==== ==== ===============================================================
 
@@ -294,6 +295,7 @@ dns-inwx           Y    Y    DNS Authentication for INWX through the XML API
 .. _dns-standalone: https://github.com/siilike/certbot-dns-standalone
 .. _dns-ispconfig: https://github.com/m42e/certbot-dns-ispconfig
 .. _dns-clouddns: https://github.com/vshosting/certbot-dns-clouddns
+.. _dns-lightsail: https://github.com/noi/certbot-dns-lightsail
 .. _dns-inwx: https://github.com/oGGy990/certbot-dns-inwx/
 
 If you're interested, you can also :ref:`write your own plugin <dev-plugin>`.


### PR DESCRIPTION
Hi, I made authenticator plugin for [Amazon Lightsail](https://aws.amazon.com/lightsail/) DNS:
https://github.com/noi/certbot-dns-lightsail

So I want to add it to third-party plugins in document if there is no problem.

Thank you.

## Pull Request Checklist
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Include your name in `AUTHORS.md` if you like.
