### PR TITLE
Remove deprecated options as early as possible using an explicit list

### DIFF
--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -472,6 +472,8 @@ def set_by_cli(var):
     (CLI or config file) including if the user explicitly set it to the
     default.  Returns False if the variable was assigned a default value.
     """
+    # We should probably never actually hit this code. But if we do,
+    # a deprecated option has logically never been set by the CLI.
     if var in DEPRECATED_OPTIONS:
         return False
 
@@ -535,6 +537,7 @@ def option_was_set(option, value):
     :rtype: bool
 
     """
+    # If an option is deprecated, it was effectively not set by the user.
     if option in DEPRECATED_OPTIONS:
         return False
     return set_by_cli(option) or not has_default_value(option, value)

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -471,6 +471,9 @@ def set_by_cli(var):
     (CLI or config file) including if the user explicitly set it to the
     default.  Returns False if the variable was assigned a default value.
     """
+    if var in DEPRECATED_OPTIONS:
+        return False
+
     detector = set_by_cli.detector  # type: ignore
     if detector is None and helpful_parser is not None:
         # Setup on first run: `detector` is a weird version of config in which
@@ -531,6 +534,8 @@ def option_was_set(option, value):
     :rtype: bool
 
     """
+    if option in DEPRECATED_OPTIONS:
+        return False
     return set_by_cli(option) or not has_default_value(option, value)
 
 

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -28,7 +28,8 @@ from certbot._internal.cli.cli_constants import (
     ARGPARSE_PARAMS_TO_REMOVE,
     EXIT_ACTIONS,
     ZERO_ARG_ACTIONS,
-    VAR_MODIFIERS
+    VAR_MODIFIERS,
+    DEPRECATED_OPTIONS
 )
 
 from certbot._internal.cli.cli_utils import (

--- a/certbot/certbot/_internal/cli/cli_constants.py
+++ b/certbot/certbot/_internal/cli/cli_constants.py
@@ -105,3 +105,5 @@ VAR_MODIFIERS = {"account": {"server",},
                  "renew_hook": {"deploy_hook",},
                  "server": {"dry_run", "staging",},
                  "webroot_map": {"webroot_path",}}
+
+DEPRECATED_OPTIONS = {"manual_public_ip_logging_ok",}

--- a/certbot/certbot/_internal/cli/cli_constants.py
+++ b/certbot/certbot/_internal/cli/cli_constants.py
@@ -106,4 +106,7 @@ VAR_MODIFIERS = {"account": {"server",},
                  "server": {"dry_run", "staging",},
                  "webroot_map": {"webroot_path",}}
 
+# This is a list of all CLI options that we have ever deprecated. It lets us
+# opt out of the default detection, which can interact strangely with option
+# deprecation. See https://github.com/certbot/certbot/issues/8540 for more info.
 DEPRECATED_OPTIONS = {"manual_public_ip_logging_ok",}

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -190,6 +190,14 @@ def restore_required_config_elements(config, renewalparams):
 
 
 def _remove_deprecated_config_elements(renewalparams):
+    """Removes deprecated config options from the parsed renewalparams.
+
+    :param dict renewalparams: list of parsed renewalparams
+
+    :returns: list of renewalparams with deprecated config options removed
+    :rtype: dict
+
+    """
     return {option_name: v for (option_name, v) in renewalparams.items()
         if option_name not in cli.DEPRECATED_OPTIONS}
 

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -190,7 +190,7 @@ def restore_required_config_elements(config, renewalparams):
 
 
 def _remove_deprecated_config_elements(renewalparams):
-    return {option_name : v for (option_name, v) in renewalparams.items()
+    return {option_name: v for (option_name, v) in renewalparams.items()
         if option_name not in cli.DEPRECATED_OPTIONS}
 
 

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -85,6 +85,7 @@ def _reconstitute(config, full_path):
         return None
     # Now restore specific values along with their data types, if
     # those elements are present.
+    renewalparams = _remove_deprecated_config_elements(renewalparams)
     try:
         restore_required_config_elements(config, renewalparams)
         _restore_plugin_configs(config, renewalparams)
@@ -186,6 +187,11 @@ def restore_required_config_elements(config, renewalparams):
         if item_name in renewalparams and not cli.set_by_cli(item_name):
             value = restore_func(item_name, renewalparams[item_name])
             setattr(config, item_name, value)
+
+
+def _remove_deprecated_config_elements(renewalparams):
+    return {option_name : v for option_name, v in renewalparams.iteritems()
+        if option_name not in cli.DEPRECATED_OPTIONS}
 
 
 def _restore_pref_challs(unused_name, value):

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -190,7 +190,7 @@ def restore_required_config_elements(config, renewalparams):
 
 
 def _remove_deprecated_config_elements(renewalparams):
-    return {option_name : v for option_name, v in renewalparams.iteritems()
+    return {option_name : v for (option_name, v) in renewalparams.items()
         if option_name not in cli.DEPRECATED_OPTIONS}
 
 

--- a/certbot/certbot/tests/testdata/sample-renewal-deprecated-option.conf
+++ b/certbot/certbot/tests/testdata/sample-renewal-deprecated-option.conf
@@ -1,0 +1,14 @@
+# renew_before_expiry = 30 days
+version = 1.11.0
+archive_dir = MAGICDIR/live/sample-renewal-deprecated-option
+cert = MAGICDIR/live/sample-renewal-deprecated-option/cert.pem
+privkey = MAGICDIR/live/sample-renewal-deprecated-option/privkey.pem
+chain = MAGICDIR/live/sample-renewal-deprecated-option/chain.pem
+fullchain = MAGICDIR/live/sample-renewal-deprecated-option/fullchain.pem
+
+# Options used in the renewal process
+[renewalparams]
+account = ffffffffffffffffffffffffffffffff
+authenticator = nginx
+installer = nginx
+manual_public_ip_logging_ok = None

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -77,6 +77,17 @@ class RelevantValuesTest(unittest.TestCase):
 
         self.assertEqual(self._call(self.values), expected_relevant_values)
 
+    @mock.patch("certbot._internal.cli.set_by_cli")
+    def test_deprecated_item(self, unused_mock_set_by_cli):
+        # deprecated items should never be relevant to store
+        expected_relevant_values = self.values.copy()
+        self.values["manual_public_ip_logging_ok"] = None
+        self.assertEqual(self._call(self.values), expected_relevant_values)
+        self.values["manual_public_ip_logging_ok"] = True
+        self.assertEqual(self._call(self.values), expected_relevant_values)
+        self.values["manual_public_ip_logging_ok"] = False
+        self.assertEqual(self._call(self.values), expected_relevant_values)
+
 
 class BaseRenewableCertTest(test_util.ConfigTestCase):
     """Base class for setting up Renewable Cert tests.


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8540.

This PR removes deprecated options from renewal configs, and stops them from being saved to renewal configs in the future. It does so by creating an explicit list of deprecated option names that we will keep around forever.

The value and the default value of a deprecated option should not be relevant at all.

My philosophy here was:

- Do things as explicitly as possible
- Keep deprecated-option code as close to the cli module as possible.

I ran some searches to try to track down where else we might want to do things, but only immediately found the same places that were suggested at https://github.com/certbot/certbot/issues/8540#issuecomment-767186124, though I ended up making the change in slightly different/earlier places.