### PR TITLE
Remove pytest run from release script

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -177,23 +177,6 @@ cd ~-
 CERTBOT_DOCS=1 certbot --help all > certbot/docs/cli-help.txt
 jws --help > acme/docs/jws-help.txt
 
-cd ..
-# freeze before installing anything else, so that we know end-user KGS
-# make sure "twine upload" doesn't catch "kgs"
-if [ -d kgs ] ; then
-    echo Deleting old kgs...
-    rm -rf kgs
-fi
-mkdir kgs
-kgs="kgs/$version"
-pip freeze | tee $kgs
-python ../tools/pip_install.py pytest
-cd ~-
-for module in $SUBPKGS ; do
-    echo testing $module
-    # use an empty configuration file rather than the one in the repo root
-    pytest -c <(echo '') $module
-done
 deactivate
 
 


### PR DESCRIPTION
Fixes #8802.

Also removed the unused `kgs` cruft while I was here, since it's leftover from the [initial release commit](https://github.com/certbot/certbot/commit/3c08b512c3b546528880a1353f6b8607307533a3) and I'm pretty sure we don't use that anymore.