### PR TITLE
apache/nginx: certbot>=1.10.0 -> 1.10.1

### DIFF
--- a/certbot-apache/local-oldest-requirements.txt
+++ b/certbot-apache/local-oldest-requirements.txt
@@ -1,3 +1,3 @@
 # Remember to update setup.py to match the package versions below.
 acme[dev]==1.8.0
-certbot[dev]==1.10.0
+certbot[dev]==1.10.1

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -7,7 +7,7 @@ version = '1.16.0.dev0'
 # acme/certbot version.
 install_requires = [
     'acme>=1.8.0',
-    'certbot>=1.10.0',
+    'certbot>=1.10.1',
     'python-augeas',
     'setuptools>=39.0.1',
     'zope.component',

--- a/certbot-nginx/local-oldest-requirements.txt
+++ b/certbot-nginx/local-oldest-requirements.txt
@@ -1,3 +1,3 @@
 # Remember to update setup.py to match the package versions below.
 acme[dev]==1.8.0
-certbot[dev]==1.10.0
+certbot[dev]==1.10.1

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -7,7 +7,7 @@ version = '1.16.0.dev0'
 # acme/certbot version.
 install_requires = [
     'acme>=1.8.0',
-    'certbot>=1.10.0',
+    'certbot>=1.10.1',
     'PyOpenSSL>=17.3.0',
     'pyparsing>=2.2.0',
     'setuptools>=39.0.1',


### PR DESCRIPTION
1.10.0 was a bad release and this breaks our oldest Boulder tests.

---

I bumped the version to 1.10.0 in #8852 to get access to a new public display_util API, but that was the release with the broken deprecation of `--manual-public-ip-logging-ok`. So let's bump it to 1.10.1.

https://dev.azure.com/certbot/certbot/_build/results?buildId=4011&view=logs&j=c3edb878-cb85-5ad8-f576-457672e933e4&t=ee759786-22f1-5029-9bc0-2590e8eecf55 is the broken CI.