### PR TITLE
Remove python_version setting from mypy.ini

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -201,7 +201,7 @@ class ClientBase(object):
             when = parsedate_tz(retry_after)
             if when is not None:
                 try:
-                    tz_secs = datetime.timedelta(when[-1] if when[-1] else 0)
+                    tz_secs = datetime.timedelta(when[-1] if when[-1] is not None else 0)
                     return datetime.datetime(*when[:7]) - tz_secs
                 except (ValueError, OverflowError):
                     pass

--- a/acme/acme/magic_typing.py
+++ b/acme/acme/magic_typing.py
@@ -12,4 +12,5 @@ try:
     from typing import *  # pylint: disable=wildcard-import, unused-wildcard-import
     from typing import Collection, IO  # type: ignore
 except ImportError:
-    sys.modules[__name__] = TypingClass()
+    # mypy complains because TypingClass is not a module
+    sys.modules[__name__] = TypingClass()  # type: ignore

--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -9,7 +9,6 @@ import re
 import socket
 import time
 
-import six
 import zope.component
 import zope.interface
 try:
@@ -464,21 +463,6 @@ class ApacheConfigurator(common.Installer):
             metadata=metadata
         )
 
-    def _wildcard_domain(self, domain):
-        """
-        Checks if domain is a wildcard domain
-
-        :param str domain: Domain to check
-
-        :returns: If the domain is wildcard domain
-        :rtype: bool
-        """
-        if isinstance(domain, six.text_type):
-            wildcard_marker = u"*."
-        else:
-            wildcard_marker = b"*."
-        return domain.startswith(wildcard_marker)
-
     def deploy_cert(self, domain, cert_path, key_path,
                     chain_path=None, fullchain_path=None):
         """Deploys certificate to specified virtual host.
@@ -513,7 +497,7 @@ class ApacheConfigurator(common.Installer):
         :rtype: `list` of :class:`~certbot_apache._internal.obj.VirtualHost`
         """
 
-        if self._wildcard_domain(domain):
+        if util.is_wildcard_domain(domain):
             if domain in self._wildcard_vhosts:
                 # Vhosts for a wildcard domain were already selected
                 return self._wildcard_vhosts[domain]

--- a/certbot-apache/tests/configurator_test.py
+++ b/certbot-apache/tests/configurator_test.py
@@ -1337,13 +1337,6 @@ class MultipleVhostsTest(util.ApacheTest):
                           self.config.enable_mod,
                           "whatever")
 
-    def test_wildcard_domain(self):
-        # pylint: disable=protected-access
-        cases = {u"*.example.org": True, b"*.x.example.org": True,
-                 u"a.example.org": False, b"a.x.example.org": False}
-        for key in cases:
-            self.assertEqual(self.config._wildcard_domain(key), cases[key])
-
     def test_choose_vhosts_wildcard(self):
         # pylint: disable=protected-access
         mock_path = "certbot_apache._internal.display_ops.select_vhost_multiple"

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
@@ -69,11 +69,10 @@ class Proxy(object):
         shutil.copy(cert_path, cert)
         key = os.path.join(cert_and_key_dir, "key")
         shutil.copy(key_path, key)
+        chain = None
         if chain_path:
             chain = os.path.join(cert_and_key_dir, "chain")
             shutil.copy(chain_path, chain)
-        else:
-            chain = None
 
         return cert, key, chain
 

--- a/certbot-compatibility-test/certbot_compatibility_test/validator.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/validator.py
@@ -18,7 +18,7 @@ class Validator(object):
     def certificate(self, cert, name, alt_host=None, port=443):
         """Verifies the certificate presented at name is cert"""
         if alt_host is None:
-            host = socket.gethostbyname(name)
+            host = socket.gethostbyname(name).encode()
         elif isinstance(alt_host, six.binary_type):
             host = alt_host
         else:

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -16,6 +16,7 @@ from acme import crypto_util as acme_crypto_util
 from acme.magic_typing import Dict
 from acme.magic_typing import List
 from acme.magic_typing import Set
+from acme.magic_typing import Text
 from certbot import crypto_util
 from certbot import errors
 from certbot import interfaces
@@ -1175,7 +1176,7 @@ def nginx_restart(nginx_ctl, nginx_conf, sleep_duration):
 
     """
     try:
-        reload_output = "" # type: unicode
+        reload_output = u"" # type: Text
         with tempfile.TemporaryFile() as out:
             proc = subprocess.Popen([nginx_ctl, "-c", nginx_conf, "-s", "reload"],
                                     env=util.env_no_snap_for_external_calls(),

--- a/certbot/certbot/_internal/lock.py
+++ b/certbot/certbot/_internal/lock.py
@@ -235,7 +235,11 @@ class _WindowsLockMechanism(_BaseLockMechanism):
             # Under Windows, filesystem.open will raise directly an EACCES error
             # if the lock file is already locked.
             fd = filesystem.open(self._path, open_mode, 0o600)
-            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            # The need for this "type: ignore" was fixed in
+            # https://github.com/python/typeshed/pull/3607 and included in
+            # newer versions of mypy so it can be removed when mypy is
+            # upgraded.
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)  # type: ignore
         except (IOError, OSError) as err:
             if fd:
                 os.close(fd)
@@ -250,7 +254,11 @@ class _WindowsLockMechanism(_BaseLockMechanism):
     def release(self):
         """Release the lock."""
         try:
-            msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
+            # The need for this "type: ignore" was fixed in
+            # https://github.com/python/typeshed/pull/3607 and included in
+            # newer versions of mypy so it can be removed when mypy is
+            # upgraded.
+            msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)  # type: ignore
             os.close(self._fd)
 
             try:

--- a/certbot/certbot/_internal/plugins/disco.py
+++ b/certbot/certbot/_internal/plugins/disco.py
@@ -234,6 +234,9 @@ class PluginsRegistry(Mapping):
                 constants.OLD_SETUPTOOLS_PLUGINS_ENTRY_POINT),)
         for entry_point in entry_points:
             plugin_ep = cls._load_entry_point(entry_point, plugins, with_prefix=False)
+            # entry_point.dist cannot be None here, we would have blown up
+            # earlier, however, this assertion is needed for mypy.
+            assert entry_point.dist is not None
             if entry_point.dist.key not in PREFIX_FREE_DISTRIBUTIONS:
                 prefixed_plugin_ep = cls._load_entry_point(entry_point, plugins, with_prefix=True)
                 prefixed_plugin_ep.hidden = True

--- a/certbot/certbot/_internal/reporter.py
+++ b/certbot/certbot/_internal/reporter.py
@@ -34,7 +34,7 @@ class Reporter(object):
     _msg_type = collections.namedtuple('ReporterMsg', 'priority text on_crash')
 
     def __init__(self, config):
-        self.messages = queue.PriorityQueue()
+        self.messages = queue.PriorityQueue()  # type: queue.PriorityQueue[Reporter._msg_type]
         self.config = config
 
     def add_message(self, msg, priority, on_crash=True):

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -25,6 +25,7 @@ import zope.component
 
 from acme import crypto_util as acme_crypto_util
 from acme.magic_typing import IO  # pylint: disable=unused-import
+from acme.magic_typing import Union  # pylint: disable=unused-import
 from certbot import errors
 from certbot import interfaces
 from certbot import util
@@ -455,7 +456,7 @@ def _notAfterBefore(cert_path, method):
     reformatted_timestamp = [timestamp[0:4], b"-", timestamp[4:6], b"-",
                              timestamp[6:8], b"T", timestamp[8:10], b":",
                              timestamp[10:12], b":", timestamp[12:]]
-    timestamp_str = b"".join(reformatted_timestamp)
+    timestamp_str = b"".join(reformatted_timestamp)  # type: Union[str, bytes]
     # pyrfc3339 uses "native" strings. That is, bytes on Python 2 and unicode
     # on Python 3
     if six.PY3:

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -25,7 +25,6 @@ import zope.component
 
 from acme import crypto_util as acme_crypto_util
 from acme.magic_typing import IO  # pylint: disable=unused-import
-from acme.magic_typing import Union
 from certbot import errors
 from certbot import interfaces
 from certbot import util

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -456,11 +456,14 @@ def _notAfterBefore(cert_path, method):
     reformatted_timestamp = [timestamp[0:4], b"-", timestamp[4:6], b"-",
                              timestamp[6:8], b"T", timestamp[8:10], b":",
                              timestamp[10:12], b":", timestamp[12:]]
-    timestamp_str = b"".join(reformatted_timestamp)  # type: Union[str, bytes]
-    # pyrfc3339 uses "native" strings. That is, bytes on Python 2 and unicode
-    # on Python 3
+    # pyrfc3339 always uses the type `str`. This means that in Python 2, it
+    # expects str/bytes and in Python 3 it expects its str type or the Python 2
+    # equivalent of the type unicode.
+    timestamp_bytes = b"".join(reformatted_timestamp)
     if six.PY3:
         timestamp_str = timestamp_str.decode('ascii')
+    else:
+        timestamp_str = timestamp_bytes
     return pyrfc3339.parse(timestamp_str)
 
 

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -460,7 +460,7 @@ def _notAfterBefore(cert_path, method):
     # equivalent of the type unicode.
     timestamp_bytes = b"".join(reformatted_timestamp)
     if six.PY3:
-        timestamp_str = timestamp_str.decode('ascii')
+        timestamp_str = timestamp_bytes.decode('ascii')
     else:
         timestamp_str = timestamp_bytes
     return pyrfc3339.parse(timestamp_str)

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -25,7 +25,7 @@ import zope.component
 
 from acme import crypto_util as acme_crypto_util
 from acme.magic_typing import IO  # pylint: disable=unused-import
-from acme.magic_typing import Union  # pylint: disable=unused-import
+from acme.magic_typing import Union
 from certbot import errors
 from certbot import interfaces
 from certbot import util

--- a/certbot/certbot/plugins/common.py
+++ b/certbot/certbot/plugins/common.py
@@ -2,9 +2,7 @@
 import logging
 import re
 import shutil
-import sys
 import tempfile
-import warnings
 
 from josepy import util as jose_util
 import pkg_resources
@@ -419,34 +417,3 @@ def dir_setup(test_dir, pkg):  # pragma: no cover
         test_configs, os.path.join(temp_dir, test_dir), symlinks=True)
 
     return temp_dir, config_dir, work_dir
-
-
-# This class takes a similar approach to the cryptography project to deprecate attributes
-# in public modules. See the _ModuleWithDeprecation class here:
-# https://github.com/pyca/cryptography/blob/91105952739442a74582d3e62b3d2111365b0dc7/src/cryptography/utils.py#L129
-class _TLSSNI01DeprecationModule(object):
-    """
-    Internal class delegating to a module, and displaying warnings when
-    attributes related to TLS-SNI-01 are accessed.
-    """
-    def __init__(self, module):
-        self.__dict__['_module'] = module
-
-    def __getattr__(self, attr):
-        if attr == 'TLSSNI01':
-            warnings.warn('TLSSNI01 is deprecated and will be removed soon.',
-                          DeprecationWarning, stacklevel=2)
-        return getattr(self._module, attr)
-
-    def __setattr__(self, attr, value):  # pragma: no cover
-        setattr(self._module, attr, value)
-
-    def __delattr__(self, attr):  # pragma: no cover
-        delattr(self._module, attr)
-
-    def __dir__(self):  # pragma: no cover
-        return ['_module'] + dir(self._module)
-
-
-# Patching ourselves to warn about TLS-SNI challenge deprecation and removal.
-sys.modules[__name__] = _TLSSNI01DeprecationModule(sys.modules[__name__])

--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -578,11 +578,9 @@ def is_wildcard_domain(domain):
 
     """
     if isinstance(domain, six.text_type):
-        wildcard_marker = u"*."
+        return domain.startswith(u"*.")
     else:
-        wildcard_marker = b"*."
-
-    return domain.startswith(wildcard_marker)
+        return domain.startswith(b"*.")
 
 
 def get_strict_version(normalized):

--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -17,6 +17,7 @@ import sys
 import configargparse
 import six
 
+from acme.magic_typing import Text
 from acme.magic_typing import Tuple
 from acme.magic_typing import Union
 from certbot import errors
@@ -577,7 +578,7 @@ def is_wildcard_domain(domain):
     :rtype: bool
 
     """
-    wildcard_marker = b"*."  # type: Union[str, bytes]
+    wildcard_marker = b"*."  # type: Union[Text, bytes]
     if isinstance(domain, six.text_type):
         wildcard_marker = u"*."
     return domain.startswith(wildcard_marker)

--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -577,10 +577,10 @@ def is_wildcard_domain(domain):
     :rtype: bool
 
     """
+    wildcard_marker = b"*."  # type: Union[str, bytes]
     if isinstance(domain, six.text_type):
-        return domain.startswith(u"*.")
-    else:
-        return domain.startswith(b"*.")
+        wildcard_marker = u"*."
+    return domain.startswith(wildcard_marker)
 
 
 def get_strict_version(normalized):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,6 @@
 [mypy]
 check_untyped_defs = True
 ignore_missing_imports = True
-python_version = 2.7
 
 [mypy-acme.magic_typing_test]
 ignore_errors = True


### PR DESCRIPTION
Fixes #7806.

This is needed to unblock https://github.com/certbot/certbot/issues/8134 as described at https://github.com/certbot/certbot/issues/8134#issuecomment-715618364.

One change in this PR which isn't ideal is disabling the type checking on `msvcrt` in `lock.py`. As said in the comment, this is fixed in newer versions of `mypy` so I tried to upgrade `mypy` to fix it but it's a fair bit of work. Instead, I opened https://github.com/certbot/certbot/issues/8425 to track that as part of our planned mypy work in a few months.