### PR TITLE
Use standard errno

### DIFF
--- a/certbot/certbot/_internal/plugins/standalone.py
+++ b/certbot/certbot/_internal/plugins/standalone.py
@@ -1,9 +1,8 @@
 """Standalone Authenticator."""
 import collections
+import errno
 import logging
 import socket
-# https://github.com/python/typeshed/blob/master/stdlib/2and3/socket.pyi
-from socket import errno as socket_errors  # type: ignore
 from typing import DefaultDict
 from typing import Dict
 from typing import Set
@@ -187,13 +186,13 @@ class Authenticator(common.Plugin):
 
 
 def _handle_perform_error(error):
-    if error.socket_error.errno == socket_errors.EACCES:
+    if error.socket_error.errno == errno.EACCES:
         raise errors.PluginError(
             "Could not bind TCP port {0} because you don't have "
             "the appropriate permissions (for example, you "
             "aren't running this program as "
             "root).".format(error.port))
-    if error.socket_error.errno == socket_errors.EADDRINUSE:
+    if error.socket_error.errno == errno.EADDRINUSE:
         display = zope.component.getUtility(interfaces.IDisplay)
         msg = (
             "Could not bind TCP port {0} because it is already in "

--- a/certbot/tests/plugins/standalone_test.py
+++ b/certbot/tests/plugins/standalone_test.py
@@ -1,7 +1,6 @@
 """Tests for certbot._internal.plugins.standalone."""
-# https://github.com/python/typeshed/blob/master/stdlib/2and3/socket.pyi
+import errno
 import socket
-from socket import errno as socket_errors  # type: ignore
 import unittest
 from typing import Dict, Set, Tuple
 
@@ -106,8 +105,8 @@ class AuthenticatorTest(unittest.TestCase):
     @test_util.patch_get_utility()
     def test_perform_eaddrinuse_retry(self, mock_get_utility):
         mock_utility = mock_get_utility()
-        errno = socket_errors.EADDRINUSE
-        error = errors.StandaloneBindError(mock.MagicMock(errno=errno), -1)
+        encountered_errno = errno.EADDRINUSE
+        error = errors.StandaloneBindError(mock.MagicMock(errno=encountered_errno), -1)
         self.auth.servers.run.side_effect = [error] + 2 * [mock.MagicMock()]
         mock_yesno = mock_utility.yesno
         mock_yesno.return_value = True
@@ -121,8 +120,8 @@ class AuthenticatorTest(unittest.TestCase):
         mock_yesno = mock_utility.yesno
         mock_yesno.return_value = False
 
-        errno = socket_errors.EADDRINUSE
-        self.assertRaises(errors.PluginError, self._fail_perform, errno)
+        encountered_errno = errno.EADDRINUSE
+        self.assertRaises(errors.PluginError, self._fail_perform, encountered_errno)
         self._assert_correct_yesno_call(mock_yesno)
 
     def _assert_correct_yesno_call(self, mock_yesno):
@@ -131,16 +130,16 @@ class AuthenticatorTest(unittest.TestCase):
         self.assertFalse(yesno_kwargs.get("default", True))
 
     def test_perform_eacces(self):
-        errno = socket_errors.EACCES
-        self.assertRaises(errors.PluginError, self._fail_perform, errno)
+        encountered_errno = errno.EACCES
+        self.assertRaises(errors.PluginError, self._fail_perform, encountered_errno)
 
     def test_perform_unexpected_socket_error(self):
-        errno = socket_errors.ENOTCONN
+        encountered_errno = errno.ENOTCONN
         self.assertRaises(
-            errors.StandaloneBindError, self._fail_perform, errno)
+            errors.StandaloneBindError, self._fail_perform, encountered_errno)
 
-    def _fail_perform(self, errno):
-        error = errors.StandaloneBindError(mock.MagicMock(errno=errno), -1)
+    def _fail_perform(self, encountered_errno):
+        error = errors.StandaloneBindError(mock.MagicMock(errno=encountered_errno), -1)
         self.auth.servers.run.side_effect = error
         self.auth.perform(self._get_achalls())
 


### PR DESCRIPTION
We were originally using `socket.errno` with a `type: ignore` and a comment suggesting that this attribute needs to be included in the typeshed. This is incorrect.

While it's true that [socket imports errno](https://github.com/python/cpython/blob/43682f1e39a3c61f0e8a638b887bcdcbfef766c5/Lib/socket.py#L58), it's not intended to be part of its API. https://docs.python.org/3/library/socket.html has no mention of it.

Instead, we should be using the standard `errno` module and remove this `type: ignore`.