### PR TITLE
Fix EC curve name typo in crypto_util

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -60,6 +60,7 @@ Authors
 * [DanCld](https://github.com/DanCld)
 * [Daniel Albers](https://github.com/AID)
 * [Daniel Aleksandersen](https://github.com/da2x)
+* [Daniel Almasi](https://github.com/almasen)
 * [Daniel Convissor](https://github.com/convissor)
 * [Daniel "Drex" Drexler](https://github.com/aeturnum)
 * [Daniel Huang](https://github.com/dhuang)

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import time
 
-from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, SECP384R1
+from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, SECP384R1, SECP521R1
 from cryptography.x509 import NameOID
 
 import pytest
@@ -498,6 +498,13 @@ def test_renew_with_ec_keys(context):
     assert_elliptic_key(key2, SECP384R1)
     assert 280 < os.stat(key2).st_size < 320  # ec keys of 384 bits are ~310 bytes
 
+    context.certbot(['renew', '--elliptic-curve', 'secp521r1'])
+
+    assert_cert_count_for_lineage(context.config_dir, certname, 3)
+    key3 = join(context.config_dir, 'archive', certname, 'privkey3.pem')
+    assert_elliptic_key(key3, SECP521R1)
+    assert 340 < os.stat(key3).st_size < 390  # ec keys of 521 bits are ~365 bytes
+
     # We expect here that the command will fail because without --key-type specified,
     # Certbot must error out to prevent changing an existing certificate key type,
     # without explicit user consent (by specifying both --cert-name and --key-type).
@@ -511,9 +518,9 @@ def test_renew_with_ec_keys(context):
     # We expect that the previous behavior of requiring both --cert-name and
     # --key-type to be set to not apply to the renew subcommand.
     context.certbot(['renew', '--force-renewal', '--key-type', 'rsa'])
-    assert_cert_count_for_lineage(context.config_dir, certname, 3)
-    key3 = join(context.config_dir, 'archive', certname, 'privkey3.pem')
-    assert_rsa_key(key3)
+    assert_cert_count_for_lineage(context.config_dir, certname, 4)
+    key4 = join(context.config_dir, 'archive', certname, 'privkey4.pem')
+    assert_rsa_key(key4)
 
 
 def test_ocsp_must_staple(context):

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Fixed the apache component on openSUSE Tumbleweed which no longer provides
   an apache2ctl symlink and uses apachectl instead.
+* Fixed a typo in `certbot/crypto_util.py` causing an error upon attempting `secp521r1` key generation
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -205,7 +205,7 @@ def make_key(bits=1024, key_type="rsa", elliptic_curve=None):
     elif key_type == 'ecdsa':
         try:
             name = elliptic_curve.upper()
-            if name in ('SECP256R1', 'SECP384R1', 'SECP512R1'):
+            if name in ('SECP256R1', 'SECP384R1', 'SECP521R1'):
                 _key = ec.generate_private_key(
                     curve=getattr(ec, elliptic_curve.upper(), None)(),
                     backend=default_backend()


### PR DESCRIPTION
Fix typo of secp521r1 in crypto util module.
- secp521r1 is to be supported by certbot, but a typo of "SECP512R1" in the input validation section of the `make_key` function results in an error being thrown

![Screenshot_20210110_190317(1)](https://user-images.githubusercontent.com/47671879/104132955-85beff80-5378-11eb-96a6-6f46494d9b5e.png)


## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR. - (N/A i think)
- [x] Include your name in `AUTHORS.md` if you like.
