### PR TITLE
delete: warn that certificate may still be installed

### DIFF
--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -2510,6 +2510,23 @@ class ApacheConfigurator(common.Installer):
                 "changes made by Certbot. Ensure that the listed domains point to this Apache "
                 "server and that it is accessible from the internet.")
 
+    def find_deployed_certificate(self, cert_path: str, key_path: str, chain_path: str,
+                                  fullchain_path: str) -> List[str]:
+        locs = set()
+
+        dir_combos = (
+            ("SSLCertificateFile", fullchain_path),
+            ("SSLCertificateKeyFile", key_path),
+            ("SSLCertificateFile", cert_path),
+            ("SSLCertificateChainFile", chain_path),
+        )
+        for vh in self.vhosts:
+            if any(self.parser.find_dir(*c, vh.path) for c in dir_combos):
+                locs.add(vh.filep)
+
+        return list(locs)
+
+
     ###########################################################################
     # Challenges Section
     ###########################################################################

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -1088,6 +1088,22 @@ class NginxConfigurator(common.Installer):
             "accessible from the internet."
         )
 
+    def find_deployed_certificate(self, cert_path: str, key_path: str, chain_path: str,
+                                  fullchain_path: str) -> List[str]:
+        locs: Set[str] = set()
+
+        combos = [
+            ["ssl_certificate", fullchain_path],
+            ["ssl_certificate", cert_path],
+            ["ssl_certificate_key", key_path],
+            ["ssl_trusted_certificate", chain_path],
+        ]
+        for vh in self.parser.get_vhosts():
+            if any(self.parser.has_directive(vh, combo) for combo in combos):
+                locs.add(vh.filep)
+
+        return list(locs)
+
     ###################################################
     # Wrapper functions for Reverter class (IInstaller)
     ###################################################

--- a/certbot-nginx/certbot_nginx/_internal/parser.py
+++ b/certbot-nginx/certbot_nginx/_internal/parser.py
@@ -286,6 +286,25 @@ class NginxParser:
 
         return False
 
+    def has_directive(self, vhost: obj.VirtualHost, dir_needle: List[str]) -> bool:
+        """Does this vhost has a directive that begins with or matches dir_needle?
+
+        :param vhost: The vhost to look within
+        :type vhost: obj.VirtualHost
+
+        :param dir_needle: The directive to look for. Must contain at least 1 item.
+        :type dir_needle: List[str]
+
+        :returns: True if vhost contains any directive matching the dir_needle.
+        :rtype: bool
+
+        """
+        def _match_func(haystack: List[str]) -> bool:
+            if len(haystack) < len(dir_needle):
+                return False
+            return haystack[1:len(dir_needle)] == dir_needle[1:]
+        return _find_location(vhost.raw, dir_needle[0], _match_func) is not None
+
     def add_server_directives(self, vhost, directives, insert_at_top=False):
         """Add directives to the server block identified by vhost.
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -124,13 +124,6 @@ def delete(config: interfaces.IConfig, plugins: plugins_disco.PluginsRegistry):
             "See https://certbot.org/deleting-certs for more information."
         )
 
-        # msg.append(
-        #     "\nWARNING: Some of the selected certificate(s) are still in-use by the webserver. "
-        #     "It is HIGHLY advised to remove all references to these certificate(s) from any "
-        #     "webserver configuration, before deleting them. Failing to do so may result in a "
-        #     "broken webserver. See https://certbot.org/deleting-certs "
-        #     "for more info.")
-
     msg.append("\nAre you sure you want to delete the above certificate(s)?")
     if not disp.yesno("\n".join(msg), default=True):
         logger.info("Deletion of certificate(s) canceled.")
@@ -484,7 +477,7 @@ def _get_cert_install_locations(config: interfaces.IConfig, plugins: plugins_dis
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # ~~~~!!! Don't merge this without fixing it !!!~~~~
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        config.install = installer
+        config.installer = installer
         installer, _ = plug_sel.choose_configurator_plugins(config, plugins, "install")
 
         try:

--- a/certbot/certbot/plugins/common.py
+++ b/certbot/certbot/plugins/common.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import tempfile
 from typing import List
+from typing import Tuple
 
 from josepy import util as jose_util
 import pkg_resources
@@ -226,6 +227,24 @@ class Installer(Plugin):
             self.updated_ssl_dhparams_digest,
             constants.SSL_DHPARAMS_SRC,
             constants.ALL_SSL_DHPARAMS_HASHES)
+
+    def find_deployed_certificate(self, cert_path: str, key_path: str, chain_path: str,
+                                  fullchain_path: str) -> List[str]:
+        """Returns locations where a certificate is deployed in the installer.
+
+        :param str cert_path: The certificate path.
+        :param str key_path: The certificate path.
+        :param str chain_path: The certificate path.
+        :param str fullchain_path: The certificate path.
+
+        :returns: list of human-understandable locations (e.g. `file:line_no`) where the
+                  certificate is deployed.
+        :rtype: `List` of `str`
+
+        :raises NotImplementedError: if the installer doesn't implement this functionality.
+
+        """
+        raise NotImplementedError()
 
 
 class Addr:


### PR DESCRIPTION
Implemented in the nginx and apache installers. no-op for others.

---

Fixes #6734.
Fixes #8755.

This is a very early draft, I'm just looking for design feedback for the high level approach.

The existing interactive warning gets enhanced to:

![image](https://user-images.githubusercontent.com/311534/121991193-8ace2200-cde2-11eb-824f-a8eccd4289d9.png)
