### PR TITLE
Simplify setup.py

### DIFF
--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -7,6 +7,13 @@ from setuptools import setup
 
 version = '0.32.0.dev0'
 
+# setuptools 36.2+ is needed for support for environment markers
+min_setuptools_version='36.2'
+# This conditional isn't necessary, but it provides better error messages to
+# people who try to install this package with older versions of setuptools.
+if LooseVersion(setuptools_version) < LooseVersion(min_setuptools_version):
+    raise RuntimeError(f'setuptools {min_setuptools_version}+ is required')
+
 install_requires = [
     'coverage',
     'cryptography',
@@ -18,20 +25,12 @@ install_requires = [
     # "workerinput".  See https://github.com/pytest-dev/pytest-xdist/pull/268.
     'pytest-xdist>=1.22.1',
     'python-dateutil',
+    # This dependency needs to be added using environment markers to avoid its
+    # installation on Linux.
+    'pywin32>=300 ; sys_platform == "win32"',
     'pyyaml',
     'requests',
 ]
-
-# Add pywin32 on Windows platforms to handle low-level system calls.
-# This dependency needs to be added using environment markers to avoid its installation on Linux.
-# However environment markers are supported only with setuptools >= 36.2.
-# So this dependency is not added for old Linux distributions with old setuptools,
-# in order to allow these systems to build certbot from sources.
-if LooseVersion(setuptools_version) >= LooseVersion('36.2'):
-    install_requires.append("pywin32>=224 ; sys_platform == 'win32'")
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
-                       'of setuptools. Version 36.2+ of setuptools is required.')
 
 setup(
     name='certbot-ci',

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -8,6 +8,12 @@ from setuptools import __version__ as setuptools_version
 from setuptools import find_packages
 from setuptools import setup
 
+min_setuptools_version='39.0.1'
+# This conditional isn't necessary, but it provides better error messages to
+# people who try to install this package with older versions of setuptools.
+if LooseVersion(setuptools_version) < LooseVersion(min_setuptools_version):
+    raise RuntimeError(f'setuptools {min_setuptools_version}+ is required')
+
 # Workaround for https://bugs.python.org/issue8876, see
 # https://bugs.python.org/issue8876#msg208792
 # This can be removed when using Python 2.7.9 or later:
@@ -49,28 +55,13 @@ install_requires = [
     'parsedatetime>=2.4',
     'pyrfc3339',
     'pytz',
-    'setuptools>=39.0.1',
+    # This dependency needs to be added using environment markers to avoid its
+    # installation on Linux.
+    'pywin32>=300 ; sys_platform == "win32"',
+    f'setuptools>={min_setuptools_version}',
     'zope.component',
     'zope.interface',
 ]
-
-# Add pywin32 on Windows platforms to handle low-level system calls.
-# This dependency needs to be added using environment markers to avoid its installation on Linux.
-# However environment markers are supported only with setuptools >= 36.2.
-# So this dependency is not added for old Linux distributions with old setuptools,
-# in order to allow these systems to build certbot from sources.
-pywin32_req = 'pywin32>=300'
-setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
-if setuptools_known_environment_markers:
-    install_requires.append(pywin32_req + " ; sys_platform == 'win32'")
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Error, you are trying to build certbot wheels using an old version '
-                       'of setuptools. Version 36.2+ of setuptools is required.')
-elif os.name == 'nt':
-    # This branch exists to improve this package's behavior on Windows. Without
-    # it, if the sdist is installed on Windows with an old version of
-    # setuptools, pywin32 will not be specified as a dependency.
-    install_requires.append(pywin32_req)
 
 dev_extras = [
     'astroid',


### PR DESCRIPTION
I recently noticed that we only support versions of `setuptools` that support environment markers which allows us to simplify our `setup.py` files a bit.
