### PR TITLE
Remove empty lines from `certbot certificates` when envoked with `--cert-name` or `-d`.

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -17,7 +17,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Don't output an empty line for a hidden certificate when `certbot certificates` is being used
+  in combination with `--cert-name` or `-d`.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -266,9 +266,9 @@ def human_readable_cert_info(config, cert, skip_filter_checks=False):
     checker = ocsp.RevocationChecker()
 
     if config.certname and cert.lineagename != config.certname and not skip_filter_checks:
-        return ""
+        return None
     if config.domains and not set(config.domains).issubset(cert.names()):
-        return ""
+        return None
     now = pytz.UTC.fromutc(datetime.datetime.utcnow())
 
     reasons = []
@@ -358,7 +358,9 @@ def _report_human_readable(config, parsed_certs):
     """Format a results report for a parsed cert"""
     certinfo = []
     for cert in parsed_certs:
-        certinfo.append(human_readable_cert_info(config, cert))
+        cert_info = human_readable_cert_info(config, cert)
+        if cert_info is not None:
+            certinfo.append(cert_info)
     return "\n".join(certinfo)
 
 


### PR DESCRIPTION
Fixes #8722

## Pull Request Checklist

- [X] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [X] Include your name in `AUTHORS.md` if you like.

Not entirely enthusiastic about the variable name `cert_info`, but it fits.. 