### PR TITLE
Add curl binary in the Certbot docker

### DIFF
--- a/tools/docker/core/Dockerfile
+++ b/tools/docker/core/Dockerfile
@@ -28,7 +28,8 @@ RUN apk add --no-cache --virtual .certbot-deps \
         libssl1.1 \
         openssl \
         ca-certificates \
-        binutils
+        binutils \
+        curl
 
 # Install certbot from sources
 #


### PR DESCRIPTION
Fixes #8582

Given the number of times the lack of `curl` in a docker bored me when I wanted to interact with an API, and given that Certbot is likely to communicate with APIs in manual mode/DNS challenges, I think it makes a lot of sense to add this by default in the docker image.