### PR TITLE
Clean up certbot-auto docs

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -12,7 +12,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * We deprecated support for Python 2 in Certbot and its ACME library.
   Support for Python 2 will be removed in the next planned release of Certbot.
-* certbot-auto was deprecated on all systems.
+* certbot-auto was deprecated on all systems. For more information about this
+  change, see
+  https://community.letsencrypt.org/t/certbot-auto-no-longer-works-on-debian-based-systems/139702/7.
 * We deprecated support for Apache 2.2 in the certbot-apache plugin and it will
   be removed in a future release of Certbot.
 

--- a/certbot/docs/compatibility.rst
+++ b/certbot/docs/compatibility.rst
@@ -9,7 +9,7 @@ application itself. This means that we will not change behavior in a backwards
 incompatible way except in a new major version of the project.
 
 .. note:: None of this applies to the behavior of Certbot distribution
-    mechanisms such as :ref:`certbot-auto <certbot-auto>` or OS packages whose
+    mechanisms such as :ref:`our snaps <snap-install>` or OS packages whose
     behavior may change at any time. Semantic versioning only applies to the
     common Certbot components that are installed by various distribution
     methods.

--- a/certbot/docs/install.rst
+++ b/certbot/docs/install.rst
@@ -44,17 +44,6 @@ supports
 <https://github.com/certbot/certbot/blob/master/certbot-apache/certbot_apache/_internal/constants.py>`_
 modern OSes based on Debian, Ubuntu, Fedora, SUSE, Gentoo and Darwin.
 
-
-Additional integrity verification of certbot-auto script can be done by verifying its digital signature.
-This requires a local installation of gpg2, which comes packaged in many Linux distributions under name gnupg or gnupg2.
-
-
-Installing with ``certbot-auto`` requires 512MB of RAM in order to build some
-of the dependencies. Installing from pre-built OS packages avoids this
-requirement. You can also temporarily set a swap file. See "Problems with
-Python virtual environment" below for details.
-
-
 Alternate installation methods
 ================================
 

--- a/certbot/docs/install.rst
+++ b/certbot/docs/install.rst
@@ -78,74 +78,6 @@ choosing "snapd" in the "System" dropdown menu. (You should select "snapd"
 regardless of your operating system, as our instructions are the same across
 all systems.)
 
-.. _certbot-auto:
-
-Certbot-Auto
-------------
-
-The ``certbot-auto`` wrapper script installs Certbot, obtaining some dependencies
-from your web server OS and putting others in a python virtual environment. You can
-download and run it as follows::
-
-  wget https://dl.eff.org/certbot-auto
-  sudo mv certbot-auto /usr/local/bin/certbot-auto
-  sudo chown root /usr/local/bin/certbot-auto
-  sudo chmod 0755 /usr/local/bin/certbot-auto
-  /usr/local/bin/certbot-auto --help
-
-To remove certbot-auto, just delete it and the files it places under /opt/eff.org, along with any cronjob or systemd timer you may have created.
-
-To check the integrity of the ``certbot-auto`` script,
-you can use these steps::
-
-
-	    user@webserver:~$ wget -N https://dl.eff.org/certbot-auto.asc
-	    user@webserver:~$ gpg2 --keyserver pool.sks-keyservers.net --recv-key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    user@webserver:~$ gpg2 --trusted-key 4D17C995CD9775F2 --verify certbot-auto.asc /usr/local/bin/certbot-auto
-
-
-
-The output of the last command should look something like::
-
-
-	    gpg: Signature made Wed 02 May 2018 05:29:12 AM IST
-	    gpg:                using RSA key A2CFB51FA275A7286234E7B24D17C995CD9775F2
-	    gpg: key 4D17C995CD9775F2 marked as ultimately trusted
-	    gpg: checking the trustdb
-	    gpg: marginals needed: 3  completes needed: 1  trust model: pgp
-	    gpg: depth: 0  valid:   2  signed:   2  trust: 0-, 0q, 0n, 0m, 0f, 2u
-	    gpg: depth: 1  valid:   2  signed:   0  trust: 2-, 0q, 0n, 0m, 0f, 0u
-	    gpg: next trustdb check due at 2027-11-22
-	    gpg: Good signature from "Let's Encrypt Client Team <letsencrypt-client@eff.org>" [ultimate]
-
-
-
-The ``certbot-auto`` command updates to the latest client release automatically.
-Since ``certbot-auto`` is a wrapper to ``certbot``, it accepts exactly
-the same command line flags and arguments. For more information, see
-`Certbot command-line options <https://certbot.eff.org/docs/using.html#command-line-options>`_.
-
-For full command line help, you can type::
-
-  /usr/local/bin/certbot-auto --help all
-
-Problems with Python virtual environment
-----------------------------------------
-
-On a low memory system such as VPS with less than 512MB of RAM, the required dependencies of Certbot will fail to build.
-This can be identified if the pip outputs contains something like ``internal compiler error: Killed (program cc1)``.
-You can workaround this restriction by creating a temporary swapfile::
-
-  user@webserver:~$ sudo fallocate -l 1G /tmp/swapfile
-  user@webserver:~$ sudo chmod 600 /tmp/swapfile
-  user@webserver:~$ sudo mkswap /tmp/swapfile
-  user@webserver:~$ sudo swapon /tmp/swapfile
-
-Disable and remove the swapfile once the virtual environment is constructed::
-
-  user@webserver:~$ sudo swapoff /tmp/swapfile
-  user@webserver:~$ sudo rm /tmp/swapfile
-
 .. _docker-user:
 
 Running with Docker
@@ -302,6 +234,33 @@ They need to be installed separately if you require their functionality.
 OS packaging is an ongoing effort. If you'd like to package
 Certbot for your distribution of choice please have a
 look at the :doc:`packaging`.
+
+.. _certbot-auto:
+
+Certbot-Auto
+------------
+
+We used to have a shell script named ``certbot-auto`` to help people install
+Certbot on UNIX operating systems, however, this script is no longer supported.
+
+Problems with Python virtual environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using ``certbot-auto`` on a low memory system such as VPS with less than
+512MB of RAM, the required dependencies of Certbot may fail to build.  This can
+be identified if the pip outputs contains something like ``internal compiler
+error: Killed (program cc1)``.  You can workaround this restriction by creating
+a temporary swapfile::
+
+  user@webserver:~$ sudo fallocate -l 1G /tmp/swapfile
+  user@webserver:~$ sudo chmod 600 /tmp/swapfile
+  user@webserver:~$ sudo mkswap /tmp/swapfile
+  user@webserver:~$ sudo swapon /tmp/swapfile
+
+Disable and remove the swapfile once the virtual environment is constructed::
+
+  user@webserver:~$ sudo swapoff /tmp/swapfile
+  user@webserver:~$ sudo rm /tmp/swapfile
 
 Installing from source
 ----------------------

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -179,10 +179,9 @@ If you'd like to obtain a wildcard certificate from Let's Encrypt or run
 Certbot's DNS plugins.
 
 These plugins are not included in a default Certbot installation and must be
-installed separately. While the DNS plugins cannot currently be used with
-``certbot-auto``, they are available in many OS package managers, as Docker
-images, and as snaps. Visit https://certbot.eff.org to learn the best way to use
-the DNS plugins on your system.
+installed separately. They are available in many OS package managers, as Docker
+images, and as snaps. Visit https://certbot.eff.org to learn the best way to
+use the DNS plugins on your system.
 
 Once installed, you can find documentation on how to use each plugin at:
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8519.

I left the `certbot-auto` docs in `install.rst` to avoid breaking links and to help propagate information about our changes there. I moved it closer to the bottom of the doc though since I think our documentation about OS packages and Docker is more helpful to most people.

Screenshots of the docs where any significant changes are made are below and the "our snaps" link I added works.

### compatibility.rst:
![Screen Shot 2020-12-14 at 9 53 52 AM](https://user-images.githubusercontent.com/6504915/102119483-06c8bc80-3df6-11eb-8f63-b9057f8ade86.png)
### install.rst:
![Screen Shot 2020-12-14 at 10 06 11 AM](https://user-images.githubusercontent.com/6504915/102119487-07615300-3df6-11eb-9360-4915be5edffc.png)

