### PR TITLE
Remove check for 'fake' in issuer name when renewing certs

### DIFF
--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -312,12 +312,9 @@ def _avoid_invalidating_lineage(config, lineage, original_server):
         contents = the_file.read()
     latest_cert = OpenSSL.crypto.load_certificate(
         OpenSSL.crypto.FILETYPE_PEM, contents)
-    # all our test certificates are from happy hacker fake CA, though maybe one day
-    # we should test more methodically
-    now_valid = "fake" not in repr(latest_cert.get_issuer()).lower()
 
     if util.is_staging(config.server):
-        if not util.is_staging(original_server) or now_valid:
+        if not util.is_staging(original_server):
             if not config.break_my_certs:
                 names = ", ".join(lineage.names())
                 raise errors.Error(

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1053,7 +1053,7 @@ class MainTest(test_util.ConfigTestCase):
                             mock_get_utility().notification.side_effect = write_msg
                         with mock.patch('certbot._internal.main.renewal.OpenSSL') as mock_ssl:
                             mock_latest = mock.MagicMock()
-                            mock_latest.get_issuer.return_value = "Fake fake"
+                            mock_latest.get_issuer.return_value = "Artificial pretend"
                             mock_ssl.crypto.load_certificate.return_value = mock_latest
                             with mock.patch('certbot._internal.main.renewal.crypto_util') \
                                 as mock_crypto_util:


### PR DESCRIPTION
Fixes #8680.

We seem to have no existing testing code anywhere in this vicinity, so figured I'd get this up quickly then work on that. Manual tests (renew staging certificate, should allow it; renew non-staging cert as staging, should error) passed.