### PR TITLE
Pin DNS plugin snap build dependencies

### DIFF
--- a/tools/snap/generate_dnsplugins_all.sh
+++ b/tools/snap/generate_dnsplugins_all.sh
@@ -11,5 +11,6 @@ for PLUGIN_PATH in "${CERTBOT_DIR}"/certbot-dns-*; do
   # Create constraints file
   "${CERTBOT_DIR}"/tools/merge_requirements.py tools/dev_constraints.txt \
     <("${CERTBOT_DIR}"/tools/strip_hashes.py letsencrypt-auto-source/pieces/dependency-requirements.txt) \
+    <("${CERTBOT_DIR}"/tools/strip_hashes.py tools/pipstrap_constraints.txt) \
     > "${PLUGIN_PATH}"/snap-constraints.txt
 done

--- a/tools/snap/generate_dnsplugins_snapcraft.sh
+++ b/tools/snap/generate_dnsplugins_snapcraft.sh
@@ -32,7 +32,7 @@ parts:
       # used. This is done to let these constraints be applied not only on the certbot package
       # build, but also on any isolated build that pip could trigger when building wheels for
       # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
-      - PIP_CONSTRAINT: $SNAPCRAFT_PART_SRC/snap-constraints.txt
+      - PIP_CONSTRAINT: \$SNAPCRAFT_PART_SRC/snap-constraints.txt
       - SNAP_BUILD: "True"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]

--- a/tools/snap/generate_dnsplugins_snapcraft.sh
+++ b/tools/snap/generate_dnsplugins_snapcraft.sh
@@ -23,11 +23,16 @@ parts:
   ${PLUGIN}:
     plugin: python
     source: .
-    constraints: [\$SNAPCRAFT_PART_SRC/snap-constraints.txt]
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version \`grep ^version \$SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"\`
     build-environment:
+      # Constraints are passed through the environment variable PIP_CONSTRAINTS instead of using the
+      # parts.[part_name].constraints option available in snapcraft.yaml when the Python plugin is
+      # used. This is done to let these constraints be applied not only on the certbot package
+      # build, but also on any isolated build that pip could trigger when building wheels for
+      # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
+      - PIP_CONSTRAINT: $SNAPCRAFT_PART_SRC/snap-constraints.txt
       - SNAP_BUILD: "True"
     # To build cryptography and cffi if needed
     build-packages: [gcc, libffi-dev, libssl-dev, python3-dev]


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8544 by taking the approach in https://github.com/certbot/certbot/pull/8443.

You can see tests passing, including for ARM snaps, at https://dev.azure.com/certbot/certbot/_build/results?buildId=3210&view=results.

To ensure things were working as expected, I pinned a nonexistent version of setuptools causing the builds to fail which you can see at https://dev.azure.com/certbot/certbot/_build/results?buildId=3212&view=results.