### PR TITLE
Update a few type ignore comments

### DIFF
--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -28,8 +28,8 @@ class NonceError(ClientError):
 
 class BadNonce(NonceError):
     """Bad nonce error."""
-    def __init__(self, nonce, error, *args, **kwargs):
-        super(BadNonce, self).__init__(*args, **kwargs)  # type: ignore
+    def __init__(self, nonce, error, *args):
+        super(BadNonce, self).__init__(*args)
         self.nonce = nonce
         self.error = error
 
@@ -47,9 +47,8 @@ class MissingNonce(NonceError):
     :ivar requests.Response ~.response: HTTP Response
 
     """
-    def __init__(self, response, *args, **kwargs):
-        # See comment in BadNonce constructor above for an explanation of type: ignore here.
-        super(MissingNonce, self).__init__(*args, **kwargs)  # type: ignore
+    def __init__(self, response, *args):
+        super(MissingNonce, self).__init__(*args)
         self.response = response
 
     def __str__(self):

--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -29,11 +29,6 @@ class NonceError(ClientError):
 class BadNonce(NonceError):
     """Bad nonce error."""
     def __init__(self, nonce, error, *args, **kwargs):
-        # MyPy complains here that there is too many arguments for BaseException constructor.
-        # This is an error fixed in typeshed, see https://github.com/python/mypy/issues/4183
-        # The fix is included in MyPy>=0.740, but upgrading it would bring dozen of errors due to
-        #   new types definitions. So we ignore the error until the code base is fixed to match
-        #   with MyPy>=0.740 referential.
         super(BadNonce, self).__init__(*args, **kwargs)  # type: ignore
         self.nonce = nonce
         self.error = error

--- a/certbot/certbot/_internal/lock.py
+++ b/certbot/certbot/_internal/lock.py
@@ -205,10 +205,9 @@ class _WindowsLockMechanism(_BaseLockMechanism):
             # Under Windows, filesystem.open will raise directly an EACCES error
             # if the lock file is already locked.
             fd = filesystem.open(self._path, open_mode, 0o600)
-            # The need for this "type: ignore" was fixed in
-            # https://github.com/python/typeshed/pull/3607 and included in
-            # newer versions of mypy so it can be removed when mypy is
-            # upgraded.
+            # This "type: ignore" is currently needed because msvcrt methods
+            # are only defined on Windows. See
+            # https://github.com/python/typeshed/blob/16ae4c61201cd8b96b8b22cdfb2ab9e89ba5bcf2/stdlib/msvcrt.pyi.
             msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)  # type: ignore
         except (IOError, OSError) as err:
             if fd:
@@ -224,10 +223,9 @@ class _WindowsLockMechanism(_BaseLockMechanism):
     def release(self):
         """Release the lock."""
         try:
-            # The need for this "type: ignore" was fixed in
-            # https://github.com/python/typeshed/pull/3607 and included in
-            # newer versions of mypy so it can be removed when mypy is
-            # upgraded.
+            # This "type: ignore" is currently needed because msvcrt methods
+            # are only defined on Windows. See
+            # https://github.com/python/typeshed/blob/16ae4c61201cd8b96b8b22cdfb2ab9e89ba5bcf2/stdlib/msvcrt.pyi.
             msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)  # type: ignore
             os.close(self._fd)
 

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -301,8 +301,7 @@ def verify_signed_payload(public_key, signature, payload, signature_hash_algorit
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         if isinstance(public_key, RSAPublicKey):
-            # https://github.com/python/typeshed/blob/master/third_party/2/cryptography/hazmat/primitives/asymmetric/rsa.pyi
-            verifier = public_key.verifier(  # type: ignore
+            verifier = public_key.verifier(
                 signature, PKCS1v15(), signature_hash_algorithm
             )
             verifier.update(payload)


### PR DESCRIPTION
Some are no longer needed and other's comments are out of date.

For the changes to the acme nonce errors, `Exception` doesn't take kwargs. The error message about this our own classes isn't super helpful:
```
In [2]: BadNonce('nonce', 'error', foo='bar')                                                                                                                                                                                                                                                                               
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-54555658ef99> in <module>
----> 1 BadNonce('nonce', 'error', foo='bar')

TypeError: __init__() got an unexpected keyword argument 'foo'
```
but if you try this on `Exception` which these classes inherit from, you get:
```
In [4]: Exception(foo='bar')                                                                                                                                                                                                                                                                                                
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-028b924f74c5> in <module>
----> 1 Exception(foo='bar')

TypeError: Exception() takes no keyword arguments
```
See https://github.com/python/typeshed/pull/2348 for more info.