### PR TITLE
Split snap build over three Azure jobs (one per architecture)

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -116,13 +116,17 @@ jobs:
   - job: snaps_build
     pool:
       vmImage: ubuntu-18.04
+    strategy:
+      matrix:
+        amd64:
+          SNAP_ARCH: amd64
+        # Do not run the heavy non-amd64 builds for test branches
+        ${{ if not(startsWith(variables['Build.SourceBranchName'], 'test-')) }}:
+          armhf:
+            SNAP_ARCH: armhf
+          arm64:
+            SNAP_ARCH: arm64
     timeoutInMinutes: 0
-    variables:
-      # Do not run the heavy non-amd64 builds for test branches
-      ${{ if not(startsWith(variables['Build.SourceBranchName'], 'test-')) }}:
-        ARCHS: amd64 arm64 armhf
-      ${{ if startsWith(variables['Build.SourceBranchName'], 'test-') }}:
-        ARCHS: amd64
     steps:
       - script: |
           set -e
@@ -144,7 +148,7 @@ jobs:
           git config --global user.name "$(Build.RequestedFor)"
           mkdir -p ~/.local/share/snapcraft/provider/launchpad
           cp $(credentials.secureFilePath) ~/.local/share/snapcraft/provider/launchpad/credentials
-          python3 tools/snap/build_remote.py ALL --archs ${ARCHS} --timeout 19800
+          python3 tools/snap/build_remote.py ALL --archs ${SNAP_ARCH} --timeout 19800
         displayName: Build snaps
       - script: |
           set -e
@@ -154,7 +158,7 @@ jobs:
       - task: PublishPipelineArtifact@1
         inputs:
           path: $(Build.ArtifactStagingDirectory)
-          artifact: snaps
+          artifact: snaps_$(SNAP_ARCH)
         displayName: Store snaps artifacts
   - job: snap_run
     dependsOn: snaps_build
@@ -175,12 +179,12 @@ jobs:
         displayName: Install dependencies
       - task: DownloadPipelineArtifact@2
         inputs:
-          artifact: snaps
+          artifact: snaps_amd64
           path: $(Build.SourcesDirectory)/snap
         displayName: Retrieve Certbot snaps
       - script: |
           set -e
-          sudo snap install --dangerous --classic snap/certbot_*_amd64.snap
+          sudo snap install --dangerous --classic snap/certbot_*.snap
         displayName: Install Certbot snap
       - script: |
           set -e
@@ -202,7 +206,7 @@ jobs:
           addToPath: true
       - task: DownloadPipelineArtifact@2
         inputs:
-          artifact: snaps
+          artifact: snaps_amd64
           path: $(Build.SourcesDirectory)/snap
         displayName: Retrieve Certbot snaps
       - script: |

--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -37,6 +37,14 @@ stages:
           vmImage: ubuntu-18.04
         variables:
           - group: certbot-common
+        strategy:
+          matrix:
+            amd64:
+              SNAP_ARCH: amd64
+            arm32v6:
+              SNAP_ARCH: armhf
+            arm64v8:
+              SNAP_ARCH: arm64
         steps:
           - bash: |
               set -e
@@ -46,7 +54,7 @@ stages:
             displayName: Install dependencies
           - task: DownloadPipelineArtifact@2
             inputs:
-              artifact: snaps
+              artifact: snaps_$(SNAP_ARCH)
               path: $(Build.SourcesDirectory)/snap
             displayName: Retrieve Certbot snaps
           - task: DownloadSecureFile@1


### PR DESCRIPTION
Fixes #8700

Now that `snapcraft remote-build` truly uses new builds for each call, we can split the builds to have a dedicated Azure job for each target architecture. This PR does that.
