### PR TITLE
hooks: send hook stdout to CLI stdout

### DIFF
--- a/certbot/certbot/_internal/hooks.py
+++ b/certbot/certbot/_internal/hooks.py
@@ -9,6 +9,7 @@ from certbot import util
 from certbot.compat import filesystem
 from certbot.compat import misc
 from certbot.compat import os
+from certbot.display import ops as display_ops
 from certbot.plugins import util as plug_util
 
 logger = logging.getLogger(__name__)
@@ -227,7 +228,9 @@ def _run_hook(cmd_name, shell_cmd):
     :type shell_cmd: `list` of `str` or `str`
 
     :returns: stderr if there was any"""
-    err, _ = misc.execute_command(cmd_name, shell_cmd, env=util.env_no_snap_for_external_calls())
+    returncode, err, out = misc.execute_command_status(
+        cmd_name, shell_cmd, env=util.env_no_snap_for_external_calls())
+    display_ops.report_executed_command(f"Hook '{cmd_name}'", returncode, out, err)
     return err
 
 

--- a/certbot/certbot/_internal/plugins/manual.py
+++ b/certbot/certbot/_internal/plugins/manual.py
@@ -1,4 +1,5 @@
 """Manual authenticator plugin"""
+import logging
 from typing import Dict
 
 import zope.component
@@ -13,8 +14,10 @@ from certbot import util
 from certbot._internal import hooks
 from certbot.compat import misc
 from certbot.compat import os
+from certbot.display import ops as display_ops
 from certbot.plugins import common
 
+logger = logging.getLogger(__name__)
 
 @zope.interface.implementer(interfaces.IAuthenticator)
 @zope.interface.provider(interfaces.IPluginFactory)
@@ -60,7 +63,7 @@ with the following value:
 {validation}
 """
     _DNS_VERIFY_INSTRUCTIONS = """
-Before continuing, verify the TXT record has been deployed. Depending on the DNS 
+Before continuing, verify the TXT record has been deployed. Depending on the DNS
 provider, this may take some time, from a few seconds to multiple minutes. You can
 check if it has finished deploying with aid of online tools, such as the Google
 Admin Toolbox: https://toolbox.googleapps.com/apps/dig/#TXT/{domain}.
@@ -153,7 +156,7 @@ permitted by DNS standards.)
         else:
             os.environ.pop('CERTBOT_TOKEN', None)
         os.environ.update(env)
-        _, out = self._execute_hook('auth-hook')
+        _, out = self._execute_hook('auth-hook', achall.domain)
         env['CERTBOT_AUTH_OUTPUT'] = out.strip()
         self.env[achall] = env
 
@@ -196,9 +199,16 @@ permitted by DNS standards.)
                 if 'CERTBOT_TOKEN' not in env:
                     os.environ.pop('CERTBOT_TOKEN', None)
                 os.environ.update(env)
-                self._execute_hook('cleanup-hook')
+                self._execute_hook('cleanup-hook', achall.domain)
         self.reverter.recovery_routine()
 
-    def _execute_hook(self, hook_name):
-        return misc.execute_command(self.option_name(hook_name), self.conf(hook_name),
-                                    env=util.env_no_snap_for_external_calls())
+    def _execute_hook(self, hook_name, achall_domain):
+        returncode, err, out = misc.execute_command_status(
+            self.option_name(hook_name), self.conf(hook_name),
+            env=util.env_no_snap_for_external_calls()
+        )
+
+        display_ops.report_executed_command(
+            f"Hook '--manual-{hook_name}' for {achall_domain}", returncode, out, err)
+
+        return err, out

--- a/certbot/certbot/compat/misc.py
+++ b/certbot/certbot/compat/misc.py
@@ -119,13 +119,15 @@ def execute_command_status(cmd_name: str, shell_cmd: str,
         - on Linux command will be run by the standard shell selected with Popen(shell=True)
         - on Windows command will be run in a Powershell shell
 
+    This differs from execute_command: it returns the exit code, and does not log the result
+    and output of the command.
+
     :param str cmd_name: the user facing name of the hook being run
     :param str shell_cmd: shell command to execute
     :param dict env: environ to pass into Popen
 
     :returns: `tuple` (`int` returncode, `str` stderr, `str` stdout)
     """
-    # TODO: redesign execute_command and execute_command_status in Certbot 2.0 API.
     logger.info("Running %s command: %s", cmd_name, shell_cmd)
 
     if POSIX_MODE:
@@ -149,7 +151,8 @@ def execute_command(cmd_name: str, shell_cmd: str, env: Optional[dict] = None) -
         - on Linux command will be run by the standard shell selected with Popen(shell=True)
         - on Windows command will be run in a Powershell shell
 
-    If the process return code is required, use execute_command_status.
+    This differs from execute_command_status: it does not return the exit code, but logs
+    the result and output of the command.
 
     :param str cmd_name: the user facing name of the hook being run
     :param str shell_cmd: shell command to execute
@@ -157,7 +160,6 @@ def execute_command(cmd_name: str, shell_cmd: str, env: Optional[dict] = None) -
 
     :returns: `tuple` (`str` stderr, `str` stdout)
     """
-    # TODO: redesign execute_command and execute_command_status in Certbot 2.0 API.
     returncode, err, out = execute_command_status(cmd_name, shell_cmd, env)
     base_cmd = os.path.basename(shell_cmd.split(None, 1)[0])
     if out:

--- a/certbot/certbot/compat/misc.py
+++ b/certbot/certbot/compat/misc.py
@@ -8,6 +8,7 @@ import logging
 import select
 import subprocess
 import sys
+import warnings
 from typing import Optional
 from typing import Tuple
 
@@ -160,6 +161,11 @@ def execute_command(cmd_name: str, shell_cmd: str, env: Optional[dict] = None) -
 
     :returns: `tuple` (`str` stderr, `str` stdout)
     """
+    # Deprecation per https://github.com/certbot/certbot/issues/8854
+    warnings.warn(
+        "execute_command will be deprecated in future, use execute_command_status instead",
+        PendingDeprecationWarning
+    )
     returncode, err, out = execute_command_status(cmd_name, shell_cmd, env)
     base_cmd = os.path.basename(shell_cmd.split(None, 1)[0])
     if out:

--- a/certbot/certbot/compat/misc.py
+++ b/certbot/certbot/compat/misc.py
@@ -163,7 +163,7 @@ def execute_command(cmd_name: str, shell_cmd: str, env: Optional[dict] = None) -
     """
     # Deprecation per https://github.com/certbot/certbot/issues/8854
     warnings.warn(
-        "execute_command will be deprecated in future, use execute_command_status instead",
+        "execute_command will be deprecated in the future, use execute_command_status instead",
         PendingDeprecationWarning
     )
     returncode, err, out = execute_command_status(cmd_name, shell_cmd, env)

--- a/certbot/certbot/compat/misc.py
+++ b/certbot/certbot/compat/misc.py
@@ -112,7 +112,8 @@ def underscores_for_unsupported_characters_in_path(path: str) -> str:
     return drive + tail.replace(':', '_')
 
 
-def execute_command(cmd_name: str, shell_cmd: str, env: Optional[dict] = None) -> Tuple[str, str]:
+def execute_command_status(cmd_name: str, shell_cmd: str,
+                           env: Optional[dict] = None) -> Tuple[int, str, str]:
     """
     Run a command:
         - on Linux command will be run by the standard shell selected with Popen(shell=True)
@@ -122,8 +123,9 @@ def execute_command(cmd_name: str, shell_cmd: str, env: Optional[dict] = None) -
     :param str shell_cmd: shell command to execute
     :param dict env: environ to pass into Popen
 
-    :returns: `tuple` (`str` stderr, `str` stdout)
+    :returns: `tuple` (`int` returncode, `str` stderr, `str` stdout)
     """
+    # TODO: redesign execute_command and execute_command_status in Certbot 2.0 API.
     logger.info("Running %s command: %s", cmd_name, shell_cmd)
 
     if POSIX_MODE:
@@ -138,12 +140,31 @@ def execute_command(cmd_name: str, shell_cmd: str, env: Optional[dict] = None) -
     # universal_newlines causes Popen.communicate()
     # to return str objects instead of bytes in Python 3
     out, err = cmd.communicate()
+    return cmd.returncode, err, out
+
+
+def execute_command(cmd_name: str, shell_cmd: str, env: Optional[dict] = None) -> Tuple[str, str]:
+    """
+    Run a command:
+        - on Linux command will be run by the standard shell selected with Popen(shell=True)
+        - on Windows command will be run in a Powershell shell
+
+    If the process return code is required, use execute_command_status.
+
+    :param str cmd_name: the user facing name of the hook being run
+    :param str shell_cmd: shell command to execute
+    :param dict env: environ to pass into Popen
+
+    :returns: `tuple` (`str` stderr, `str` stdout)
+    """
+    # TODO: redesign execute_command and execute_command_status in Certbot 2.0 API.
+    returncode, err, out = execute_command_status(cmd_name, shell_cmd, env)
     base_cmd = os.path.basename(shell_cmd.split(None, 1)[0])
     if out:
         logger.info('Output from %s command %s:\n%s', cmd_name, base_cmd, out)
-    if cmd.returncode != 0:
+    if returncode != 0:
         logger.error('%s command "%s" returned error code %d',
-                     cmd_name, shell_cmd, cmd.returncode)
+                     cmd_name, shell_cmd, returncode)
     if err:
         logger.error('Error output from %s command %s:\n%s', cmd_name, base_cmd, err)
     return err, out

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -1,5 +1,6 @@
 """Contains UI methods for LE user operations."""
 import logging
+from textwrap import indent
 
 import zope.component
 
@@ -271,6 +272,24 @@ def success_revocation(cert_path):
         "Congratulations! You have successfully revoked the certificate "
         "that was located at {0}.".format(cert_path)
     )
+
+
+def report_executed_command(command_name: str, returncode: int, stdout: str, stderr: str) -> None:
+    """Display a message describing the success or failure of an executed process (e.g. hook).
+
+    :param str command_name: Human-readable description of the executed command
+    :param int returncode: The exit code of the executed command
+    :param str stdout: The stdout output of the executed command
+    :param str stderr: The stderr output of the executed command
+
+    """
+    out_s, err_s = stdout.strip(), stderr.strip()
+    if returncode != 0:
+        logger.warning("%s reported error code %d", command_name, returncode)
+    if out_s:
+        display_util.notify(f"{command_name} ran with output:\n{indent(out_s, ' ')}")
+    if err_s:
+        logger.warning("%s ran with error output:\n%s", command_name, indent(err_s, ' '))
 
 
 def _gen_https_names(domains):

--- a/certbot/tests/compat/misc_test.py
+++ b/certbot/tests/compat/misc_test.py
@@ -46,3 +46,6 @@ class ExecuteTest(unittest.TestCase):
                                              mock.ANY, stdout)
         if stderr or returncode:
             self.assertIs(mock_logger.error.called, True)
+
+if __name__ == "__main__":
+    unittest.main()  # pragma: no cover

--- a/certbot/tests/compat/misc_test.py
+++ b/certbot/tests/compat/misc_test.py
@@ -4,8 +4,10 @@ try:
 except ImportError:  # pragma: no cover
     from unittest import mock  # type: ignore
 import unittest
+import warnings
 
 from certbot.compat import os
+
 
 
 class ExecuteTest(unittest.TestCase):
@@ -14,7 +16,10 @@ class ExecuteTest(unittest.TestCase):
     @classmethod
     def _call(cls, *args, **kwargs):
         from certbot.compat.misc import execute_command
-        return execute_command(*args, **kwargs)
+        # execute_command is superseded by execute_command_status
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=PendingDeprecationWarning)
+            return execute_command(*args, **kwargs)
 
     def test_it(self):
         for returncode in range(0, 2):
@@ -46,6 +51,37 @@ class ExecuteTest(unittest.TestCase):
                                              mock.ANY, stdout)
         if stderr or returncode:
             self.assertIs(mock_logger.error.called, True)
+
+
+class ExecuteStatusTest(ExecuteTest):
+    """Tests for certbot.compat.misc.execute_command_status."""
+
+    @classmethod
+    def _call(cls, *args, **kwargs):
+        from certbot.compat.misc import execute_command_status
+        return execute_command_status(*args, **kwargs)
+
+    def _test_common(self, returncode, stdout, stderr):
+        given_command = "foo"
+        given_name = "foo-hook"
+        with mock.patch("certbot.compat.misc.subprocess.Popen") as mock_popen:
+            mock_popen.return_value.communicate.return_value = (stdout, stderr)
+            mock_popen.return_value.returncode = returncode
+            with mock.patch("certbot.compat.misc.logger") as mock_logger:
+                self.assertEqual(self._call(given_name, given_command),
+                                 (returncode, stderr, stdout))
+
+        executed_command = mock_popen.call_args[1].get(
+            "args", mock_popen.call_args[0][0])
+        if os.name == 'nt':
+            expected_command = ['powershell.exe', '-Command', given_command]
+        else:
+            expected_command = given_command
+        self.assertEqual(executed_command, expected_command)
+
+        mock_logger.info.assert_any_call("Running %s command: %s",
+                                         given_name, given_command)
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -500,5 +500,29 @@ class ChooseValuesTest(unittest.TestCase):
         self.assertEqual(mock_util().checklist.call_args[0][0], question)
 
 
+@mock.patch('certbot.display.ops.logger')
+@mock.patch('certbot.display.util.notify')
+class ReportExecutedCommand(unittest.TestCase):
+    """Test report_executed_command"""
+    @classmethod
+    def _call(cls, cmd_name: str, rc: int, out: str, err: str):
+        from certbot.display.ops import report_executed_command
+        report_executed_command(cmd_name, rc, out, err)
+
+    def test_mixed_success(self, mock_notify, mock_logger):
+        self._call("some-hook", 0, "Did a thing", "Some warning")
+        self.assertEqual(mock_logger.warning.call_count, 1)
+        self.assertEqual(mock_notify.call_count, 1)
+
+    def test_mixed_error(self, mock_notify, mock_logger):
+        self._call("some-hook", -127, "Did a thing", "Some warning")
+        self.assertEqual(mock_logger.warning.call_count, 2)
+        self.assertEqual(mock_notify.call_count, 1)
+
+    def test_empty_success(self, mock_notify, mock_logger):
+        self._call("some-hook", 0, "\n", " ")
+        self.assertEqual(mock_logger.warning.call_count, 0)
+        self.assertEqual(mock_notify.call_count, 0)
+
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -72,14 +72,14 @@ class HookTest(test_util.ConfigTestCase):
 
     @classmethod
     def _call_with_mock_execute(cls, *args, **kwargs):
-        """Calls self._call after mocking out certbot.compat.misc.execute_command.
+        """Calls self._call after mocking out certbot.compat.misc.execute_command_status.
 
         The mock execute object is returned rather than the return value
         of self._call.
 
         """
-        with mock.patch("certbot.compat.misc.execute_command") as mock_execute:
-            mock_execute.return_value = ("", "")
+        with mock.patch("certbot.compat.misc.execute_command_status") as mock_execute:
+            mock_execute.return_value = (0, "", "")
             cls._call(*args, **kwargs)
         return mock_execute
 
@@ -292,7 +292,7 @@ class RenewalHookTest(HookTest):
     # pylint: disable=abstract-method
 
     def _call_with_mock_execute(self, *args, **kwargs):
-        """Calls self._call after mocking out certbot.compat.misc.execute_command.
+        """Calls self._call after mocking out certbot.compat.misc.execute_command_status.
 
         The mock execute object is returned rather than the return value
         of self._call. The mock execute object asserts that environment
@@ -311,9 +311,9 @@ class RenewalHookTest(HookTest):
             """
             self.assertEqual(os.environ["RENEWED_DOMAINS"], " ".join(domains))
             self.assertEqual(os.environ["RENEWED_LINEAGE"], lineage)
-            return ("", "")
+            return (0, "", "")
 
-        with mock.patch("certbot.compat.misc.execute_command") as mock_execute:
+        with mock.patch("certbot.compat.misc.execute_command_status") as mock_execute:
             mock_execute.side_effect = execute_side_effect
             self._call(*args, **kwargs)
         return mock_execute

--- a/certbot/tests/plugins/manual_test.py
+++ b/certbot/tests/plugins/manual_test.py
@@ -1,5 +1,6 @@
 """Tests for certbot._internal.plugins.manual"""
 import sys
+import textwrap
 import unittest
 
 try:
@@ -20,6 +21,10 @@ class AuthenticatorTest(test_util.TempDirTestCase):
 
     def setUp(self):
         super().setUp()
+        get_utility_patch = test_util.patch_get_utility()
+        self.mock_get_utility = get_utility_patch.start()
+        self.addCleanup(get_utility_patch.stop)
+
         self.http_achall = acme_util.HTTP01_A
         self.dns_achall = acme_util.DNS01_A
         self.dns_achall_2 = acme_util.DNS01_A_2
@@ -89,12 +94,19 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             self.auth.env[self.http_achall]['CERTBOT_AUTH_OUTPUT'],
             http_expected)
 
-    @test_util.patch_get_utility()
-    def test_manual_perform(self, mock_get_utility):
+        # Successful hook output should be sent to notify
+        self.assertEqual(self.mock_get_utility().notification.call_count, len(self.achalls))
+        for i, (args, _) in enumerate(self.mock_get_utility().notification.call_args_list):
+            needle = textwrap.indent(self.auth.env[self.achalls[i]]['CERTBOT_AUTH_OUTPUT'], ' ')
+            self.assertIn(needle, args[0])
+
+    def test_manual_perform(self):
         self.assertEqual(
             self.auth.perform(self.achalls),
             [achall.response(achall.account_key) for achall in self.achalls])
-        for i, (args, kwargs) in enumerate(mock_get_utility().notification.call_args_list):
+
+        self.assertEqual(self.mock_get_utility().notification.call_count, len(self.achalls))
+        for i, (args, kwargs) in enumerate(self.mock_get_utility().notification.call_args_list):
             achall = self.achalls[i]
             self.assertIn(achall.validation(achall.account_key), args[0])
             self.assertIs(kwargs['wrap'], False)


### PR DESCRIPTION
includes both --manual and --{pre,post,renew} hooks

---

This change is about making sure that the success output of hooks (both `--manual-*-hook` and `--{pre,post,renew}-hook`) is shown to the user at the default logging verbosity. We are doing this to avoid breaking the workflow that the [acme-dns hook relies on](https://github.com/joohoi/acme-dns-certbot-joohoi), when we reduce the default verbosity level in #8852.

Because of a module import cycle and wanting to access the exit code of the hooks, we're adding a couple of new APIs to facilitate this. Hopefully we can get rid of them again easily and soon in 2.0.

- [x] Update [before/after](https://docs.google.com/document/d/1-u5LfxDPyXDDeIXnZ5JG92eUEK-iugJ0lIYawYheP70/edit#) examples that involve hooks
- [x] Post some screenshots here of various combinations. ~~(Coming soon, I wanted to get the code up ASAP for review).~~

Not to be merged to master, merge into #8852.