### PR TITLE
Remove broken test for typing import failure

### DIFF
--- a/acme/acme/magic_typing.py
+++ b/acme/acme/magic_typing.py
@@ -1,16 +1,14 @@
-"""Shim class to not have to depend on typing module in prod."""
-import sys
+"""Simple shim around the typing module.
+
+This was useful when this code supported Python 2 and typing wasn't always
+available. This code is being kept for now for backwards compatibility.
+
+"""
+from typing import *  # pylint: disable=wildcard-import, unused-wildcard-import
+from typing import Collection, IO  # type: ignore
 
 
 class TypingClass:
     """Ignore import errors by getting anything"""
     def __getattr__(self, name):
         return None
-
-try:
-    # mypy doesn't respect modifying sys.modules
-    from typing import *  # pylint: disable=wildcard-import, unused-wildcard-import
-    from typing import Collection, IO  # type: ignore
-except ImportError:
-    # mypy complains because TypingClass is not a module
-    sys.modules[__name__] = TypingClass()  # type: ignore

--- a/acme/acme/magic_typing.py
+++ b/acme/acme/magic_typing.py
@@ -11,4 +11,4 @@ from typing import Collection, IO  # type: ignore
 class TypingClass:
     """Ignore import errors by getting anything"""
     def __getattr__(self, name):
-        return None
+        return None  # pragma: no cover

--- a/acme/tests/magic_typing_test.py
+++ b/acme/tests/magic_typing_test.py
@@ -22,19 +22,6 @@ class MagicTypingTest(unittest.TestCase):
         del sys.modules['acme.magic_typing']
         sys.modules['typing'] = temp_typing
 
-    def test_import_failure(self):
-        try:
-            import typing as temp_typing
-        except ImportError: # pragma: no cover
-            temp_typing = None # pragma: no cover
-        sys.modules['typing'] = None
-        if 'acme.magic_typing' in sys.modules:
-            del sys.modules['acme.magic_typing'] # pragma: no cover
-        from acme.magic_typing import Text
-        self.assertTrue(Text is None)
-        del sys.modules['acme.magic_typing']
-        sys.modules['typing'] = temp_typing
-
 
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
The unit test here test doesn't work with newer versions of `cryptography`. See https://github.com/certbot/josepy/pull/88#issuecomment-786911443.

Since `magic_typing` is deprecated and `typing` should always be available since we only support Python 3.6+, I think we should just delete this test.

To not cause a drop in code coverage I also deleted code handling the case where `typing` isn't available since we should never hit it. I left `TypingClass` since one could argue its part of the public API (that almost certainly no one is using), but I could delete it if people prefer.