### PR TITLE
Edit certs -> certificates in user-facing text.

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -621,7 +621,7 @@ def test_revoke_multiple_lineages(context):
     ])
 
     with open(join(context.workspace, 'logs', 'letsencrypt.log'), 'r') as f:
-        assert 'Not deleting revoked certs due to overlapping archive dirs' in f.read()
+        assert 'Not deleting revoked certificates due to overlapping archive dirs' in f.read()
 
 
 def test_wildcard_certificates(context):

--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
@@ -19,7 +19,8 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the DigitalOcean API to fulfill a dns-01 challenge.
     """
 
-    description = 'Obtain certificates using a DNS TXT record (if you are using DigitalOcean for DNS).'
+    description = 'Obtain certificates using a DNS TXT record (if you are ' + \
+                  'using DigitalOcean for DNS).'
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)

--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
@@ -19,7 +19,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the DigitalOcean API to fulfill a dns-01 challenge.
     """
 
-    description = 'Obtain certs using a DNS TXT record (if you are using DigitalOcean for DNS).'
+    description = 'Obtain certificates using a DNS TXT record (if you are using DigitalOcean for DNS).'
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)

--- a/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
@@ -24,7 +24,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the Linode API to fulfill a dns-01 challenge.
     """
 
-    description = 'Obtain certs using a DNS TXT record (if you are using Linode for DNS).'
+    description = 'Obtain certificates using a DNS TXT record (if you are using Linode for DNS).'
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -226,7 +226,7 @@ class NginxConfigurator(common.Installer):
         if not fullchain_path:
             raise errors.PluginError(
                 "The nginx plugin currently requires --fullchain-path to "
-                "install a cert.")
+                "install a certificate.")
 
         vhosts = self.choose_vhosts(domain, create_if_no_match=True)
         for vhost in vhosts:

--- a/certbot/README.rst
+++ b/certbot/README.rst
@@ -96,7 +96,7 @@ Current Features
   - apache/2.x
   - nginx/0.8.48+
   - webroot (adds files to webroot directories in order to prove control of
-    domains and obtain certs)
+    domains and obtain certificates)
   - standalone (runs its own simple webserver to prove you control a domain)
   - other server software via `third party plugins <https://certbot.eff.org/docs/using.html#third-party-plugins>`_
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -369,7 +369,7 @@ def _describe_certs(config, parsed_certs, parse_failures):
     notify = out.append
 
     if not parsed_certs and not parse_failures:
-        notify("No certs found.")
+        notify("No certificates found.")
     else:
         if parsed_certs:
             match = "matching " if config.certname or config.domains else ""

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -254,7 +254,7 @@ def _handle_identical_cert_request(config,  # type: configuration.NamespaceConfi
     elif config.verb == "certonly":
         keep_opt = "Keep the existing certificate for now"
     choices = [keep_opt,
-               "Renew & replace the cert (may be subject to CA rate limits)"]
+               "Renew & replace the certificate (may be subject to CA rate limits)"]
 
     display = zope.component.getUtility(interfaces.IDisplay)
     response = display.menu(question, choices,
@@ -434,8 +434,8 @@ def _ask_user_to_confirm_new_names(config, new_domains, certname, old_domains):
                _format_list("-", removed),
                br=os.linesep))
     obj = zope.component.getUtility(interfaces.IDisplay)
-    if not obj.yesno(msg, "Update cert", "Cancel", default=True):
-        raise errors.ConfigurationError("Specified mismatched cert name and domains.")
+    if not obj.yesno(msg, "Update certificate", "Cancel", default=True):
+        raise errors.ConfigurationError("Specified mismatched certificate name and domains.")
 
 
 def _find_domains_or_certname(config, installer, question=None):
@@ -513,7 +513,7 @@ def _report_new_cert(config, cert_path, fullchain_path, key_path=None):
     # and say something more informative here.
     msg = ('Congratulations! Your certificate and chain have been saved at:{br}'
            '{0}{br}{1}'
-           'Your cert will expire on {2}. To obtain a new or tweaked version of this '
+           'Your certificate will expire on {2}. To obtain a new or tweaked version of this '
            'certificate in the future, simply run {3} again{4}. '
            'To non-interactively renew *all* of your certificates, run "{3} renew"'
            .format(fullchain_path, privkey_statement, expiry, cli.cli_command, verbswitch,
@@ -597,8 +597,8 @@ def _delete_if_appropriate(config):
 
     attempt_deletion = config.delete_after_revoke
     if attempt_deletion is None:
-        msg = ("Would you like to delete the cert(s) you just revoked, along with all earlier and "
-            "later versions of the cert?")
+        msg = ("Would you like to delete the certificate(s) you just revoked, "
+               "along with all earlier and later versions of the certificate?")
         attempt_deletion = display.yesno(msg, yes_label="Yes (recommended)", no_label="No",
                 force_interactive=True, default=True)
 
@@ -620,8 +620,8 @@ def _delete_if_appropriate(config):
         cert_manager.match_and_check_overlaps(config, [lambda x: archive_dir],
             lambda x: x.archive_dir, lambda x: x)
     except errors.OverlappingMatchFound:
-        logger.warning("Not deleting revoked certs due to overlapping archive dirs. More than "
-                       "one certificate is using %s", archive_dir)
+        logger.warning("Not deleting revoked certificates due to overlapping archive dirs. "
+                       "More than one certificate is using %s", archive_dir)
         return
     except Exception as e:
         msg = ('config.default_archive_dir: {0}, config.live_dir: {1}, archive_dir: {2},'
@@ -1098,7 +1098,7 @@ def revoke(config, unused_plugins):
         raise errors.Error("Error! Exactly one of --cert-path or --cert-name must be specified!")
 
     if config.key_path is not None:  # revocation by cert key
-        logger.debug("Revoking %s using cert key %s",
+        logger.debug("Revoking %s using certificate key %s",
                      config.cert_path[0], config.key_path[0])
         crypto_util.verify_cert_matches_priv_key(config.cert_path[0], config.key_path[0])
         key = jose.JWK.load(config.key_path[1])

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -293,13 +293,13 @@ def should_renew(config, lineage):
 
 def _avoid_invalidating_lineage(config, lineage, original_server):
     "Do not renew a valid cert with one from a staging server!"
-    # Some lineages may have begun with --staging, but then had production certs
-    # added to them
+    # Some lineages may have begun with --staging, but then had production
+    # certificates added to them
     with open(lineage.cert) as the_file:
         contents = the_file.read()
     latest_cert = OpenSSL.crypto.load_certificate(
         OpenSSL.crypto.FILETYPE_PEM, contents)
-    # all our test certs are from happy hacker fake CA, though maybe one day
+    # all our test certificates are from happy hacker fake CA, though maybe one day
     # we should test more methodically
     now_valid = "fake" not in repr(latest_cert.get_issuer()).lower()
 
@@ -366,7 +366,7 @@ def _renew_describe_results(config, renew_successes, renew_failures,
     renewal_noun = "simulated renewal" if config.dry_run else "renewal"
 
     if renew_skipped:
-        notify("The following certs are not due for renewal yet:")
+        notify("The following certificates are not due for renewal yet:")
         notify(report(renew_skipped, "skipped"))
     if not renew_successes and not renew_failures:
         notify("No {renewal}s were attempted.".format(renewal=renewal_noun))
@@ -377,7 +377,7 @@ def _renew_describe_results(config, renew_successes, renew_failures,
         notify("Congratulations, all {renewal}s succeeded: ".format(renewal=renewal_noun))
         notify(report(renew_successes, "success"))
     elif renew_failures and not renew_successes:
-        notify_error("All %ss failed. The following certs could "
+        notify_error("All %ss failed. The following certificates could "
                "not be renewed:", renewal_noun)
         notify_error(report(renew_failures, "failure"))
     elif renew_failures and renew_successes:

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -99,7 +99,7 @@ def _reconstitute(config, full_path):
         config.domains = [util.enforce_domain_sanity(d)
                           for d in renewal_candidate.names()]
     except errors.ConfigurationError as error:
-        logger.warning("Renewal configuration file %s references a cert "
+        logger.warning("Renewal configuration file %s references a certificate "
                        "that contains an invalid domain name. The problem "
                        "was: %s. Skipping.", full_path, error)
         return None
@@ -482,7 +482,7 @@ def handle_renewal_request(config):
         except Exception as e:  # pylint: disable=broad-except
             # obtain_cert (presumably) encountered an unanticipated problem.
             logger.error(
-                "Failed to renew cert %s with error: %s",
+                "Failed to renew certificate %s with error: %s",
                 lineagename, e
             )
             logger.debug("Traceback was:\n%s", traceback.format_exc())

--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -809,7 +809,7 @@ class RenewableCert(interfaces.RenewableCert):
         May need to recover from rare interrupted / crashed states."""
 
         if self.has_pending_deployment():
-            logger.warning("Found a new certiifcate /archive/ that was not "
+            logger.warning("Found a new certificate /archive/ that was not "
                            "linked to in /live/; fixing...")
             self.update_all_links_to(self.latest_common_version())
             return False

--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -809,8 +809,8 @@ class RenewableCert(interfaces.RenewableCert):
         May need to recover from rare interrupted / crashed states."""
 
         if self.has_pending_deployment():
-            logger.warning("Found a new cert /archive/ that was not linked to in /live/; "
-                        "fixing...")
+            logger.warning("Found a new certiifcate /archive/ that was not "
+                           "linked to in /live/; fixing...")
             self.update_all_links_to(self.latest_common_version())
             return False
         return True
@@ -883,7 +883,7 @@ class RenewableCert(interfaces.RenewableCert):
         """
         target = self.current_target("cert")
         if target is None:
-            raise errors.CertStorageError("could not find cert file")
+            raise errors.CertStorageError("could not find the certificate file")
         with open(target) as f:
             return crypto_util.get_names_from_cert(f.read())
 

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -279,7 +279,7 @@ def verify_renewable_cert_sig(renewable_cert):
             verify_signed_payload(pk, cert.signature, cert.tbs_certificate_bytes,
                                   cert.signature_hash_algorithm)
     except (IOError, ValueError, InvalidSignature) as e:
-        error_str = "verifying the signature of the cert located at {0} has failed. \
+        error_str = "verifying the signature of the certificate located at {0} has failed. \
                 Details: {1}".format(renewable_cert.cert_path, e)
         logger.exception(error_str)
         raise errors.Error(error_str)
@@ -330,7 +330,7 @@ def verify_cert_matches_priv_key(cert_path, key_path):
         context.use_privatekey_file(key_path)
         context.check_privatekey()
     except (IOError, SSL.Error) as e:
-        error_str = "verifying the cert located at {0} matches the \
+        error_str = "verifying the certificate located at {0} matches the \
                 private key located at {1} has failed. \
                 Details: {2}".format(cert_path,
                         key_path, e)

--- a/certbot/certbot/ocsp.py
+++ b/certbot/certbot/ocsp.py
@@ -167,7 +167,7 @@ def _determine_ocsp_server(cert_path):
 
     if host:
         return url, host
-    logger.info("Cannot process OCSP host from URL (%s) in cert at %s", url, cert_path)
+    logger.info("Cannot process OCSP host from URL (%s) in certificate at %s", url, cert_path)
     return None, None
 
 

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -282,8 +282,8 @@ support for IIS, Icecast and Plesk.
 Installers and Authenticators will oftentimes be the same class/object
 (because for instance both tasks can be performed by a webserver like nginx)
 though this is not always the case (the standalone plugin is an authenticator
-that listens on port 80, but it cannot install certs; a postfix plugin would
-be an installer but not an authenticator).
+that listens on port 80, but it cannot install certificates; a postfix plugin
+would be an installer but not an authenticator).
 
 Installers and Authenticators are kept separate because
 it should be possible to use the `~.StandaloneAuthenticator` (it sets

--- a/certbot/docs/install.rst
+++ b/certbot/docs/install.rst
@@ -161,7 +161,7 @@ Docker if you are sure you know what you are doing and have a good reason to do
 so.
 
 You should definitely read the :ref:`where-certs` section, in order to
-know how to manage the certs
+know how to manage the certificates
 manually. `Our ciphersuites page <ciphers.html>`__
 provides some information about recommended ciphersuites. If none of
 these make much sense to you, you should definitely use the installation method
@@ -285,8 +285,8 @@ Optionally to install the Certbot Apache plugin, you can use:
 
 **Gentoo**
 
-The official Certbot client is available in Gentoo Portage. From the 
-official Certbot plugins, three of them are also available in Portage. 
+The official Certbot client is available in Gentoo Portage. From the
+official Certbot plugins, three of them are also available in Portage.
 They need to be installed separately if you require their functionality.
 
 .. code-block:: shell
@@ -296,7 +296,7 @@ They need to be installed separately if you require their functionality.
    emerge -av app-crypt/certbot-nginx
    emerge -av app-crypt/certbot-dns-nsone
 
-.. Note:: The ``app-crypt/certbot-dns-nsone`` package has a different 
+.. Note:: The ``app-crypt/certbot-dns-nsone`` package has a different
    maintainer than the other packages and can lag behind in version.
 
 **NetBSD**

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -314,7 +314,7 @@ the ``certificates`` subcommand:
 
 This returns information in the following format::
 
-  Found the following certs:
+  Found the following certificates:
     Certificate Name: example.com
       Domains: example.com, www.example.com
       Expiry Date: 2017-02-19 19:53:00+00:00 (VALID: 30 days)

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1169,7 +1169,7 @@ class MainTest(test_util.ConfigTestCase):
         _, _, stdout = self._test_renewal_common(False, extra_args=None, should_renew=False,
                                                  args=['renew'], expiry_date=expiry)
         self.assertTrue('No renewals were attempted.' in stdout.getvalue())
-        self.assertTrue('The following certs are not due for renewal yet:' in stdout.getvalue())
+        self.assertTrue('The following certificates are not due for renewal yet:' in stdout.getvalue())
 
     @mock.patch('certbot._internal.log.post_arg_parse_setup')
     def test_quiet_renew(self, _):

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -204,7 +204,7 @@ class DescribeResultsTest(unittest.TestCase):
             '- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -',
         ])
         self.mock_error.assert_has_calls([
-            mock.call('All %ss failed. The following certs could not be renewed:', 'renewal'),
+            mock.call('All %ss failed. The following certificates could not be renewed:', 'renewal'),
             mock.call('  bad.pem (failure)'),
         ])
 
@@ -214,7 +214,7 @@ class DescribeResultsTest(unittest.TestCase):
                    ['foo.pem expires on 123'], ['errored.conf'])
         self._assert_success_output([
             '\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -',
-            'The following certs are not due for renewal yet:',
+            'The following certificates are not due for renewal yet:',
             '  foo.pem expires on 123 (skipped)',
             'The following simulated renewals succeeded:',
             '  good.pem (success)\n  good2.pem (success)\n',


### PR DESCRIPTION
To reduce confusion, we should consistently use the full term.