### PR TITLE
Do not guess HTTP-01 response encoding

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -316,11 +316,11 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
             return False
         # By default, http_response.text will try to guess the encoding to use
         # when decoding the response to Python unicode strings. This guesswork
-        # is error prone and since RFC 8555 specifies that key authorizations
-        # (which is the expected response for HTTP-01 challenges) are composed
-        # entirely of the base64 alphabet plus ".", we tell requests that the
-        # response should be ASCII. See
-        # https://datatracker.ietf.org/doc/html/rfc8555#section-8.1 for more
+        # is error prone. RFC 8555 specifies that HTTP-01 responses should be
+        # key authorizations with possible trailing whitespace. Since key
+        # authorizations must be composed entirely of the base64url alphabet
+        # plus ".", we tell requests that the response should be ASCII. See
+        # https://datatracker.ietf.org/doc/html/rfc8555#section-8.3 for more
         # info.
         http_response.encoding = "ascii"
         logger.debug("Received %s: %s. Headers: %s", http_response,

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -314,6 +314,15 @@ class HTTP01Response(KeyAuthorizationChallengeResponse):
         except requests.exceptions.RequestException as error:
             logger.error("Unable to reach %s: %s", uri, error)
             return False
+        # By default, http_response.text will try to guess the encoding to use
+        # when decoding the response to Python unicode strings. This guesswork
+        # is error prone and since RFC 8555 specifies that key authorizations
+        # (which is the expected response for HTTP-01 challenges) are composed
+        # entirely of the base64 alphabet plus ".", we tell requests that the
+        # response should be ASCII. See
+        # https://datatracker.ietf.org/doc/html/rfc8555#section-8.1 for more
+        # info.
+        http_response.encoding = "ascii"
         logger.debug("Received %s: %s. Headers: %s", http_response,
                      http_response.text, http_response.headers)
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,11 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* When self-validating HTTP-01 challenges using
+  acme.challenges.HTTP01Response.simple_verify, we now assume that the response
+  is composed of only ASCII characters. Previously we were relying on the
+  default behavior of the requests library which tries to guess the encoding of
+  the response which was error prone.
 
 ### Fixed
 


### PR DESCRIPTION
As described at https://docs.python-requests.org/en/master/user/quickstart/#response-content, by default requests tries to guess the encoding used on responses. In requests' release yesterday, they changed the library used by default for this guesswork. See https://github.com/psf/requests/blob/a1a6a549a0143d9b32717dbe3d75cd543ae5a4f6/HISTORY.md#2260-2021-07-13. This broke some of our tests which you can see at https://dev.azure.com/certbot/certbot/_build/results?buildId=4264&view=logs&j=480f82d6-f9f6-59af-7738-86a19d01c5b2&t=5526b0e6-8a49-58bf-13ee-a4ead6820134.

This PR fixes those failures. You can see the unpinned tests passing at https://dev.azure.com/certbot/certbot/_build/results?buildId=4266&view=results.