### PR TITLE
Fix Sphinx manpage Building

### DIFF
--- a/acme/docs/conf.py
+++ b/acme/docs/conf.py
@@ -87,7 +87,6 @@ language = 'en'
 # directories to ignore when looking for source files.
 exclude_patterns = [
     '_build',
-    'man/*'
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/acme/docs/man/jws.rst
+++ b/acme/docs/man/jws.rst
@@ -1,1 +1,3 @@
+:orphan:
+
 .. literalinclude:: ../jws-help.txt

--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -97,7 +97,6 @@ language = None
 # directories to ignore when looking for source files.
 exclude_patterns = [
     '_build',
-    'man',
     'challenges.rst',
     'ciphers.rst'
 ]

--- a/certbot/docs/man/certbot.rst
+++ b/certbot/docs/man/certbot.rst
@@ -1,1 +1,3 @@
+:orphan:
+
 .. literalinclude:: ../cli-help.txt


### PR DESCRIPTION
Fixes #8633

I was heavy handed in #8530, and broke manpage building by just excluding the `man` directories due to "missing toctree" errors.

I verified `html`, `man`, and `latex` sphinx builds for this PR. The sphinx tests added in #8530 could be extended to include more formats if desired. 