### PR TITLE
Remove old apache tests

### DIFF
--- a/letstest/scripts/test_apache2.sh
+++ b/letstest/scripts/test_apache2.sh
@@ -12,25 +12,6 @@ then
     # For apache 2.4, set up ServerName
     sudo sed -i '/ServerName/ s/#ServerName/ServerName/' $CONFFILE
     sudo sed -i '/ServerName/ s/www.example.com/'$PUBLIC_HOSTNAME'/' $CONFFILE
-    if [ $(python3 -V 2>&1 | cut -d" " -f 2 | cut -d. -f1,2 | sed 's/\.//') -lt 36 ]
-    then
-        # Upgrade python version using pyenv because py3.5 is deprecated
-        # Don't upgrade if it's already 3.8 because pyenv doesn't work great on arm, and
-        # our arm representative happens to be ubuntu20, which already has a perfectly
-        # good version of python.
-        sudo apt-get install -y make gcc build-essential libssl-dev zlib1g-dev libbz2-dev \
-          libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-          xz-utils tk-dev libffi-dev liblzma-dev python-openssl git # pyenv deps
-        curl https://pyenv.run | bash
-        export PATH="~/.pyenv/bin:$PATH"
-        pyenv init -
-        pyenv virtualenv-init -
-        pyenv install 3.8.5
-        pyenv global 3.8.5
-        # you do, in fact need to run these again, exactly like this.
-        eval "$(pyenv init -)"
-        eval "$(pyenv virtualenv-init -)"
-    fi
 elif [ "$OS_TYPE" = "centos" ]
 then
     CONFFILE=/etc/httpd/conf/httpd.conf

--- a/letstest/targets/apache2_targets.yaml
+++ b/letstest/targets/apache2_targets.yaml
@@ -21,20 +21,10 @@ targets:
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-09677e0a6b14905b0
-    name: ubuntu16.04LTS
-    type: ubuntu
-    virt: hvm
-    user: ubuntu
   #-----------------------------------------------------------------------------
   # Debian
   - ami: ami-01db78123b2b99496
     name: debian10
-    type: ubuntu
-    virt: hvm
-    user: admin
-  - ami: ami-003f19e0e687de1cd
-    name: debian9
     type: ubuntu
     virt: hvm
     user: admin


### PR DESCRIPTION
Apache test farm tests started failing last night due to a change in pyenv. See https://dev.azure.com/certbot/certbot/_build/results?buildId=3948&view=logs&j=f67c2a39-2c4f-5190-915f-6f32a7a4306f&t=96f0f394-f513-5158-f5e7-a26e55aeadbf&l=26943.

I managed to fix that in https://github.com/certbot/certbot/commit/d94f20f8b709e088b0c3036683bbda88b354f254, however, the OSes the tests were failing on were Debian 9 and Ubuntu 16.04. [Debian 9 reached its end-of-life in July 2020](https://wiki.debian.org/DebianReleases) and [Ubuntu 16.04 reached its end of standard support in April 2021](https://wiki.ubuntu.com/Releases). As shown at the same links, Debian 9 still has support from the LTS team and Ubuntu 16.04 has ESM support. Do we still want to support either of these OSes?

If so, we can use the commit I linked in the first sentence of the last paragraph, but I think supporting the OSes through their standard support is good enough. The Certbot team has enough on their plate and especially when the OSes are so old that we can't even use their packaged version of Python anymore which complicates our tests, I think we can just drop support and move on.

I don't have a strong opinion here though so if someone else does, let me know what you'd like to see or make the PR yourself based on the changes in my linked commit and I'll merge it.

You can see the tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=3955&view=results.