### PR TITLE
Add reminders to update github issue

### DIFF
--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -242,6 +242,9 @@ class ApacheConfigurator(common.Installer):
     @property
     def mod_ssl_conf(self):
         """Full absolute path to SSL configuration file."""
+        # If we're changing the path used here, it'd be nice to post an update
+        # to https://github.com/certbot/certbot/issues/7584 where there is at
+        # least one person relying on this behavior.
         return os.path.join(self.config.config_dir, constants.MOD_SSL_CONF_DEST)
 
     @property
@@ -354,6 +357,10 @@ class ApacheConfigurator(common.Installer):
         # We may try to enable mod_ssl later. If so, we shouldn't warn if we can't find it now.
         # This is currently only true for debian/ubuntu.
         warn_on_no_mod_ssl = not self.option("handle_modules")
+        # If we're no longer creating the TLS options file during prepare, it'd
+        # be nice to post an update to
+        # https://github.com/certbot/certbot/issues/7584 where there is at
+        # least one person relying on this behavior.
         self.install_ssl_options_conf(self.mod_ssl_conf,
                                       self.updated_mod_ssl_conf_digest,
                                       warn_on_no_mod_ssl)

--- a/certbot-apache/certbot_apache/_internal/constants.py
+++ b/certbot-apache/certbot_apache/_internal/constants.py
@@ -3,6 +3,9 @@ import pkg_resources
 
 from certbot.compat import os
 
+# If we're changing the path used here, it'd be nice to post an update
+# to https://github.com/certbot/certbot/issues/7584 where there is at
+# least one person relying on this behavior.
 MOD_SSL_CONF_DEST = "options-ssl-apache.conf"
 """Name of the mod_ssl config file as saved in `IConfig.config_dir`."""
 

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -161,6 +161,9 @@ class NginxConfigurator(common.Installer):
     @property
     def mod_ssl_conf(self):
         """Full absolute path to SSL configuration file."""
+        # If we're changing the path used here, it'd be nice to post an update
+        # to https://github.com/certbot/certbot/issues/7584 where there is at
+        # least one person relying on this behavior.
         return os.path.join(self.config.config_dir, constants.MOD_SSL_CONF_DEST)
 
     @property
@@ -198,8 +201,11 @@ class NginxConfigurator(common.Installer):
         if self.openssl_version is None:
             self.openssl_version = self._get_openssl_version()
 
+        # If we're no longer creating the TLS options or DH params files during
+        # prepare, it'd be nice to post an update to
+        # https://github.com/certbot/certbot/issues/7584 where there is at
+        # least one person relying on this behavior.
         self.install_ssl_options_conf(self.mod_ssl_conf, self.updated_mod_ssl_conf_digest)
-
         self.install_ssl_dhparams()
 
         # Prevent two Nginx plugins from modifying a config at once

--- a/certbot-nginx/certbot_nginx/_internal/constants.py
+++ b/certbot-nginx/certbot_nginx/_internal/constants.py
@@ -23,6 +23,9 @@ CLI_DEFAULTS = dict(
 """CLI defaults."""
 
 
+# If we're changing the path used here, it'd be nice to post an update
+# to https://github.com/certbot/certbot/issues/7584 where there is at
+# least one person relying on this behavior.
 MOD_SSL_CONF_DEST = "options-ssl-nginx.conf"
 """Name of the mod_ssl config file as saved in `IConfig.config_dir`."""
 

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -208,6 +208,9 @@ FORCE_INTERACTIVE_FLAG = "--force-interactive"
 EFF_SUBSCRIBE_URI = "https://supporters.eff.org/subscribe/certbot"
 """EFF URI used to submit the e-mail address of users who opt-in."""
 
+# If we're changing the path used here, it'd be nice to post an update
+# to https://github.com/certbot/certbot/issues/7584 where there is at
+# least one person relying on this behavior.
 SSL_DHPARAMS_DEST = "ssl-dhparams.pem"
 """Name of the ssl_dhparams file as saved in `IConfig.config_dir`."""
 

--- a/certbot/certbot/plugins/common.py
+++ b/certbot/certbot/plugins/common.py
@@ -185,6 +185,9 @@ class Installer(Plugin):
     @property
     def ssl_dhparams(self):
         """Full absolute path to ssl_dhparams file."""
+        # If we're changing the path used here, it'd be nice to post an update
+        # to https://github.com/certbot/certbot/issues/7584 where there is at
+        # least one person relying on this behavior.
         return os.path.join(self.config.config_dir, constants.SSL_DHPARAMS_DEST)
 
     @property


### PR DESCRIPTION
This came out of the conversation at https://github.com/certbot/certbot/issues/7584.

This is a bit weird, but I think this is an easy thing we can do to try and help the user there out without tying ourselves to specific behavior by making these files or their creation during `prepare` part of the public API.