### PR TITLE
Fix Windows installer tests

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -103,7 +103,7 @@ jobs:
       # a recent version of pip, but we also to disable the isolated feature as described in
       # https://github.com/certbot/certbot/issues/8256
       - script: |
-          py -3 -m venv venv
+          python -m venv venv
           venv\Scripts\python -m pip install pip==20.2.3 setuptools==50.3.0 wheel==0.35.1
           venv\Scripts\python tools\pip_install.py -e certbot-ci
         env:


### PR DESCRIPTION
[Windows installer tests failed last night](https://dev.azure.com/certbot/certbot/_build/results?buildId=2916&view=results) because they suddenly switched to Python 3.9. See [here](https://dev.azure.com/certbot/certbot/_build/results?buildId=2918&view=logs&j=253b2422-a4e1-591a-b15c-71c2950d5206&t=aa6f1083-b4b0-5a08-0737-88d42ebe7ec7&l=12) where I modified the tests to print the Python version used.

This is happening despite https://github.com/certbot/certbot/blob/bf07ec20b0096912fb02759f25923b9091643b63/.azure-pipelines/templates/jobs/packaging-jobs.yml#L92-L95 just a few lines earlier than what I modified in the PR here.

I think what's going on is `py -3` is finding and preferring the newer version of Python 3, Python 3.9, which was [just recently added to the image](https://github.com/actions/virtual-environments/issues/1740#issuecomment-717849233).

The [documentation for UsePythonVersion](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/use-python-version?view=azure-devops) says that:

> After running this task with "Add to PATH," the `python` command in subsequent scripts will be for the highest available version of the interpreter matching the version spec and architecture.

So let's just use `python` instead of `py`. You can see the tests running with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2921&view=results.