### PR TITLE
Remove fedora test farm tests

### DIFF
--- a/tests/letstest/apache2_targets.yaml
+++ b/tests/letstest/apache2_targets.yaml
@@ -37,18 +37,6 @@ targets:
     virt: hvm
     user: admin
   #-----------------------------------------------------------------------------
-  # Fedora
-  - ami: ami-0fcbe88944a53b4c8
-    name: fedora31
-    type: centos
-    virt: hvm
-    user: fedora
-  - ami: ami-00bbc6858140f19ed
-    name: fedora30
-    type: centos
-    virt: hvm
-    user: fedora
-  #-----------------------------------------------------------------------------
   # CentOS
   - ami: ami-9887c6e7
     name: centos7

--- a/tests/letstest/auto_targets.yaml
+++ b/tests/letstest/auto_targets.yaml
@@ -47,16 +47,6 @@ targets:
     type: centos
     virt: hvm
     user: ec2-user
-  - ami: ami-0fcbe88944a53b4c8
-    name: fedora31
-    type: centos
-    virt: hvm
-    user: fedora
-  - ami: ami-00bbc6858140f19ed
-    name: fedora30
-    type: centos
-    virt: hvm
-    user: fedora
   #-----------------------------------------------------------------------------
   # CentOS
   # These Marketplace AMIs must, irritatingly, have their terms manually

--- a/tests/letstest/targets.yaml
+++ b/tests/letstest/targets.yaml
@@ -38,16 +38,6 @@ targets:
     type: centos
     virt: hvm
     user: ec2-user
-  - ami: ami-0fcbe88944a53b4c8
-    name: fedora31
-    type: centos
-    virt: hvm
-    user: fedora
-  - ami: ami-00bbc6858140f19ed
-    name: fedora30
-    type: centos
-    virt: hvm
-    user: fedora
   #-----------------------------------------------------------------------------
   # CentOS
   # These Marketplace AMIs must, irritatingly, have their terms manually


### PR DESCRIPTION
While working on https://github.com/certbot/certbot/issues/8400, I noticed our Fedora AMIs are quite out of date. I considered updating them and what we could do to avoid the AMIs becoming so out-of-date in the future, but I think we don't actually need these tests.

I pulled a new count of Certbot users by OS and we have less than 7,000 Fedora users meaning only ~0.26% of Certbot users run Fedora. (I think Fedora is a popular desktop OS, but not as popular of a server OS which is where Certbot normally runs.)

Also, Certbot is regularly updated on Fedora including Fedora Rawhide or the rolling release version of Fedora which is similar to Debian sid/unstable. Rawhide changes far too frequently for it to make sense for us to run tests there in my opinon, but that also means that many problems such as Certbot's unit tests failing to run because of Fedora changes will be caught there by our Fedora maintainers before we'd even see it. This is how https://github.com/certbot/certbot/issues/7106 became an issue and how I learned [Certbot worked on Python 3.9 before we could run tests on it](https://github.com/certbot/certbot/issues/8134#issuecomment-655106169).

Because of all this, I think we should just simplify things and remove these tests. If a problem arises in the future, we can always add them back.

You can see the test farm tests passing with these changes at https://dev.azure.com/certbot/certbot/_build/results?buildId=2927&view=results.