### PR TITLE
manual: warn that --manual without hook wont renew

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Added an interactive prompt warning about renewal when using `--manual` without an authentication
+  hook.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/plugins/manual.py
+++ b/certbot/certbot/_internal/plugins/manual.py
@@ -30,6 +30,7 @@ class Authenticator(common.Plugin):
     hidden = True
     long_description = (
         'Authenticate through manual configuration or custom shell scripts. '
+        'Without shell scripts, automatic renewal is NOT supported. '
         'When using shell scripts, an authenticator script must be provided. '
         'The environment variables available to this script depend on the '
         'type of challenge. $CERTBOT_DOMAIN will always contain the domain '
@@ -92,6 +93,17 @@ permitted by DNS standards.)
                 'An authentication script must be provided with --{0} when '
                 'using the manual plugin non-interactively.'.format(
                     self.option_name('auth-hook')))
+        elif not self.conf('auth-hook'):
+            if not zope.component.getUtility(interfaces.IDisplay).yesno(
+                'WARNING: Using the --manual plugin without --manual-auth-hook means that Certbot '
+                'will not be able to automatically renew this certificate. To renew, you will be '
+                'required to run this command again and follow the instructions each time. '
+                '\n\nIf possible, use a Certbot plugin supporting automatic renewal or provide a '
+                '--manual-auth-hook to automate the process (see "certbot --help manual").'
+                '\n\nAre you sure you want to create this certificate manually?',
+                default=True
+            ):
+                raise errors.PluginError('User declined to create a manual certificate.')
         self._validate_hooks()
 
     def _validate_hooks(self):

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -211,6 +211,11 @@ the UI, you can use the plugin to obtain a certificate by specifying
 to copy and paste commands into another terminal session, which may
 be on a different computer.
 
+Obtaining a certificate using the manual plugin does **not** support
+automatic certificate renewal, unless using hooks (described below). You will
+be required to run the same command and repeat the manual steps every time you
+need to renew your certificate.
+
 The manual plugin can use either the ``http`` or the ``dns`` challenge. You can use the ``--preferred-challenges`` option
 to choose the challenge of your preference.
 

--- a/certbot/tests/plugins/manual_test.py
+++ b/certbot/tests/plugins/manual_test.py
@@ -58,7 +58,7 @@ class AuthenticatorTest(test_util.TempDirTestCase):
         mock_get_utility().yesno.return_value = False
         with self.assertRaises(errors.PluginError) as e:
             self.auth.prepare()
-        mock_get_utility().yesno.assert_called_once()
+        self.assertEqual(mock_get_utility().yesno.call_count, 1)
         self.assertIn('WARNING: Using the --manual plugin without --manual-auth-hook',
                       mock_get_utility().yesno.call_args[0][0])
         self.assertEqual(str(e.exception), 'User declined to create a manual certificate.')


### PR DESCRIPTION
Sometimes users do not understand that obtaining a certificate using
`-manual` (without `--manual-auth-hook`) means that Certbot will not be
able to automatically renew that certificate. This results in an
unwelcome surprise at renewal time.

This change introduces a proactive yes/no prompt explaining the
situation and tries to point them toward either using a hook or using a
different plugin. It appears only during interactive execution.

Fixes #6280.

---

    $ certbot certonly --manual -d example.com
    Saving debug log to /var/log/letsencrypt/letsencrypt.log

    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    WARNING: Using the --manual plugin without --manual-auth-hook means that Certbot
    will not be able to automatically renew this certificate. To renew, you will be
    required to run this command again and follow the instructions each time.

    If possible, use a Certbot plugin supporting automatic renewal or provide a
    --manual-auth-hook to automate the process (see "certbot --help manual").

    Are you sure you want to create this certificate manually?
    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    (Y)es/(N)o:

![doc screenshot](https://i.imgur.com/4jtLluC.png)


