### PR TITLE
delete: add a warning about safe deletion

### DIFF
--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -93,6 +93,12 @@ def delete(config):
     msg = ["The following certificate(s) are selected for deletion:\n"]
     for certname in certnames:
         msg.append("  * " + certname)
+    msg.append(
+        "\nWARNING: Before continuing, ensure that the listed certificates are not being used "
+        "by any installed server software (e.g. Apache, nginx, mail servers). Deleting a "
+        "certificate that is still being used will cause the server software to stop working. "
+        "See https://certbot.org/deleting-certs for information on deleting certificates safely."
+    )
     msg.append("\nAre you sure you want to delete the above certificate(s)?")
     if not display_util.yesno("\n".join(msg), default=True):
         logger.info("Deletion of certificate(s) canceled.")


### PR DESCRIPTION
----

Replaces #8909. I/we came to the conclusion that automatic detection on a best-effort basis ended up feeling very wishy-washy, and also attracted a high technical cost. It seems more sensible to address this via a warning and documentation.

Fixes #6734.
Fixes #8755.

Don't merge until:

- [ ] #8910 (documentation) is merged
- [ ] the website submodule is updated and site republished
- [ ] the shortlink is created

![image](https://user-images.githubusercontent.com/311534/126575236-18d1d012-8792-4c1d-911c-08a6d8aea309.png)
