### PR TITLE
Fix changelog typo

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -26,7 +26,7 @@ More details about these changes can be found on our GitHub repo.
 * Confirmation when deleting certificates
 * CLI flag `--key-type` has been added to specify 'rsa' or 'ecdsa' (default 'rsa').
 * CLI flag `--elliptic-curve` has been added which takes an NIST/SECG elliptic curve. Any of
-  `secp256r1`, `secp284r1` and `secp521r1` are accepted values.
+  `secp256r1`, `secp384r1` and `secp521r1` are accepted values.
 * The command `certbot certficates` lists the which type of the private key that was used
   for the private key.
 * Support for Python 3.9 was added to Certbot and all of its components.

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -36,7 +36,6 @@ More details about these changes can be found on our GitHub repo.
 * certbot-auto was deprecated on Debian based systems.
 * CLI flag `--manual-public-ip-logging-ok` is now a no-op, generates a
   deprecation warning, and will be removed in a future release.
-*
 
 ### Fixed
 


### PR DESCRIPTION
The changelog will be incorrect for the 1.10.0 tag and release, but we can and I think we should fix it going forward.