### PR TITLE
test: certbot-ci crash due to no p521 on boulder

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import time
 
-from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, SECP384R1, SECP521R1
+from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, SECP384R1
 from cryptography.x509 import NameOID
 
 import pytest
@@ -498,13 +498,6 @@ def test_renew_with_ec_keys(context):
     assert_elliptic_key(key2, SECP384R1)
     assert 280 < os.stat(key2).st_size < 320  # ec keys of 384 bits are ~310 bytes
 
-    context.certbot(['renew', '--elliptic-curve', 'secp521r1'])
-
-    assert_cert_count_for_lineage(context.config_dir, certname, 3)
-    key3 = join(context.config_dir, 'archive', certname, 'privkey3.pem')
-    assert_elliptic_key(key3, SECP521R1)
-    assert 340 < os.stat(key3).st_size < 390  # ec keys of 521 bits are ~365 bytes
-
     # We expect here that the command will fail because without --key-type specified,
     # Certbot must error out to prevent changing an existing certificate key type,
     # without explicit user consent (by specifying both --cert-name and --key-type).
@@ -518,9 +511,9 @@ def test_renew_with_ec_keys(context):
     # We expect that the previous behavior of requiring both --cert-name and
     # --key-type to be set to not apply to the renew subcommand.
     context.certbot(['renew', '--force-renewal', '--key-type', 'rsa'])
-    assert_cert_count_for_lineage(context.config_dir, certname, 4)
-    key4 = join(context.config_dir, 'archive', certname, 'privkey4.pem')
-    assert_rsa_key(key4)
+    assert_cert_count_for_lineage(context.config_dir, certname, 3)
+    key3 = join(context.config_dir, 'archive', certname, 'privkey3.pem')
+    assert_rsa_key(key3)
 
 
 def test_ocsp_must_staple(context):

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -184,11 +184,13 @@ class MakeKeyTest(unittest.TestCase):
     def test_ec(self):  # pylint: disable=no-self-use
         # ECDSA Key Type Tests
         from certbot.crypto_util import make_key
-        # Do not test larger keys as it takes too long.
 
-        # Try a good key size for ECDSA
-        OpenSSL.crypto.load_privatekey(
-            OpenSSL.crypto.FILETYPE_PEM, make_key(elliptic_curve="secp256r1", key_type='ecdsa'))
+        for (name, bits) in [('secp256r1', 256), ('secp384r1', 384), ('secp521r1', 521)]:
+            pkey = OpenSSL.crypto.load_privatekey(
+                OpenSSL.crypto.FILETYPE_PEM,
+                make_key(elliptic_curve=name, key_type='ecdsa')
+            )
+            self.assertEqual(pkey.bits(), bits)
 
     def test_bad_key_sizes(self):
         from certbot.crypto_util import make_key


### PR DESCRIPTION
The bugfix in #8598 added an integration test to request a certificate
for an EC P-521 key, which is unsupported when ACME_SERVER=boulder,
failing our nightly integration tests.

---

Rather than branching on `context.acme_server` in `test_renew_with_ec_keys` or breaking out a separate integration test for E2E P-521 issuance, I have chosen to replace the coverage of the bug with a unit test. If it is important to have an E2E test of P-521 issuance, I'd be happy to re-add it.