### PR TITLE
snap: workaround for snapctl crash in plugin hook

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -27,6 +27,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * The Apache authenticator no longer crashes with "Unable to insert label"
   when encountering a completely empty vhost. This issue affected Certbot 1.17.0.
+* Users of the Certbot snap on Debian 9 (Stretch) should no longer encounter an
+  "access denied" error when installing DNS plugins.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/snap/hooks/prepare-plug-plugin
+++ b/snap/hooks/prepare-plug-plugin
@@ -1,8 +1,19 @@
 #!/bin/sh -e
 
-if [ "$(snapctl get trust-plugin-with-root)" = "ok" ]; then
+# Workaround for a very old snapctl binary on the host connecting to the wrong socket and crashing.
+# Prefer an up-to-date snapctl from the core or snapd snaps, if they exist. We ask users to install
+# the core snap in the Certbot installation instructions.
+# See https://github.com/certbot/certbot/issues/8922, https://bugs.launchpad.net/snapd/+bug/1933392
+SNAPCTL="snapctl"
+if [ -x "/snap/core/current/usr/bin/snapctl" ]; then
+    SNAPCTL="/snap/core/current/usr/bin/snapctl"
+elif [ -x "/snap/snapd/current/usr/bin/snapctl" ]; then
+    SNAPCTL="/snap/snapd/current/usr/bin/snapctl"
+fi
+
+if [ "$($SNAPCTL get trust-plugin-with-root)" = "ok" ]; then
     # allow the connection, but reset config to allow for other slots to go through this auth flow
-    snapctl unset trust-plugin-with-root
+    $SNAPCTL unset trust-plugin-with-root
     exit 0
 else
     echo "Only connect this interface if you trust the plugin author to have root on the system."

--- a/snap/hooks/prepare-plug-plugin
+++ b/snap/hooks/prepare-plug-plugin
@@ -4,11 +4,13 @@
 # Prefer an up-to-date snapctl from the core or snapd snaps, if they exist. We ask users to install
 # the core snap in the Certbot installation instructions.
 # See https://github.com/certbot/certbot/issues/8922, https://bugs.launchpad.net/snapd/+bug/1933392
+SNAPCTL_CORE="/snap/core/current/usr/bin/snapctl"
+SNAPCTL_SNAPD="/snap/snapd/current/usr/bin/snapctl"
 SNAPCTL="snapctl"
-if [ -x "/snap/core/current/usr/bin/snapctl" ]; then
-    SNAPCTL="/snap/core/current/usr/bin/snapctl"
-elif [ -x "/snap/snapd/current/usr/bin/snapctl" ]; then
-    SNAPCTL="/snap/snapd/current/usr/bin/snapctl"
+if $SNAPCTL_CORE get x 2>/dev/null; then
+    SNAPCTL=$SNAPCTL_CORE
+elif $SNAPCTL_SNAPD get x 2>/dev/null; then
+    SNAPCTL=$SNAPCTL_SNAPD
 fi
 
 if [ "$($SNAPCTL get trust-plugin-with-root)" = "ok" ]; then


### PR DESCRIPTION
For #8922.

----

This implements a workaround similar to what is suggested at https://bugs.launchpad.net/snapd/+bug/1933392/comments/5 but this is a little bit simpler. 

The idea is that it will prioritize using `snapctl` from the `core` snap if that's available, otherwise from the`snapd` snap if it exists, and finally falling back to whatever it can find in the `PATH` (the old behavior).

I am mindful that this might go sideways, if on some systems,`snapctl` on the host works but the one in `core`/`snapd` doesn't, but it doesn't seem like a realistic concern.

I tested this on Debian Stretch and CentOS 7 (with and without installing the core snap first).