### PR TITLE
Add instructions for setting up a cronjob in the docs

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -720,7 +720,7 @@ Run the following line, which will add a cron job to `/etc/crontab`:
 
 .. code-block:: shell
 
-  SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME &amp;&amp; certbot renew -q" | sudo tee -a /etc/crontab > /dev/null
+  SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME && certbot renew -q" | sudo tee -a /etc/crontab > /dev/null
 
 If you needed to stop your webserver to run Certbot, you'll want to
 add ``--pre-hook`` and ``--post-hook`` flags after ``certbot renew`` to stop

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -710,9 +710,9 @@ Setting up automated renewal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you think you may need to set up automated renewal, follow these instructions to set up a
-scheduled task to automatically renew your certificates in the background. On the off chance you
-ended up at these instructions but automated renewal was pre-installed on your system, following
-these instructions should not cause any problems.
+scheduled task to automatically renew your certificates in the background. If you are unsure 
+whether your system has a pre-installed scheduled task for Certbot, it is safe to follow these
+instructions to create one.
 
 If you're using Windows, these instructions will not work.
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -716,7 +716,7 @@ these instructions should not cause any problems.
 
 If you're using Windows, these instructions will not work.
 
-Run the following line, which will add a cron job to the default crontab:
+Run the following line, which will add a cron job to `/etc/crontab`:
 
 .. code-block:: shell
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -729,7 +729,7 @@ command as follows:
 
 .. code-block:: shell
 
-  SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME &amp;&amp; certbot renew -q --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null
+  SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME && certbot renew -q --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null
 
 
 Congratulations, Certbot will now automatically renew your certificates in the background.

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -731,7 +731,7 @@ in the appropriate directory:
 
   echo 'service haproxy stop' | sudo tee -a /etc/letsencrypt/renewal-hooks/pre/haproxy-stop > /dev/null
   echo 'service haproxy start' | sudo tee -a /etc/letsencrypt/renewal-hooks/post/haproxy-start > /dev/null
-  chmod +x /etc/letsencrypt/renewal-hooks/pre/haproxy-stop /etc/letsencrypt/renewal-hooks/post/haproxy-start
+  sudo chmod +x /etc/letsencrypt/renewal-hooks/pre/haproxy-stop /etc/letsencrypt/renewal-hooks/post/haproxy-start
 
 Congratulations, Certbot will now automatically renew your certificates in the background.
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -714,7 +714,8 @@ scheduled task to automatically renew your certificates in the background. If yo
 whether your system has a pre-installed scheduled task for Certbot, it is safe to follow these
 instructions to create one.
 
-If you're using Windows, these instructions will not work.
+If you're using Windows, these instructions are not neccessary as Certbot on Windows comes with
+a scheduled task for automated renewal pre-installed.
 
 Run the following line, which will add a cron job to `/etc/crontab`:
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -730,9 +730,10 @@ in the appropriate directory:
 
 .. code-block:: shell
 
-  echo 'service haproxy stop' | sudo tee -a /etc/letsencrypt/renewal-hooks/pre/haproxy-stop > /dev/null
-  echo 'service haproxy start' | sudo tee -a /etc/letsencrypt/renewal-hooks/post/haproxy-start > /dev/null
-  sudo chmod +x /etc/letsencrypt/renewal-hooks/pre/haproxy-stop /etc/letsencrypt/renewal-hooks/post/haproxy-start
+  sudo sh -c 'printf "#!/bin/sh\nservice haproxy stop\n" > /etc/letsencrypt/renewal-hooks/pre/haproxy.sh'
+  sudo sh -c 'printf "#!/bin/sh\nservice haproxy start\n" > /etc/letsencrypt/renewal-hooks/post/haproxy.sh'
+  sudo chmod 755 /etc/letsencrypt/renewal-hooks/pre/haproxy.sh
+  sudo chmod 755 /etc/letsencrypt/renewal-hooks/post/haproxy.sh
 
 Congratulations, Certbot will now automatically renew your certificates in the background.
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -695,10 +695,47 @@ is done by means of a scheduled task which runs ``certbot renew`` periodically.
 
 If you are unsure whether you need to configure automated renewal:
 
-1. Review the instructions for your system at https://certbot.eff.org/instructions.
-   They will describe how to set up a scheduled task, if necessary.
-2. (Linux/BSD): Check your system's crontab (typically `/etc/crontab` and
-   `/etc/cron.*/*`) and systemd timers (``systemctl list-timers``).
+1. Review the instructions for your system and installation method at
+   https://certbot.eff.org/instructions. They will describe how to set up a scheduled task,
+   if necessary. If no step is listed, your system comes with automated renewal pre-installed,
+   and you should not need to take any additional actions.
+2. On Linux and BSD, you can check to see if your installation method has pre-installed a timer
+   for you. To do so, look for the ``certbot renew`` command in either your system's crontab
+   (typically `/etc/crontab` or `/etc/cron.*/*`) or systemd timers (``systemctl list-timers``).
+3. If you're still not sure, you can configure automated renewal manually by following the steps
+   in the next section. Certbot has been carefully engineered to handle the case where both manual
+   automated renewal and pre-installed automated renewal are set up.
+
+Setting up automated renewal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you think you may need to set up automated renewal, follow these instructions to set up a
+scheduled task to automatically renew your certificates in the background. On the off chance you
+ended up at these instructions but automated renewal was pre-installed on your system, following
+these instructions should not cause any problems.
+
+If you're using Windows, these instructions will not work.
+
+Run the following line, which will add a cron job to the default crontab:
+
+.. code-block:: shell
+
+  SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME &amp;&amp; certbot renew -q" | sudo tee -a /etc/crontab > /dev/null
+
+If you needed to stop your webserver to run Certbot, you'll want to
+add ``--pre-hook`` and ``--post-hook`` flags after ``certbot renew`` to stop
+and start your webserver automatically. For example, if your webserver is HAProxy, modify the
+command as follows:
+
+.. code-block:: shell
+
+  SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME &amp;&amp; certbot renew -q --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null
+
+
+Congratulations, Certbot will now automatically renew your certificates in the background.
+
+If you are interested in learning more about how Certbot renews your certificates, see the
+`Renewing certificates`_ section above.
 
 .. _where-certs:
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -723,14 +723,15 @@ Run the following line, which will add a cron job to `/etc/crontab`:
   SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME && certbot renew -q" | sudo tee -a /etc/crontab > /dev/null
 
 If you needed to stop your webserver to run Certbot, you'll want to
-add ``--pre-hook`` and ``--post-hook`` flags after ``certbot renew`` to stop
-and start your webserver automatically. For example, if your webserver is HAProxy, modify the
-command as follows:
+add ``pre`` and ``post`` hooks to stop and start your webserver automatically.
+For example, if your webserver is HAProxy, run the following commands to create the hook files
+in the appropriate directory:
 
 .. code-block:: shell
 
-  SLEEPTIME=$(awk 'BEGIN{srand(); print int(rand()*(3600+1))}'); echo "0 0,12 * * * root sleep $SLEEPTIME && certbot renew -q --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null
-
+  echo 'service haproxy stop' | sudo tee -a /etc/letsencrypt/renewal-hooks/pre/haproxy-stop > /dev/null
+  echo 'service haproxy start' | sudo tee -a /etc/letsencrypt/renewal-hooks/post/haproxy-start > /dev/null
+  chmod +x /etc/letsencrypt/renewal-hooks/pre/haproxy-stop /etc/letsencrypt/renewal-hooks/post/haproxy-start
 
 Congratulations, Certbot will now automatically renew your certificates in the background.
 


### PR DESCRIPTION
These changes provide guidelines for setting up automated renewal in the certbot documentation, so we can link users directly from the command line. This is based on a cognitive walkthrough done by Katharina Krombholz's graduate students.

In doing this, we had to update the command we provide, because we don't know for sure what python on the system will be called. `awk` and `srand` and `rand` and `sleep` are posix compliant, so this should work on all posix systems. Unlike the other command, the random delay for each user is set once, to keep the command from being egregiously complicated.

Screenshot of the updated section of the docs:

![Screenshot from 2021-05-27 13-51-18](https://user-images.githubusercontent.com/1227205/119895470-adab9b80-bef2-11eb-9836-6a465fd8c895.png)


And the rest of the command text:
![Screenshot from 2021-05-27 13-51-29](https://user-images.githubusercontent.com/1227205/119895461-aa181480-bef2-11eb-9684-5e0a0e93c818.png)


When `--preconfigured-renewal` is not set, the instructions will link directly to "Setting up automated renewal"
