### PR TITLE
Add Ubuntu 20.10 test farm tests

### DIFF
--- a/certbot-apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/tests/apache-conf-files/apache-conf-test
@@ -52,7 +52,7 @@ function Cleanup() {
 # if our environment asks us to enable modules, do our best!
 if [ "$1" = --debian-modules ] ; then
     sudo apt-get install -y apache2
-    sudo apt-get install -y libapache2-mod-wsgi
+    sudo apt-get install -y libapache2-mod-wsgi-py3
     sudo apt-get install -y libapache2-mod-macro
 
     for mod in  ssl rewrite macro wsgi deflate userdir version mime setenvif ; do

--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -3,6 +3,11 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
+  - ami: ami-0f2e2c076f4c2f941
+    name: ubuntu20.10
+    type: ubuntu
+    virt: hvm
+    user: ubuntu
   - ami: ami-0758470213bdd23b1
     name: ubuntu20.04
     type: ubuntu

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -3,6 +3,11 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
+  - ami: ami-0f2e2c076f4c2f941
+    name: ubuntu20.10
+    type: ubuntu
+    virt: hvm
+    user: ubuntu
   - ami: ami-0758470213bdd23b1
     name: ubuntu20.04
     type: ubuntu


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8400.

I had to switch the package installed in `apacheconftest` to `libapache2-mod-wsgi-py3` because Ubuntu 20.10 removed the Python 2 version of this module.

I didn't add this AMI to `tests/letstest/auto_targets.yaml` because like Ubuntu 20.04, `certbot-auto` has never worked on the OS.

You can see the relevant tests running at https://dev.azure.com/certbot/certbot/_build/results?buildId=2925&view=results.