### PR TITLE
Removed --manual-public-ip-logging-ok arg in certbot integration tests

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/certbot_integration_tests/utils/certbot_call.py
@@ -100,7 +100,6 @@ def _prepare_args_env(certbot_args, directory_url, http_01_port, tls_alpn_01_por
         '--no-verify-ssl',
         '--http-01-port', str(http_01_port),
         '--https-port', str(tls_alpn_01_port),
-        '--manual-public-ip-logging-ok',
         '--config-dir', config_dir,
         '--work-dir', os.path.join(workspace, 'work'),
         '--logs-dir', os.path.join(workspace, 'logs'),


### PR DESCRIPTION
Seems to be an old remnant that should have been removed in 1.10.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
