### PR TITLE
Enable dns-inwx link in third-party plugins

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -282,7 +282,7 @@ dns-standalone_    Y    N    Obtain certificates via an integrated DNS server
 dns-ispconfig_     Y    N    DNS Authentication using ISPConfig as DNS server
 dns-clouddns_      Y    N    DNS Authentication using CloudDNS API
 dns-lightsail_     Y    N    DNS Authentication using Amazon Lightsail DNS API
-dns-inwx           Y    Y    DNS Authentication for INWX through the XML API
+dns-inwx_          Y    Y    DNS Authentication for INWX through the XML API
 ================== ==== ==== ===============================================================
 
 .. _haproxy: https://github.com/greenhost/certbot-haproxy


### PR DESCRIPTION
Hi, I found one of the mistakes in document.
`dns-inwx` link is not enabled in third-party plugins, but I think the author forgot to add an underscore as suffix because he had written an URL to his repository.

Please refer to https://github.com/certbot/certbot/pull/8115/files if you need it.

## Pull Request Checklist
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Include your name in `AUTHORS.md` if you like.
