### PR TITLE
Fix ubuntu package name in INSTALL.rst

### DIFF
--- a/certbot/docs/install.rst
+++ b/certbot/docs/install.rst
@@ -191,7 +191,7 @@ Optionally to install the Certbot Apache plugin, you can use:
 
 .. code-block:: shell
 
-   sudo apt-get install python-certbot-apache
+   sudo apt-get install python3-certbot-apache
 
 **Fedora**
 


### PR DESCRIPTION
Since Ubuntu 18.04 there is python3-certbot-apache which should be the recommended version. 
The Package 'python-certbot-apache' has no installation candidate on 20.04.
The Debian package names should probably be updated accordingly.

## Pull Request Checklist

- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [X] Add or update any documentation as needed to support the changes in this PR.
It *is* updating the docs :-)
- [ ] Include your name in `AUTHORS.md` if you like.
Not needed.