### PR TITLE
Use verbose=3 in sample dev cli.ini now that count is allowed in config

### DIFF
--- a/certbot/examples/dev-cli.ini
+++ b/certbot/examples/dev-cli.ini
@@ -13,8 +13,6 @@ domains = example.com
 text = True
 agree-tos = True
 debug = True
-# Unfortunately, it's not possible to specify "verbose" multiple times
-# (correspondingly to -vvvvvv)
-verbose = True
+verbose = 3
 
 authenticator = standalone


### PR DESCRIPTION
This was enabled in https://github.com/bw2/ConfigArgParse/pull/216.