### PR TITLE
Fix python-augeas failure on Windows

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -658,7 +658,7 @@ class ClientV2(ClientBase):
         response = self._post(self.directory['newOrder'], order)
         body = messages.Order.from_json(response.json())
         authorizations = []
-        for url in body.authorizations:
+        for url in body.authorizations:  # pylint: disable=not-an-iterable
             authorizations.append(self._authzr_from_response(self._post_as_get(url), uri=url))
         return messages.OrderResource(
             body=body,

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -10,7 +10,7 @@ if sys.platform == 'win32':
     # problem at build time or run time with python-augeas
     packages = []
     install_requires = []
-    extra_require = {}
+    extra_require = {'dev': []}
     entry_points = {}
 else:
     packages = find_packages()

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -1,22 +1,39 @@
+import sys
+
 from setuptools import find_packages
 from setuptools import setup
 
 version = '1.16.0.dev0'
 
-# Remember to update local-oldest-requirements.txt when changing the minimum
-# acme/certbot version.
-install_requires = [
-    'acme>=1.8.0',
-    'certbot>=1.10.1',
-    'python-augeas',
-    'setuptools>=39.0.1',
-    'zope.component',
-    'zope.interface',
-]
-
-dev_extras = [
-    'apacheconfig>=0.3.2',
-]
+if sys.platform == 'win32':
+    # On Windows, makes certbot-apache essentially an empty project to avoid any
+    # problem at build time or run time with python-augeas
+    packages = []
+    install_requires = []
+    extra_require = {}
+    entry_points = {}
+else:
+    packages = find_packages()
+    # Remember to update local-oldest-requirements.txt when changing the minimum
+    # acme/certbot version.
+    install_requires = [
+        'acme>=1.8.0',
+        'certbot>=1.10.1',
+        'python-augeas',
+        'setuptools>=39.0.1',
+        'zope.component',
+        'zope.interface',
+    ]
+    extra_require = {
+        'dev': [
+            'apacheconfig>=0.3.2',
+        ],
+    }
+    entry_points = {
+        'certbot.plugins': [
+            'apache = certbot_apache._internal.entrypoint:ENTRYPOINT',
+        ],
+    }
 
 setup(
     name='certbot-apache',
@@ -47,15 +64,9 @@ setup(
         'Topic :: Utilities',
     ],
 
-    packages=find_packages(),
+    packages=packages,
     include_package_data=True,
     install_requires=install_requires,
-    extras_require={
-        'dev': dev_extras,
-    },
-    entry_points={
-        'certbot.plugins': [
-            'apache = certbot_apache._internal.entrypoint:ENTRYPOINT',
-        ],
-    },
+    extras_require=extra_require,
+    entry_points=entry_points,
 )

--- a/certbot-apache/tests/conftest.py
+++ b/certbot-apache/tests/conftest.py
@@ -1,6 +1,8 @@
 import sys
 
+
 def pytest_ignore_collect(path, config):  # pragma: no cover
-    # Do not run any test for certbot-apache on Windows.
+    # Do not run any test for certbot-apache on Windows, except obj_test which is safe
+    # (to avoid pytest to fail because no test was found).
     if sys.platform == 'win32':
-        return True
+        return path.basename != 'obj_test.py'

--- a/certbot-apache/tests/conftest.py
+++ b/certbot-apache/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+
+def pytest_ignore_collect(path, config):
+    # Do not run any test for certbot-apache on Windows.
+    if sys.platform == 'win32':
+        return True

--- a/certbot-apache/tests/conftest.py
+++ b/certbot-apache/tests/conftest.py
@@ -1,6 +1,6 @@
 import sys
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(path, config):  # pragma: no cover
     # Do not run any test for certbot-apache on Windows.
     if sys.platform == 'win32':
         return True

--- a/certbot-apache/tests/conftest.py
+++ b/certbot-apache/tests/conftest.py
@@ -5,4 +5,4 @@ def pytest_ignore_collect(path, config):  # pragma: no cover
     # Do not run any test for certbot-apache on Windows, except obj_test which is safe
     # (to avoid pytest to fail because no test was found).
     if sys.platform == 'win32':
-        return path.basename != 'obj_test.py'
+        return path.basename != 'dummy_test.py'

--- a/certbot-apache/tests/dummy_test.py
+++ b/certbot-apache/tests/dummy_test.py
@@ -1,0 +1,11 @@
+"""
+This test module is here to provide at least on test on Windows, and thus avoid
+pytest to fail because no tests could be found.
+"""
+import unittest
+
+
+class DummyTest(unittest.TestCase):
+    """Dummy test"""
+    def test_dummy(self):
+        self.assertTrue(True)

--- a/tools/install_and_test.py
+++ b/tools/install_and_test.py
@@ -10,8 +10,6 @@ import re
 import subprocess
 import sys
 
-SKIP_PROJECTS_ON_WINDOWS = ['certbot-apache']
-
 
 def call_with_print(command):
     print(command)
@@ -22,16 +20,7 @@ def main(args):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     command = [sys.executable, os.path.join(script_dir, 'pip_install_editable.py')]
 
-    new_args = []
-    for arg in args:
-        if os.name == 'nt' and arg in SKIP_PROJECTS_ON_WINDOWS:
-            print((
-                'Info: currently {0} is not supported on Windows and will not be tested.'
-                .format(arg)))
-        else:
-            new_args.append(arg)
-
-    for requirement in new_args:
+    for requirement in args:
         current_command = command[:]
         current_command.append(requirement)
         call_with_print(' '.join(current_command))
@@ -39,6 +28,7 @@ def main(args):
 
         call_with_print(' '.join([
             sys.executable, '-m', 'pytest', pkg]))
+
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/tools/pinning/pin.sh
+++ b/tools/pinning/pin.sh
@@ -4,6 +4,9 @@
 # modifying pyproject.toml in the same directory as this file.
 set -euo pipefail
 
+# Since certbot-apache is crafted as an empty project on Windows, the
+# result of pinning dependencies would not be accurate on that platform,
+# so we forbid it.
 if uname -a | grep -q -E 'CYGWIN|MINGW'; then
     echo "This script cannot be run on Windows"
     exit 1

--- a/tools/pinning/pin.sh
+++ b/tools/pinning/pin.sh
@@ -4,6 +4,11 @@
 # modifying pyproject.toml in the same directory as this file.
 set -euo pipefail
 
+if uname -a | grep -q -E 'CYGWIN|MINGW'; then
+    echo "This script cannot be run on Windows"
+    exit 1
+fi
+
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 REPO_ROOT="$(dirname "$(dirname "${WORK_DIR}")")"
 PIPSTRAP_CONSTRAINTS="${REPO_ROOT}/tools/pipstrap_constraints.txt"

--- a/tools/pinning/pyproject.toml
+++ b/tools/pinning/pyproject.toml
@@ -58,12 +58,6 @@ cython = "*"
 # needed. This dependency can be removed here once Certbot's support for the
 # 3rd party mock library has been dropped.
 mock = "*"
-# We were originally pinning back python-augeas for certbot-auto because we
-# found the way older versions of the library linked to Augeas were more
-# reliable. That's no longer a concern, however, we continue to pin back the
-# library for now because it causes Certbot tests on Windows to fail. See
-# https://github.com/certbot/certbot/issues/8732.
-python-augeas = "0.5.0"
 # Because some parts of Certbot documentation are generated from zope.interfaces,
 # we need the Sphinx plugin repoze.sphinx.autointerface. This plugin is not
 # currently compatible with Sphinx>=4 though so we're pinning an older version

--- a/tools/pip_install_editable.py
+++ b/tools/pip_install_editable.py
@@ -18,5 +18,6 @@ def main(args):
 
     pip_install.main(new_args)
 
+
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -10,23 +10,23 @@ apacheconfig==0.3.2; python_version >= "3.6"
 apipkg==1.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 appdirs==1.4.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
 appnope==0.1.2
-astroid==2.5.6; python_version >= "3.6" and python_version < "4.0"
+astroid==2.5.7; python_version >= "3.6" and python_version < "4.0"
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0"
 attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-awscli==1.19.83; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+awscli==1.19.84; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 azure-devops==6.0.0b4; python_version >= "3.6"
 babel==2.9.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
 backcall==0.2.0
 bcrypt==3.2.0; python_version >= "3.6"
 beautifulsoup4==4.9.3; python_version >= "3.6" and python_version < "4.0"
 bleach==3.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
-boto3==1.17.83; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-botocore==1.20.83; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+boto3==1.17.84; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+botocore==1.20.84; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 cachecontrol==0.12.6; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
 cached-property==1.5.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 cachetools==4.2.2; python_version >= "3.5" and python_version < "4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 cachy==0.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
-certifi==2020.12.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+certifi==2021.5.30; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 cffi==1.14.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
 chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 cleo==0.8.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
@@ -41,7 +41,7 @@ cryptography==3.4.7; python_version >= "3.6" and python_full_version < "3.0.0" a
 cython==0.29.23; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 decorator==5.0.9
 deprecated==1.2.12; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
-distlib==0.3.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
+distlib==0.3.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
 distro==1.5.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 dns-lexicon==3.6.0; python_version >= "3.6" and python_version < "4.0"
 dnspython==2.1.0; python_version >= "3.6"
@@ -116,7 +116,7 @@ pycparser==2.20; python_version >= "3.6" and python_full_version < "3.0.0" or py
 pygithub==1.55; python_version >= "3.6"
 pygments==2.9.0
 pyjwt==2.1.0; python_version >= "3.6"
-pylev==1.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
+pylev==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
 pylint==2.8.2; python_version >= "3.6" and python_version < "4.0"
 pynacl==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
 pynsist==2.7; python_version >= "3.6"
@@ -129,13 +129,13 @@ pytest-cov==2.12.0; python_version >= "3.6" and python_full_version < "3.0.0" or
 pytest-forked==1.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 pytest-xdist==2.2.1; python_version >= "3.6"
 pytest==6.2.4; python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
-python-augeas==0.5.0
+python-augeas==1.1.0; python_version >= "3.6"
 python-dateutil==2.8.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 python-digitalocean==1.16.0; python_version >= "3.6"
 python-dotenv==0.17.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pytz==2021.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.6.0"
 pywin32-ctypes==0.2.0; python_version >= "3.6" and python_version < "4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32"
-pywin32==300; sys_platform == "win32" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+pywin32==301; sys_platform == "win32" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
 pyyaml==5.4.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.6.0" and python_version >= "3.6" and python_version < "4.0"
 readme-renderer==29.0; python_version >= "3.6"
 repoze.sphinx.autointerface==0.8; python_version >= "3.6"
@@ -169,7 +169,7 @@ tqdm==4.61.0; python_version >= "3.6" and python_full_version < "3.0.0" or pytho
 traitlets==4.3.3
 twine==3.3.0; python_version >= "3.6"
 typed-ast==1.4.3; implementation_name == "cpython" and python_version < "3.8" and python_version >= "3.6"
-typing-extensions==3.10.0.0; python_version >= "3.6"
+typing-extensions==3.10.0.0; python_version >= "3.6" and python_version < "3.8"
 uritemplate==3.0.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 urllib3==1.26.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 virtualenv==20.4.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"

--- a/tools/venv.py
+++ b/tools/venv.py
@@ -48,6 +48,7 @@ REQUIREMENTS = [
 ]
 
 if sys.platform == 'win32':
+    REQUIREMENTS.remove('-e certbot-apache')
     REQUIREMENTS.append('-e windows-installer')
 
 VERSION_PATTERN = re.compile(r'^(\d+)\.(\d+).*$')

--- a/tools/venv.py
+++ b/tools/venv.py
@@ -48,7 +48,6 @@ REQUIREMENTS = [
 ]
 
 if sys.platform == 'win32':
-    REQUIREMENTS.remove('-e certbot-apache')
     REQUIREMENTS.append('-e windows-installer')
 
 VERSION_PATTERN = re.compile(r'^(\d+)\.(\d+).*$')

--- a/tox.cover.py
+++ b/tox.cover.py
@@ -16,7 +16,7 @@ DEFAULT_PACKAGES = [
 COVER_THRESHOLDS = {
     'certbot': {'linux': 95, 'windows': 96},
     'acme': {'linux': 100, 'windows': 99},
-    'certbot_apache': {'linux': 100, 'windows': 100},
+    'certbot_apache': {'linux': 100, 'windows': 0},
     'certbot_dns_cloudflare': {'linux': 98, 'windows': 98},
     'certbot_dns_cloudxns': {'linux': 98, 'windows': 98},
     'certbot_dns_digitalocean': {'linux': 98, 'windows': 98},

--- a/tox.cover.py
+++ b/tox.cover.py
@@ -34,19 +34,11 @@ COVER_THRESHOLDS = {
     'certbot_nginx': {'linux': 97, 'windows': 97},
 }
 
-SKIP_PROJECTS_ON_WINDOWS = ['certbot-apache']
-
 
 def cover(package):
     threshold = COVER_THRESHOLDS.get(package)['windows' if os.name == 'nt' else 'linux']
 
     pkg_dir = package.replace('_', '-')
-
-    if os.name == 'nt' and pkg_dir in SKIP_PROJECTS_ON_WINDOWS:
-        print((
-            'Info: currently {0} is not supported on Windows and will not be tested/covered.'
-            .format(pkg_dir)))
-        return
 
     subprocess.check_call([sys.executable, '-m', 'pytest',
                            '--cov', pkg_dir, '--cov-append', '--cov-report=', pkg_dir])


### PR DESCRIPTION
Fixes #8732

This PR avoids the failure about installing newer version of `python-augeas` on Windows as part of the dependencies of the `certbot-apache` project.

Instead of modifying various scripts to conditionally not install `certbot-apache` on Windows, I made a unique modification that has the same result: the `setup.py` of `certbot-apache` makes it effectively an empty project on Windows (no packages, no dependencies, no entry_points).

I also take the occasion to centrally disable any `certbot-apache` tests on Windows by leveraging `conftest.py` hooks.