### PR TITLE
Fix incompatibility with lexicon >= v3.6.0

### DIFF
--- a/certbot-dns-cloudxns/setup.py
+++ b/certbot-dns-cloudxns/setup.py
@@ -9,7 +9,7 @@ version = '1.16.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
+    'dns-lexicon>=3.1.0',  # Changed `rtype` parameter name
     'setuptools>=39.0.1',
     'zope.interface',
 ]

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -32,7 +32,7 @@ if os.environ.get('SNAP_BUILD'):
 # which allows us to potentially upgrade our packages in these distros
 # as necessary.
 if os.environ.get('CERTBOT_OLDEST') == '1':
-    install_requires.append('dns-lexicon>=2.2.1')
+    install_requires.append('dns-lexicon>=3.1.0')  # Changed parameter name
 else:
     install_requires.append('dns-lexicon>=3.2.1')
 

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -9,7 +9,7 @@ version = '1.16.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
+    'dns-lexicon>=3.1.0',  # Changed `rtype` parameter name
     'setuptools>=39.0.1',
     'zope.interface',
 ]

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -8,7 +8,7 @@ version = '1.16.0.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'dns-lexicon>=2.1.22',
+    'dns-lexicon>=3.1.0',  # Changed `rtype` parameter name
     'setuptools>=39.0.1',
     'zope.interface',
 ]

--- a/certbot-dns-linode/local-oldest-requirements.txt
+++ b/certbot-dns-linode/local-oldest-requirements.txt
@@ -1,4 +1,3 @@
 # Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==1.1.0
-dns-lexicon==2.2.3

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -8,7 +8,7 @@ version = '1.16.0.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'dns-lexicon>=2.2.3',
+    'dns-lexicon>=3.1.0',  # Changed `rtype` parameter name
     'setuptools>=39.0.1',
     'zope.interface',
 ]

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -9,7 +9,7 @@ version = '1.16.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
+    'dns-lexicon>=3.1.0',  # Changed `rtype` parameter name
     'setuptools>=39.0.1',
     'zope.interface',
 ]

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -9,7 +9,7 @@ version = '1.16.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'dns-lexicon>=2.2.1',  # Support for >1 TXT record per name
+    'dns-lexicon>=3.1.0',  # Changed `rtype` parameter name
     'setuptools>=39.0.1',
     'zope.interface',
 ]

--- a/certbot-dns-ovh/local-oldest-requirements.txt
+++ b/certbot-dns-ovh/local-oldest-requirements.txt
@@ -1,4 +1,3 @@
 # Remember to update setup.py to match the package versions below.
 acme[dev]==0.31.0
 certbot[dev]==1.1.0
-dns-lexicon==2.7.14

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -9,7 +9,7 @@ version = '1.16.0.dev0'
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'dns-lexicon>=2.7.14',  # Correct proxy use on OVH provider
+    'dns-lexicon>=3.1.0',  # Changed `rtype` parameter name
     'setuptools>=39.0.1',
     'zope.interface',
 ]

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -8,7 +8,7 @@ version = '1.16.0.dev0'
 
 # Please update tox.ini when modifying dependency version requirements
 install_requires = [
-    'dns-lexicon>=2.1.23',
+    'dns-lexicon>=3.1.0',  # Changed `rtype` parameter name
     'setuptools>=39.0.1',
     'zope.interface',
 ]

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,11 +10,11 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* DNS plugins based on lexicon now require dns-lexicon >= v3.1.0
 
 ### Fixed
 
-*
+* Fix TypeError due to incompatibility with lexicon >= v3.6.0
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/plugins/dns_common_lexicon.py
+++ b/certbot/certbot/plugins/dns_common_lexicon.py
@@ -45,7 +45,7 @@ class LexiconClient:
         self._find_domain_id(domain)
 
         try:
-            self.provider.create_record(type='TXT', name=record_name, content=record_content)
+            self.provider.create_record(rtype='TXT', name=record_name, content=record_content)
         except RequestException as e:
             logger.debug('Encountered error adding TXT record: %s', e, exc_info=True)
             raise errors.PluginError('Error adding TXT record: {0}'.format(e))
@@ -67,7 +67,7 @@ class LexiconClient:
             return
 
         try:
-            self.provider.delete_record(type='TXT', name=record_name, content=record_content)
+            self.provider.delete_record(rtype='TXT', name=record_name, content=record_content)
         except RequestException as e:
             logger.debug('Encountered error deleting TXT record: %s', e, exc_info=True)
 

--- a/certbot/certbot/plugins/dns_test_common_lexicon.py
+++ b/certbot/certbot/plugins/dns_test_common_lexicon.py
@@ -94,7 +94,7 @@ class BaseLexiconClientTest:
     def test_add_txt_record(self: _LexiconAwareTestCase):
         self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
 
-        self.provider_mock.create_record.assert_called_with(type='TXT',
+        self.provider_mock.create_record.assert_called_with(rtype='TXT',
                                                             name=self.record_name,
                                                             content=self.record_content)
 
@@ -103,7 +103,7 @@ class BaseLexiconClientTest:
 
         self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
 
-        self.provider_mock.create_record.assert_called_with(type='TXT',
+        self.provider_mock.create_record.assert_called_with(rtype='TXT',
                                                             name=self.record_name,
                                                             content=self.record_content)
 
@@ -147,7 +147,7 @@ class BaseLexiconClientTest:
     def test_del_txt_record(self: _LexiconAwareTestCase):
         self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
 
-        self.provider_mock.delete_record.assert_called_with(type='TXT',
+        self.provider_mock.delete_record.assert_called_with(rtype='TXT',
                                                             name=self.record_name,
                                                             content=self.record_content)
 

--- a/tools/oldest_constraints.txt
+++ b/tools/oldest_constraints.txt
@@ -59,9 +59,6 @@ zope.hookable==4.0.4
 # Ubuntu Bionic constraints.
 cryptography==2.1.4
 distro==1.0.1
-# Lexicon oldest constraint is overridden appropriately on relevant DNS provider plugins
-# using their local-oldest-requirements.txt
-dns-lexicon==2.2.1
 httplib2==0.9.2
 idna==2.6
 setuptools==39.0.1
@@ -77,3 +74,6 @@ parsedatetime==2.4
 # Tracking at https://github.com/certbot/certbot/issues/6473
 boto3==1.4.7
 botocore==1.7.41
+# Lexicon oldest constraint is overridden appropriately on relevant DNS provider plugins
+# using their local-oldest-requirements.txt
+dns-lexicon==3.1.0


### PR DESCRIPTION
Hi,

this resolves the following error in `dns_common_lexicon.py`:

```
  File "/usr/lib/python3.9/site-packages/certbot/plugins/dns_common_lexicon.py", line 48, in add_txt_record
    self.provider.create_record(type='TXT', name=record_name, content=record_content)
TypeError: create_record() got an unexpected keyword argument 'type'
```

The variable `type` parameter was renamed to `rtype` more than [2 years ago](https://github.com/AnalogJ/lexicon/commit/74b70b1efaf87a9a8eb0bbe901f05fb8013c88ca) (v3.1.0), and has been deprecated since. The old form has been removed [about a month ago](https://github.com/AnalogJ/lexicon/commit/174cf1cb13d38133475ee6d87d7a2f73aa0c0941) (v3.6.0) and now triggers a `TypeError`.

Since the renaming was done more than 2 years ago, I think it's safe to simply rename here as well (without adding compatibility `try ... except ...` clauses).