### PR TITLE
docs: explain the situation with --manual renewal

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -60,8 +60,8 @@ standalone_ Y    N    | Uses a "standalone" webserver to obtain a certificate.  
 manual_     Y    N    | Obtain a certificate by manually following instructions to    http-01_ (80) or
                       | perform domain validation yourself. Certificates created this dns-01_ (53)
                       | way do not support autorenewal.
-                      | Autorenewal may be enabled by specifying scripts to automate
-                      | the domain validation steps.
+                      | Autorenewal may be enabled by providing an authentication
+                      | hook script to automate the domain validation steps.
 =========== ==== ==== =============================================================== =============================
 
 .. |dns_plugs| replace:: :ref:`DNS plugins <dns_plugins>`

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -57,10 +57,11 @@ standalone_ Y    N    | Uses a "standalone" webserver to obtain a certificate.  
                       | domain. Doing domain validation in this way is
                       | the only way to obtain wildcard certificates from Let's
                       | Encrypt.
-manual_     Y    N    | Helps you obtain a certificate by giving you instructions to  http-01_ (80) or
-                      | perform domain validation yourself. Additionally allows you   dns-01_ (53)
-                      | to specify scripts to automate the validation task in a
-                      | customized way.
+manual_     Y    N    | Obtain a certificate by manually following instructions to    http-01_ (80) or
+                      | perform domain validation yourself. Certificates created this dns-01_ (53)
+                      | way do not support autorenewal.
+                      | Autorenewal may be enabled by specifying scripts to automate
+                      | the domain validation steps.
 =========== ==== ==== =============================================================== =============================
 
 .. |dns_plugs| replace:: :ref:`DNS plugins <dns_plugins>`

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -229,11 +229,14 @@ For example, for the domain ``example.com``, a zone file entry would look like:
 
         _acme-challenge.example.com. 300 IN TXT "gfj9Xq...Rg85nM"
 
+**Renewal with the manual plugin**
 
-Additionally you can specify scripts to prepare for validation and
-perform the authentication procedure and/or clean up after it by using
-the ``--manual-auth-hook`` and ``--manual-cleanup-hook`` flags. This is
-described in more depth in the hooks_ section.
+Certificates created using ``--manual`` **do not** support automatic renewal unless
+combined with an `authentication hook script <#hooks>`_  via ``--manual-auth-hook``
+to automatically set up the required HTTP and/or TXT challenges.
+
+To renew a certificate using ``--manual`` without hooks, repeat the same ``certbot --manual``
+command you used to create the certificate originally.
 
 .. _combination:
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -235,8 +235,10 @@ Certificates created using ``--manual`` **do not** support automatic renewal unl
 combined with an `authentication hook script <#hooks>`_  via ``--manual-auth-hook``
 to automatically set up the required HTTP and/or TXT challenges.
 
-To renew a certificate using ``--manual`` without hooks, repeat the same ``certbot --manual``
-command you used to create the certificate originally.
+To manually renew a certificate using ``--manual`` without hooks, repeat the same
+``certbot --manual`` command you used to create the certificate originally. As this
+will require you to copy and paste a new HTTP file or DNS TXT record, the command
+cannot be automated with a cron job.
 
 .. _combination:
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -238,9 +238,12 @@ Certificates created using ``--manual`` **do not** support automatic renewal unl
 combined with an `authentication hook script <#hooks>`_  via ``--manual-auth-hook``
 to automatically set up the required HTTP and/or TXT challenges.
 
+If you can use one of the other plugins_ which support autorenewal to create
+your certificate, doing so is highly recommended.
+
 To manually renew a certificate using ``--manual`` without hooks, repeat the same
 ``certbot --manual`` command you used to create the certificate originally. As this
-will require you to copy and paste a new HTTP file or DNS TXT record, the command
+will require you to copy and paste new HTTP files or DNS TXT records, the command
 cannot be automated with a cron job.
 
 .. _combination:

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -229,6 +229,8 @@ For example, for the domain ``example.com``, a zone file entry would look like:
 
         _acme-challenge.example.com. 300 IN TXT "gfj9Xq...Rg85nM"
 
+.. _manual-renewal:
+
 **Renewal with the manual plugin**
 
 Certificates created using ``--manual`` **do not** support automatic renewal unless
@@ -533,6 +535,10 @@ Renewing certificates
 .. seealso:: Most Certbot installations come with automatic
    renewal out of the box. See `Automated Renewals`_ for more details.
 
+.. seealso:: Users of the `Manual`_ plugin should note that ``--manual`` certificates
+   will not renew automatically, unless combined with authentication hook scripts.
+   See `Renewal with the manual plugin <#manual-renewal>`_.
+
 As of version 0.10.0, Certbot supports a ``renew`` action to check
 all installed certificates for impending expiry and attempt to renew
 them. The simplest form is simply
@@ -721,7 +727,7 @@ Setting up automated renewal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you think you may need to set up automated renewal, follow these instructions to set up a
-scheduled task to automatically renew your certificates in the background. If you are unsure 
+scheduled task to automatically renew your certificates in the background. If you are unsure
 whether your system has a pre-installed scheduled task for Certbot, it is safe to follow these
 instructions to create one.
 


### PR DESCRIPTION
Users keep hitting this. This is the documentation half of #6280. On top of this, we still need to add some CLI output that achieves the same thing.

I can't remember why I closed #8601. Our meeting notes on that day just say:

> - Manual that doesn’t renew -- let’s try to integrate throughout, where it’s relevant
>    - Update documentation
>    - Add a message in the renewal information message
>    - Possibly contact prominent tutorials, such as the amazon one
>       - https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-using-lets-encrypt-certificates-with-wordpress We can submit a PR!
>    - Potential future: update --manual to be --manual-without-renewal or something, make --manual hidden

Screenshot:

![image](https://user-images.githubusercontent.com/311534/122488524-f998be80-d020-11eb-91d7-d3d175ef1ad1.png)

![image](https://user-images.githubusercontent.com/311534/122488556-0ddcbb80-d021-11eb-9745-bba3099d23ac.png)

