### PR TITLE
snap: disable the "user site-packages directory"

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* The Certbot snap no longer loads packages installed via `pip install --user`. This
+  was unintended and DNS plugins should be installed via `snap` instead.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,13 +20,13 @@ adopt-info: certbot
 
 apps:
   certbot:
-    command: bin/python3 $SNAP/bin/certbot
+    command: bin/python3 -s $SNAP/bin/certbot
     environment:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
   renew:
-    command: bin/python3 $SNAP/bin/certbot -q renew
+    command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot
     environment:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"


### PR DESCRIPTION
snap: disable the "user site-packages directory"

Although Certbot is a classic snap, it shouldn't load Python code from
the host system. This change prevents packages being loaded from the
"user site-packages directory" (PEP-370). i.e. Certbot will no longer
load DNS plugins installed via `pip install --user certbot-dns-*`.

---

Fixes #8502.

**Update**: This was force-pushed to use `-s` rather than full-blown isolated mode (`-I`) following discussion with @adferrand. Below discussion is outdated. 

See Python documentation for [`-I`](https://docs.python.org/3/using/cmdline.html#id2).

Disabling all `PYTHON*` environment variables might be slightly extreme. [Here is the list of affected variables](https://docs.python.org/3/using/cmdline.html#environment-variables). I don't see any that we'd potentially want to use in future (outside of debugging), but please double-check that.

A less extreme approach would be to use only [`-s`](https://docs.python.org/3/using/cmdline.html#cmdoption-s), which would disable the user site-packages directory, but then we'd need to think of another solution to filter `PYTHONPATH`.

I tested this in four ways (on Focal):

1. After this change, `pip3 --user install certbot-dns-hetzner` no longer appears in `certbot plugins`
2. ~~Before this change, running `PYTHONPATH=/usr/lib/python2.7 certbot --version` would result in a crash. After this change, it is ignored. (This requires py2 to actually be installed)~~ (still crashes with only  `-s`, but it's an accepted limitation)
3. After this change, it's still possible to use `--post-hook hook.py`, where `hook.py` calls a Python library which is installed on the host but not inside the snap. This shows that hooks remain unaffected by the isolation mode.
4. After this change, it's still possible to obtain a certificate using the DNS plugins.