### PR TITLE
Dump test farm failure logs

### DIFF
--- a/tests/letstest/multitester.py
+++ b/tests/letstest/multitester.py
@@ -496,12 +496,17 @@ def main():
         outputs = [outq for outq in iter(outqueue.get, SENTINEL)]
         outputs.sort(key=lambda x: x[0])
         failed = False
+        results_msg = ""
         for outq in outputs:
             ii, target, status = outq
             if status == Status.FAIL:
                 failed = True
-            print('%d %s %s'%(ii, target['name'], status))
+                with open(log_dir+'/'+'%d_%s.log'%(ii,target['name']), 'r') as f:
+                    print(target['name'] + " test failed. Test log:")
+                    print(f.read())
+            results_msg = results_msg + '%d %s %s\n'%(ii, target['name'], status)
             results_file.write('%d %s %s\n'%(ii, target['name'], status))
+        print(results_msg)
         if len(outputs) != num_processes:
             failed = True
             failure_message = 'FAILURE: Some target machines failed to run and were not tested. ' +\


### PR DESCRIPTION
Fixes #7071.

I decided to dump all failed logs; waiting to [see (check test_sdists)](https://dev.azure.com/certbot/certbot/_build/results?buildId=3660&view=results) if this is too much for azure to handle, in which case I'll only dump the first one. Worked as expected when I ran it manually.