### PR TITLE
Use Python 3.8 for Linux integration tests

### DIFF
--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -52,7 +52,7 @@ jobs:
           TOXENV: mypy
         linux-integration:
           IMAGE_NAME: ubuntu-18.04
-          PYTHON_VERSION: 2.7
+          PYTHON_VERSION: 3.8
           TOXENV: integration
           ACME_SERVER: pebble
         apache-compat:


### PR DESCRIPTION
Do we have any specific reason to run the standard Linux integration tests on Python 2.7?

If not, we should move to a more recent version of Python. This PR does it for Python 3.8.