### PR TITLE
cli: later printing of renewal and install retry advice

### DIFF
--- a/certbot/certbot/_internal/client.py
+++ b/certbot/certbot/_internal/client.py
@@ -516,11 +516,9 @@ class Client:
 
         return abs_cert_path, abs_chain_path, abs_fullchain_path
 
-    def deploy_certificate(self, cert_name, domains, privkey_path,
-                           cert_path, chain_path, fullchain_path):
+    def deploy_certificate(self, domains, privkey_path, cert_path, chain_path, fullchain_path):
         """Install certificate
 
-        :param str cert_name: name of the certificate lineage (optional)
         :param list domains: list of domains to install the certificate
         :param str privkey_path: path to certificate private key
         :param str cert_path: certificate file path (optional)
@@ -536,12 +534,7 @@ class Client:
 
         display_util.notify("Deploying certificate")
 
-        msg = f"Failed to install the certificate (installer: {self.config.installer})."
-        if cert_name:
-            msg += (" Try again after fixing errors by running:\n\n"
-                    f"  {cli.cli_constants.cli_command} install --cert-name {cert_name}\n")
-
-        with error_handler.ErrorHandler(self._recovery_routine_with_msg, msg):
+        with error_handler.ErrorHandler(self._recovery_routine_with_msg, None):
             for dom in domains:
                 self.installer.deploy_cert(
                     domain=dom, cert_path=os.path.abspath(cert_path),
@@ -616,9 +609,7 @@ class Client:
 
 
         """
-        msg = ("We were unable to set up enhancement %s for your server, "
-               "however, we successfully installed your certificate."
-               % (enhancement))
+        msg = f"Could not set up {enhancement} enhancement"
         with error_handler.ErrorHandler(self._recovery_routine_with_msg, msg):
             for dom in domains:
                 try:
@@ -644,7 +635,8 @@ class Client:
 
         """
         self.installer.recovery_routine()
-        display_util.notify(success_msg)
+        if success_msg:
+            display_util.notify(success_msg)
 
     def _rollback_and_restart(self, success_msg):
         """Rollback the most recent checkpoint and restart the webserver

--- a/certbot/certbot/_internal/client.py
+++ b/certbot/certbot/_internal/client.py
@@ -534,7 +534,8 @@ class Client:
 
         display_util.notify("Deploying certificate")
 
-        with error_handler.ErrorHandler(self._recovery_routine_with_msg, None):
+        msg = "Could not install certificate"
+        with error_handler.ErrorHandler(self._recovery_routine_with_msg, msg):
             for dom in domains:
                 self.installer.deploy_cert(
                     domain=dom, cert_path=os.path.abspath(cert_path),
@@ -635,8 +636,7 @@ class Client:
 
         """
         self.installer.recovery_routine()
-        if success_msg:
-            display_util.notify(success_msg)
+        display_util.notify(success_msg)
 
     def _rollback_and_restart(self, success_msg):
         """Rollback the most recent checkpoint and restart the webserver

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -509,9 +509,11 @@ def _report_next_steps(config: interfaces.IConfig, installer_err: Optional[error
                 "Certbot command again.")
         elif not config.preconfigured_renewal:
             steps.append(
-                f'Run "{cli.cli_constants.cli_command} renew" to renew expiring certificates. '
-                 "We recommend setting up a scheduled task for renewal; see "
-                 "https://certbot.eff.org/docs/using.html#automated-renewals for instructions.")
+                "The certificate will need to be renewed before it expires. Certbot can "
+                "automatically renew the certificate in the background, but you may need "
+                "to take steps to enable that functionality. "
+                "See https://certbot.eff.org/docs/using.html#automated-renewals for "
+                "instructions.")
 
     if not steps:
         return

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -484,7 +484,8 @@ def _show_renewal_advice(config: interfaces.IConfig) -> None:
         msg = ("Certificates created using --csr will not be renewed automatically by Certbot. "
                "Run the same command again in order to renew the certificate, as necessary.")
     elif config.preconfigured_renewal:
-        msg = "Certbot will automatically renew this certificate in the background."
+        msg = ("Certbot has set up a scheduled task to automatically renew this certificate in "
+               "the background.")
     else:
         msg = (f'Run "{cli.cli_constants.cli_command} renew" to renew expiring certificates. '
                 "We recommend setting up a scheduled task for renewal; see "

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -505,7 +505,8 @@ def _report_next_steps(config: interfaces.IConfig, installer_err: Optional[error
         if config.csr:
             steps.append(
                 "Certificates created using --csr will not be renewed automatically by Certbot. "
-                "Run the same command again in order to renew the certificate, as necessary.")
+                "You will need to renew the certificate before it expires, by running the same "
+                "Certbot command again.")
         elif not config.preconfigured_renewal:
             steps.append(
                 f'Run "{cli.cli_constants.cli_command} renew" to renew expiring certificates. '

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -562,8 +562,8 @@ def _report_new_cert(config, cert_path, fullchain_path, key_path=None):
             cert_path=fullchain_path,
             expiry=crypto_util.notAfter(cert_path).date(),
             key_msg="Key is saved at:         {}\n".format(key_path) if key_path else "",
-            renewal_msg=f"\nCertbot has set up a scheduled task to automatically renew this "
-                        f"certificate in the background." if config.preconfigured_renewal else "",
+            renewal_msg="\nCertbot has set up a scheduled task to automatically renew this "
+                        "certificate in the background." if config.preconfigured_renewal else "",
             nl="\n" if config.verb == "run" else "" # Normalize spacing across verbs
         )
     )

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -521,13 +521,12 @@ class ClientTest(ClientTestCommon):
     @test_util.patch_get_utility()
     def test_deploy_certificate_success(self, mock_util):
         self.assertRaises(errors.Error, self.client.deploy_certificate,
-                          "foo.bar", ["foo.bar"], "key", "cert", "chain", "fullchain")
+                          ["foo.bar"], "key", "cert", "chain", "fullchain")
 
         installer = mock.MagicMock()
         self.client.installer = installer
 
-        self.client.deploy_certificate(
-            "foo.bar", ["foo.bar"], "key", "cert", "chain", "fullchain")
+        self.client.deploy_certificate(["foo.bar"], "key", "cert", "chain", "fullchain")
         installer.deploy_cert.assert_called_once_with(
             cert_path=os.path.abspath("cert"),
             chain_path=os.path.abspath("chain"),
@@ -546,31 +545,10 @@ class ClientTest(ClientTestCommon):
 
         installer.deploy_cert.side_effect = errors.PluginError
         self.assertRaises(errors.PluginError, self.client.deploy_certificate,
-                          "foo.bar", ["foo.bar"], "key", "cert", "chain", "fullchain")
+                          ["foo.bar"], "key", "cert", "chain", "fullchain")
         installer.recovery_routine.assert_called_once_with()
 
         mock_notify.assert_any_call('Deploying certificate')
-        mock_notify.assert_any_call(
-            'Failed to install the certificate (installer: foobar). '
-            'Try again after fixing errors by running:\n\n  certbot install --cert-name foo.bar\n'
-        )
-
-    @mock.patch('certbot._internal.client.display_util.notify')
-    @test_util.patch_get_utility()
-    def test_deploy_certificate_failure_no_certname(self, mock_util, mock_notify):
-        installer = mock.MagicMock()
-        self.client.installer = installer
-        self.config.installer = "foobar"
-
-        installer.deploy_cert.side_effect = errors.PluginError
-        self.assertRaises(errors.PluginError, self.client.deploy_certificate,
-                          None, ["foo.bar"], "key", "cert", "chain", "fullchain")
-        installer.recovery_routine.assert_called_once_with()
-
-        mock_notify.assert_any_call('Deploying certificate')
-        mock_notify.assert_any_call(
-            'Failed to install the certificate (installer: foobar).'
-        )
 
 
     @test_util.patch_get_utility()
@@ -580,7 +558,7 @@ class ClientTest(ClientTestCommon):
 
         installer.save.side_effect = errors.PluginError
         self.assertRaises(errors.PluginError, self.client.deploy_certificate,
-                          "foo.bar", ["foo.bar"], "key", "cert", "chain", "fullchain")
+                          ["foo.bar"], "key", "cert", "chain", "fullchain")
         installer.recovery_routine.assert_called_once_with()
 
     @mock.patch('certbot._internal.client.display_util.notify')
@@ -591,7 +569,7 @@ class ClientTest(ClientTestCommon):
         self.client.installer = installer
 
         self.assertRaises(errors.PluginError, self.client.deploy_certificate,
-                          "foo.bar", ["foo.bar"], "key", "cert", "chain", "fullchain")
+                          ["foo.bar"], "key", "cert", "chain", "fullchain")
         mock_notify.assert_called_with(
             'We were unable to install your certificate, however, we successfully restored '
             'your server to its prior configuration.')
@@ -607,7 +585,7 @@ class ClientTest(ClientTestCommon):
         self.client.installer = installer
 
         self.assertRaises(errors.PluginError, self.client.deploy_certificate,
-                          "foo.bar", ["foo.bar"], "key", "cert", "chain", "fullchain")
+                          ["foo.bar"], "key", "cert", "chain", "fullchain")
         self.assertEqual(mock_logger.error.call_count, 1)
         self.assertIn(
             'An error occurred and we failed to restore your config',

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -250,12 +250,13 @@ class CertonlyTest(unittest.TestCase):
         self.assertRaises(errors.ConfigurationError, self._call,
             'certonly --webroot -d example.com -d test.com --cert-name example.com'.split())
 
+    @mock.patch('certbot._internal.main._report_next_steps')
     @mock.patch('certbot._internal.cert_manager.domains_for_certname')
     @mock.patch('certbot.display.ops.choose_names')
     @mock.patch('certbot._internal.cert_manager.lineage_for_certname')
     @mock.patch('certbot._internal.main._report_new_cert')
     def test_find_lineage_for_domains_new_certname(self, mock_report_cert,
-        mock_lineage, mock_choose_names, mock_domains_for_certname):
+        mock_lineage, mock_choose_names, mock_domains_for_certname, unused_mock_report_next_steps):
         mock_lineage.return_value = None
 
         # no lineage with this name but we specified domains so create a new cert

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -112,6 +112,7 @@ class RunTest(test_util.ConfigTestCase):
             mock.patch('certbot._internal.main._report_new_cert'),
             mock.patch('certbot._internal.main._find_cert'),
             mock.patch('certbot._internal.eff.handle_subscription'),
+            mock.patch('certbot._internal.main._show_renewal_advice'),
         ]
 
         self.mock_auth = patches[0].start()
@@ -122,6 +123,7 @@ class RunTest(test_util.ConfigTestCase):
         self.mock_report_cert = patches[5].start()
         self.mock_find_cert = patches[6].start()
         self.mock_subscription = patches[7].start()
+        self.mock_renewal_advice = patches[8].start()
         for patch in patches:
             self.addCleanup(patch.stop)
 
@@ -139,6 +141,7 @@ class RunTest(test_util.ConfigTestCase):
         self.mock_find_cert.return_value = True, None
         self._call()
         self.mock_success_installation.assert_called_once_with([self.domain])
+        self.mock_renewal_advice.assert_called_once()
 
     def test_reinstall_success(self):
         self.mock_auth.return_value = mock.Mock()
@@ -161,6 +164,21 @@ class RunTest(test_util.ConfigTestCase):
                           main.run,
                           self.config, plugins)
 
+    @mock.patch('certbot._internal.main._install_cert')
+    @mock.patch('certbot._internal.main.logger')
+    def test_cert_success_install_error(self, mock_logger, mock_install_cert):
+        mock_install_cert.side_effect = errors.PluginError("Fake installation error")
+        self.mock_auth.return_value = mock.Mock()
+        self.mock_find_cert.return_value = True, None
+        self.assertRaises(errors.PluginError, self._call)
+
+        # Advice to retry `certbot install` should be printed
+        mock_logger.error.assert_called_once()
+        self.assertIn("try installing it again", mock_logger.error.call_args[0][0])
+        # Renewal advice should be printed, because the certificate was saved
+        self.mock_renewal_advice.assert_called_once()
+        # The final success message shouldn't be shown
+        self.mock_success_installation.assert_not_called()
 
 class CertonlyTest(unittest.TestCase):
     """Tests for certbot._internal.main.certonly."""
@@ -198,13 +216,14 @@ class CertonlyTest(unittest.TestCase):
     def _assert_no_pause(self, message, pause=True):  # pylint: disable=unused-argument
         self.assertIs(pause, False)
 
+    @mock.patch('certbot._internal.main._show_renewal_advice')
     @mock.patch('certbot._internal.cert_manager.lineage_for_certname')
     @mock.patch('certbot._internal.cert_manager.domains_for_certname')
     @mock.patch('certbot._internal.renewal.renew_cert')
     @mock.patch('certbot._internal.main._handle_unexpected_key_type_migration')
     @mock.patch('certbot._internal.main._report_new_cert')
     def test_find_lineage_for_domains_and_certname(self, mock_report_cert,
-        mock_handle_type, mock_renew_cert, mock_domains, mock_lineage):
+        mock_handle_type, mock_renew_cert, mock_domains, mock_lineage, mock_renewal_advice):
         domains = ['example.com', 'test.org']
         mock_domains.return_value = domains
         mock_lineage.names.return_value = domains
@@ -216,6 +235,7 @@ class CertonlyTest(unittest.TestCase):
         self.assertEqual(mock_renew_cert.call_count, 1)
         self.assertEqual(mock_report_cert.call_count, 1)
         self.assertEqual(mock_handle_type.call_count, 1)
+        self.assertEqual(mock_renewal_advice.call_count, 1)
 
         # user confirms updating lineage with new domains
         self._call(('certonly --webroot -d example.com -d test.com '
@@ -1823,7 +1843,6 @@ class ReportNewCertTest(unittest.TestCase):
             'Key is saved at:         /path/to/privkey.pem\n'
             'This certificate expires on 1970-01-01.\n'
             'These files will be updated when the certificate renews.\n'
-            'Certbot will automatically renew this certificate in the background.'
         )
 
     def test_report_no_key(self):
@@ -1836,7 +1855,6 @@ class ReportNewCertTest(unittest.TestCase):
             'Certificate is saved at: /path/to/fullchain.pem\n'
             'This certificate expires on 1970-01-01.\n'
             'These files will be updated when the certificate renews.\n'
-            'Certbot will automatically renew this certificate in the background.'
         )
 
     def test_report_no_preconfigured_renewal(self):
@@ -1850,9 +1868,6 @@ class ReportNewCertTest(unittest.TestCase):
             'Key is saved at:         /path/to/privkey.pem\n'
             'This certificate expires on 1970-01-01.\n'
             'These files will be updated when the certificate renews.\n'
-            'Run "certbot renew" to renew expiring certificates. We recommend setting up a '
-            'scheduled task for renewal; see https://certbot.eff.org/docs/using.html#automated'
-            '-renewals for instructions.'
         )
 
 


### PR DESCRIPTION
Move printing of advice for automated renewal, and retrying installation
in case of failure, towards the end of run and certonly.

Also adds some renewal advice for the --csr case (no autorenewal).

---

https://github.com/alexzorin/certbot/pull/2 but rebased on master.

The [before/after doc](https://docs.google.com/document/d/1-u5LfxDPyXDDeIXnZ5JG92eUEK-iugJ0lIYawYheP70/edit?usp=sharing) is up-to-date with this branch. Here are some of the more significant cases:

Issue success/deploy failure:
![image](https://user-images.githubusercontent.com/311534/119477492-5989a580-bd92-11eb-908d-c5ebae6831f5.png)

CSR success:
![image](https://user-images.githubusercontent.com/311534/119477636-77570a80-bd92-11eb-9374-7b89c968aac6.png)

Run success:
![image](https://user-images.githubusercontent.com/311534/119477836-aa999980-bd92-11eb-8980-e8156904f2f0.png)

Run success *with* `--preconfigured-renewal` (no NEXT STEPS, the most common output):
![image](https://user-images.githubusercontent.com/311534/119478006-c9982b80-bd92-11eb-9d18-be0048cabfb0.png)



