### PR TITLE
Move 5040495 CHANGELOG.md entry to correct version

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -11,6 +11,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 * DNS plugins based on lexicon now require dns-lexicon >= v3.1.0
+* Use UTF-8 encoding for renewal configuration files
 * Windows installer now cleans up old Certbot dependency packages
   before installing the new ones to avoid version conflicts.
 
@@ -48,7 +49,6 @@ More details about these changes can be found on our GitHub repo.
 * The module `acme.magic_typing` is deprecated and will be removed in a future release.
   Please use the built-in module `typing` instead.
 * The DigitalOcean plugin now creates TXT records for the DNS-01 challenge with a lower 30s TTL.
-* Use UTF-8 encoding for renewal configuration files
 
 ### Fixed
 


### PR DESCRIPTION
The merge of #8789 left the CHANGELOG.md entry at a previous certbot release. This PR puts the entry at the correct certbot version.