### PR TITLE
Fix TTL mismatch leading to HTTP 412

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -279,3 +279,4 @@ Authors
 * [Yuseong Cho](https://github.com/g6123)
 * [Zach Shepherd](https://github.com/zjs)
 * [陈三](https://github.com/chenxsan)
+* [Lorenzo Fundaró](https://github.com/lfundaro)

--- a/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
@@ -118,10 +118,10 @@ class _GoogleClient(object):
 
         record_contents = self.get_existing_txt_rrset(zone_id, record_name)
         if record_contents is None:
-            record_contents = []
-        add_records = record_contents[:]
+            record_contents = {"rrdatas": [], "ttl": record_ttl}
+        add_records = record_contents["rrdatas"][:]
 
-        if "\""+record_content+"\"" in record_contents:
+        if "\""+record_content+"\"" in record_contents["rrdatas"]:
             # The process was interrupted previously and validation token exists
             return
 
@@ -140,15 +140,15 @@ class _GoogleClient(object):
             ],
         }
 
-        if record_contents:
+        if record_contents["rrdatas"]:
             # We need to remove old records in the same request
             data["deletions"] = [
                 {
                     "kind": "dns#resourceRecordSet",
                     "type": "TXT",
                     "name": record_name + ".",
-                    "rrdatas": record_contents,
-                    "ttl": record_ttl,
+                    "rrdatas": record_contents["rrdatas"],
+                    "ttl": record_contents["ttl"],
                 },
             ]
 
@@ -188,7 +188,7 @@ class _GoogleClient(object):
 
         record_contents = self.get_existing_txt_rrset(zone_id, record_name)
         if record_contents is None:
-            record_contents = ["\"" + record_content + "\""]
+            record_contents = {"rrdatas": ["\"" + record_content + "\""], "ttl": record_ttl}
 
         data = {
             "kind": "dns#change",
@@ -197,14 +197,14 @@ class _GoogleClient(object):
                     "kind": "dns#resourceRecordSet",
                     "type": "TXT",
                     "name": record_name + ".",
-                    "rrdatas": record_contents,
-                    "ttl": record_ttl,
+                    "rrdatas": record_contents["rrdatas"],
+                    "ttl": record_contents["ttl"],
                 },
             ],
         }
 
         # Remove the record being deleted from the list
-        readd_contents = [r for r in record_contents if r != "\"" + record_content + "\""]
+        readd_contents = [r for r in record_contents["rrdatas"] if r != "\"" + record_content + "\""]
         if readd_contents:
             # We need to remove old records in the same request
             data["additions"] = [
@@ -213,7 +213,7 @@ class _GoogleClient(object):
                     "type": "TXT",
                     "name": record_name + ".",
                     "rrdatas": readd_contents,
-                    "ttl": record_ttl,
+                    "ttl": record_contents["ttl"],
                 },
             ]
 
@@ -235,8 +235,8 @@ class _GoogleClient(object):
         :param str zone_id: The ID of the managed zone.
         :param str record_name: The record name (typically beginning with '_acme-challenge.').
 
-        :returns: List of TXT record values or None
-        :rtype: `list` of `string` or `None`
+        :returns: The TXT record that corresponds to `record_name` or None
+        :rtype: `object` or `None`
 
         """
         rrs_request = self.dns.resourceRecordSets()
@@ -252,7 +252,7 @@ class _GoogleClient(object):
             logger.debug("Error was:", exc_info=True)
         else:
             if response and len(response["rrsets"]) != 0:
-                return response["rrsets"][0]["rrdatas"]
+                return response["rrsets"][0]
         return None
 
     def _find_managed_zone_id(self, domain):

--- a/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
@@ -240,9 +240,10 @@ class _GoogleClient(object):
 
         """
         rrs_request = self.dns.resourceRecordSets()
-        request = rrs_request.list(managedZone=zone_id, project=self.project_id)
         # Add dot as the API returns absolute domains
         record_name += "."
+        request = rrs_request.list(project=self.project_id, managedZone=zone_id, name=record_name,
+                                   type="TXT")
         try:
             response = request.execute()
         except googleapiclient_errors.Error:
@@ -250,10 +251,8 @@ class _GoogleClient(object):
                         "requesting a wildcard certificate, this might not work.")
             logger.debug("Error was:", exc_info=True)
         else:
-            if response:
-                for rr in response["rrsets"]:
-                    if rr["name"] == record_name and rr["type"] == "TXT":
-                        return rr["rrdatas"]
+            if response and len(response["rrsets"]) != 0:
+                return response["rrsets"][0]["rrdatas"]
         return None
 
     def _find_managed_zone_id(self, domain):

--- a/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
@@ -204,7 +204,8 @@ class _GoogleClient(object):
         }
 
         # Remove the record being deleted from the list
-        readd_contents = [r for r in record_contents["rrdatas"] if r != "\"" + record_content + "\""]
+        readd_contents = [r for r in record_contents["rrdatas"]
+                            if r != "\"" + record_content + "\""]
         if readd_contents:
             # We need to remove old records in the same request
             data["additions"] = [

--- a/certbot-dns-google/tests/dns_google_test.py
+++ b/certbot-dns-google/tests/dns_google_test.py
@@ -91,12 +91,6 @@ class GoogleClientTest(unittest.TestCase):
             if name == "_acme-challenge.example.org.":
                 response = {"rrsets": [{"name": "_acme-challenge.example.org.", "type": "TXT",
                               "rrdatas": ["\"example-txt-contents\""], "ttl": 60}]}
-            # elif name == "_acme-challenge.non-default-ttl.org":
-            #     response = {"rrsets": [{"name": "_acme-challenge.non-default-ttl.org.", "type": "TXT",
-            #                   "rrdatas": ["\"example-txt-contents\""], "ttl": 300}]}
-            # elif name == "_acme-challenge.delete.org":
-            #     response = {"rrsets": [{"name": "_acme-challenge.delete.org.", "type": "TXT",
-            #                   "rrdatas": ["\"foo\"", "\"bar\""], "ttl": 300}]}
             class x:
                 @staticmethod
                 def execute():
@@ -257,12 +251,9 @@ class GoogleClientTest(unittest.TestCase):
                 mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'), create=True)
     def test_del_txt_record(self, unused_credential_mock):
         client, changes = self._setUp_client_with_mock([{'managedZones': [{'id': self.zone}]}])
-
         # pylint: disable=line-too-long
         mock_get_rrs = "certbot_dns_google._internal.dns_google._GoogleClient.get_existing_txt_rrset"
         with mock.patch(mock_get_rrs) as mock_rrs:
-            # can we have this mock in the setup ? 
-            # should we test different ttl ? 
             mock_rrs.return_value = {"rrdatas": ["\"sample-txt-contents\"",
                                      "\"example-txt-contents\""], "ttl": self.record_ttl}
             client.del_txt_record(DOMAIN, "_acme-challenge.example.org",

--- a/certbot-dns-google/tests/dns_google_test.py
+++ b/certbot-dns-google/tests/dns_google_test.py
@@ -87,7 +87,7 @@ class GoogleClientTest(unittest.TestCase):
 
         mock_rrs = mock.MagicMock()
         def rrs_list(project=None, managedZone=None, name="foo", type="TXT"):
-            response = {"rrsets": []}
+            response = None
             if name == "_acme-challenge.example.org.":
                 response = {"rrsets": [{"name": "_acme-challenge.example.org.", "type": "TXT",
                               "rrdatas": ["\"example-txt-contents\""], "ttl": 60}]}

--- a/certbot-dns-google/tests/dns_google_test.py
+++ b/certbot-dns-google/tests/dns_google_test.py
@@ -245,7 +245,7 @@ class GoogleClientTest(unittest.TestCase):
 
         self.assertRaises(errors.PluginError, client.add_txt_record,
                           DOMAIN, self.record_name, self.record_content, self.record_ttl)
-                                               
+
     @mock.patch('oauth2client.service_account.ServiceAccountCredentials.from_json_keyfile_name')
     @mock.patch('certbot_dns_google._internal.dns_google.open',
                 mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'), create=True)

--- a/certbot-dns-google/tests/dns_google_test.py
+++ b/certbot-dns-google/tests/dns_google_test.py
@@ -92,6 +92,7 @@ class GoogleClientTest(unittest.TestCase):
                 response = {"rrsets": [{"name": "_acme-challenge.example.org.", "type": "TXT",
                               "rrdatas": ["\"example-txt-contents\""]}]}
             class x:
+                @staticmethod
                 def execute():
                     if rrs_list_error is not None:
                         raise rrs_list_error

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * The Certbot snap no longer loads packages installed via `pip install --user`. This
   was unintended and DNS plugins should be installed via `snap` instead.
+* Fixed #6036. A bug on certbot-dns-google while fetching existing TXT records. 
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
This PR is a follow up from #8521 where we address the
issue of potentially having a mismatch of TTL when executing
a DNS change (transaction = deletion + additions). Let's say
we have a record `foo.org 30 IN TXT foo-content` with TTL 30s,
when creating challenge or cleaning we might need to perform
a deletion operation in the transaction. Currently certbot
would ask Google API to delete the `foo` record like this:
`foo.org 60 in TXT foo-content` ignoring the record's original
TTL and using 60s instead. This leads to HTTP 412 as Google would
expect a perfect match of what we want to delete with what it is
on the DNS. See also #8523