### PR TITLE
docs: add missing /directory to ACMEv2 server URL

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -912,7 +912,7 @@ Changing the ACME Server
 ========================
 
 By default, Certbot uses Let's Encrypt's production server at
-https://acme-v02.api.letsencrypt.org/. You can tell Certbot to use a
+https://acme-v02.api.letsencrypt.org/directory. You can tell Certbot to use a
 different CA by providing ``--server`` on the command line or in a
 :ref:`configuration file <config-file>` with the URL of the server's
 ACME directory. For example, if you would like to use Let's Encrypt's


### PR DESCRIPTION
We had a user on the forums who copied the incomplete `https://acme-v02.api.letsencrypt.org/` from here as their `--server` and got into trouble.