### PR TITLE
Python 3 obsoletes explicit __ne__ methods

### DIFF
--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -156,9 +156,6 @@ class _Constant(jose.JSONDeSerializable, Hashable):  # type: ignore
     def __hash__(self):
         return hash((self.__class__, self.name))
 
-    def __ne__(self, other):
-        return not self == other
-
 
 class Status(_Constant):
     """ACME "status" field."""

--- a/certbot-apache/certbot_apache/_internal/obj.py
+++ b/certbot-apache/certbot_apache/_internal/obj.py
@@ -20,9 +20,6 @@ class Addr(common.Addr):
                      self.is_wildcard() and other.is_wildcard()))
         return False
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __repr__(self):
         return "certbot_apache._internal.obj.Addr(" + repr(self.tup) + ")"
 
@@ -190,9 +187,6 @@ class VirtualHost(object):
                     self.modmacro == other.modmacro)
 
         return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     def __hash__(self):
         return hash((self.filep, self.path,


### PR DESCRIPTION
This shouldn't be needed as of Python 3+.

https://stackoverflow.com/questions/4352244/should-ne-be-implemented-as-the-negation-of-eq-in-python#30676267

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
