### PR TITLE
Fix sphinx followup

### DIFF
--- a/.azure-pipelines/templates/steps/sphinx-steps.yml
+++ b/.azure-pipelines/templates/steps/sphinx-steps.yml
@@ -9,7 +9,7 @@ steps:
       do
         echo ""
         echo "##[group]Building $doc_path"
-        pip install -q -e $doc_path/..[docs] -c tools/requirements.txt
+        tools/pip_install_editable.py $doc_path/..[docs]
         if ! sphinx-build -W --keep-going -b html $doc_path $doc_path/_build/html; then
           FINAL_STATUS=1
           FAILED_BUILDS[${#FAILED_BUILDS[@]}]="${doc_path%/docs}"

--- a/tools/pinning/pyproject.toml
+++ b/tools/pinning/pyproject.toml
@@ -71,10 +71,11 @@ pytest-forked = "0.2"
 # https://github.com/certbot/certbot/issues/8732.
 python-augeas = "0.5.0"
 # Because some parts of Certbot documentation are generated from zope.interfaces,
-# we need the Sphinx plugin repoze.sphinx.autointerface. But this plugin is not
-# maintained anymore, and it is not compatible with Sphinx 4.x. So we need to
-# pin Sphinx to 3.5 to make it work. This situation will be unblocked by the
-# removal of zope.interface in Certbot.
+# we need the Sphinx plugin repoze.sphinx.autointerface. This plugin is not
+# currently compatible with Sphinx>=4 though so we're pinning an older version
+# for now. See https://github.com/repoze/repoze.sphinx.autointerface/issues/16
+# for more info. This pinning could also be removed by the removal of
+# zope.interface in Certbot.
 sphinx = "<4"
 # Library traitlets is a transitive dependency of ipdb (traitlets -> ipython -> ipdb).
 # Version 5.x is incompatible with Python 3.6 but for some reasons, poetry fails to


### PR DESCRIPTION
I think we should use our `pip_install*` scripts wherever we can and I'm not quite sure yet if I'd call `repoze.sphinx.autointerface` unmaintained.