### PR TITLE
Use worker terminology in pytest-xdist

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/context.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/context.py
@@ -12,9 +12,9 @@ class IntegrationTestsContext:
     def __init__(self, request):
         self.request = request
 
-        if hasattr(request.config, 'slaveinput'):  # Worker node
-            self.worker_id = request.config.slaveinput['slaveid']
-            acme_xdist = request.config.slaveinput['acme_xdist']
+        if hasattr(request.config, 'workerinput'):  # Worker node
+            self.worker_id = request.config.workerinput['workerid']
+            acme_xdist = request.config.workerinput['acme_xdist']
         else:  # Primary node
             self.worker_id = 'primary'
             acme_xdist = request.config.acme_xdist

--- a/certbot-ci/certbot_integration_tests/conftest.py
+++ b/certbot-ci/certbot_integration_tests/conftest.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
     Standard pytest hook used to add a configuration logic for each node of a pytest run.
     :param config: the current pytest configuration
     """
-    if not hasattr(config, 'slaveinput'):  # If true, this is the primary node
+    if not hasattr(config, 'workerinput'):  # If true, this is the primary node
         with _print_on_err():
             _setup_primary_node(config)
 
@@ -44,8 +44,8 @@ def pytest_configure_node(node):
     Standard pytest-xdist hook used to configure a worker node.
     :param node: current worker node
     """
-    node.slaveinput['acme_xdist'] = node.config.acme_xdist
-    node.slaveinput['dns_xdist'] = node.config.dns_xdist
+    node.workerinput['acme_xdist'] = node.config.acme_xdist
+    node.workerinput['dns_xdist'] = node.config.dns_xdist
 
 
 @contextlib.contextmanager

--- a/certbot-ci/certbot_integration_tests/rfc2136_tests/context.py
+++ b/certbot-ci/certbot_integration_tests/rfc2136_tests/context.py
@@ -18,8 +18,8 @@ class IntegrationTestsContext(certbot_context.IntegrationTestsContext):
         self.request = request
 
         self._dns_xdist = None
-        if hasattr(request.config, 'slaveinput'):  # Worker node
-            self._dns_xdist = request.config.slaveinput['dns_xdist']
+        if hasattr(request.config, 'workerinput'):  # Worker node
+            self._dns_xdist = request.config.workerinput['dns_xdist']
         else:  # Primary node
             self._dns_xdist = request.config.dns_xdist
 

--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -14,7 +14,9 @@ install_requires = [
     'pyopenssl',
     'pytest',
     'pytest-cov',
-    'pytest-xdist',
+    # This version is needed for "worker" attributes we currently use like
+    # "workerinput".  See https://github.com/pytest-dev/pytest-xdist/pull/268.
+    'pytest-xdist>=1.22.1',
     'python-dateutil',
     'pyyaml',
     'requests',


### PR DESCRIPTION
This will be needed for me to update `pytest-xdist` as part of https://github.com/certbot/certbot/issues/8705 since `pytest-xdist` removed the "slave" terminology. See https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst#deprecations-and-removals.