### PR TITLE
Remove references to certbot_constraints.txt

### DIFF
--- a/tools/dev_constraints.txt
+++ b/tools/dev_constraints.txt
@@ -1,7 +1,7 @@
-# Specifies Python package versions for development and building Docker images.
-# It includes in particular packages not specified in tools/certbot_constraints.txt.
-# Some dev package versions specified here may be overridden by higher level constraints
-# files during tests (eg. tools/oldest_constraints.txt).
+# Specifies extra Python package versions during our tests with the oldest
+# supported versions of our dependencies. Some dev package versions specified
+# here may be overridden by higher level constraints files during tests (eg.
+# tools/oldest_constraints.txt).
 alabaster==0.7.10
 apacheconfig==0.3.2
 apipkg==1.4

--- a/tools/pip_install.py
+++ b/tools/pip_install.py
@@ -2,11 +2,9 @@
 # pip installs packages using pinned package versions. If CERTBOT_OLDEST is set
 # to 1, a combination of tools/oldest_constraints.txt,
 # tools/dev_constraints.txt, and local-oldest-requirements.txt contained in the
-# top level of the package's directory is used, otherwise, a combination of
-# tools/certbot_constraints.txt and tools/dev_constraints.txt is used. The
-# other file always takes precedence over tools/dev_constraints.txt. If
-# CERTBOT_OLDEST is set, this script must be run with `-e <package-name>` and
-# no other arguments.
+# top level of the package's directory is used, otherwise,
+# tools/requirements.txt is used. If CERTBOT_OLDEST is set, this script must
+# be run with `-e <package-name>` and no other arguments.
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/tools/pip_install_editable.py
+++ b/tools/pip_install_editable.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# pip installs packages in editable mode using tools/certbot_constraints.txt
-# as constraints
+# pip installs packages in editable mode using pip_install.py
 #
 # cryptography is currently using this script in their CI at
 # https://github.com/pyca/cryptography/blob/a02fdd60d98273ca34427235c4ca96687a12b239/.travis/downstream.d/certbot.sh#L8-L9.


### PR DESCRIPTION
I missed these comments when I removed the file in https://github.com/certbot/certbot/pull/8741.