### PR TITLE
Delete eggs before running poetry

### DIFF
--- a/tools/pinning/pin.sh
+++ b/tools/pinning/pin.sh
@@ -17,6 +17,12 @@ if ! command -v poetry >/dev/null; then
     exit 1
 fi
 
+# Old eggs can cause outdated dependency information to be used by poetry so we
+# delete them before generating the lock file. See
+# https://github.com/python-poetry/poetry/issues/4103 for more info.
+cd "${REPO_ROOT}"
+rm -rf */*.egg-info
+
 cd "${WORK_DIR}"
 
 if [ -f poetry.lock ]; then


### PR DESCRIPTION
I hit this recently and I think it's worth automating a solution so others don't hit it themselves. You can see the problem by ensuring an egg-info directory exists for a package (which can be done by doing something like running `tools/venv.py`), modifying a `setup.py` file to add a new dependency, and running the script modified in this PR. Before this change, the new dependency won't be picked up, but now it will.