### PR TITLE
fix --manual-public-ip-logging-ok deprecation

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/certbot_integration_tests/utils/certbot_call.py
@@ -92,6 +92,7 @@ def _prepare_args_env(certbot_args, directory_url, http_01_port, tls_alpn_01_por
         '--no-verify-ssl',
         '--http-01-port', str(http_01_port),
         '--https-port', str(tls_alpn_01_port),
+        '--manual-public-ip-logging-ok',
         '--config-dir', config_dir,
         '--work-dir', os.path.join(workspace, 'work'),
         '--logs-dir', os.path.join(workspace, 'logs'),

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Using the deprecated `--manual-public-ip-logging-ok` flag would cause
+  Certbot to crash on obtaining a certificate.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/_internal/plugins/manual.py
+++ b/certbot/certbot/_internal/plugins/manual.py
@@ -1,4 +1,6 @@
 """Manual authenticator plugin"""
+import argparse
+import logging
 import zope.component
 import zope.interface
 
@@ -13,6 +15,8 @@ from certbot._internal import hooks
 from certbot.compat import misc
 from certbot.compat import os
 from certbot.plugins import common
+
+logger = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(interfaces.IAuthenticator)
@@ -84,7 +88,8 @@ permitted by DNS standards.)
             help='Path or command to execute for the authentication script')
         add('cleanup-hook',
             help='Path or command to execute for the cleanup script')
-        util.add_deprecated_argument(add, 'public-ip-logging-ok', 0)
+        # TODO: remove this deprecated argument
+        add('public-ip-logging-ok', action='store_true', help=argparse.SUPPRESS)
 
     def prepare(self):  # pylint: disable=missing-function-docstring
         if self.config.noninteractive_mode and not self.conf('auth-hook'):
@@ -113,6 +118,8 @@ permitted by DNS standards.)
         return [challenges.HTTP01, challenges.DNS01]
 
     def perform(self, achalls):  # pylint: disable=missing-function-docstring
+        if self.conf('public-ip-logging-ok'):
+            logger.warning('Use of --manual-public-ip-logging-ok is deprecated.')
         responses = []
         for achall in achalls:
             if self.conf('auth-hook'):


### PR DESCRIPTION
Fixes #8495, where Certbot will crash when creating or renewing a lineage if `--manual-public-ip-logging-ok` is part of the CLI arguments.

This change just inlines the desired deprecation behavior in `manual.py` without using the existing utility functions. 

(We could instead try fix whatever causes the problem with `util.add_deprecated_argument` instead.  Alternatively, #8381 could be reverted fully.)

I think two things went wrong in #8381:

1. `util.add_deprecated_argument` results in problems if used with a `store_` argument, if `certbot._internal.storage.relevant_values` gets called at any point, which in turn causes re-processing of all CLI arguments.
2. More importantly, removing `--manual-public-ip-logging-ok` from the Certbot integration test was a mistake. Not doing so would have allowed this to be caught.
---

Failure looks like it might be CentOS 6 EOL-related.