### PR TITLE
Upgrade Windows Python to 3.8.8

### DIFF
--- a/windows-installer/construct.py
+++ b/windows-installer/construct.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import time
 
-PYTHON_VERSION = (3, 8, 6)
+PYTHON_VERSION = (3, 8, 8)
 PYTHON_BITNESS = 32
 PYWIN32_VERSION = 300  # do not forget to edit pywin32 dependency accordingly in setup.py
 NSIS_VERSION = '3.06.1'


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8681. https://python-security.readthedocs.io/vuln/ctypes-buffer-overflow-pycarg_repr.html is the best resource I found linking to the original Python bug, when each Python branch was fixed, etc.

You can see the Windows tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=3471&view=results. You can see Python 3.8.8 being used in the logs at https://dev.azure.com/certbot/certbot/_build/results?buildId=3471&view=logs&j=ad29f110-3cce-5317-4ef2-0a692ae1dee7&t=77c032fc-b05c-5dec-8653-7a08a1a052d4&l=1096.