### PR TITLE
Fix ciphers link

### DIFF
--- a/certbot/docs/ciphers.rst
+++ b/certbot/docs/ciphers.rst
@@ -1,3 +1,11 @@
+..
+  Sphinx complains that this file isn't included in any toctree, however, we
+  currently link to it in the section about installing Certbot through Docker.
+  Setting :orphan: below suppresses this warning. See
+  https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#special-metadata-fields.
+
+:orphan:
+
 ============
 Ciphersuites
 ============

--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -98,7 +98,6 @@ language = None
 exclude_patterns = [
     '_build',
     'challenges.rst',
-    'ciphers.rst'
 ]
 
 # The reST default role (used for this markup: `text`) to use for all


### PR DESCRIPTION
Currently if you try to build the documentation, the link to `ciphers.html` in `install.html` is a 404 as can be seen in the Travis errors of https://github.com/certbot/website/pull/706. This was caused by https://github.com/certbot/certbot/pull/8530 which configured Sphinx to stop building `ciphers.rst` since Sphinx was complaining about it not being included in any document tree.

While it's true we're not including it in our table of contents, we are linking to the file. This PR configures Sphinx to still build the file without complaining about it not being linked to. I tested that the Docker link still works and there is no visual change to the ciphers page which looks like:
![Screen Shot 2021-04-21 at 12 01 38 PM](https://user-images.githubusercontent.com/6504915/115607489-e7590900-a299-11eb-8467-f91603f36444.png)
