### PR TITLE
Fixing imports in cli module

### DIFF
--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -1,65 +1,51 @@
 """Certbot command line argument & config processing."""
 # pylint: disable=too-many-lines
+import argparse
 import logging
 import logging.handlers
-import argparse
 import sys
-import certbot._internal.plugins.selection as plugin_selection
-from certbot._internal.plugins import disco as plugins_disco
+from typing import Optional
 
-from acme.magic_typing import Optional
-
-# pylint: disable=ungrouped-imports
 import certbot
 from certbot._internal import constants
-
-import certbot.plugins.enhancements as enhancements
-
-
-from certbot._internal.cli.cli_constants import (
-    LEAUTO,
-    old_path_fragment,
-    new_path_prefix,
-    cli_command,
-    SHORT_USAGE,
-    COMMAND_OVERVIEW,
-    HELP_AND_VERSION_USAGE,
-    ARGPARSE_PARAMS_TO_REMOVE,
-    EXIT_ACTIONS,
-    ZERO_ARG_ACTIONS,
-    VAR_MODIFIERS,
-    DEPRECATED_OPTIONS
-)
-
-from certbot._internal.cli.cli_utils import (
-    _Default,
-    read_file,
-    flag_default,
-    config_help,
-    HelpfulArgumentGroup,
-    CustomHelpFormatter,
-    _DomainsAction,
-    add_domains,
-    CaseInsensitiveList,
-    _user_agent_comment_type,
-    _EncodeReasonAction,
-    parse_preferred_challenges,
-    _PrefChallAction,
-    _DeployHookAction,
-    _RenewHookAction,
-    nonnegative_int
-)
-
-# These imports depend on cli_constants and cli_utils.
-from certbot._internal.cli.verb_help import VERB_HELP, VERB_HELP_MAP
+from certbot._internal.cli.cli_constants import ARGPARSE_PARAMS_TO_REMOVE
+from certbot._internal.cli.cli_constants import cli_command
+from certbot._internal.cli.cli_constants import COMMAND_OVERVIEW
+from certbot._internal.cli.cli_constants import DEPRECATED_OPTIONS
+from certbot._internal.cli.cli_constants import EXIT_ACTIONS
+from certbot._internal.cli.cli_constants import HELP_AND_VERSION_USAGE
+from certbot._internal.cli.cli_constants import LEAUTO
+from certbot._internal.cli.cli_constants import new_path_prefix
+from certbot._internal.cli.cli_constants import old_path_fragment
+from certbot._internal.cli.cli_constants import SHORT_USAGE
+from certbot._internal.cli.cli_constants import VAR_MODIFIERS
+from certbot._internal.cli.cli_constants import ZERO_ARG_ACTIONS
+from certbot._internal.cli.cli_utils import _Default
+from certbot._internal.cli.cli_utils import _DeployHookAction
+from certbot._internal.cli.cli_utils import _DomainsAction
+from certbot._internal.cli.cli_utils import _EncodeReasonAction
+from certbot._internal.cli.cli_utils import _PrefChallAction
+from certbot._internal.cli.cli_utils import _RenewHookAction
+from certbot._internal.cli.cli_utils import _user_agent_comment_type
+from certbot._internal.cli.cli_utils import add_domains
+from certbot._internal.cli.cli_utils import CaseInsensitiveList
+from certbot._internal.cli.cli_utils import config_help
+from certbot._internal.cli.cli_utils import CustomHelpFormatter
+from certbot._internal.cli.cli_utils import flag_default
+from certbot._internal.cli.cli_utils import HelpfulArgumentGroup
+from certbot._internal.cli.cli_utils import nonnegative_int
+from certbot._internal.cli.cli_utils import parse_preferred_challenges
+from certbot._internal.cli.cli_utils import read_file
 from certbot._internal.cli.group_adder import _add_all_groups
-from certbot._internal.cli.subparsers import _create_subparsers
+from certbot._internal.cli.helpful import HelpfulArgumentParser
 from certbot._internal.cli.paths_parser import _paths_parser
 from certbot._internal.cli.plugins_parsing import _plugins_parsing
-
-# These imports depend on some or all of the submodules for cli.
-from certbot._internal.cli.helpful import HelpfulArgumentParser
-# pylint: enable=ungrouped-imports
+from certbot._internal.cli.subparsers import _create_subparsers
+from certbot._internal.cli.verb_help import VERB_HELP
+from certbot._internal.cli.verb_help import VERB_HELP_MAP
+from certbot._internal.plugins import disco as plugins_disco
+import certbot._internal.plugins.selection as plugin_selection
+import certbot.plugins.enhancements as enhancements
 
 
 logger = logging.getLogger(__name__)

--- a/certbot/certbot/_internal/cli/cli_utils.py
+++ b/certbot/certbot/_internal/cli/cli_utils.py
@@ -5,11 +5,11 @@ import copy
 import zope.interface.interface  # pylint: disable=unused-import
 
 from acme import challenges
+from certbot import errors
 from certbot import interfaces
 from certbot import util
-from certbot import errors
-from certbot.compat import os
 from certbot._internal import constants
+from certbot.compat import os
 
 
 class _Default:

--- a/certbot/certbot/_internal/cli/group_adder.py
+++ b/certbot/certbot/_internal/cli/group_adder.py
@@ -1,6 +1,6 @@
 """This module contains a function to add the groups of arguments for the help
 display"""
-from certbot._internal.cli import VERB_HELP
+from certbot._internal.cli.verb_help import VERB_HELP
 
 
 def _add_all_groups(helpful):

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -5,40 +5,35 @@ import copy
 import functools
 import glob
 import sys
+from typing import Any
+from typing import Dict
 
 import configargparse
 import zope.component
 import zope.interface
-
 from zope.interface import interfaces as zope_interfaces
-
-from acme.magic_typing import Any, Dict
 
 from certbot import crypto_util
 from certbot import errors
 from certbot import interfaces
 from certbot import util
-from certbot.compat import os
 from certbot._internal import constants
 from certbot._internal import hooks
-
+from certbot._internal.cli.cli_constants import ARGPARSE_PARAMS_TO_REMOVE
+from certbot._internal.cli.cli_constants import COMMAND_OVERVIEW
+from certbot._internal.cli.cli_constants import EXIT_ACTIONS
+from certbot._internal.cli.cli_constants import HELP_AND_VERSION_USAGE
+from certbot._internal.cli.cli_constants import SHORT_USAGE
+from certbot._internal.cli.cli_constants import ZERO_ARG_ACTIONS
+from certbot._internal.cli.cli_utils import _Default
+from certbot._internal.cli.cli_utils import add_domains
+from certbot._internal.cli.cli_utils import CustomHelpFormatter
+from certbot._internal.cli.cli_utils import flag_default
+from certbot._internal.cli.cli_utils import HelpfulArgumentGroup
+from certbot._internal.cli.verb_help import VERB_HELP
+from certbot._internal.cli.verb_help import VERB_HELP_MAP
+from certbot.compat import os
 from certbot.display import util as display_util
-
-from certbot._internal.cli import (
-    SHORT_USAGE,
-    CustomHelpFormatter,
-    flag_default,
-    VERB_HELP,
-    VERB_HELP_MAP,
-    COMMAND_OVERVIEW,
-    HELP_AND_VERSION_USAGE,
-    _Default,
-    add_domains,
-    EXIT_ACTIONS,
-    ZERO_ARG_ACTIONS,
-    ARGPARSE_PARAMS_TO_REMOVE,
-    HelpfulArgumentGroup
-)
 
 
 class HelpfulArgumentParser:

--- a/certbot/certbot/_internal/cli/paths_parser.py
+++ b/certbot/certbot/_internal/cli/paths_parser.py
@@ -1,10 +1,8 @@
 """This is a module that adds configuration to the argument parser regarding
 paths for certificates"""
+from certbot._internal.cli.cli_utils import config_help
+from certbot._internal.cli.cli_utils import flag_default
 from certbot.compat import os
-from certbot._internal.cli import (
-    flag_default,
-    config_help
-)
 
 
 def _paths_parser(helpful):

--- a/certbot/certbot/_internal/cli/plugins_parsing.py
+++ b/certbot/certbot/_internal/cli/plugins_parsing.py
@@ -1,5 +1,5 @@
 """This is a module that handles parsing of plugins for the argument parser"""
-from certbot._internal.cli import flag_default
+from certbot._internal.cli.cli_utils import flag_default
 
 
 def _plugins_parsing(helpful, plugins):

--- a/certbot/certbot/_internal/cli/subparsers.py
+++ b/certbot/certbot/_internal/cli/subparsers.py
@@ -1,14 +1,11 @@
 """This module creates subparsers for the argument parser"""
 from certbot import interfaces
 from certbot._internal import constants
-
-from certbot._internal.cli import (
-    flag_default,
-    read_file,
-    CaseInsensitiveList,
-    _user_agent_comment_type,
-    _EncodeReasonAction
-)
+from certbot._internal.cli.cli_utils import _EncodeReasonAction
+from certbot._internal.cli.cli_utils import _user_agent_comment_type
+from certbot._internal.cli.cli_utils import CaseInsensitiveList
+from certbot._internal.cli.cli_utils import flag_default
+from certbot._internal.cli.cli_utils import read_file
 
 
 def _create_subparsers(helpful):

--- a/certbot/certbot/_internal/cli/verb_help.py
+++ b/certbot/certbot/_internal/cli/verb_help.py
@@ -1,9 +1,7 @@
 """This module contain help information for verbs supported by certbot"""
+from certbot._internal.cli.cli_constants import SHORT_USAGE
+from certbot._internal.cli.cli_utils import flag_default
 from certbot.compat import os
-from certbot._internal.cli import (
-    SHORT_USAGE,
-    flag_default
-)
 
 # The attributes here are:
 # short: a string that will be displayed by "certbot -h commands"


### PR DESCRIPTION
While working on #8640, I realized that there were some hidden circular dependencies in `certbot._internal.cli` package. Then cerbot could break if the order of these imports changes.

This PR fixes that and apply isort on top of the result.