### PR TITLE
Use `dd` instead of `fallocate`

### DIFF
--- a/certbot/docs/install.rst
+++ b/certbot/docs/install.rst
@@ -136,7 +136,7 @@ On a low memory system such as VPS with less than 512MB of RAM, the required dep
 This can be identified if the pip outputs contains something like ``internal compiler error: Killed (program cc1)``.
 You can workaround this restriction by creating a temporary swapfile::
 
-  user@webserver:~$ sudo fallocate -l 1G /tmp/swapfile
+  user@webserver:~$ sudo dd if=/dev/zero of=/tmp/swapfile bs=1M count=1024
   user@webserver:~$ sudo chmod 600 /tmp/swapfile
   user@webserver:~$ sudo mkswap /tmp/swapfile
   user@webserver:~$ sudo swapon /tmp/swapfile


### PR DESCRIPTION
The [`swapon` man page](https://manpages.debian.org/buster/mount/swapon.8.en.html) recommends not to use `fallocate` to create swap files but to use `dd` instead:
>The swap file implementation in the kernel expects to be able to write to the file directly, without the assistance of the filesystem. This is a problem on preallocated files (e.g. fallocate(1)) on filesystems like XFS or ext4, and on copy-on-write filesystems like btrfs.
>
>It is recommended to use dd(1) and /dev/zero to avoid holes on XFS and ext4.