### PR TITLE
Update lexion create record rtype argument

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -251,6 +251,7 @@ Authors
 * [Tan Jay Jun](https://github.com/jayjun)
 * [Tapple Gao](https://github.com/tapple)
 * [Telepenin Nikolay](https://github.com/telepenin)
+* [tengattack](https://github.com/tengattack)
 * [Thomas Cottier](https://github.com/tcottier-enalean)
 * [Thomas Mayer](https://github.com/thomaszbz)
 * [Thomas Waldmann](https://github.com/ThomasWaldmann)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fix lexicon `create_record` and `delete_record` argument `rtype` changed.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/plugins/dns_common_lexicon.py
+++ b/certbot/certbot/plugins/dns_common_lexicon.py
@@ -45,7 +45,7 @@ class LexiconClient:
         self._find_domain_id(domain)
 
         try:
-            self.provider.create_record(type='TXT', name=record_name, content=record_content)
+            self.provider.create_record(rtype='TXT', name=record_name, content=record_content)
         except RequestException as e:
             logger.debug('Encountered error adding TXT record: %s', e, exc_info=True)
             raise errors.PluginError('Error adding TXT record: {0}'.format(e))
@@ -67,7 +67,7 @@ class LexiconClient:
             return
 
         try:
-            self.provider.delete_record(type='TXT', name=record_name, content=record_content)
+            self.provider.delete_record(rtype='TXT', name=record_name, content=record_content)
         except RequestException as e:
             logger.debug('Encountered error deleting TXT record: %s', e, exc_info=True)
 

--- a/certbot/certbot/plugins/dns_test_common_lexicon.py
+++ b/certbot/certbot/plugins/dns_test_common_lexicon.py
@@ -94,7 +94,7 @@ class BaseLexiconClientTest:
     def test_add_txt_record(self: _LexiconAwareTestCase):
         self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
 
-        self.provider_mock.create_record.assert_called_with(type='TXT',
+        self.provider_mock.create_record.assert_called_with(rtype='TXT',
                                                             name=self.record_name,
                                                             content=self.record_content)
 
@@ -103,7 +103,7 @@ class BaseLexiconClientTest:
 
         self.client.add_txt_record(DOMAIN, self.record_name, self.record_content)
 
-        self.provider_mock.create_record.assert_called_with(type='TXT',
+        self.provider_mock.create_record.assert_called_with(rtype='TXT',
                                                             name=self.record_name,
                                                             content=self.record_content)
 
@@ -147,7 +147,7 @@ class BaseLexiconClientTest:
     def test_del_txt_record(self: _LexiconAwareTestCase):
         self.client.del_txt_record(DOMAIN, self.record_name, self.record_content)
 
-        self.provider_mock.delete_record.assert_called_with(type='TXT',
+        self.provider_mock.delete_record.assert_called_with(rtype='TXT',
                                                             name=self.record_name,
                                                             content=self.record_content)
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.

Due to https://github.com/AnalogJ/lexicon/pull/341 lexicon change the `type` keyword argument to `rtype`.

Here make a change to `LexiconClient` to fix this problem:
```
  File "/opt/certbot/src/certbot/certbot/plugins/dns_common_lexicon.py", line 48, in add_txt_record
    self.provider.create_record(type='TXT', name=record_name, content=record_content)
TypeError: create_record() got an unexpected keyword argument 'type'
```