### PR TITLE
fix various fd leaks

### DIFF
--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1,6 +1,7 @@
 """Certbot main entry point."""
 # pylint: disable=too-many-lines
 
+import atexit
 import functools
 import logging.handlers
 import sys
@@ -1359,8 +1360,12 @@ def set_displayer(config):
     """
     if config.quiet:
         config.noninteractive_mode = True
+
+        devnull = open(os.devnull, "w")
+        atexit.register(devnull.close)
+
         displayer: Union[None, display_util.NoninteractiveDisplay, display_util.FileDisplay] =\
-            display_util.NoninteractiveDisplay(open(os.devnull, "w"))
+            display_util.NoninteractiveDisplay(devnull)
     elif config.noninteractive_mode:
         displayer = display_util.NoninteractiveDisplay(sys.stdout)
     else:

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -28,7 +28,8 @@ class PreArgParseSetupTest(unittest.TestCase):
     @classmethod
     def _call(cls, *args, **kwargs):  # pylint: disable=unused-argument
         from certbot._internal.log import pre_arg_parse_setup
-        return pre_arg_parse_setup()
+        with mock.patch('builtins.open', mock.mock_open()):
+            return pre_arg_parse_setup()
 
     @mock.patch('certbot._internal.log.sys')
     @mock.patch('certbot._internal.log.pre_arg_parse_except_hook')

--- a/certbot/tests/plugins/webroot_test.py
+++ b/certbot/tests/plugins/webroot_test.py
@@ -141,7 +141,8 @@ class AuthenticatorTest(unittest.TestCase):
             f.write("thingimy")
         filesystem.chmod(self.path, 0o000)
         try:
-            open(permission_canary, "r")
+            with open(permission_canary, "r"):
+                pass
             print("Warning, running tests as root skips permissions tests...")
         except IOError:
             # ok, permissions work, test away...


### PR DESCRIPTION
As reported in #8746, using `pytest>=6.2.0` with Python 3.8 or newer causes unraisable exceptions like `ResourceWarning` to fail some tests.

This change cleans up 2x fd leaks in tests and 1x harmless leak in Certbot.

Fixes #8746.