### PR TITLE
Add dns-hetzner as third-party plugin

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -284,6 +284,7 @@ dns-ispconfig_     Y    N    DNS Authentication using ISPConfig as DNS server
 dns-clouddns_      Y    N    DNS Authentication using CloudDNS API
 dns-lightsail_     Y    N    DNS Authentication using Amazon Lightsail DNS API
 dns-inwx_          Y    Y    DNS Authentication for INWX through the XML API
+dns-hetzner_       Y    N    DNS Authentication using Hetzner DNS Public API 
 ================== ==== ==== ===============================================================
 
 .. _haproxy: https://github.com/greenhost/certbot-haproxy
@@ -298,6 +299,7 @@ dns-inwx_          Y    Y    DNS Authentication for INWX through the XML API
 .. _dns-clouddns: https://github.com/vshosting/certbot-dns-clouddns
 .. _dns-lightsail: https://github.com/noi/certbot-dns-lightsail
 .. _dns-inwx: https://github.com/oGGy990/certbot-dns-inwx/
+.. _dns-hetzner: https://github.com/BigMichi1/certbot-dns-hetzner
 
 If you're interested, you can also :ref:`write your own plugin <dev-plugin>`.
 


### PR DESCRIPTION
hi I created a snap installable version of the existing [dns-hetzner-plugin](https://github.com/ctrlaltcoop/certbot-dns-hetzner) and would like to link it here
see: https://snapcraft.io/certbot-dns-hetzner
 
## Pull Request Checklist

- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
