### PR TITLE
Add certbot-auto uninstall docs

### DIFF
--- a/certbot/docs/install.rst
+++ b/certbot/docs/install.rst
@@ -243,6 +243,8 @@ Certbot-Auto
 
 We used to have a shell script named ``certbot-auto`` to help people install
 Certbot on UNIX operating systems, however, this script is no longer supported.
+If you want to uninstall ``certbot-auto``, you can follow our instructions
+:doc:`here <uninstall>`.
 
 Problems with Python virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/certbot/docs/uninstall.rst
+++ b/certbot/docs/uninstall.rst
@@ -7,8 +7,8 @@ To uninstall ``certbot-auto``, you need to do three things:
 1. If you added a cron job or systemd timer to automatically run
    ``certbot-auto`` to renew your certificates, you should delete it. If you
    did this by following our instructions, you can delete the entry added to
-   ``/etc/crontab`` by running a command like ``sudo sed -i '/certbot-auto
-   renew/d' /etc/crontab``.
+   ``/etc/crontab`` by running a command like ``sudo sed -i '/certbot-auto/d'
+   /etc/crontab``.
 2. Delete the ``certbot-auto`` script. If you placed it in ``/usr/local/bin``
    like we recommended, you can delete it by running ``sudo rm
    /usr/local/bin/certbot-auto``.

--- a/certbot/docs/uninstall.rst
+++ b/certbot/docs/uninstall.rst
@@ -1,0 +1,16 @@
+=========================
+Uninstalling certbot-auto
+=========================
+
+To uninstall ``certbot-auto``, you need to do three things:
+
+1. If you added a cron job or systemd timer to automatically run
+   ``certbot-auto`` to renew your certificates, you should delete it. If you
+   did this by following our instructions, you can delete the entry added to
+   ``/etc/crontab`` by running a command like ``sudo sed -i '/certbot-auto
+   renew/d' /etc/crontab``.
+2. Delete the ``certbot-auto`` script. If you placed it in ``/usr/local/bin``
+   like we recommended, you can delete it by running ``sudo rm
+   /usr/local/bin/certbot-auto``.
+3. Delete the Certbot installation created by ``certbot-auto`` by running
+   ``sudo rm -rf /opt/eff.org``.


### PR DESCRIPTION
This is part of https://github.com/certbot/certbot/issues/8545.

After this PR lands, the submodule in the website repo needs to be updated and our snap install instructions need to be updated to link to these docs.

Screenshots of the changes here are:

### uninstall.html
![Screen Shot 2020-12-18 at 12 15 18 PM](https://user-images.githubusercontent.com/6504915/102657613-d4d39500-412a-11eb-9b98-617cda045404.png)

### install.html
![Screen Shot 2020-12-18 at 12 15 29 PM](https://user-images.githubusercontent.com/6504915/102657621-d69d5880-412a-11eb-972a-b4a448f2e059.png)
