### PR TITLE
Remove crufty pytest exception

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,6 @@
 # settings we want to also change there must be added to the release script
 # directly.
 [pytest]
-# In general, all warnings are treated as errors. Here are the exceptions:
-#   1- decodestring: https://github.com/rthalley/dnspython/issues/338
 # Warnings being triggered by our plugins using deprecated features in
 # acme/certbot should be fixed by having our plugins no longer using the
 # deprecated code rather than adding them to the list of ignored warnings here.
@@ -13,4 +11,3 @@
 # we release breaking changes.
 filterwarnings =
     error
-    ignore:decodestring:DeprecationWarning


### PR DESCRIPTION
Now that we're using `dnspython>=2.0`, this shouldn't be needed anymore.