### PR TITLE
Use os.path.normcase to have Windows compatible challenge paths on Windows

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -148,6 +148,17 @@ def test_certonly(context):
     """Test the certonly verb on certbot."""
     context.certbot(['certonly', '--cert-name', 'newname', '-d', context.get_domain('newname')])
 
+    assert_cert_count_for_lineage(context.config_dir, 'newname', 1)
+
+
+def test_certonly_webroot(context):
+    """Test the certonly verb with webroot plugin"""
+    with misc.create_http_server(context.http_01_port) as webroot:
+        certname = context.get_domain('webroot')
+        context.certbot(['certonly', '-a', 'webroot', '--webroot-path', webroot, '-d', certname])
+
+    assert_cert_count_for_lineage(context.config_dir, certname, 1)
+
 
 def test_auth_and_install_with_csr(context):
     """Test certificate issuance and install using an existing CSR."""

--- a/certbot/certbot/_internal/plugins/webroot.py
+++ b/certbot/certbot/_internal/plugins/webroot.py
@@ -157,7 +157,7 @@ to serve all files under specified web root ({0})."""
                 "--webroot-path and --domains, or --webroot-map. Run with "
                 " --help webroot for examples.")
         for name, path in path_map.items():
-            self.full_roots[name] = os.path.join(path, challenges.HTTP01.URI_ROOT_PATH)
+            self.full_roots[name] = os.path.join(path, os.path.normcase(challenges.HTTP01.URI_ROOT_PATH))
             logger.debug("Creating root challenges validation dir at %s",
                          self.full_roots[name])
 

--- a/certbot/certbot/_internal/plugins/webroot.py
+++ b/certbot/certbot/_internal/plugins/webroot.py
@@ -157,7 +157,8 @@ to serve all files under specified web root ({0})."""
                 "--webroot-path and --domains, or --webroot-map. Run with "
                 " --help webroot for examples.")
         for name, path in path_map.items():
-            self.full_roots[name] = os.path.join(path, os.path.normcase(challenges.HTTP01.URI_ROOT_PATH))
+            self.full_roots[name] = os.path.join(path, os.path.normcase(
+                challenges.HTTP01.URI_ROOT_PATH))
             logger.debug("Creating root challenges validation dir at %s",
                          self.full_roots[name])
 


### PR DESCRIPTION
Fixes #8597

