### PR TITLE
cli: vary renewal advice for hookless manual certs

### DIFF
--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -512,7 +512,7 @@ def _report_next_steps(config: interfaces.IConfig, installer_err: Optional[error
                 "This certificate will not be renewed automatically by Certbot. The --manual "
                 "plugin requires the use of an authentication hook script (--manual-auth-hook) "
                 "in order to support autorenewal. To renew this certificate, repeat this same "
-                f"{cli.cli_command} command, before the certificate's expiry date."
+                f"{cli.cli_command} command before the certificate's expiry date."
             )
         elif not config.preconfigured_renewal:
             steps.append(

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -509,10 +509,10 @@ def _report_next_steps(config: interfaces.IConfig, installer_err: Optional[error
                 "Certbot command again.")
         elif _is_interactive_only_auth(config):
             steps.append(
-                "This certificate will not be renewed automatically by Certbot. The --manual "
-                "plugin requires the use of an authentication hook script (--manual-auth-hook) "
-                "in order to support autorenewal. To renew this certificate, repeat this same "
-                f"{cli.cli_command} command before the certificate's expiry date."
+                "This certificate will not be renewed automatically. Autorenewal of "
+                "--manual certificates requires the use of an authentication hook script "
+                "(--manual-auth-hook) but one was not provided. To renew this certificate, repeat "
+                f"this same {cli.cli_command} command before the certificate's expiry date."
             )
         elif not config.preconfigured_renewal:
             steps.append(

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1901,6 +1901,71 @@ class ReportNewCertTest(unittest.TestCase):
             'This certificate expires on 1970-01-01.'
         )
 
+    def test_manual_no_hooks_report(self):
+        """Shouldn't get a message about autorenewal if no --manual-auth-hook"""
+        self._call(mock.Mock(dry_run=False, authenticator='manual', manual_auth_hook=None),
+                  '/path/to/cert.pem', '/path/to/fullchain.pem',
+                  '/path/to/privkey.pem')
+
+        self.mock_notify.assert_called_with(
+            '\nSuccessfully received certificate.\n'
+            'Certificate is saved at: /path/to/fullchain.pem\n'
+            'Key is saved at:         /path/to/privkey.pem\n'
+            'This certificate expires on 1970-01-01.\n'
+            'These files will be updated when the certificate renews.'
+        )
+
+
+class ReportNextStepsTest(unittest.TestCase):
+    """Tests for certbot._internal.main._report_next_steps"""
+
+    def setUp(self):
+        self.config = mock.MagicMock(
+            cert_name="example.com", preconfigured_renewal=True,
+            csr=None, authenticator="nginx", manual_auth_hook=None)
+        notify_patch = mock.patch('certbot._internal.main.display_util.notify')
+        self.mock_notify = notify_patch.start()
+        self.addCleanup(notify_patch.stop)
+        self.old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+
+    def tearDown(self):
+        sys.stdout = self.old_stdout
+
+    @classmethod
+    def _call(cls, *args, **kwargs):
+        from certbot._internal.main import _report_next_steps
+        _report_next_steps(*args, **kwargs)
+
+    def _output(self) -> str:
+        self.mock_notify.assert_called_once()
+        return self.mock_notify.call_args_list[0][0][0]
+
+    def test_report(self):
+        """No steps for a normal renewal"""
+        self.config.authenticator = "manual"
+        self.config.manual_auth_hook = "/bin/true"
+        self._call(self.config, None, None)
+        self.mock_notify.assert_not_called()
+
+    def test_csr_report(self):
+        """--csr requires manual renewal"""
+        self.config.csr = "foo.csr"
+        self._call(self.config, None, None)
+        self.assertIn("--csr will not be renewed", self._output())
+
+    def test_manual_no_hook_renewal(self):
+        """--manual without a hook requires manual renewal"""
+        self.config.authenticator = "manual"
+        self._call(self.config, None, None)
+        self.assertIn("--manual plugin requires", self._output())
+
+    def test_no_preconfigured_renewal(self):
+        """No --preconfigured-renewal needs manual cron setup"""
+        self.config.preconfigured_renewal = False
+        self._call(self.config, None, None)
+        self.assertIn("https://certbot.org/renewal-setup", self._output())
+
 
 class UpdateAccountTest(test_util.ConfigTestCase):
     """Tests for certbot._internal.main.update_account"""

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1958,7 +1958,7 @@ class ReportNextStepsTest(unittest.TestCase):
         """--manual without a hook requires manual renewal"""
         self.config.authenticator = "manual"
         self._call(self.config, None, None)
-        self.assertIn("--manual plugin requires", self._output())
+        self.assertIn("--manual certificates requires", self._output())
 
     def test_no_preconfigured_renewal(self):
         """No --preconfigured-renewal needs manual cron setup"""


### PR DESCRIPTION
1. Don't print that the certificate will be automatically renewed,
because it won't be.
2. Add a "NEXT STEP" telling the user that they will need to manually
re-issue the certificate in order to renew it.

---

Fixes #8913.

This isn't *all* the CLI work we need to do around this, but it's a good start and makes sense on its own.

Manual (Hookless) has a "NEXT STEP" and no longer says anything about autorenewal where the certificate is reported:

![image](https://user-images.githubusercontent.com/311534/122481722-93a53a80-d012-11eb-9708-451d70c2901e.png)

Manual (With Hook) is unchanged:

![image](https://user-images.githubusercontent.com/311534/122319289-c3e1d000-cf63-11eb-8a7c-345a2d36d55f.png)

Here is everything firing at once (`preconfigured-renewal=False` here, but the message is not printed because the `--manual` "NEXT STEP" masks it in the logic):

![image](https://user-images.githubusercontent.com/311534/122481828-c5b69c80-d012-11eb-8dce-4c10b549d645.png)

