### PR TITLE
Fix #8436 & #8432 tests

### DIFF
--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -454,11 +454,11 @@ class PlaceParensTest(unittest.TestCase):
         self.assertEqual("(y)es please", self._call("yes please"))
 
 
-class PrintTest(unittest.TestCase):
-    """Test the print function """
+class NotifyTest(unittest.TestCase):
+    """Test the notify function """
 
     @test_util.patch_get_utility()
-    def test_print(self, mock_util):
+    def test_notify(self, mock_util):
         from certbot.display.util import notify
         notify("Hello World")
         mock_util().notification.assert_called_with(

--- a/certbot/tests/eff_test.py
+++ b/certbot/tests/eff_test.py
@@ -122,10 +122,9 @@ class SubscribeTest(unittest.TestCase):
         self.json = {'status': True}
         self.response = mock.Mock(ok=True)
         self.response.json.return_value = self.json
-        self.mock_notify = mock.patch("certbot._internal.eff.display_util.notify").start()
-
-    def tearDown(self):
-        self.mock_notify.stop()
+        patcher = mock.patch("certbot._internal.eff.display_util.notify")
+        self.mock_notify = patcher.start()
+        self.addCleanup(patcher.stop)
 
     @mock.patch('certbot._internal.eff.requests.post')
     def _call(self, mock_post):


### PR DESCRIPTION
Fixes the failure in the full test suite.

Additionally renames a test which should have been renamed in #8432.