### PR TITLE
Removed Python legacy __future__ imports

### DIFF
--- a/certbot-ci/certbot_integration_tests/assets/hook.py
+++ b/certbot-ci/certbot_integration_tests/assets/hook.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import os
 import sys
 

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -1,5 +1,4 @@
 """Module executing integration tests against certbot core."""
-from __future__ import print_function
 
 import os
 from os.path import exists

--- a/certbot-ci/certbot_integration_tests/conftest.py
+++ b/certbot-ci/certbot_integration_tests/conftest.py
@@ -6,7 +6,6 @@ for a directory a specific configuration using built-in pytest hooks.
 
 See https://docs.pytest.org/en/latest/reference.html#hook-reference
 """
-from __future__ import print_function
 import contextlib
 import subprocess
 import sys

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Module to setup an ACME CA server environment able to run multiple tests in parallel"""
-from __future__ import print_function
 
 import argparse
 import errno

--- a/certbot-ci/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/certbot_integration_tests/utils/certbot_call.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Module to call certbot in test mode"""
-from __future__ import absolute_import
 
 import os
 import subprocess

--- a/certbot-ci/certbot_integration_tests/utils/dns_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/dns_server.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 """Module to setup an RFC2136-capable DNS server"""
-from __future__ import print_function
-
 import os
 import os.path
 import shutil

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -311,7 +311,7 @@ def echo(keyword, path=None):
     if not re.match(r'^\w+$', keyword):
         raise ValueError('Error, keyword `{0}` is not a single keyword.'
                          .format(keyword))
-    return '{0} -c "from __future__ import print_function; print(\'{1}\')"{2}'.format(
+    return '{0} -c "print(\'{1}\')"{2}'.format(
         os.path.basename(sys.executable), keyword, ' >> "{0}"'.format(path) if path else '')
 
 

--- a/certbot-ci/windows_installer_integration_tests/conftest.py
+++ b/certbot-ci/windows_installer_integration_tests/conftest.py
@@ -6,7 +6,7 @@ for a directory a specific configuration using built-in pytest hooks.
 
 See https://docs.pytest.org/en/latest/reference.html#hook-reference
 """
-from __future__ import print_function
+
 import os
 
 ROOT_PATH = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -1,6 +1,5 @@
 """Certbot command line argument & config processing."""
 # pylint: disable=too-many-lines
-from __future__ import print_function
 import logging
 import logging.handlers
 import argparse

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -1,5 +1,5 @@
 """Certbot command line argument parser"""
-from __future__ import print_function
+
 import argparse
 import copy
 import functools

--- a/certbot/certbot/_internal/hooks.py
+++ b/certbot/certbot/_internal/hooks.py
@@ -1,5 +1,4 @@
 """Facilities for implementing hooks that call shell commands."""
-from __future__ import print_function
 
 import logging
 

--- a/certbot/certbot/_internal/log.py
+++ b/certbot/certbot/_internal/log.py
@@ -19,7 +19,7 @@ The preferred method to display important information to the user is to
 use `certbot.display.util` and `certbot.display.ops`.
 
 """
-from __future__ import print_function
+
 
 import functools
 import logging

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1,6 +1,5 @@
 """Certbot main entry point."""
 # pylint: disable=too-many-lines
-from __future__ import print_function
 
 import functools
 import logging.handlers

--- a/certbot/certbot/_internal/plugins/selection.py
+++ b/certbot/certbot/_internal/plugins/selection.py
@@ -1,5 +1,4 @@
 """Decide which plugins to use for authentication & installation"""
-from __future__ import print_function
 
 import logging
 

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -1,5 +1,4 @@
 """Functionality for autorenewal and associated juggling of configurations"""
-from __future__ import print_function
 
 import copy
 import itertools

--- a/certbot/certbot/_internal/reporter.py
+++ b/certbot/certbot/_internal/reporter.py
@@ -1,6 +1,4 @@
 """Collects and displays information to the user."""
-from __future__ import print_function
-
 import collections
 import logging
 import queue

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 """Tests for certbot._internal.main."""
 # pylint: disable=too-many-lines
-from __future__ import print_function
-
 import datetime
 from importlib import reload as reload_module
 import io
@@ -1353,7 +1351,7 @@ class MainTest(test_util.ConfigTestCase):
         _, _, stdout = self._test_renewal_common(
             due_for_renewal=False, extra_args=None, should_renew=False,
             args=['renew', '--post-hook',
-                  '{0} -c "from __future__ import print_function; print(\'hello world\');"'
+                  '{0} -c "print(\'hello world\');"'
                   .format(sys.executable)])
         self.assertTrue('No hooks were run.' in stdout.getvalue())
 

--- a/certbot/tests/plugins/manual_test.py
+++ b/certbot/tests/plugins/manual_test.py
@@ -60,7 +60,7 @@ class AuthenticatorTest(test_util.TempDirTestCase):
 
     def test_script_perform(self):
         self.config.manual_auth_hook = (
-            '{0} -c "from __future__ import print_function;'
+            '{0} -c "'
             'from certbot.compat import os;'
             'print(os.environ.get(\'CERTBOT_DOMAIN\'));'
             'print(os.environ.get(\'CERTBOT_TOKEN\', \'notoken\'));'

--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -27,10 +27,6 @@ see:
   https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
   https://docs.aws.amazon.com/cli/latest/userguide/cli-ec2-keypairs.html
 """
-
-from __future__ import print_function
-from __future__ import with_statement
-
 import argparse
 import multiprocessing as mp
 from multiprocessing import Manager

--- a/tests/lock_test.py
+++ b/tests/lock_test.py
@@ -1,6 +1,4 @@
 """Tests to ensure the lock order is preserved."""
-from __future__ import print_function
-
 import atexit
 import datetime
 import functools

--- a/tools/install_and_test.py
+++ b/tools/install_and_test.py
@@ -5,8 +5,6 @@
 # set to 1, packages are installed using pinned versions of all of our
 # dependencies. See pip_install.py for more information on the versions pinned
 # to.
-from __future__ import print_function
-
 import os
 import re
 import subprocess

--- a/tools/merge_requirements.py
+++ b/tools/merge_requirements.py
@@ -6,8 +6,6 @@ Only the simple formats SomeProject==1.2.3 or SomeProject<=1.2.3 are
 currently supported.
 
 """
-from __future__ import print_function
-
 import sys
 
 

--- a/tools/pip_install_editable.py
+++ b/tools/pip_install_editable.py
@@ -6,9 +6,6 @@
 # https://github.com/pyca/cryptography/blob/a02fdd60d98273ca34427235c4ca96687a12b239/.travis/downstream.d/certbot.sh#L8-L9.
 # We should try to remember to keep their repo updated if we make any changes
 # to this script which may break things for them.
-
-from __future__ import absolute_import
-
 import sys
 
 import pip_install

--- a/tools/pipstrap.py
+++ b/tools/pipstrap.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Uses pip to upgrade Python packaging tools to pinned versions."""
-from __future__ import absolute_import
 import os
 
 import pip_install

--- a/tools/readlink.py
+++ b/tools/readlink.py
@@ -6,8 +6,6 @@ useful as there are often differences in readlink on different
 platforms.
 
 """
-from __future__ import print_function
-
 import os
 import sys
 


### PR DESCRIPTION
There are still some left, but the `modification_check` test fails. Some are still in `tools`, and they can probably be removed as well. `with_statement` was introduced officially in Python 2.5, so there's really old stuff in the code base.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
