### PR TITLE
docs: fix simple typo, serveral -> several

### DIFF
--- a/certbot/certbot/ocsp.py
+++ b/certbot/certbot/ocsp.py
@@ -222,7 +222,7 @@ def _check_ocsp_cryptography(cert_path, chain_path, url, timeout):
 
 
 def _check_ocsp_response(response_ocsp, request_ocsp, issuer_cert, cert_path):
-    """Verify that the OCSP is valid for serveral criteria"""
+    """Verify that the OCSP is valid for several criteria"""
     # Assert OCSP response corresponds to the certificate we are talking about
     if response_ocsp.serial_number != request_ocsp.serial_number:
         raise AssertionError('the certificate in response does not correspond '


### PR DESCRIPTION
There is a small typo in certbot/certbot/ocsp.py.

Should read `several` rather than `serveral`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md