### PR TITLE
cli: miscellaneous IReporter removals

### DIFF
--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -100,8 +100,7 @@ def delete(config):
         return
     for certname in certnames:
         storage.delete_files(config, certname)
-        disp.notification("Deleted all files relating to certificate {0}."
-            .format(certname), pause=False)
+        logger.info("Deleted all files relating to certificate %s.", certname)
 
 ###################
 # Public Helpers

--- a/certbot/certbot/_internal/eff.py
+++ b/certbot/certbot/_internal/eff.py
@@ -133,5 +133,4 @@ def _report_failure(reason=None):
         msg.append(' because ')
         msg.append(reason)
     msg.append('. You can try again later by visiting https://act.eff.org.')
-    reporter = zope.component.getUtility(interfaces.IReporter)
-    reporter.add_message(''.join(msg), reporter.LOW_PRIORITY)
+    logger.warning("".join(msg))

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -163,17 +163,13 @@ def _handle_subset_cert_request(config, domains, cert):
                                        cli_flag="--expand",
                                        force_interactive=True):
         return "renew", cert
-    reporter_util = zope.component.getUtility(interfaces.IReporter)
-    reporter_util.add_message(
+    logger.info(
         "To obtain a new certificate that contains these names without "
-        "replacing your existing certificate for {0}, you must use the "
-        "--duplicate option.{br}{br}"
-        "For example:{br}{br}{1} --duplicate {2}".format(
-            existing,
-            sys.argv[0], " ".join(sys.argv[1:]),
-            br=os.linesep
-        ),
-        reporter_util.HIGH_PRIORITY)
+        "replacing your existing certificate for %s, you must use the "
+        "--duplicate option. For example:\n\n"
+        "  %s --duplicate %s\n",
+        existing, sys.argv[0], " ".join(sys.argv[1:])
+    )
     raise errors.Error(USER_CANCELLED)
 
 
@@ -623,7 +619,6 @@ def unregister(config, unused_plugins):
     """
     account_storage = account.AccountFileStorage(config)
     accounts = account_storage.find_all()
-    reporter_util = zope.component.getUtility(interfaces.IReporter)
 
     if not accounts:
         return "Could not find existing account to deactivate."
@@ -645,7 +640,7 @@ def unregister(config, unused_plugins):
     # delete local account files
     account_files.delete(config.account)
 
-    reporter_util.add_message("Account deactivated.", reporter_util.MEDIUM_PRIORITY)
+    logger.info("Account deactivated.")
     return None
 
 
@@ -696,8 +691,6 @@ def update_account(config, unused_plugins):
     # exist or not.
     account_storage = account.AccountFileStorage(config)
     accounts = account_storage.find_all()
-    reporter_util = zope.component.getUtility(interfaces.IReporter)
-    add_msg = lambda m: reporter_util.add_message(m, reporter_util.MEDIUM_PRIORITY)
 
     if not accounts:
         return "Could not find an existing account to update."
@@ -722,10 +715,10 @@ def update_account(config, unused_plugins):
     account_storage.update_regr(acc, cb_client.acme)
 
     if config.email is None:
-        add_msg("Any contact information associated with this account has been removed.")
+        logger.info("Any contact information associated with this account has been removed.")
     else:
         eff.prepare_subscription(config, acc)
-        add_msg("Your e-mail address was updated to {0}.".format(config.email))
+        logger.info("Your e-mail address was updated to %s.", config.email)
 
     return None
 

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -543,7 +543,6 @@ def _delete_if_appropriate(config):
         archive dir is found for the specified lineage, etc ...
     """
     display = zope.component.getUtility(interfaces.IDisplay)
-    reporter_util = zope.component.getUtility(interfaces.IReporter)
 
     attempt_deletion = config.delete_after_revoke
     if attempt_deletion is None:
@@ -553,7 +552,6 @@ def _delete_if_appropriate(config):
                 force_interactive=True, default=True)
 
     if not attempt_deletion:
-        reporter_util.add_message("Not deleting revoked certs.", reporter_util.LOW_PRIORITY)
         return
 
     # config.cert_path must have been set
@@ -571,9 +569,8 @@ def _delete_if_appropriate(config):
         cert_manager.match_and_check_overlaps(config, [lambda x: archive_dir],
             lambda x: x.archive_dir, lambda x: x)
     except errors.OverlappingMatchFound:
-        msg = ('Not deleting revoked certs due to overlapping archive dirs. More than '
-                'one lineage is using {0}'.format(archive_dir))
-        reporter_util.add_message(''.join(msg), reporter_util.MEDIUM_PRIORITY)
+        logger.warning("Not deleting revoked certs due to overlapping archive dirs. More than "
+                       "one certificate is using %s", archive_dir)
         return
     except Exception as e:
         msg = ('config.default_archive_dir: {0}, config.live_dir: {1}, archive_dir: {2},'
@@ -1067,7 +1064,11 @@ def revoke(config, unused_plugins):
     except acme_errors.ClientError as e:
         return str(e)
 
-    display_ops.success_revocation(config.cert_path[0])
+    logger.info(
+        "Congratulations! You have successfully revoked "
+        "the certificate that was located at %s",
+        config.cert_path[0]
+    )
     return None
 
 

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -261,20 +261,6 @@ def success_renewal(domains):
         pause=False)
 
 
-def success_revocation(cert_path):
-    """Display a box confirming a certificate has been revoked.
-
-    :param list cert_path: path to certificate which was revoked.
-
-    """
-    z_util(interfaces.IDisplay).notification(
-        "Congratulations! You have successfully revoked the certificate "
-        "that was located at {0}{1}{1}".format(
-            cert_path,
-            os.linesep),
-        pause=False)
-
-
 def _gen_https_names(domains):
     """Returns a string of the https domains.
 

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -376,25 +376,6 @@ class SuccessRenewalTest(unittest.TestCase):
         for name in names:
             self.assertTrue(name in arg)
 
-class SuccessRevocationTest(unittest.TestCase):
-    """Test the success revocation message."""
-    @classmethod
-    def _call(cls, path):
-        from certbot.display.ops import success_revocation
-        success_revocation(path)
-
-    @test_util.patch_get_utility("certbot.display.ops.z_util")
-    def test_success_revocation(self, mock_util):
-        mock_util().notification.return_value = None
-        path = "/path/to/cert.pem"
-        self._call(path)
-        mock_util().notification.assert_called_once_with(
-            "Congratulations! You have successfully revoked the certificate "
-            "that was located at {0}{1}{1}".format(
-                path,
-                os.linesep), pause=False)
-        self.assertTrue(path in mock_util().notification.call_args[0][0])
-
 
 class ValidatorTests(unittest.TestCase):
     """Tests for `validated_input` and `validated_directory`."""

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -380,7 +380,7 @@ class DeleteIfAppropriateTest(test_util.ConfigTestCase):
         mock_match_and_check_overlaps.side_effect = errors.OverlappingMatchFound()
         self._call(config)
         mock_delete.assert_not_called()
-        mock_warning.assert_called_once()
+        self.assertEqual(mock_warning.call_count, 1)
 
     @mock.patch('certbot._internal.storage.renewal_file_for_certname')
     @mock.patch('certbot._internal.cert_manager.match_and_check_overlaps')


### PR DESCRIPTION
Per #8331 and UX discussions ([1](https://docs.google.com/document/d/1aKnQYEzCrZgYX-iuE-ErOdIKERUuLmZSX_BDb7d0M6I/edit?usp=sharing), [2](https://docs.google.com/document/d/1viiuYQafSxrTQtBI2a1_p3Q_IBVDAZAw8xkSWOQglHM/edit?usp=sharing)), we are ditching the `IReporter` mechanism and inlining the output.

This PR addresses some of the easier to change, standalone instances. The remainder will come as part of a larger changeset, in order to prevent bifurcating the output of e.g. `certbot run` too much.

This PR covers:

- Changing `certbot delete` and `certbot revoke` to use `logger` instead of `IReporter` and `IDisplay`. Also removes some superfluous output.
- Changes the EFF subscription error message to use `logger` instead of `IReporter`
- Changes `certbot unregister` to use `logger` instead of `IReporter` to report success
- Changes `certbot update_account` to use `logger` instead of `IReporter` to report success
- Changes the expand/duplicate prompt of `certbot run` to use `logger` instead of `IReporter`