### PR TITLE
Start disabling certbot-auto upgrades 

### DIFF
--- a/certbot-auto
+++ b/certbot-auto
@@ -31,7 +31,7 @@ if [ -z "$VENV_PATH" ]; then
 fi
 VENV_BIN="$VENV_PATH/bin"
 BOOTSTRAP_VERSION_PATH="$VENV_PATH/certbot-auto-bootstrap-version.txt"
-LE_AUTO_VERSION="1.11.0"
+LE_AUTO_VERSION="99.99.99"
 BASENAME=$(basename $0)
 USAGE="Usage: $BASENAME [OPTIONS]
 A self-updating wrapper script for the Certbot ACME client. When run, updates

--- a/certbot-auto
+++ b/certbot-auto
@@ -31,7 +31,7 @@ if [ -z "$VENV_PATH" ]; then
 fi
 VENV_BIN="$VENV_PATH/bin"
 BOOTSTRAP_VERSION_PATH="$VENV_PATH/certbot-auto-bootstrap-version.txt"
-LE_AUTO_VERSION="99.99.99"
+LE_AUTO_VERSION="1.11.0"
 BASENAME=$(basename $0)
 USAGE="Usage: $BASENAME [OPTIONS]
 A self-updating wrapper script for the Certbot ACME client. When run, updates

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -15,10 +15,11 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   every certificate in the chain.
   See [#8577](https://github.com/certbot/certbot/issues/8577).
 * Support for Python 2 has been removed.
-* certbot-auto will stop receiving updates on systems other than those based on
-  Debian or RHEL (excluding Amazon Linux who stopped receiving updates in this
-  release). We plan to make this change to the certbot-auto script for all
-  users in the coming months.
+* In previous releases, we caused certbot-auto to stop updating its Certbot
+  installation. In this release, we are beginning to disable updates to the
+  certbot-auto script itself. This release includes Amazon Linux users, and all
+  other systems that are not based on Debian or RHEL. We plan to make this
+  change to the certbot-auto script for all users in the coming months.
 
 ### Fixed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -15,6 +15,10 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   every certificate in the chain.
   See [#8577](https://github.com/certbot/certbot/issues/8577).
 * Support for Python 2 has been removed.
+* certbot-auto will stop receiving updates on systems other than those based on
+  Debian or RHEL (excluding Amazon Linux who stopped receiving updates in this
+  release). We plan to make this change to the certbot-auto script for all
+  users in the coming months.
 
 ### Fixed
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1117,7 +1117,9 @@ if [ "$1" = "--le-auto-phase2" ]; then
     fi
 
     if [ -f "$VENV_BIN/letsencrypt" -a "$INSTALL_ONLY" != 1 ]; then
-      error "certbot-auto will no longer receive updates and may stop working in the future."
+      error "certbot-auto and its Certbot installation will no longer receive updates."
+      error "You will not receive any bug fixes including those fixing server compatibility"
+      error "or security problems."
       error "Please visit https://certbot.eff.org/ to check for other alternatives."
       "$VENV_BIN/letsencrypt" "$@"
       exit 0

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -1117,7 +1117,7 @@ if [ "$1" = "--le-auto-phase2" ]; then
     fi
 
     if [ -f "$VENV_BIN/letsencrypt" -a "$INSTALL_ONLY" != 1 ]; then
-      error "Certbot will no longer receive updates."
+      error "certbot-auto will no longer receive updates and may stop working in the future."
       error "Please visit https://certbot.eff.org/ to check for other alternatives."
       "$VENV_BIN/letsencrypt" "$@"
       exit 0

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -803,6 +803,7 @@ if [ -f /etc/debian_version ]; then
 elif [ -f /etc/mageia-release ]; then
   # Mageia has both /etc/mageia-release and /etc/redhat-release
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/redhat-release ]; then
   DEPRECATED_OS=1
   # Run DeterminePythonVersion to decide on the basis of available Python versions
@@ -863,22 +864,31 @@ elif [ -f /etc/redhat-release ]; then
   LE_PYTHON="$prev_le_python"
 elif [ -f /etc/os-release ] && `grep -q openSUSE /etc/os-release` ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/arch-release ]; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/manjaro-release ]; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/gentoo-release ]; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif uname | grep -iq FreeBSD ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif uname | grep -iq Darwin ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/product ] && grep -q "Joyent Instance" /etc/product ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 else
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 fi
 
 # We handle this case after determining the normal bootstrap version to allow

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -325,6 +325,7 @@ if [ -f /etc/debian_version ]; then
 elif [ -f /etc/mageia-release ]; then
   # Mageia has both /etc/mageia-release and /etc/redhat-release
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/redhat-release ]; then
   DEPRECATED_OS=1
   # Run DeterminePythonVersion to decide on the basis of available Python versions
@@ -385,22 +386,31 @@ elif [ -f /etc/redhat-release ]; then
   LE_PYTHON="$prev_le_python"
 elif [ -f /etc/os-release ] && `grep -q openSUSE /etc/os-release` ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/arch-release ]; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/manjaro-release ]; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/gentoo-release ]; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif uname | grep -iq FreeBSD ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif uname | grep -iq Darwin ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/issue ] && grep -iq "Amazon Linux" /etc/issue ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/product ] && grep -q "Joyent Instance" /etc/product ; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 else
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 fi
 
 # We handle this case after determining the normal bootstrap version to allow

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -531,7 +531,7 @@ if [ "$1" = "--le-auto-phase2" ]; then
     fi
 
     if [ -f "$VENV_BIN/letsencrypt" -a "$INSTALL_ONLY" != 1 ]; then
-      error "Certbot will no longer receive updates."
+      error "certbot-auto will no longer receive updates and may stop working in the future."
       error "Please visit https://certbot.eff.org/ to check for other alternatives."
       "$VENV_BIN/letsencrypt" "$@"
       exit 0

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -531,7 +531,9 @@ if [ "$1" = "--le-auto-phase2" ]; then
     fi
 
     if [ -f "$VENV_BIN/letsencrypt" -a "$INSTALL_ONLY" != 1 ]; then
-      error "certbot-auto will no longer receive updates and may stop working in the future."
+      error "certbot-auto and its Certbot installation will no longer receive updates."
+      error "You will not receive any bug fixes including those fixing server compatibility"
+      error "or security problems."
       error "Please visit https://certbot.eff.org/ to check for other alternatives."
       "$VENV_BIN/letsencrypt" "$@"
       exit 0

--- a/tests/letstest/auto_targets.yaml
+++ b/tests/letstest/auto_targets.yaml
@@ -57,3 +57,10 @@ targets:
     type: centos
     virt: hvm
     user: centos
+  #-----------------------------------------------------------------------------
+  # Amazon Linux
+  - ami: ami-0ff8a91507f77f867
+    name: amazon
+    type: centos
+    virt: hvm
+    user: ec2-user

--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -147,7 +147,7 @@ if ! ./letsencrypt-auto -v --debug --version 2>&1 | tail -n1 | grep "^certbot $E
     echo unexpected certbot version found
     exit 1
 fi
-if ! ./letsencrypt-auto -v --debug --version 2>&1 | grep "certbot-auto will no longer receive updates" ; then
+if ! ./letsencrypt-auto -v --debug --version 2>&1 | grep "will no longer receive updates" ; then
     echo script did not print warning about not receiving updates!
     exit 1
 fi

--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -138,13 +138,17 @@ cp "$LOG_FILE" "$PREVIOUS_LOG_FILE"
 
 # Next we run letsencrypt-auto and make sure there were no problems checking
 # for updates, the Certbot install still works, the version number is what
-# we expect.
+# we expect, and it prints a message about not receiving updates.
 if ./letsencrypt-auto -v --debug --version | grep "WARNING: couldn't find Python" ; then
     echo "Had problems checking for updates!"
     exit 1
 fi
 if ! ./letsencrypt-auto -v --debug --version 2>&1 | tail -n1 | grep "^certbot $EXPECTED_VERSION$" ; then
     echo unexpected certbot version found
+    exit 1
+fi
+if ! ./letsencrypt-auto -v --debug --version 2>&1 | grep "certbot-auto will no longer receive updates" ; then
+    echo script did not print warning about not receiving updates!
     exit 1
 fi
 

--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -47,7 +47,7 @@ LOG_FILE="$MY_TEMP_DIR/log"
 SERVER_PATH=$("$PYTHON_NAME" tools/readlink.py tools/simple_http_server.py)
 cd "$MY_TEMP_DIR"
 # We set PYTHONUNBUFFERED to disable buffering of output to LOG_FILE
-PYTHONUNBUFFERED=1 "$PYTHON_NAME" "$SERVER_PATH" 0 > $PORT_FILE 2 > "$LOG_FILE" &
+PYTHONUNBUFFERED=1 "$PYTHON_NAME" "$SERVER_PATH" 0 > $PORT_FILE 2> "$LOG_FILE" &
 SERVER_PID=$!
 trap 'kill "$SERVER_PID" && rm -rf "$MY_TEMP_DIR"' EXIT
 cd ~-


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8615.

You can see the certbot-auto test farm tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=3353&view=results.

Amazon Linux AMI was taken from https://aws.amazon.com/amazon-linux-ami/.

@adferrand and @ohemorange, if possible I'd like this to be included in the release on Tuesday so we can start the process of killing this thing, but I also think we shouldn't rush this change and that it's not a big deal if it misses the release. If you find time to take a look soon and raise any concerns you may have, please do so, but please also take your time.