### PR TITLE
fix test_non_systemd_os_info

### DIFF
--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -547,8 +547,7 @@ class OsInfoTest(unittest.TestCase):
             m_distro.linux_distribution.return_value = ("something", "else")
             self.assertEqual(cbutil.get_os_info(), ("something", "else"))
 
-    @mock.patch("certbot.util.subprocess.Popen")
-    def test_non_systemd_os_info(self, popen_mock):
+    def test_non_systemd_os_info(self):
         import certbot.util as cbutil
         with mock.patch('certbot.util._USE_DISTRO', False):
             with mock.patch('platform.system_alias',
@@ -557,13 +556,14 @@ class OsInfoTest(unittest.TestCase):
 
             with mock.patch('platform.system_alias',
                             return_value=('darwin', '', '')):
-                comm_mock = mock.Mock()
-                comm_attrs = {'communicate.return_value':
-                            ('42.42.42', 'error')}
-                comm_mock.configure_mock(**comm_attrs)
-                popen_mock.return_value = comm_mock
-                self.assertEqual(cbutil.get_python_os_info()[0], 'darwin')
-                self.assertEqual(cbutil.get_python_os_info()[1], '42.42.42')
+                with mock.patch("subprocess.Popen") as popen_mock:
+                    comm_mock = mock.Mock()
+                    comm_attrs = {'communicate.return_value':
+                                ('42.42.42', 'error')}
+                    comm_mock.configure_mock(**comm_attrs)
+                    popen_mock.return_value = comm_mock
+                    self.assertEqual(cbutil.get_python_os_info()[0], 'darwin')
+                    self.assertEqual(cbutil.get_python_os_info()[1], '42.42.42')
 
             with mock.patch('platform.system_alias',
                             return_value=('freebsd', '9.3-RC3-p1', '')):


### PR DESCRIPTION
`python certbot/tests/util_test.py` fails for me on macOS. The traceback is:
```
======================================================================
ERROR: test_non_systemd_os_info (__main__.OsInfoTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/unittest/mock.py", line 1325, in patched
    return func(*newargs, **newkeywargs)
  File "certbot/tests/util_test.py", line 556, in test_non_systemd_os_info
    self.assertEqual(cbutil.get_python_os_info()[0], 'nonsystemd')
  File "/Users/bmw/Development/github.com/certbot/certbot/certbot/certbot/util.py", line 387, in get_python_os_info
    platform.system(),
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/platform.py", line 891, in system
    return uname().system
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/platform.py", line 857, in uname
    processor = _syscmd_uname('-p', '')
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/platform.py", line 613, in _syscmd_uname
    output = subprocess.check_output(('uname', option),
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/subprocess.py", line 491, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
ValueError: not enough values to unpack (expected 2, got 0)

----------------------------------------------------------------------
```
The cause of the problem is the `Popen` mock at the top of the function. Some of the unmocked calls into the Python standard library try to use `Popen` and since it is mocked it doesn't behave correctly.

I fixed this by reducing the scope of the mock to where we're actually using it.

The reason this doesn't show up during normal testing seems to be that the function in the standard library that was blowing up has a cache and `pytest` happens to call this function itself before running our tests which fills the cache and avoids this problem. I found this by playing around with breakpoints and if you're curious you can see the cache at https://github.com/python/cpython/blob/b9ced83cf427ec86802ba4c9a562c6d9cafc72f5/Lib/platform.py#L809-L812.