### PR TITLE
Fix typo in integration tests

### DIFF
--- a/certbot-ci/snap_integration_tests/dns_tests/test_main.py
+++ b/certbot-ci/snap_integration_tests/dns_tests/test_main.py
@@ -44,4 +44,4 @@ def test_dns_plugin_install(dns_snap_path):
             'certbot:certbot-metadata'])
         subprocess.check_call(['snap', 'install', '--dangerous', dns_snap_path])
     finally:
-        subprocess.call(['snap', 'remove', 'plugin_name'])
+        subprocess.call(['snap', 'remove', plugin_name])


### PR DESCRIPTION
I noticed [this](https://dev.azure.com/certbot/certbot/_build/results?buildId=3902&view=logs&j=f035736c-7a55-55cd-c5d9-373620f375ce&t=61643669-51fc-50fe-4b3c-019d150dfcbf&l=71) on the failed release build yesterday. You can see tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=3907&view=results.