### PR TITLE
Use snapcraft login

### DIFF
--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -63,8 +63,7 @@ stages:
               secureFile: snapcraft.cfg
           - bash: |
               set -e
-              mkdir -p .snapcraft
-              ln -s $(snapcraftCfg.secureFilePath) .snapcraft/snapcraft.cfg
+              snapcraft login --with $(snapcraftCfg.secureFilePath)
               for SNAP_FILE in snap/*.snap; do
                 tools/retry.sh eval snapcraft upload --release=${{ parameters.snapReleaseChannel }} "${SNAP_FILE}"
               done


### PR DESCRIPTION
This fixes the failure seen at https://dev.azure.com/certbot/certbot/_build/results?buildId=3691&view=results. You can see this working at https://dev.azure.com/certbot/certbot/_build/results?buildId=3692&view=results. See https://forum.snapcraft.io/t/snapcraft-4-6-no-longer-uses-snapcraft-snapcraft-cfg/23647 for more info.
