### PR TITLE
Final update to certbot-auto

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* certbot-auto no longer checks for updates on any operating system.
 
 ### Fixed
 

--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -800,6 +800,7 @@ BootstrapMageiaCommon() {
 # packages BOOTSTRAP_VERSION is not set.
 if [ -f /etc/debian_version ]; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/mageia-release ]; then
   # Mageia has both /etc/mageia-release and /etc/redhat-release
   DEPRECATED_OS=1

--- a/letsencrypt-auto-source/letsencrypt-auto.template
+++ b/letsencrypt-auto-source/letsencrypt-auto.template
@@ -322,6 +322,7 @@ DeterminePythonVersion() {
 # packages BOOTSTRAP_VERSION is not set.
 if [ -f /etc/debian_version ]; then
   DEPRECATED_OS=1
+  NO_SELF_UPGRADE=1
 elif [ -f /etc/mageia-release ]; then
   # Mageia has both /etc/mageia-release and /etc/redhat-release
   DEPRECATED_OS=1

--- a/tests/letstest/scripts/test_leauto_upgrades.sh
+++ b/tests/letstest/scripts/test_leauto_upgrades.sh
@@ -153,17 +153,8 @@ if ! ./letsencrypt-auto -v --debug --version 2>&1 | grep "will no longer receive
     exit 1
 fi
 
-# Finally, we check if our local server received more requests. Over time,
-# we'll move more and more OSes into this case until it this is the expected
-# behavior on all systems.
-if [ -f /etc/redhat-release ]; then
-    if ! diff "$LOG_FILE" "$PREVIOUS_LOG_FILE" ; then
-        echo our local server received unexpected requests
-        exit 1
-    fi
-else
-    if diff "$LOG_FILE" "$PREVIOUS_LOG_FILE" ; then
-        echo our local server did not receive the requests we expected
-        exit 1
-    fi
+# Finally, we check if our local server received more requests.
+if ! diff "$LOG_FILE" "$PREVIOUS_LOG_FILE" ; then
+    echo our local server received unexpected requests
+    exit 1
 fi


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8690.

You can see certbot-auto test farm tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=3515&view=results.

After this PR, we'll let the release script make its automated changes to certbot-auto as part of the 1.14.0 release and then never make any code changes to certbot-auto ever again!