### PR TITLE
Merge dev and dev3 extras

### DIFF
--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -81,22 +81,19 @@ elif sys.version_info < (3,3):
     install_requires.append('mock')
 
 dev_extras = [
+    'astroid',
+    'azure-devops',
     'coverage',
+    'ipdb',
+    'mypy',
+    'PyGithub',
+    'pylint',
     'pytest',
     'pytest-cov',
     'pytest-xdist',
     'tox',
     'twine',
     'wheel',
-]
-
-dev3_extras = [
-    'astroid',
-    'azure-devops',
-    'ipdb',
-    'mypy',
-    'PyGithub',
-    'pylint',
 ]
 
 docs_extras = [
@@ -144,7 +141,6 @@ setup(
     install_requires=install_requires,
     extras_require={
         'dev': dev_extras,
-        'dev3': dev3_extras,
         'docs': docs_extras,
     },
 

--- a/tools/venv.py
+++ b/tools/venv.py
@@ -25,7 +25,7 @@ import time
 
 REQUIREMENTS = [
     '-e acme[dev]',
-    '-e certbot[dev,dev3,docs]',
+    '-e certbot[dev,docs]',
     '-e certbot-apache',
     '-e certbot-dns-cloudflare',
     '-e certbot-dns-cloudxns',

--- a/tox.ini
+++ b/tox.ini
@@ -149,14 +149,12 @@ basepython = python3
 # continue, but tox return code will reflect previous error
 commands =
     {[base]install_packages}
-    {[base]pip_install} certbot[dev3]
     python -m pylint --reports=n --rcfile=.pylintrc {[base]source_paths}
 
 [testenv:mypy]
 basepython = python3
 commands =
     {[base]install_packages}
-    {[base]pip_install} certbot[dev3]
     mypy {[base]source_paths}
 
 [testenv:apacheconftest]


### PR DESCRIPTION
We initially needed `dev3` for development dependencies that only worked in Python 3. Now that Certbot only supports Python 3, I think we can simplify things and have a single `dev` extra.