### PR TITLE
Don't set unnecessary args to argparse

### DIFF
--- a/certbot/certbot/_internal/cli/paths_parser.py
+++ b/certbot/certbot/_internal/cli/paths_parser.py
@@ -20,8 +20,6 @@ def _paths_parser(helpful):
     }
     if verb == "certonly":
         cpkwargs["default"] = flag_default("auth_cert_path")
-    elif verb == "revoke":
-        cpkwargs["required"] = False
     add(["paths", "install", "revoke", "certonly", "manage"], "--cert-path", **cpkwargs)
 
     section = "paths"


### PR DESCRIPTION
I noticed this while reviewing https://github.com/certbot/certbot/pull/8687 but since the problem wasn't introduced in that PR, I didn't want to block it on this.

Setting `required` to `False` when adding arguments with `argparse` has no documented effect at https://docs.python.org/3/library/argparse.html#required. Digging into this a bit, us doing this comes from https://github.com/certbot/certbot/pull/6388 where the option went from required to optional.

I don't think setting `required` to `False` hurts anything, but let's simplify the code.