### PR TITLE
add coverage testing to dns-rfc2136 integration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -245,7 +245,10 @@ commands =
     {[base]pip_install} acme certbot certbot-dns-rfc2136 certbot-ci
     pytest certbot-ci/certbot_integration_tests/rfc2136_tests \
         --acme-server=pebble --dns-server=bind \
-        --numprocesses=1
+        --numprocesses=1 \
+        --cov=acme --cov=certbot --cov=certbot_dns_rfc2136 --cov-report= \
+        --cov-config=certbot-ci/certbot_integration_tests/.coveragerc
+    coverage report --include 'certbot-dns-rfc2136/*' --show-missing --fail-under=87
 
 [testenv:integration-external]
 # Run integration tests with Certbot outside of tox's virtual environment.

--- a/tox.ini
+++ b/tox.ini
@@ -248,6 +248,7 @@ commands =
         --numprocesses=1 \
         --cov=acme --cov=certbot --cov=certbot_dns_rfc2136 --cov-report= \
         --cov-config=certbot-ci/certbot_integration_tests/.coveragerc
+    coverage report --include 'certbot/*' --show-missing --fail-under=45
     coverage report --include 'certbot-dns-rfc2136/*' --show-missing --fail-under=87
 
 [testenv:integration-external]


### PR DESCRIPTION
Adrien explained to me that the threshold is manually configured by hand, so here I have set it to the current coverage.

Extended test suite ran successfully [here](https://dev.azure.com/certbot/certbot/_build/results?buildId=3048&view=logs&jobId=e3e29de7-c644-5e42-66af-4a0f9a6c8a57&j=e3e29de7-c644-5e42-66af-4a0f9a6c8a57&t=cee3bf2a-011f-5646-6ebc-54d330a341bb).