### PR TITLE
Remove unused PyICU pinning

### DIFF
--- a/tools/oldest_constraints.txt
+++ b/tools/oldest_constraints.txt
@@ -29,7 +29,6 @@ zope.interface==4.0.5
 # Debian Jessie has reached end of life. However:
 # When it becomes necessary to upgrade any of these dependencies, you should only update them to the oldest version of the package found
 # in a non-EOL'd version of CentOS, Debian, or Ubuntu that has Certbot packages in their OS repositories.
-PyICU==1.8
 colorama==0.3.2
 enum34==1.0.3
 html5lib==0.999


### PR DESCRIPTION
This is a follow up from https://github.com/certbot/certbot/pull/8590#discussion_r557771454. You can see the full test suite passing at https://dev.azure.com/certbot/certbot/_build/results?buildId=3313&view=results.

If you search the logs in the oldest tests, you'll see no mention of `PyICU`.

I suspect there are other dependencies we have pinned and no longer use like this. Maybe we should clean them up someday, but that feels like a very low priority to me. I just did this one because I happened to already take the time to verify we're not using it in response to the problem Alex found.