### PR TITLE
Skip meta creation to speed up tests

### DIFF
--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -113,11 +113,16 @@ class AccountFileStorageTest(test_util.ConfigTestCase):
 
         from certbot._internal.account import Account
         new_authzr_uri = "hi"
+        meta = Account.Meta(
+            creation_host="test.example.org",
+            creation_dt=datetime.datetime(
+                2021, 1, 5, 14, 4, 10, tzinfo=pytz.UTC))
         self.acc = Account(
             regr=messages.RegistrationResource(
                 uri=None, body=messages.Registration(),
                 new_authzr_uri=new_authzr_uri),
-            key=KEY)
+            key=KEY,
+            meta=meta)
         self.mock_client = mock.MagicMock()
         self.mock_client.directory.new_authz = new_authzr_uri
 


### PR DESCRIPTION
Some of Certbot's unit tests are very slow on my Macbook. Quickly profiling the tests, one of the slow files is `account_test.py` which seems to be caused by the call to `socket.getfqdn()` [here](https://github.com/certbot/certbot/blob/98fb9d2d93c58e39613a5b9126f06511b9e7f839/certbot/certbot/_internal/account.py#L60). Googling around, I found others with this problem in threads like https://apple.stackexchange.com/questions/175320/why-is-my-hostname-resolution-taking-so-long. That thread in particular suggests ways to configure macOS to speed things up which I may do, however, this problem seems to affect enough users based on my Google search that I'd also like to fix the test which this PR does. This is done by passing in an existing `Meta` object when creating the account. Since these are unit tests for `AccountFileStorage` and not `Account`, we shouldn't be losing anything here.

Here are tests running on my Macbook before this change:
```
$  time python certbot/tests/account_test.py
..................................
----------------------------------------------------------------------
Ran 34 tests in 135.353s

OK
python certbot/tests/account_test.py  0.57s user 0.17s system 0% cpu 2:15.86 total
```
Here they are afterwards:
```
$ time python certbot/tests/account_test.py                  
..................................
----------------------------------------------------------------------
Ran 34 tests in 0.180s

OK
python certbot/tests/account_test.py  0.48s user 0.13s system 98% cpu 0.626 total
```