### PR TITLE
dns-google: improve credentials error message

### DIFF
--- a/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
@@ -85,9 +85,13 @@ class _GoogleClient(object):
 
         scopes = ['https://www.googleapis.com/auth/ndev.clouddns.readwrite']
         if account_json is not None:
-            credentials = ServiceAccountCredentials.from_json_keyfile_name(account_json, scopes)
-            with open(account_json) as account:
-                self.project_id = json.load(account)['project_id']
+            try:
+                credentials = ServiceAccountCredentials.from_json_keyfile_name(account_json, scopes)
+                with open(account_json) as account:
+                    self.project_id = json.load(account)['project_id']
+            except Exception as e:
+                raise errors.PluginError(
+                    "Error parsing credentials file '{}': {}".format(account_json, e))
         else:
             credentials = None
             self.project_id = self.get_project_id()

--- a/certbot-dns-google/tests/dns_google_test.py
+++ b/certbot-dns-google/tests/dns_google_test.py
@@ -108,6 +108,17 @@ class GoogleClientTest(unittest.TestCase):
         self.assertTrue(get_project_id_mock.called)
 
     @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
+    def test_client_bad_credentials_file(self, credential_mock):
+        credential_mock.side_effect = ValueError('Some exception buried in oauth2client')
+        with self.assertRaises(errors.PluginError) as cm:
+            self._setUp_client_with_mock([])
+        self.assertEqual(
+            str(cm.exception),
+            "Error parsing credentials file '/not/a/real/path.json': "
+            "Some exception buried in oauth2client"
+        )
+
+    @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
     @mock.patch('certbot_dns_google._internal.dns_google.open',
                 mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'), create=True)
     @mock.patch('certbot_dns_google._internal.dns_google._GoogleClient.get_project_id')


### PR DESCRIPTION
This adds a 'Error parsing credentials file ...' wrapper to any errors
raised inside certbot-dns-google's usage of oauth2client, to make it
obvious to the user where the problem lies.

Fixes #8481.