### PR TITLE
Add --verbose-level flag and fix logging level calculations

### DIFF
--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -71,6 +71,11 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         default=flag_default("verbose_count"), help="This flag can be used "
         "multiple times to incrementally increase the verbosity of output, "
         "e.g. -vvv.")
+    # This is for developers to set the level in the cli.ini, and overrides
+    # the --verbose flag
+    helpful.add(
+        None, "--verbose-level", dest="verbose_level",
+        default=flag_default("verbose_level"), help=argparse.SUPPRESS)
     helpful.add(
         None, "-t", "--text", dest="text_mode", action="store_true",
         default=flag_default("text_mode"), help=argparse.SUPPRESS)
@@ -449,6 +454,7 @@ def set_by_cli(var):
         plugins = plugins_disco.PluginsRegistry.find_all()
         # reconstructed_args == sys.argv[1:], or whatever was passed to main()
         reconstructed_args = helpful_parser.args + [helpful_parser.verb]
+
         detector = set_by_cli.detector = prepare_and_parse_args(  # type: ignore
             plugins, reconstructed_args, detect_defaults=True)
         # propagate plugin requests: eg --standalone modifies config.authenticator

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -22,7 +22,7 @@ CLI_DEFAULTS = dict(
     ],
 
     # Main parser
-    verbose_count=-int(logging.WARNING / 10),
+    verbose_count=0,
     verbose_level=None,
     text_mode=False,
     max_log_backups=1000,
@@ -142,6 +142,9 @@ REVOCATION_REASONS = {
 
 QUIET_LOGGING_LEVEL = logging.ERROR
 """Logging level to use in quiet mode."""
+
+DEFAULT_LOGGING_LEVEL = logging.WARNING
+"""Default logging level to use when not in quiet mode."""
 
 RENEWER_DEFAULTS = dict(
     renewer_enabled="yes",

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -23,6 +23,7 @@ CLI_DEFAULTS = dict(
 
     # Main parser
     verbose_count=-int(logging.WARNING / 10),
+    verbose_level=None,
     text_mode=False,
     max_log_backups=1000,
     preconfigured_renewal=False,

--- a/certbot/certbot/_internal/log.py
+++ b/certbot/certbot/_internal/log.py
@@ -121,9 +121,9 @@ def post_arg_parse_setup(config):
     if config.quiet:
         level = constants.QUIET_LOGGING_LEVEL
     elif config.verbose_level is not None:
-        level = -int(config.verbose_level) * 10
+        level = constants.DEFAULT_LOGGING_LEVEL - int(config.verbose_level) * 10
     else:
-        level = -config.verbose_count * 10
+        level = constants.DEFAULT_LOGGING_LEVEL - config.verbose_count * 10
 
     stderr_handler.setLevel(level)
     logger.debug('Root logging level set at %d', level)

--- a/certbot/certbot/_internal/log.py
+++ b/certbot/certbot/_internal/log.py
@@ -120,8 +120,11 @@ def post_arg_parse_setup(config):
 
     if config.quiet:
         level = constants.QUIET_LOGGING_LEVEL
+    elif config.verbose_level is not None:
+        level = -int(config.verbose_level) * 10
     else:
         level = -config.verbose_count * 10
+
     stderr_handler.setLevel(level)
     logger.debug('Root logging level set at %d', level)
 

--- a/certbot/examples/dev-cli.ini
+++ b/certbot/examples/dev-cli.ini
@@ -13,8 +13,6 @@ domains = example.com
 text = True
 agree-tos = True
 debug = True
-# Unfortunately, it's not possible to specify "verbose" multiple times
-# (correspondingly to -vvvvvv)
-verbose = True
+verbose-level = 2 # -vv (debug)
 
 authenticator = standalone

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -122,7 +122,7 @@ class PostArgParseSetupTest(test_util.ConfigTestCase):
         if self.config.quiet:
             self.assertEqual(level, constants.QUIET_LOGGING_LEVEL)
         else:
-            self.assertEqual(level, -self.config.verbose_count * 10)
+            self.assertEqual(level, constants.DEFAULT_LOGGING_LEVEL)
 
     def test_debug(self):
         self.config.debug = True


### PR DESCRIPTION
Also, update `dev-cli.ini` example to use new flag.

Although https://github.com/bw2/ConfigArgParse/pull/216 allowed setting a `count` action value in a config file, our default detection system won't let us use that functionality. While we should eventually fix that, for now, let developers have a cli.ini with a higher logging level by adding this flag.

Also, our logging level calculations have never worked properly, but it didn't matter because there was only one level to go. Now that there's an intermediate level that users might want to set, fix the math so it actually does what we want.

Note that this flag is intended to work the same way adding `-vvv`s does; that is, as a modifier to the pre-set level, rather than setting the absolute level. The number it is set to is equivalent to the number of `v`s that would otherwise have been passed, with "2" as the current maximum effective number of levels (warning --> info --> debug).