### PR TITLE
Add certbot renew --key-type test

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/assertions.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/assertions.py
@@ -4,6 +4,7 @@ import os
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
 try:
@@ -21,6 +22,11 @@ ADMINS_SID = 'S-1-5-32-544'
 
 
 def assert_elliptic_key(key, curve):
+    """
+    Asserts that the key at the given path is an EC key using the given curve.
+    :param key: path to key
+    :param curve: name of the expected elliptic curve
+    """
     with open(key, 'rb') as file:
         privkey1 = file.read()
 
@@ -28,6 +34,18 @@ def assert_elliptic_key(key, curve):
 
     assert isinstance(key, EllipticCurvePrivateKey)
     assert isinstance(key.curve, curve)
+
+
+def assert_rsa_key(key):
+    """
+    Asserts that the key at the given path is an RSA key.
+    :param key: path to key
+    """
+    with open(filename, 'rb') as file:
+        privkey1 = file.read()
+
+    key = load_pem_private_key(data=privkey1, password=None, backend=default_backend())
+    assert isinstance(key, RSAPrivateKey)
 
 
 def assert_hook_execution(probe_path, probe_content):

--- a/certbot-ci/certbot_integration_tests/certbot_tests/assertions.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/assertions.py
@@ -41,7 +41,7 @@ def assert_rsa_key(key):
     Asserts that the key at the given path is an RSA key.
     :param key: path to key
     """
-    with open(filename, 'rb') as file:
+    with open(key, 'rb') as file:
         privkey1 = file.read()
 
     key = load_pem_private_key(data=privkey1, password=None, backend=default_backend())


### PR DESCRIPTION
As a follow up to the discussion [here](https://github.com/certbot/certbot/pull/8435#discussion_r520952343), I think it's worth adding a simple test that the logic requiring both `--cert-name` and `--key-type` to be set on the command line is not triggered with the `renew` subcommand.

You can see tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=2982&view=results.