### PR TITLE
apache: configure nameless vhosts during auth

### DIFF
--- a/certbot-apache/certbot_apache/_internal/http_01.py
+++ b/certbot-apache/certbot_apache/_internal/http_01.py
@@ -172,8 +172,8 @@ class ApacheHttp01(common.ChallengePerformer):
         return relevant_vhosts
 
     def _unnamed_vhosts(self) -> List[VirtualHost]:
-        """Return all VirtualHost objects with no ServerName or ServerAlias"""
-        return [vh for vh in self.configurator.vhosts if not vh.get_names()]
+        """Return all VirtualHost objects with no ServerName"""
+        return [vh for vh in self.configurator.vhosts if vh.name is None]
 
     def _set_up_challenges(self):
         if not os.path.isdir(self.challenge_dir):

--- a/certbot-apache/certbot_apache/_internal/http_01.py
+++ b/certbot-apache/certbot_apache/_internal/http_01.py
@@ -95,10 +95,10 @@ class ApacheHttp01(common.ChallengePerformer):
     def _mod_config(self):
         selected_vhosts: List[VirtualHost] = []
         http_port = str(self.configurator.config.http01_port)
+
+        # Search for VirtualHosts matching by name
         for chall in self.achalls:
-            # Search for matching VirtualHosts
-            for vh in self._matching_vhosts(chall.domain):
-                selected_vhosts.append(vh)
+            selected_vhosts += self._matching_vhosts(chall.domain)
 
         # Ensure that we have one or more VirtualHosts that we can continue
         # with. (one that listens to port configured with --http-01-port)
@@ -107,9 +107,13 @@ class ApacheHttp01(common.ChallengePerformer):
             if any(a.is_wildcard() or a.get_port() == http_port for a in vhost.addrs):
                 found = True
 
-        if not found:
-            for vh in self._relevant_vhosts():
-                selected_vhosts.append(vh)
+        # If there's at least one elgible VirtualHost, also add all unnamed VirtualHosts
+        # because they might match at runtime (#8890)
+        if found:
+            selected_vhosts += self._unnamed_vhosts()
+        # Otherwise, add every Virtualhost which listens on the right port
+        else:
+            selected_vhosts += self._relevant_vhosts()
 
         # Add the challenge configuration
         for vh in selected_vhosts:
@@ -166,6 +170,10 @@ class ApacheHttp01(common.ChallengePerformer):
                 " {0}.".format(http01_port))
 
         return relevant_vhosts
+
+    def _unnamed_vhosts(self) -> List[VirtualHost]:
+        """Return all VirtualHost objects with no ServerName or ServerAlias"""
+        return [vh for vh in self.configurator.vhosts if not vh.get_names()]
 
     def _set_up_challenges(self):
         if not os.path.isdir(self.challenge_dir):

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -127,7 +127,7 @@ class ApacheHttp01Test(util.ApacheTest):
 
     def test_configure_name_and_blank(self):
         domain = "certbot.demo"
-        vhosts = [v for v in self.config.vhosts if v.name == domain or not v.get_names()]
+        vhosts = [v for v in self.config.vhosts if v.name == domain or v.name is None]
         achalls = [
             achallenges.KeyAuthorizationAnnotatedChallenge(
                 challb=acme_util.chall_to_challb(

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -125,6 +125,18 @@ class ApacheHttp01Test(util.ApacheTest):
                 domain="duplicate.example.com", account_key=self.account_key)]
         self.common_perform_test(achalls, vhosts)
 
+    def test_configure_name_and_blank(self):
+        domain = "certbot.demo"
+        vhosts = [v for v in self.config.vhosts if v.name == domain or not v.get_names()]
+        achalls = [
+            achallenges.KeyAuthorizationAnnotatedChallenge(
+                challb=acme_util.chall_to_challb(
+                    challenges.HTTP01(token=((b'a' * 16))),
+                    "pending"),
+                domain=domain, account_key=self.account_key),
+        ]
+        self.common_perform_test(achalls, vhosts)
+
     def test_no_vhost(self):
         for achall in self.achalls:
             self.http.add_chall(achall)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   of the Certbot package will now always require acme>=X and version Y of a
   plugin package will always require acme>=Y and certbot=>Y. Specifying
   dependencies in this way simplifies testing and development.
+* The Apache authenticator now always configures virtual hosts which do not have
+  an explicit `ServerName`. This should make it work more reliably with the
+  default Apache configuration in Debian-based environments.
 
 ### Fixed
 


### PR DESCRIPTION
In the apache2 package on Debian-based distros, the default
000-default.conf virtual host does not include a ServerName.

Depending on the FQDN hostname of the machine and DNS setup, Apache
assigns a name to this unnamed vhost at runtime. As a result, the
Apache config can end up with vhosts that have duplicative names.

Previously, Certbot did not identify that the nameless vhost could be
a match for the requested identifier, which would, depending on
configuration load order, cause the authenticator to fail.

This change causes Certbot to include all unnamed vhosts on top of
matched vhosts, during authentication. If no vhosts matched, the
existing behavior remains the same.

---

Fixes #8890.

How I manually tested this:

1. Debian or derivative server, with a FQDN hostname that (at least locally via gai) resolves forwards and backwards.
2. Stock `apache2` installation (leave `000-default.conf` alone) + one custom vhost with its `ServerName` explicitly set to the server's FQDN hostname:

        (venv) root@temple-pattern:~/certbot# cat /etc/apache2/sites-enabled/temple-pattern.conf
        <VirtualHost *:80>
                ServerName temple-pattern.bnr.la
                DocumentRoot /var/www/html
        </VirtualHost>

We should see this, where we observe that the `000-default.conf` is assigned a name at runtime, despite not having a name in the config:

    (venv) root@temple-pattern:~/certbot# apachectl -t -D DUMP_VHOSTS                                                                                                                                                 
    VirtualHost configuration:
    *:80                   is a NameVirtualHost
            default server temple-pattern.bnr.la (/etc/apache2/sites-enabled/000-default.conf:1)
            port 80 namevhost temple-pattern.bnr.la (/etc/apache2/sites-enabled/000-default.conf:1)
            port 80 namevhost temple-pattern.bnr.la (/etc/apache2/sites-enabled/temple-pattern.conf:1)

In `master`, Certbot will fail on this, because it doesn't configure that `000-default.conf` vhost:

    (venv) root@temple-pattern:~/certbot# certbot --apache -d temple-pattern.bnr.la
    Saving debug log to /var/log/letsencrypt/letsencrypt.log
    Requesting a certificate for temple-pattern.bnr.la

    Certbot failed to authenticate some domains (authenticator: apache). The Certificate Authority reported these problems:
      Domain: temple-pattern.bnr.la
      Type:   unauthorized
      Detail: Invalid response from http://temple-pattern.bnr.la/.well-known/acme-challenge/pCN9bkjGCcr3Gnaoe9hKHZtUWVgRcuXObMfB4fhoIq0 [103.1.186.141]: "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>404 Not Found</title>\n</head><body>\n<h1>Not Found</h1>\n<p"
    ...

This PR succeeds because it configures both vhosts:

    (venv) root@temple-pattern:~/certbot# certbot --apache -d temple-pattern.bnr.la
    Saving debug log to /var/log/letsencrypt/letsencrypt.log
    Requesting a certificate for temple-pattern.bnr.la

    Successfully received certificate.
    ...