### PR TITLE
certbot-ci: fix integration-external tests

### DIFF
--- a/certbot-ci/certbot_integration_tests/nginx_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/nginx_tests/test_main.py
@@ -2,6 +2,7 @@
 import os
 import ssl
 
+from typing import List
 import pytest
 
 from certbot_integration_tests.nginx_tests import context as nginx_context
@@ -32,7 +33,7 @@ def test_context(request):
     ], {'default_server': False}),
 ], indirect=['context'])
 def test_certificate_deployment(certname_pattern, params, context):
-    # type: (str, list, nginx_context.IntegrationTestsContext) -> None
+    # type: (str, List[str], nginx_context.IntegrationTestsContext) -> None
     """
     Test various scenarios to deploy a certificate to nginx using certbot.
     """

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -13,9 +13,9 @@ import sys
 import tempfile
 import time
 
+from typing import List
 import requests
 
-from acme.magic_typing import List
 from certbot_integration_tests.utils import misc
 from certbot_integration_tests.utils import pebble_artifacts
 from certbot_integration_tests.utils import proxy
@@ -49,7 +49,7 @@ class ACMEServer(object):
         self._acme_type = 'pebble' if acme_server == 'pebble' else 'boulder'
         self._proxy = http_proxy
         self._workspace = tempfile.mkdtemp()
-        self._processes = []  # type: List
+        self._processes = []  # type: List[subprocess.Popen]
         self._stdout = sys.stdout if stdout else open(os.devnull, 'w')
         self._dns_server = dns_server
 

--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'python-dateutil',
     'pyyaml',
     'requests',
-    'six',
+    'six'
 ]
 
 # Add pywin32 on Windows platforms to handle low-level system calls.


### PR DESCRIPTION
In 96a05d9, mypy testing was added to certbot-ci, but introduced an
undeclared dependency on acme.magic_typing, resulting in a crash when
run under the integration-external tox environment.

This change uses the typing module in certbot-ci in place of
acme.magic_typing. It is already provided via dev_constraints.