### PR TITLE
certbot-apache: Add Void Linux overrides

### DIFF
--- a/certbot-apache/certbot_apache/_internal/entrypoint.py
+++ b/certbot-apache/certbot_apache/_internal/entrypoint.py
@@ -10,6 +10,7 @@ from certbot_apache._internal import override_debian
 from certbot_apache._internal import override_fedora
 from certbot_apache._internal import override_gentoo
 from certbot_apache._internal import override_suse
+from certbot_apache._internal import override_void
 
 OVERRIDE_CLASSES = {
     "arch": override_arch.ArchConfigurator,
@@ -35,6 +36,7 @@ OVERRIDE_CLASSES = {
     "sles": override_suse.OpenSUSEConfigurator,
     "scientific": override_centos.CentOSConfigurator,
     "scientific linux": override_centos.CentOSConfigurator,
+    "void": override_void.VoidConfigurator,
 }
 
 

--- a/certbot-apache/certbot_apache/_internal/override_void.py
+++ b/certbot-apache/certbot_apache/_internal/override_void.py
@@ -1,0 +1,23 @@
+""" Distribution specific override class for Arch Linux """
+import zope.interface
+
+from certbot import interfaces
+from certbot_apache._internal import configurator
+from certbot_apache._internal.configurator import OsOptions
+
+
+@zope.interface.provider(interfaces.IPluginFactory)
+class VoidConfigurator(configurator.ApacheConfigurator):
+    """Void Linux specific ApacheConfigurator override class"""
+
+    OS_DEFAULTS = OsOptions(
+        server_root="/etc/apache",
+        vhost_root="/etc/apache/extra",
+        vhost_files="*.conf",
+        logs_root="/var/log/httpd",
+        ctl="apachectl",
+        version_cmd=['apachectl', '-v'],
+        restart_cmd=['apachectl', 'graceful'],
+        conftest_cmd=['apachectl', 'configtest'],
+        challenge_location="/etc/apache/extra",
+    )

--- a/certbot-apache/certbot_apache/_internal/override_void.py
+++ b/certbot-apache/certbot_apache/_internal/override_void.py
@@ -1,4 +1,4 @@
-""" Distribution specific override class for Arch Linux """
+""" Distribution specific override class for Void Linux """
 import zope.interface
 
 from certbot import interfaces

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Add Void Linux overrides for certbot-apache.
 
 ### Changed
 


### PR DESCRIPTION
## Overview

certbot-apache doesn't work out of the box with Void Linux. It needs `--apache-ctl /usr/bin/apachectl --apache-server-root /etc/apache` flags to be passed for it to work. Hoping that adding overrides specific to Void Linux will make the user experience a bit smoother. Feel free to let me know if any changes are required.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
