### PR TITLE
Improve tools/snap/build_remote.py output

### DIFF
--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -104,7 +104,7 @@ def _build_snap(
     else:
         workspace = join(CERTBOT_DIR, target)
 
-    build_was_successful = False
+    build_success = False
     retry = 3
     while retry:
         exit_code, process_output = _execute_build(target, archs, status, workspace)
@@ -125,7 +125,7 @@ def _build_snap(
                           f'(current list: {snaps_list}).')
                     dump_output = True
                 else:
-                    build_was_successful = True
+                    build_success = True
                     break
             if dump_output:
                 print(f'Dumping snapcraft remote-build output build for {target}:')
@@ -138,7 +138,7 @@ def _build_snap(
 
     running[target] = False
 
-    return build_was_successful
+    return build_success
 
 
 def _extract_state(project: str, output: str, status: Dict[str, Dict[str, str]]) -> None:

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -76,7 +76,7 @@ def _execute_build(
         for arch in archs:
             log_name = _snap_log_name(target, arch)
             log_path = join(temp_workspace, log_name)
-            if exists(log_path)
+            if exists(log_path):
                 shutil.copy(log_path, workspace)
 
         return process_state, process_output

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -265,7 +265,7 @@ def main():
 
             build_success = True
             for async_result in async_results:
-                if not async_results.get():
+                if not async_result.get():
                     build_success = False
 
             _dump_results(archs, status)

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -183,8 +183,7 @@ def _dump_status(
 
 def _dump_failed_build_logs(
         target: str, archs: Set[str], status: Dict[str, Dict[str, str]],
-        workspace: str) -> bool:
-    failures = False
+        workspace: str) -> None:
     for arch in archs:
         result = status[target][arch]
 
@@ -204,7 +203,6 @@ def _dump_failed_build_logs(
             print(build_output)
             print('-------------------------------------------')
             print()
-    return failures
 
 
 def _dump_results(archs: Set[str], status: Dict[str, Dict[str, str]]) -> None:

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -263,7 +263,11 @@ def main():
             if process.is_alive():
                 raise ValueError(f"Timeout out reached ({args.timeout} seconds) during the build!")
 
-            build_success = all(async_result.get() for async_result in async_results)
+            build_success = True
+            for async_result in async_results:
+                if not async_results.get():
+                    build_success = False
+
             _dump_results(archs, status)
             if build_success:
                 print('All builds succeeded.')

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -28,6 +28,10 @@ CERTBOT_DIR = dirname(dirname(dirname(realpath(__file__))))
 PLUGINS = [basename(path) for path in glob.glob(join(CERTBOT_DIR, 'certbot-dns-*'))]
 
 
+def _snap_log_name(target: str, arch: str):
+    return f'{target}_{arch}.txt'
+
+
 def _execute_build(
         target: str, archs: Set[str], status: Dict[str, Dict[str, str]],
         workspace: str) -> Tuple[int, List[str]]:
@@ -69,6 +73,11 @@ def _execute_build(
 
         for path in glob.glob(join(temp_workspace, '*.snap')):
             shutil.copy(path, workspace)
+        for arch in archs:
+            log_name = _snap_log_name(target, arch)
+            log_path = join(temp_workspace, log_name)
+            if exists(log_path)
+                shutil.copy(log_path, workspace)
 
         return process_state, process_output
 
@@ -171,11 +180,12 @@ def _dump_failed_build_logs(
         if result != 'Successfully built':
             failures = True
 
-            build_output_path = join(workspace, f'{target}_{arch}.txt')
+            build_output_name = _snap_log_name(target, arch)
+            build_output_path = join(workspace, build_output_name)
             if not exists(build_output_path):
                 build_output = f'No output has been dumped by snapcraft remote-build.'
             else:
-                with open(join(workspace, f'{target}_{arch}.txt')) as file_h:
+                with open(build_output_path) as file_h:
                     build_output = file_h.read()
 
             print(f'Output for failed build target={target} arch={arch}')


### PR DESCRIPTION
I think this PR improves tools/snap/build_remote.py's output in a number of ways such as:

* Logs of snap builds were being deleted because they weren't being copied out of the temporary directory added in https://github.com/certbot/certbot/pull/8719.
* The lock should now always be acquired before printing output when multiple processes are running which helps prevent processes mixing their output with each other.
* Output is never buffered which ensures that repeated calls to `print` from the same process while it holds the output lock is kept together.
* The case where we printed output about the "chroot problem" and stopped retrying the build has been deleted because with the fix in https://github.com/certbot/certbot/pull/8719, we should be able to recover in this case.
* If the build failed for any reason, we dump as much output about the problem as we can. I think most times we won't need to read this output, but I personally prefer it being there in case we want it for some reason. Due to this change, I also simplified `_build_snap` and `_dump_results` a bit since `_build_snap` handles printing logs as needed.

You can see builds passing for just amd64 at https://dev.azure.com/certbot/certbot/_build/results?buildId=3787&view=logs&j=f44d40a4-7318-5ffe-762c-ae4557889284&t=07786725-57f8-5198-4d13-ea77f640bd5c and for all architectures at https://dev.azure.com/certbot/certbot/_build/results?buildId=3788&view=results. You can see the logs properly being printed at lines like https://dev.azure.com/certbot/certbot/_build/results?buildId=3788&view=logs&j=edd94629-6079-5d92-49f9-08bca5d8ac73&t=3e600b29-8d94-52df-4792-661ba9022898&l=1071.

@adferrand, I think you're most familiar with this code so it's probably easiest for you to review it, although other people are more than welcome to review this if they want.