### PR TITLE
Fix typo in example cli.ini

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -255,6 +255,7 @@ Authors
 * [Torsten Bögershausen](https://github.com/tboegi)
 * [Travis Raines](https://github.com/rainest)
 * [Trung Ngo](https://github.com/Ngo-The-Trung)
+* [Tyler Durr](https://github.com/TDurrr1)
 * [Valentin](https://github.com/e00E)
 * [venyii](https://github.com/venyii)
 * [Viktor Szakats](https://github.com/vszakats)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,7 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* The example config file contained an `rsa-key-size` key. This has been fixed to `rsa_key_size`.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/examples/cli.ini
+++ b/certbot/examples/cli.ini
@@ -8,7 +8,7 @@
 # here.
 
 # Use a 4096 bit RSA key instead of 2048
-rsa-key-size = 4096
+rsa_key_size = 4096
 
 # Uncomment and update to register with the specified e-mail address
 # email = foo@example.com


### PR DESCRIPTION
## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Include your name in `AUTHORS.md` if you like.

There was a typo in certbot/examples/cli.ini. The key `rsa-key-size` should be `rsa_key_size`.