### PR TITLE
Make our test farm tests instances self-destruct

### DIFF
--- a/tests/letstest/auto_targets.yaml
+++ b/tests/letstest/auto_targets.yaml
@@ -31,10 +31,6 @@ targets:
     virt: hvm
     user: admin
     machine_type: a1.medium
-    # userdata: |
-    #   #cloud-init
-    #   runcmd:
-    #     - [ apt-get, install, -y, curl ]
   #-----------------------------------------------------------------------------
   # Other Redhat Distros
   - ami: ami-0916c408cb02e310b

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -159,15 +159,15 @@ def make_instance(ec2_client,
     tags = [{'Key': 'Name', 'Value': instance_name}]
     tag_spec = [{'ResourceType': 'instance', 'Tags': tags}]
     kwargs = {
-        BlockDeviceMappings=block_device_mappings,
-        ImageId=ami_id,
-        SecurityGroupIds=[security_group_id],
-        SubnetId=subnet_id,
-        KeyName=keyname,
-        MinCount=1,
-        MaxCount=1,
-        InstanceType=machine_type,
-        TagSpecifications=tag_spec
+        'BlockDeviceMappings': block_device_mappings,
+        'ImageId': ami_id,
+        'SecurityGroupIds': [security_group_id],
+        'SubnetId': subnet_id,
+        'KeyName': keyname,
+        'MinCount': 1,
+        'MaxCount': 1,
+        'InstanceType': machine_type,
+        'TagSpecifications': tag_spec
     }
     if self_destruct:
             kwargs['InstanceInitiatedShutdownBehavior'] = 'terminate'

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -147,8 +147,8 @@ def make_instance(ec2_client,
                   keyname,
                   security_group_id,
                   subnet_id,
-                  machine_type='t2.micro',
-                  self_destruct):
+                  self_destruct,
+                  machine_type='t2.micro'):
     """Creates an instance using the given parameters.
 
     If self_destruct is True, the instance will be configured to shutdown after
@@ -341,7 +341,7 @@ def create_client_instance(ec2_client, target, security_group_id, subnet_id, sel
                          machine_type=machine_type,
                          security_group_id=security_group_id,
                          subnet_id=subnet_id,
-                         self_destruct)
+                         self_destruct=self_destruct)
 
 
 def test_client_process(fab_config, inqueue, outqueue, boulder_url, log_dir):
@@ -507,7 +507,7 @@ def main():
                                        #machine_type='t2.medium',
                                        security_group_id=security_group_id,
                                        subnet_id=subnet_id,
-                                       self_destruct)
+                                       self_destruct=self_destruct)
 
     instances = []
     try:

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -147,8 +147,7 @@ def make_instance(ec2_client,
                   keyname,
                   security_group_id,
                   subnet_id,
-                  machine_type='t2.micro',
-                  userdata=""): #userdata contains bash or cloud-init script
+                  machine_type='t2.micro'):
     block_device_mappings = _get_block_device_mappings(ec2_client, ami_id)
     tags = [{'Key': 'Name', 'Value': instance_name}]
     tag_spec = [{'ResourceType': 'instance', 'Tags': tags}]
@@ -160,7 +159,6 @@ def make_instance(ec2_client,
         KeyName=keyname,
         MinCount=1,
         MaxCount=1,
-        UserData=userdata,
         InstanceType=machine_type,
         TagSpecifications=tag_spec)[0]
 
@@ -322,10 +320,6 @@ def create_client_instance(ec2_client, target, security_group_id, subnet_id):
     else:
         # 32 bit systems
         machine_type = 'c1.medium'
-    if 'userdata' in target:
-        userdata = target['userdata']
-    else:
-        userdata = ''
     name = 'le-%s'%target['name']
     print(name, end=" ")
     return make_instance(ec2_client,
@@ -334,8 +328,7 @@ def create_client_instance(ec2_client, target, security_group_id, subnet_id):
                          KEYNAME,
                          machine_type=machine_type,
                          security_group_id=security_group_id,
-                         subnet_id=subnet_id,
-                         userdata=userdata)
+                         subnet_id=subnet_id)
 
 
 def test_client_process(fab_config, inqueue, outqueue, boulder_url, log_dir):


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/7567.

I used the first approach I described at https://github.com/certbot/certbot/issues/7567#issuecomment-743336813 which was to:

1. Change the instance shutdown behavior so shutting down the instance terminates it. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior.
2. Add a shell script in user data that runs on machine startup as described at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-data-shell-scripts. This shell script schedules the machine to power off in 60 minutes.

To help accomplish this, I made `multitester.py` no longer accept `UserData` in our "target" YAML files, but we weren't using this functionality anyway.

I tested this by locally commenting out the usual cleanup code. After the script exited, I checked the AWS console and the instances were still running, but after the allotted time, they correctly terminated themselves.

With this change, we could delete the normal termination code, but I personally think it's worth keeping around. This scheduled shutdown is a little odd and in the normal case I think we can terminate the instances earlier and maybe save some money.

You can see the test farm tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=3175&view=results.