### PR TITLE
Increase ARM build timeout

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -12,6 +12,9 @@ jobs:
             DOCKER_ARCH: arm32v6
           arm64v8:
             DOCKER_ARCH: arm64v8
+    # The default timeout of 60 minutes is a little low for compiling
+    # cryptography on ARM architectures.
+    timeoutInMinutes: 180
     steps:
       - bash: set -e && tools/docker/build.sh $(dockerTag) $DOCKER_ARCH
         displayName: Build the Docker images


### PR DESCRIPTION
ARM Docker builds have timed out twice now. This first happened at https://dev.azure.com/certbot/certbot/_build/results?buildId=3685&view=results where Azure seems to have lost the build log and again last night at https://dev.azure.com/certbot/certbot/_build/results?buildId=3694&view=results where if you toggle timestamps at https://dev.azure.com/certbot/certbot/_build/results?buildId=3694&view=logs&j=fdd3565a-f3c6-5154-eca9-9ae03666f7bd&t=5dbd9851-46a4-524f-73a8-4028241afcde&l=345, you'll see it took 40 minutes to compile cryptography.

I think bumping the Docker build timeout a bit should resolve this problem.