### PR TITLE
Remove CentOS 6 cruft from test farm tests

### DIFF
--- a/tests/letstest/scripts/bootstrap_os_packages.sh
+++ b/tests/letstest/scripts/bootstrap_os_packages.sh
@@ -98,41 +98,6 @@ BootstrapRpmCommonBase() {
   fi
 }
 
-# This bootstrap concerns old RedHat-based distributions that do not ship by default
-# with Python 2.7, but only Python 2.6. We bootstrap them by enabling SCL and installing
-# Python 3.6. Some of these distributions are: CentOS/RHEL/OL/SL 6.
-BootstrapRpmPython3Legacy() {
-  # Tested with:
-  #   - CentOS 6
-
-  InitializeRPMCommonBase
-
-  if ! "${TOOL}" list rh-python36 >/dev/null 2>&1; then
-    echo "To use Certbot on this operating system, packages from the SCL repository need to be installed."
-    if ! "${TOOL}" list centos-release-scl >/dev/null 2>&1; then
-      error "Enable the SCL repository and try running Certbot again."
-      exit 1
-    fi
-    if ! "${TOOL}" install -y centos-release-scl; then
-      error "Could not enable SCL. Aborting bootstrap!"
-      exit 1
-    fi
-  fi
-
-  # CentOS 6 must use rh-python36 from SCL
-  if "${TOOL}" list rh-python36 >/dev/null 2>&1; then
-    python_pkgs="rh-python36-python
-      rh-python36-python-virtualenv
-      rh-python36-python-devel
-    "
-  else
-    error "No supported Python package available to install. Aborting bootstrap!"
-    exit 1
-  fi
-
-  BootstrapRpmCommonBase "${python_pkgs}"
-}
-
 BootstrapRpmPython3() {
   InitializeRPMCommonBase
 
@@ -154,16 +119,9 @@ if [ -f /etc/debian_version ]; then
   }
 elif [ -f /etc/redhat-release ]; then
   DeterminePythonVersion
-  # Handle legacy RPM distributions
-  if [ "$PYVER" -eq 26 ]; then
-    Bootstrap() {
-      BootstrapRpmPython3Legacy
-    }
-  else
-    Bootstrap() {
-      BootstrapRpmPython3
-    }
-  fi
+  Bootstrap() {
+    BootstrapRpmPython3
+  }
 
 fi
 

--- a/tests/letstest/scripts/test_apache2.sh
+++ b/tests/letstest/scripts/test_apache2.sh
@@ -64,12 +64,6 @@ if [ $? -ne 0 ] ; then
     exit 1
 fi
 
-if command -v python && [ $(python -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -eq 26 ]; then
-  # RHEL/CentOS 6 will need a special treatment, so we need to detect that environment
-  # Enable the SCL Python 3.6 installed by letsencrypt-auto bootstrap
-  PATH="/opt/rh/rh-python36/root/usr/bin:$PATH"
-fi
-
 tools/venv3.py -e acme[dev] -e certbot[dev,docs] -e certbot-apache
 
 sudo "venv3/bin/certbot" -v --debug --text --agree-tos \

--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -8,12 +8,6 @@ VENV_PATH=venv3
 # install OS packages
 sudo $BOOTSTRAP_SCRIPT
 
-if command -v python && [ $(python -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -eq 26 ]; then
-  # RHEL/CentOS 6 will need a special treatment, so we need to detect that environment
-  # Enable the SCL Python 3.6 installed by letsencrypt-auto bootstrap
-  PATH="/opt/rh/rh-python36/root/usr/bin:$PATH"
-fi
-
 # setup venv
 # We strip the hashes because the venv creation script includes unhashed
 # constraints in the commands given to pip and the mix of hashed and unhashed

--- a/tests/letstest/scripts/test_tests.sh
+++ b/tests/letstest/scripts/test_tests.sh
@@ -15,12 +15,6 @@ VENV_SCRIPT="tools/venv3.py"
 
 sudo $BOOTSTRAP_SCRIPT
 
-if command -v python && [ $(python -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -eq 26 ]; then
-  # RHEL/CentOS 6 will need a special treatment, so we need to detect that environment
-  # Enable the SCL Python 3.6 installed by letsencrypt-auto bootstrap
-  PATH="/opt/rh/rh-python36/root/usr/bin:$PATH"
-fi
-
 cd $REPO_ROOT
 $VENV_SCRIPT
 . $VENV_NAME/bin/activate


### PR DESCRIPTION
You can see tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=3172&view=results.