### PR TITLE
Improve standalone errors

### DIFF
--- a/certbot/certbot/_internal/plugins/standalone.py
+++ b/certbot/certbot/_internal/plugins/standalone.py
@@ -5,6 +5,7 @@ import logging
 import socket
 from typing import DefaultDict
 from typing import Dict
+from typing import List
 from typing import Set
 from typing import Tuple
 from typing import TYPE_CHECKING
@@ -183,6 +184,14 @@ class Authenticator(common.Plugin):
         for port, servers in self.servers.running().items():
             if not self.served[servers]:
                 self.servers.stop(port)
+
+    def auth_hint(self, failed_achalls: List[achallenges.AnnotatedChallenge]) -> str:
+        port, addr = self.config.http01_port, self.config.http01_address
+        neat_addr = f"{addr}:{port}" if addr else f"port {port}"
+        return ("The Certificate Authority failed to download the challenge files from "
+                f"the temporary standalone webserver started by Certbot on {neat_addr}. "
+                "Ensure that the listed domains point to this machine and that it can "
+                "accept inbound connections from the internet.")
 
 
 def _handle_perform_error(error):

--- a/certbot/tests/plugins/standalone_test.py
+++ b/certbot/tests/plugins/standalone_test.py
@@ -177,6 +177,13 @@ class AuthenticatorTest(unittest.TestCase):
             "server1": set(), "server2": set()})
         self.auth.servers.stop.assert_called_with(2)
 
+    def test_auth_hint(self):
+        self.config.http01_port = "80"
+        self.config.http01_address = None
+        self.assertIn("on port 80", self.auth.auth_hint([]))
+        self.config.http01_address = "127.0.0.1"
+        self.assertIn("on 127.0.0.1:80", self.auth.auth_hint([]))
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
There's two changes here:

1. Add an authenticator hint for the standalone plugin, which we forgot to add. It looks like this: ![image](https://user-images.githubusercontent.com/311534/122629426-41424780-d100-11eb-8676-ee0b1b664cca.png)
2. Restores [this functionality](https://github.com/certbot/certbot/blob/bc7c953bcc53fe231b720e2591dcc9278fe3f09e/certbot/certbot/_internal/plugins/standalone.py#L188-L207) in the standalone plugin which is supposed to provide friendly error messages for `EACCES` and `EADDRINUSE`. It seems that this functionality was accidentally lost [during a change to `acme.standalone` a long time ago](https://github.com/certbot/certbot/pull/4773). We go from seeing a very generic error message in `master`: ![image](https://user-images.githubusercontent.com/311534/122629589-7a2eec00-d101-11eb-80a8-404484317712.png) to much more actionable: ![image](https://user-images.githubusercontent.com/311534/122629603-8dda5280-d101-11eb-9010-490dde915aaf.png) and: ![image](https://user-images.githubusercontent.com/311534/122629616-af3b3e80-d101-11eb-90cf-839586f2e0fd.png)





I suggest merging this PR instead of squashing it.

Fixes #8887.