### PR TITLE
Removed a Python 2 fallback in certbot.Reverter.

### DIFF
--- a/certbot-apache/certbot_apache/_internal/parser.py
+++ b/certbot-apache/certbot_apache/_internal/parser.py
@@ -3,8 +3,6 @@ import copy
 import fnmatch
 import logging
 import re
-import sys
-
 
 from acme.magic_typing import Dict
 from acme.magic_typing import List
@@ -737,9 +735,6 @@ class ApacheParser:
         :rtype: str
 
         """
-        if sys.version_info < (3, 6):
-            # This strips off final /Z(?ms)
-            return fnmatch.translate(clean_fn_match)[:-7]  # pragma: no cover
         # Since Python 3.6, it returns a different pattern like (?s:.*\.load)\Z
         return fnmatch.translate(clean_fn_match)[4:-3]  # pragma: no cover
 

--- a/certbot/certbot/reverter.py
+++ b/certbot/certbot/reverter.py
@@ -3,7 +3,6 @@ import csv
 import glob
 import logging
 import shutil
-import sys
 import time
 import traceback
 
@@ -251,11 +250,10 @@ class Reverter:
 
     def _run_undo_commands(self, filepath):
         """Run all commands in a file."""
-        # NOTE: csv module uses native strings. That is, bytes on Python 2 and
-        # unicode on Python 3
+        # NOTE: csv module uses native strings. That is unicode on Python 3
         # It is strongly advised to set newline = '' on Python 3 with CSV,
         # and it fixes problems on Windows.
-        kwargs = {'newline': ''} if sys.version_info[0] > 2 else {}
+        kwargs = {'newline': ''}
         with open(filepath, 'r', **kwargs) as csvfile:  # type: ignore
             csvreader = csv.reader(csvfile)
             for command in reversed(list(csvreader)):
@@ -354,7 +352,7 @@ class Reverter:
         command_file = None
         # It is strongly advised to set newline = '' on Python 3 with CSV,
         # and it fixes problems on Windows.
-        kwargs = {'newline': ''} if sys.version_info[0] > 2 else {}
+        kwargs = {'newline': ''}
         try:
             if os.path.isfile(commands_fp):
                 command_file = open(commands_fp, "a", **kwargs)  # type: ignore


### PR DESCRIPTION
## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
