### PR TITLE
docs: rewrite "Revoking certificates"

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -474,29 +474,44 @@ like
 Revoking certificates
 ---------------------
 
-If your account key has been compromised or you otherwise need to revoke a certificate,
-use the ``revoke`` command to do so. Note that the ``revoke`` command takes the certificate path
-(ending in ``cert.pem``), not a certificate name or domain. Example::
+If you need to revoke a certificate, use the ``revoke`` subcommand to do so.
 
-  certbot revoke --cert-path /etc/letsencrypt/live/CERTNAME/cert.pem
+.. note:: Revoking a certificate will have no effect on the rate limit imposed by the Let's Encrypt server.
+
+A certificate may be revoked by providing its name (see ``certbot certificates``) or by providing
+its path directly::
+
+  certbot revoke --cert-name example.com
+
+  certbot revoke --cert-path /etc/letsencrypt/live/example.com/cert.pem
+
+.. note:: By default, Certbot will **delete** the certificate after revoking it. Use ``--no-delete-after-revoke`` to prevent the
+          certificate from being deleted. Note that Certbot will try to renew revoked certificates if they are not deleted.
 
 You can also specify the reason for revoking your certificate by using the ``reason`` flag.
 Reasons include ``unspecified`` which is the default, as well as ``keycompromise``,
 ``affiliationchanged``, ``superseded``, and ``cessationofoperation``::
 
-  certbot revoke --cert-path /etc/letsencrypt/live/CERTNAME/cert.pem --reason keycompromise
+  certbot revoke --cert-name example.com --reason keycompromise
 
 Additionally, if a certificate
-is a test certificate obtained via the ``--staging`` or ``--test-cert`` flag, that flag must be passed to the
-``revoke`` subcommand.
-Once a certificate is revoked (or for other certificate management tasks), all of a certificate's
-relevant files can be removed from the system with the ``delete`` subcommand::
+is a test certificate obtained via the ``--staging``, ``--test-cert`` or non-default ``--server`` flag, that flag must
+be passed to the ``revoke`` subcommand.
 
-  certbot delete --cert-name example.com
+Revoking by account key or certificate private key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note:: If you don't use ``delete`` to remove the certificate completely, it will be renewed automatically at the next renewal event.
+By default, Certbot will try revoke certificates using your ACME account key. The server may complain that you
+are not authorized to perform the revocation. In this case, you will need to become authorized by requesting
+a certificate for all of the domains on the certificate you wish to revoke (include an extra domain you do not control
+to avoid creating an actual certificate)::
 
-.. note:: Revoking a certificate will have no effect on the rate limit imposed by the Let's Encrypt server.
+  certbot certonly --manual --preferred-challenges dns -d example.com -d www.example.com -d nonexistent.example.org
+
+If you instead have the corresponding private key to the certificate you wish to revoke, you may use it to
+perform the revocation (recommended)::
+
+  certbot revoke --cert-path /etc/letsencrypt/live/example.com/cert.pem --key-path /etc/letsencrypt/live/example.com/privkey.pem
 
 .. _renewal:
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -485,6 +485,9 @@ its path directly::
 
   certbot revoke --cert-path /etc/letsencrypt/live/example.com/cert.pem
 
+If the certificate being revoked was obtained via the ``--staging``, ``--test-cert`` or a non-default ``--server`` flag,
+that flag must be passed to the ``revoke`` subcommand.
+
 .. note:: By default, Certbot will **delete** the certificate after revoking it. Use ``--no-delete-after-revoke`` to prevent the
           certificate from being deleted. Note that Certbot will try to renew revoked certificates if they are not deleted.
 
@@ -494,15 +497,11 @@ Reasons include ``unspecified`` which is the default, as well as ``keycompromise
 
   certbot revoke --cert-name example.com --reason keycompromise
 
-Additionally, if a certificate
-is a test certificate obtained via the ``--staging``, ``--test-cert`` or non-default ``--server`` flag, that flag must
-be passed to the ``revoke`` subcommand.
-
 Revoking by account key or certificate private key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, Certbot will try revoke certificates using your ACME account key. The server may complain that you
-are not authorized to perform the revocation. In this case, you will need to become authorized by requesting
+are not authorized to perform the revocation. In this case, you will first need to become authorized by requesting
 a certificate for all of the domains on the certificate you wish to revoke (include an extra domain you do not control
 to avoid creating an actual certificate)::
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -498,15 +498,11 @@ Reasons include ``unspecified`` which is the default, as well as ``keycompromise
 Revoking by account key or certificate private key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Certbot will try revoke certificates using your ACME account key. The server may complain that you
-are not authorized to perform the revocation. In this case, you will first need to become authorized by requesting
-a certificate for all of the domains on the certificate you wish to revoke (include an extra domain you do not control
-to avoid creating an actual certificate)::
+By default, Certbot will try revoke the certificate using your ACME account key. If the certificate was created from
+the same ACME account, the revocation will be successful.
 
-  certbot certonly --manual --preferred-challenges dns -d example.com -d www.example.com -d nonexistent.example.org
-
-If you instead have the corresponding private key to the certificate you wish to revoke, you may use it to
-perform the revocation (recommended)::
+If you instead have the corresponding private key file to the certificate you wish to revoke, use ``--key-path`` to perform the
+revocation from any ACME account::
 
   certbot revoke --cert-path /etc/letsencrypt/live/example.com/cert.pem --key-path /etc/letsencrypt/live/example.com/privkey.pem
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -476,8 +476,6 @@ Revoking certificates
 
 If you need to revoke a certificate, use the ``revoke`` subcommand to do so.
 
-.. note:: Revoking a certificate will have no effect on the rate limit imposed by the Let's Encrypt server.
-
 A certificate may be revoked by providing its name (see ``certbot certificates``) or by providing
 its path directly::
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -486,8 +486,8 @@ its path directly::
 If the certificate being revoked was obtained via the ``--staging``, ``--test-cert`` or a non-default ``--server`` flag,
 that flag must be passed to the ``revoke`` subcommand.
 
-.. note:: By default, Certbot will **delete** the certificate after revoking it. Use ``--no-delete-after-revoke`` to prevent the
-          certificate from being deleted. Note that Certbot will try to renew revoked certificates if they are not deleted.
+.. note:: After revocation, Certbot will (by default) ask whether you want to **delete** the certificate.
+          Unless deleted, Certbot will try to renew revoked certificates the next time ``certbot renew`` runs.
 
 You can also specify the reason for revoking your certificate by using the ``reason`` flag.
 Reasons include ``unspecified`` which is the default, as well as ``keycompromise``,


### PR DESCRIPTION
- `--cert-name` is supported since a long time ago
- `--delete-after-revoke` is default
- Mention that non-default `--server` must be specified
- Document difference between account key/certificate key revocation methods
- Reshuffle text to keep more important things earlier

---

We got a little bit of feedback in https://community.letsencrypt.org/t/keys-remain-after-revoking-a-certificate/145106 that this part of the documentation needed some attention.

![revoke](https://user-images.githubusercontent.com/311534/109114087-4b2aee00-7791-11eb-8d67-f557bb38c203.png)
