### PR TITLE
windows: always run with --preconfigured-renewal

### DIFF
--- a/windows-installer/assets/preamble.py
+++ b/windows-installer/assets/preamble.py
@@ -1,0 +1,12 @@
+"""Pynsist extra_preamble for the Certbot entry point.
+
+This preamble ensures that Certbot on Windows always runs with the --preconfigured-renewal
+flag set. Since Pynsist creates a Scheduled Task for renewal, we want this flag to be set
+so that we can provide the right automated renewal advice to Certbot on Windows users.
+
+"""
+
+
+import sys
+
+sys.argv += ["--preconfigured-renewal"]

--- a/windows-installer/windows_installer/construct.py
+++ b/windows-installer/windows_installer/construct.py
@@ -82,6 +82,7 @@ def _copy_assets(build_path, repo_path):
     shutil.copy(os.path.join(repo_path, 'windows-installer', 'assets', 'template.nsi'), build_path)
     shutil.copy(os.path.join(repo_path, 'windows-installer', 'assets', 'renew-up.ps1'), build_path)
     shutil.copy(os.path.join(repo_path, 'windows-installer', 'assets', 'renew-down.ps1'), build_path)
+    shutil.copy(os.path.join(repo_path, 'windows-installer', 'assets', 'preamble.py'), build_path)
 
 
 def _generate_pynsist_config(repo_path, build_path):
@@ -121,6 +122,7 @@ files=run.bat
 
 [Command certbot]
 entry_point=certbot.main:main
+extra_preamble=preamble.py
 '''.format(certbot_version=certbot_version,
            installer_suffix='win_amd64' if PYTHON_BITNESS == 64 else 'win32',
            python_bitness=PYTHON_BITNESS,


### PR DESCRIPTION
Adds a Pynsist extra_preamble in the Certbot entry_point for the
Windows installer, ensuring the flag is always set.

Fixes #8716.
