### PR TITLE
Mock out plugin discovery in test_plugins

### DIFF
--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -813,8 +813,10 @@ class MainTest(test_util.ConfigTestCase):
         self._call_no_clientmock(['delete'])
         self.assertEqual(1, mock_cert_manager.call_count)
 
+    @mock.patch('certbot._internal.main.plugins_disco')
+    @mock.patch('certbot._internal.main.cli.HelpfulArgumentParser.determine_help_topics')
     @mock.patch('certbot._internal.log.post_arg_parse_setup')
-    def test_plugins(self, _):
+    def test_plugins(self, _, _det, mock_disco):
         flags = ['--init', '--prepare', '--authenticators', '--installers']
         for args in itertools.chain(
                 *(itertools.combinations(flags, r)


### PR DESCRIPTION
Some of Certbot's unit tests are very slow on my Macbook. Quickly profiling the tests, the worst offender by far is `certbot/tests/main_test.py::MainTest::test_plugins`. Looking into it a bit, the cause is repeatedly creating and preparing the Apache plugin which shells out to `apachectl` multiple times and is quite slow.

To fix this, since this is a unit test of the top level `plugins` subcommand, I mocked out plugin discovery as is done in the other tests of the `plugins` subcommand found below the test I modified. When doing this, you also need to mock out `determine_help_topics` or tests will fail.

## Running tests before this change

### On my Linux VPS
```
$ python certbot/tests/main_test.py MainTest.test_plugins
.
----------------------------------------------------------------------
Ran 1 test in 7.422s

OK
```
### On my Macbook
```
$ python certbot/tests/main_test.py MainTest.test_plugins 
.
----------------------------------------------------------------------
Ran 1 test in 149.145s

OK
```

## Running tests after this change

### On my Linux VPS
```
$ python certbot/tests/main_test.py MainTest.test_plugins
.
----------------------------------------------------------------------
Ran 1 test in 0.404s

OK
```

### On my Macbook
```
python certbot/tests/main_test.py MainTest.test_plugins 
.
----------------------------------------------------------------------
Ran 1 test in 0.537s

OK
```