### PR TITLE
cli: dont double-print choosing plugins error

### DIFF
--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1236,12 +1236,8 @@ def renew_cert(config, plugins, lineage):
     :raises errors.PluginSelectionError: MissingCommandlineFlag if supplied parameters do not pass
 
     """
-    try:
-        # installers are used in auth mode to determine domain names
-        installer, auth = plug_sel.choose_configurator_plugins(config, plugins, "certonly")
-    except errors.PluginSelectionError as e:
-        logger.info("Could not choose appropriate plugin: %s", e)
-        raise
+    # installers are used in auth mode to determine domain names
+    installer, auth = plug_sel.choose_configurator_plugins(config, plugins, "certonly")
     le_client = _init_le_client(config, auth, installer)
 
     renewed_lineage = _get_and_save_cert(le_client, config, lineage=lineage)
@@ -1279,12 +1275,8 @@ def certonly(config, plugins):
 
     """
     # SETUP: Select plugins and construct a client instance
-    try:
-        # installers are used in auth mode to determine domain names
-        installer, auth = plug_sel.choose_configurator_plugins(config, plugins, "certonly")
-    except errors.PluginSelectionError as e:
-        logger.info("Could not choose appropriate plugin: %s", e)
-        raise
+    # installers are used in auth mode to determine domain names
+    installer, auth = plug_sel.choose_configurator_plugins(config, plugins, "certonly")
 
     le_client = _init_le_client(config, auth, installer)
 


### PR DESCRIPTION
... for `certonly` and `renew`. Other verbs aren't affected.

I don't think the `Could not choose appropriate plugin: ...` message adds any meaning to the error. 

----

`certonly` before:

![image](https://user-images.githubusercontent.com/311534/118461326-eacc9c80-b740-11eb-9b35-a3866869e40f.png)

`certonly` after:
![image](https://user-images.githubusercontent.com/311534/118461359-f1f3aa80-b740-11eb-8dcf-e1daa80e7dca.png)

`renew` before:

![image](https://user-images.githubusercontent.com/311534/118460696-49dde180-b740-11eb-9514-118c2769f8d8.png)

`renew` after:

![image](https://user-images.githubusercontent.com/311534/118460752-57936700-b740-11eb-9d50-20f7dd65e056.png)
