### PR TITLE
Remove reference to letsencrypt(-auto)

### DIFF
--- a/certbot/README.rst
+++ b/certbot/README.rst
@@ -18,10 +18,6 @@ systems.
 To see the changes made to Certbot between versions please refer to our
 `changelog <https://github.com/certbot/certbot/blob/master/certbot/CHANGELOG.md>`_.
 
-Until May 2016, Certbot was named simply ``letsencrypt`` or ``letsencrypt-auto``,
-depending on install method. Instructions on the Internet, and some pieces of the
-software, may still refer to this older name.
-
 Contributing
 ------------
 


### PR DESCRIPTION
I found this as part of https://github.com/certbot/certbot/issues/8519.

Maybe it's worth us keeping around information about this rename somewhere, but I personally don't think it really is. It's been 4.5 years and it's been years since I can remember someone asking about this. At the very least, I don't think we need this info near the top of our README.