### PR TITLE
Fix tests with newer versions of pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,10 @@ jobs=0
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+# CERTBOT COMMENT
+# This is needed for pylint to import linter_plugin.py since
+# https://github.com/PyCQA/pylint/pull/3396.
+init-hook="import pylint.config, os, sys; sys.path.append(os.path.dirname(pylint.config.PYLINTRC))"
 
 # Profiled execution.
 profile=no


### PR DESCRIPTION
This will be needed for me to update `pylint` as part of https://github.com/certbot/certbot/issues/8705.

If you want to verify this, run `pip install -U pylint` in Certbot's developer environment and run a simple command like `python -m pylint --help` on `master`. You should get a traceback like:
```
Traceback (most recent call last):
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/bmw/Development/github.com/certbot/certbot/venv/lib/python3.8/site-packages/pylint/__main__.py", line 18, in <module>
    pylint.run_pylint()
  File "/Users/bmw/Development/github.com/certbot/certbot/venv/lib/python3.8/site-packages/pylint/__init__.py", line 22, in run_pylint
    PylintRun(sys.argv[1:])
  File "/Users/bmw/Development/github.com/certbot/certbot/venv/lib/python3.8/site-packages/pylint/lint/run.py", line 317, in __init__
    linter.load_plugin_modules(plugins)
  File "/Users/bmw/Development/github.com/certbot/certbot/venv/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 490, in load_plugin_modules
    module = modutils.load_module_from_name(modname)
  File "/Users/bmw/Development/github.com/certbot/certbot/venv/lib/python3.8/site-packages/astroid/modutils.py", line 210, in load_module_from_name
    return importlib.import_module(dotted_name)
  File "/Users/bmw/.pyenv/versions/3.8.6/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'linter_plugin'
```