### PR TITLE
Added missing from typing imports.

### DIFF
--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -5,6 +5,7 @@ import datetime
 import http.client as http_client
 import json
 import unittest
+from typing import Dict
 from unittest import mock
 
 import josepy as jose

--- a/acme/tests/crypto_util_test.py
+++ b/acme/tests/crypto_util_test.py
@@ -5,6 +5,7 @@ import socketserver
 import threading
 import time
 import unittest
+from typing import List
 
 import josepy as jose
 import OpenSSL

--- a/acme/tests/standalone_test.py
+++ b/acme/tests/standalone_test.py
@@ -4,6 +4,7 @@ import socket
 import socketserver
 import threading
 import unittest
+from typing import Set
 from unittest import mock
 
 import josepy as jose

--- a/certbot-apache/tests/augeasnode_test.py
+++ b/certbot-apache/tests/augeasnode_test.py
@@ -1,4 +1,6 @@
 """Tests for AugeasParserNode classes"""
+from typing import List
+
 try:
     import mock
 except ImportError: # pragma: no cover

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -1,6 +1,7 @@
 """Test for certbot_apache._internal.http_01."""
 import unittest
 import errno
+from typing import List
 
 try:
     import mock

--- a/certbot-nginx/tests/parser_test.py
+++ b/certbot-nginx/tests/parser_test.py
@@ -3,6 +3,7 @@ import glob
 import re
 import shutil
 import unittest
+from typing import List
 
 from certbot import errors
 from certbot.compat import os

--- a/certbot/tests/display/completer_test.py
+++ b/certbot/tests/display/completer_test.py
@@ -1,4 +1,6 @@
 """Test certbot._internal.display.completer."""
+from typing import List
+
 try:
     import readline  # pylint: disable=import-error
 except ImportError:

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -3,6 +3,7 @@ import contextlib
 import signal
 import sys
 import unittest
+from typing import Callable, Dict, Union
 
 try:
     import mock

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -5,7 +5,7 @@ import logging.handlers
 import sys
 import time
 import unittest
-
+from typing import Optional
 
 from acme import messages
 from certbot import errors

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import traceback
 import unittest
+from typing import List
 
 import josepy as jose
 import pytz

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -2,6 +2,7 @@
 import functools
 import string
 import unittest
+from typing import List
 
 try:
     import mock

--- a/certbot/tests/plugins/selection_test.py
+++ b/certbot/tests/plugins/selection_test.py
@@ -1,6 +1,7 @@
 """Tests for letsencrypt.plugins.selection"""
 import sys
 import unittest
+from typing import List
 
 try:
     import mock

--- a/certbot/tests/plugins/standalone_test.py
+++ b/certbot/tests/plugins/standalone_test.py
@@ -3,6 +3,7 @@
 import socket
 from socket import errno as socket_errors  # type: ignore
 import unittest
+from typing import Dict, Set, Tuple
 
 import josepy as jose
 try:


### PR DESCRIPTION
I'm not sure if this was intentional, or if they were forgotten by mistake.

I caught them by PyCharm, and added the imports how it likes. Is the style only to import one element per line?

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
