### PR TITLE
Execute basic integration tests against Certbot dockers during CI

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -45,9 +45,9 @@ jobs:
         displayName: Load Docker images
       - bash: |
           set -e
-          DOCKER_IMAGES=$(docker images --filter reference='*/certbot' --filter reference='*/dns-*' --format '{{.Repository}}')
-          for DOCKER_IMAGE in $DOCKER_IMAGES
-            do docker run --rm $DOCKER_IMAGE plugin --prepare
+          DOCKER_IMAGES=$(docker images --filter reference='*/certbot' --filter reference='*/dns-*' --format '{{.Repository}}:{{.Tag}}')
+          for DOCKER_IMAGE in ${DOCKER_IMAGES}
+            do docker run --rm "${DOCKER_IMAGE}:amd64-nightly" plugin --prepare
           done
   - job: installer_build
     pool:

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -46,7 +46,7 @@ jobs:
       - bash: |
           set -e
           DOCKER_IMAGES=$(docker images --filter reference='*/certbot' --filter reference='*/dns-*' --format '{{.Repository}}')
-          for $DOCKER_IMAGE in DOCKER_IMAGES
+          for DOCKER_IMAGE in $DOCKER_IMAGES
             do docker run --rm $DOCKER_IMAGE plugin --prepare
           done
   - job: installer_build

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -44,10 +44,10 @@ jobs:
       - bash: set -e && docker load --input $(Build.SourcesDirectory)/images.tar
         displayName: Load Docker images
       - bash: |
-          set -e
+          set -ex
           DOCKER_IMAGES=$(docker images --filter reference='*/certbot' --filter reference='*/dns-*' --format '{{.Repository}}:{{.Tag}}')
           for DOCKER_IMAGE in ${DOCKER_IMAGES}
-            do docker run --rm "${DOCKER_IMAGE}:amd64-nightly" plugin --prepare
+            do docker run --rm "${DOCKER_IMAGE}" plugin --prepare
           done
   - job: installer_build
     pool:

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -49,6 +49,7 @@ jobs:
           for DOCKER_IMAGE in ${DOCKER_IMAGES}
             do docker run --rm "${DOCKER_IMAGE}" plugins --prepare
           done
+        displayName: Run integration tests for Docker images
   - job: installer_build
     pool:
       vmImage: vs2017-win2016

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -47,7 +47,7 @@ jobs:
           set -ex
           DOCKER_IMAGES=$(docker images --filter reference='*/certbot' --filter reference='*/dns-*' --format '{{.Repository}}:{{.Tag}}')
           for DOCKER_IMAGE in ${DOCKER_IMAGES}
-            do docker run --rm "${DOCKER_IMAGE}" plugin --prepare
+            do docker run --rm "${DOCKER_IMAGE}" plugins --prepare
           done
   - job: installer_build
     pool:

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -31,6 +31,24 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)
           artifact: docker_$(DOCKER_ARCH)
         displayName: Store Docker artifact
+  - job: docker_run
+    dependsOn: docker_build
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifact: docker_amd64
+          path: $(Build.SourcesDirectory)
+        displayName: Retrieve Docker images
+      - bash: set -e && docker load --input $(Build.SourcesDirectory)/images.tar
+        displayName: Load Docker images
+      - bash: |
+          set -e
+          DOCKER_IMAGES=$(docker images --filter reference='*/certbot' --filter reference='*/dns-*' --format '{{.Repository}}')
+          for $DOCKER_IMAGE in DOCKER_IMAGES
+            do docker run --rm $DOCKER_IMAGE plugin --prepare
+          done
   - job: installer_build
     pool:
       vmImage: vs2017-win2016


### PR DESCRIPTION
Fixes #8202

This PR adds an Azure Pipeline job to execute `certbot plugins --prepare` for each Docker image created during the CI on `amd64`.