### PR TITLE
Use pip in test_sdists.sh

### DIFF
--- a/tests/letstest/scripts/test_sdists.sh
+++ b/tests/letstest/scripts/test_sdists.sh
@@ -9,31 +9,31 @@ VENV_PATH=venv
 . $BOOTSTRAP_SCRIPT
 
 # setup venv
-# We strip the hashes because the venv creation script includes unhashed
-# constraints in the commands given to pip and the mix of hashed and unhashed
-# packages makes pip error out.
-python3 tools/strip_hashes.py tools/pipstrap_constraints.txt > constraints.txt
-python3 tools/strip_hashes.py tools/certbot_constraints.txt > requirements.txt
+python3 -m venv $VENV_PATH
+$VENV_PATH/bin/python3 tools/pipstrap.py
+. "$VENV_PATH/bin/activate"
+# pytest is needed to run tests on our packages so we install a pinned version here.
+tools/pip_install.py pytest
+
+# setup constraints
+TEMP_DIR=$(mktemp -d)
+CONSTRAINTS="$TEMP_DIR/constraints.txt"
+# We strip the hashes because we don't have hashes of our local packages and
+# the mix of hashed and unhashed packages makes pip error out.
+python3 tools/strip_hashes.py tools/certbot_constraints.txt > "$CONSTRAINTS"
+python3 tools/strip_hashes.py tools/pipstrap_constraints.txt >> "$CONSTRAINTS"
 
 # We pin cryptography to 3.1.1 and pyOpenSSL to 19.1.0 specifically for CentOS 7 / RHEL 7
 # because these systems ship only with OpenSSL 1.0.2, and this OpenSSL version support has been
 # dropped on cryptography>=3.2 and pyOpenSSL>=20.0.0.
 # Using this old version of OpenSSL would break the cryptography and pyOpenSSL wheels builds.
 if [ -f /etc/redhat-release ] && [ "$(. /etc/os-release 2> /dev/null && echo "$VERSION_ID" | cut -d '.' -f1)" -eq 7 ]; then
-  sed -i 's|cryptography==.*|cryptography==3.1.1|g' requirements.txt
-  sed -i 's|pyOpenSSL==.*|pyOpenSSL==19.1.0|g' requirements.txt
+  sed -i 's|cryptography==.*|cryptography==3.1.1|g' "$CONSTRAINTS"
+  sed -i 's|pyOpenSSL==.*|pyOpenSSL==19.1.0|g' "$CONSTRAINTS"
 fi
 
-python3 -m venv $VENV_PATH
-$VENV_PATH/bin/python3 tools/pipstrap.py
-PIP_CONSTRAINT=constraints.txt PIP_NO_BINARY=:all: $VENV_PATH/bin/python3 -m pip install --requirement requirements.txt
-. "$VENV_PATH/bin/activate"
-# pytest is needed to run tests on some of our packages so we install a pinned version here.
-tools/pip_install.py pytest
 
 PLUGINS="certbot-apache certbot-nginx"
-TEMP_DIR=$(mktemp -d)
-
 # build sdists
 for pkg_dir in acme certbot $PLUGINS; do
     cd $pkg_dir
@@ -50,8 +50,7 @@ cd $TEMP_DIR
 for pkg in acme certbot $PLUGINS; do
     tar -xvf "$pkg-$VERSION.tar.gz"
     cd "$pkg-$VERSION"
-    python setup.py build
+    PIP_CONSTRAINT=../constraints.txt PIP_NO_BINARY=:all: pip install .
     python -m pytest
-    python setup.py install
     cd -
 done


### PR DESCRIPTION
I want this for my work on https://github.com/certbot/certbot/issues/8705.

The problem I'm having is for that issue I've essentially merged `dev_constraints.txt` and `certbot_constraints.txt` into one file which I think has a lot of benefits, however, it breaks this test because we use `certbot_constraints.txt` as a requirements file with `pip` in the line `...pip install --requirement requirements.txt`. We cannot do this with a requirements file containing all of our dependencies because only a subset of them can/need to be installed. Instead, we need to use the requirements file as constraints for pip like we normally do. This is currently the only place in our repo where we use `certbot_constraints.txt` as requirements to `pip` like this.

To fix this, I switched from installing our packages with `python setup.py` to installing them with `pip` which allows me to set `PIP_CONSTRAINTS`. I'm not aware of any downsides of this approach and in addition to helping me with my pinning work it would allow us to test our DNS plugins in this test which we previously could not do.

You can see tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=3649&view=results.