### PR TITLE
Remove no names found in configuration files because it sounds like an error but actually it is fine

### DIFF
--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -191,7 +191,7 @@ def _choose_names_manually(prompt_prefix=""):
     """
     code, input_ = z_util(interfaces.IDisplay).input(
         prompt_prefix +
-        "Please enter in your domain name(s) (comma and/or space separated) ",
+        "Please enter the domain name(s) you would like on your certificate (comma and/or space separated)",
         cli_flag="--domains", force_interactive=True)
 
     if code == display_util.OK:

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -123,8 +123,7 @@ def choose_names(installer, question=None):
     names = get_valid_domains(domains)
 
     if not names:
-        return _choose_names_manually(
-            "No names were found in your configuration files. ")
+        return _choose_names_manually()
 
     code, names = _filter_names(names, question)
     if code == display_util.OK and names:

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -191,7 +191,8 @@ def _choose_names_manually(prompt_prefix=""):
     """
     code, input_ = z_util(interfaces.IDisplay).input(
         prompt_prefix +
-        "Please enter the domain name(s) you would like on your certificate (comma and/or space separated)",
+        "Please enter the domain name(s) you would like on your certificate "
+        "(comma and/or space separated)",
         cli_flag="--domains", force_interactive=True)
 
     if code == display_util.OK:

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -209,7 +209,6 @@ class ChooseNamesTest(unittest.TestCase):
         actual_doms = self._call(self.mock_install)
         self.assertEqual(mock_util().input.call_count, 1)
         self.assertEqual(actual_doms, [domain])
-        self.assertIn("configuration files", mock_util().input.call_args[0][0])
 
     def test_sort_names_trivial(self):
         from certbot.display.ops import _sort_names


### PR DESCRIPTION
This came from feedback from a cognitive walkthrough with research students from CISPA.

We should eventually deprecate the ability to say something before the choose names prompt, since we no longer use that ourselves.