### PR TITLE
Added note about CA/Browser forum in docs

### DIFF
--- a/certbot/docs/what.rst
+++ b/certbot/docs/what.rst
@@ -2,14 +2,14 @@
 What is a Certificate?
 ======================
 
-A public key or digital *certificate* (formerly called an SSL certificate) uses a public key 
-and a private key to enable secure communication between a client program (web browser, email client, 
+A public key or digital *certificate* (formerly called an SSL certificate) uses a public key
+and a private key to enable secure communication between a client program (web browser, email client,
 etc.) and a server over an encrypted SSL (secure socket layer) or TLS (transport layer security) connection.
-The certificate is used both to encrypt the initial stage of communication (secure key exchange) 
+The certificate is used both to encrypt the initial stage of communication (secure key exchange)
 and to identify the server. The certificate
 includes information about the key, information about the server identity, and the digital signature
 of the certificate issuer. If the issuer is trusted by the software that initiates the communication,
-and the signature is valid, then the key can be used to communicate securely with the server identified by 
+and the signature is valid, then the key can be used to communicate securely with the server identified by
 the certificate. Using a certificate is a good way to prevent "man-in-the-middle" attacks, in which
 someone in between you and the server you think you are talking to is able to insert their own (harmful)
 content.
@@ -23,9 +23,18 @@ Certificates and Lineages
 Certbot introduces the concept of a *lineage,* which is a collection of all the versions of a certificate
 plus Certbot configuration information maintained for that certificate from
 renewal to renewal. Whenever you renew a certificate, Certbot keeps the same configuration unless
-you explicitly change it, for example by adding or removing domains. If you add domains, you can 
+you explicitly change it, for example by adding or removing domains. If you add domains, you can
 either add them to an existing lineage or create
-a new one. 
+a new one.
 
 See also:
 :ref:`updating_certs`
+
+CA/Browser forum
+================
+
+Certbot follows the requirements given in the
+`document <https://cabforum.org/baseline-requirements-documents/>`_ from CA/Browser forum.
+These requirements describe which algorithms that browsers should support, as well as
+different properties for the certificates. `LetsEncrypt <https://letsencrypt.org/>`_
+is used by Certbot also follows these guidelines.  


### PR DESCRIPTION
I was recently tagged in an issue (fortunately now deleted) with very in-appropriate language. The whole confusion about the NIST curves may be alleviated by some notes. This is a first take; please feel free to suggest improvements as well as an alternative place to put the note. 

The ed448 and ed25519 are not mentioned in the document from CA/Browser forum, and I hope it will be eventually be included :) 

I apologize for unrelated trailing whitespace clean-up changes in the file. Maybe everything could be fixed in a single commit, so these changes are not committed when touching various files.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
