### PR TITLE
Note required scopes for Linode API credentials

### DIFF
--- a/certbot-dns-linode/certbot_dns_linode/__init__.py
+++ b/certbot-dns-linode/certbot_dns_linode/__init__.py
@@ -30,9 +30,9 @@ Credentials
 -----------
 
 Use of this plugin requires a configuration file containing Linode API
-credentials, obtained from your Linode account's `Applications & API
-Tokens page (legacy) <https://manager.linode.com/profile/api>`_ or `Applications
-& API Tokens page (new) <https://cloud.linode.com/profile/tokens>`_.
+credentials, obtained from your Linode account's `Applications & API Tokens
+page <https://cloud.linode.com/profile/tokens>`_. The credentials need to
+have Read access to the Account scope, and Read/Write access to Domains.
 
 .. code-block:: ini
    :name: credentials.ini


### PR DESCRIPTION
The documentation for certbot-dns-linode doesn't currently mention which Linode
API scopes are required for it to function properly, which may result in users either
over-granting permissions to the credentials they provide or encountering cryptic
errors when attempting to obtain a certificate. Fix that by providing details on the
which scopes are necessary for this plugin to function.

Also clean up a link to the old Linode manager tool which is no longer available
(and automatically redirects to the main page of the new Cloud console).

## Pull Request Checklist

- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
