### PR TITLE
certbot-dns-digitalocean: set TTL

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -43,6 +43,7 @@ Authors
 * [Chad Whitacre](https://github.com/whit537)
 * [Chhatoi Pritam Baral](https://github.com/pritambaral)
 * [Chris Johns](https://github.com/ter0)
+* [Chris Jones](https://github.com/magikid)
 * [Chris Lamb](https://github.com/lamby)
 * [chrismarget](https://github.com/chrismarget)
 * [Christian Gärtner](https://github.com/ChristianGaertner)

--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
@@ -85,6 +85,9 @@ class _DigitalOceanClient(object):
                                      .format(e, ' ({0})'.format(hint) if hint else ''))
 
         try:
+            # Set a TTL of 30 seconds on our new record
+            record_content['ttl'] = 30
+            
             result = domain.create_new_domain_record(
                 type='TXT',
                 name=self._compute_record_name(domain, record_name),

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -20,7 +20,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * certbot-auto was deprecated on Debian based systems.
 * CLI flag `--manual-public-ip-logging-ok` is now a no-op, generates a
   deprecation warning, and will be removed in a future release.
-*
+* Set 30 second TTL for DigitalOcean validation records
 
 ### Fixed
 


### PR DESCRIPTION
## Pull Request Checklist

- [X] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [X] Include your name in `AUTHORS.md` if you like.

I ran into an issue where my domains were failing to validate because the records weren't updating quickly enough for the client.  Setting a short TTL on the validation records resolved the issue for me.
