### PR TITLE
Add matching route53 readme

### DIFF
--- a/certbot-dns-route53/MANIFEST.in
+++ b/certbot-dns-route53/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE.txt
+include README.rst
 recursive-include docs *
 recursive-include tests *
 global-exclude __pycache__

--- a/certbot-dns-route53/README.rst
+++ b/certbot-dns-route53/README.rst
@@ -1,0 +1,1 @@
+Amazon Web Services Route 53 Authenticator plugin for Certbot

--- a/certbot-dns-route53/README.rst
+++ b/certbot-dns-route53/README.rst
@@ -1,1 +1,1 @@
-Amazon Web Services Route 53 Authenticator plugin for Certbot
+Amazon Web Services Route 53 DNS Authenticator plugin for Certbot


### PR DESCRIPTION
Building on https://github.com/certbot/certbot/pull/8581, our other DNS plugins have a simple `README.rst` file and this PR adds a matching one for the route53 plugin.