### PR TITLE
Remove outdated comment

### DIFF
--- a/tools/docker/core/Dockerfile
+++ b/tools/docker/core/Dockerfile
@@ -27,10 +27,6 @@ RUN apk add --no-cache --virtual .certbot-deps \
         binutils
 
 # Install certbot from sources
-#
-# We don't use tools/pip_install.py below so the hashes in
-# dependency-requirements.txt can be used when installing packages for extra
-# security.
 RUN apk add --no-cache --virtual .build-deps \
         gcc \
         linux-headers \


### PR DESCRIPTION
This comment is no longer accurate. If you look at the lines below, you can see we're using `pip_install.py` which strips hashes from our constraints file. I think it'd be nice to check hashes again (although I'm personally not that worried about it because plenty of other steps in our build process currently are just relying on HTTPS including getting our constraints file to Azure), but I think the best way to accomplish that is to resolve https://github.com/pypa/pip/issues/4995.