### PR TITLE
Don't ignore "kgs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 build/
 dist*/
 /venv*/
-/kgs/
 /.tox/
 /releases*/
 /log*


### PR DESCRIPTION
I noticed this while reviewing https://github.com/certbot/certbot/pull/8810 and figured that by writing a quick PR myself, we could save a round trip.

Since we're no longer creating "kgs" (and it was already ignored because it was in the "releases" directory which is ignored a couple lines down), I don't think we need this line in `.gitignore`.