### PR TITLE
Remove import fallback for collections.abc

### DIFF
--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -1,5 +1,6 @@
 """ACME protocol messages."""
 import json
+from collections.abc import Hashable
 
 import josepy as jose
 
@@ -9,13 +10,6 @@ from acme import fields
 from acme import jws
 from acme import util
 from acme.mixins import ResourceMixin
-
-try:
-    from collections.abc import Hashable
-except ImportError:  # pragma: no cover
-    from collections import Hashable
-
-
 
 OLD_ERROR_PREFIX = "urn:acme:error:"
 ERROR_PREFIX = "urn:ietf:params:acme:error:"

--- a/certbot/certbot/_internal/plugins/disco.py
+++ b/certbot/certbot/_internal/plugins/disco.py
@@ -3,6 +3,7 @@ import collections
 import itertools
 import logging
 import sys
+from collections.abc import Mapping
 
 import pkg_resources
 import zope.interface
@@ -13,12 +14,6 @@ from certbot import errors
 from certbot import interfaces
 from certbot._internal import constants
 from certbot.compat import os
-
-try:
-    # Python 3.3+
-    from collections.abc import Mapping
-except ImportError:  # pragma: no cover
-    from collections import Mapping
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Yet another small thing to do when Python 3 is the minimum supported version :)

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
