### PR TITLE
Deprecate certbot-auto specific flags

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* CLI flags `--os-packages-only`, `--no-self-upgrade`, `--no-bootstrap` and `--no-permissions-check`,
+  which are related to certbot-auto, are deprecated and will be removed in a future release.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -250,27 +250,6 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         help="Allow making a certificate lineage that duplicates an existing one "
              "(both can be renewed in parallel)")
     helpful.add(
-        "automation", "--os-packages-only", action="store_true",
-        default=flag_default("os_packages_only"),
-        help="(certbot-auto only) install OS package dependencies and then stop")
-    helpful.add(
-        "automation", "--no-self-upgrade", action="store_true",
-        default=flag_default("no_self_upgrade"),
-        help="(certbot-auto only) prevent the certbot-auto script from"
-             " upgrading itself to newer released versions (default: Upgrade"
-             " automatically)")
-    helpful.add(
-        "automation", "--no-bootstrap", action="store_true",
-        default=flag_default("no_bootstrap"),
-        help="(certbot-auto only) prevent the certbot-auto script from"
-             " installing OS-level dependencies (default: Prompt to install "
-             " OS-wide dependencies, but exit if the user says 'No')")
-    helpful.add(
-        "automation", "--no-permissions-check", action="store_true",
-        default=flag_default("no_permissions_check"),
-        help="(certbot-auto only) skip the check on the file system"
-             " permissions of the certbot-auto script")
-    helpful.add(
         ["automation", "renew", "certonly", "run"],
         "-q", "--quiet", dest="quiet", action="store_true",
         default=flag_default("quiet"),
@@ -450,6 +429,12 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         "renew", "--no-autorenew", action="store_false",
         default=flag_default("autorenew"), dest="autorenew",
         help="Disable auto renewal of certificates.")
+
+    # Deprecated arguments
+    helpful.add_deprecated_argument("--os-packages-only", 0)
+    helpful.add_deprecated_argument("--no-self-upgrade", 0)
+    helpful.add_deprecated_argument("--no-bootstrap", 0)
+    helpful.add_deprecated_argument("--no-permissions-check", 0)
 
     # Populate the command line parameters for new style enhancements
     enhancements.populate_cli(helpful.add)

--- a/certbot/certbot/_internal/cli/cli_constants.py
+++ b/certbot/certbot/_internal/cli/cli_constants.py
@@ -109,4 +109,10 @@ VAR_MODIFIERS = {"account": {"server",},
 # This is a list of all CLI options that we have ever deprecated. It lets us
 # opt out of the default detection, which can interact strangely with option
 # deprecation. See https://github.com/certbot/certbot/issues/8540 for more info.
-DEPRECATED_OPTIONS = {"manual_public_ip_logging_ok",}
+DEPRECATED_OPTIONS = {
+    "manual_public_ip_logging_ok",
+    "os_packages_only",
+    "no_self_upgrade",
+    "no_bootstrap",
+    "no_permissions_check",
+}

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -479,10 +479,6 @@ class ParseTest(unittest.TestCase):
             for topic in ['all', 'plugins', 'dns-route53']:
                 self.assertFalse('certbot-route53:auth' in self._help_output([help_flag, topic]))
 
-    def test_no_permissions_check_accepted(self):
-        namespace = self.parse(["--no-permissions-check"])
-        self.assertTrue(namespace.no_permissions_check)
-
 
 class DefaultTest(unittest.TestCase):
     """Tests for certbot._internal.cli._Default."""


### PR DESCRIPTION
This PR deprecates the certbot-auto specific CLI flags, in the perspective of removing them in a future release as said in #8483.
