### PR TITLE
cli: reduce default logging verbosity

### DIFF
--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -22,7 +22,7 @@ CLI_DEFAULTS = dict(
     ],
 
     # Main parser
-    verbose_count=-int(logging.INFO / 10),
+    verbose_count=-int(logging.WARNING / 10),
     text_mode=False,
     max_log_backups=1000,
     preconfigured_renewal=False,
@@ -139,7 +139,7 @@ REVOCATION_REASONS = {
 
 """Defaults for CLI flags and `.IConfig` attributes."""
 
-QUIET_LOGGING_LEVEL = logging.WARNING
+QUIET_LOGGING_LEVEL = logging.ERROR
 """Logging level to use in quiet mode."""
 
 RENEWER_DEFAULTS = dict(

--- a/tests/lock_test.py
+++ b/tests/lock_test.py
@@ -135,7 +135,7 @@ def set_up_command(config_dir, logs_dir, work_dir, nginx_dir):
     return (
         'certbot --cert-path {0} --key-path {1} --config-dir {2} '
         '--logs-dir {3} --work-dir {4} --nginx-server-root {5} --debug '
-        '--force-renewal --nginx --verbose '.format(
+        '--force-renewal --nginx -vv '.format(
             test_util.vector_path('cert.pem'),
             test_util.vector_path('rsa512_key.pem'),
             config_dir, logs_dir, work_dir, nginx_dir).split())


### PR DESCRIPTION
WIP

New logging level meanings:
* `debug` is just technical junk like requests logging (-vv?)
* `info` is "what is certbot doing that the user doesn't critically need to know about" (-v). Some things which are info should probably go to display_util.notify and maybe vice versa.
* `warning` is "this will probably work even though it's not technically correct"/ "small errors that do not impede" as `apache_util` so nicely puts it. seems to also apply to things that would be errors, but they're in enhancements.
* `error` is "something has gone wrong enough that this code path isn't going to work out today, but maybe certbot as a whole could catch it try something else, though it's not really my responsibility to figure that out"
* `critical` is "something has gone terribly wrong, cancel everything." we don't seem to use this as much in new code, can probably just use error instead.
* `warning/error/critical`, i'm still slightly iffy about because we are using them inconsistently. But it's also not something that I think is important to fix right now because the CLI visibility isn't changing right now for these.
* `display_util.notify` gets shown to user by default

TODO
- [x] Reclassify [a number of messages to ensure important ones aren't accidentally hidden](https://docs.google.com/spreadsheets/d/10_SJU4a-9fRLXlISODpWO0hRfcd6n9jZyfmGprp0Wlo/edit#gid=1628828086)
    - [x] "Waiting %d seconds for DNS changes to propagate"
- [ ] Write a CHANGELOG entry explaining the overall changes