### PR TITLE
Update snapcraft.cfg comment

### DIFF
--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -19,11 +19,12 @@ stages:
       # Then the file was added as a secure file in Azure pipelines
       # with the name snapcraft.cfg by following the instructions at
       # https://docs.microsoft.com/en-us/azure/devops/pipelines/library/secure-files?view=azure-devops
-      # including authorizing the file in all pipelines as described at
-      # https://docs.microsoft.com/en-us/azure/devops/pipelines/library/secure-files?view=azure-devops#how-do-i-authorize-a-secure-file-for-use-in-all-pipelines.
+      # including authorizing the file for use in the "nightly" and "release"
+      # pipelines as described at
+      # https://docs.microsoft.com/en-us/azure/devops/pipelines/library/secure-files?view=azure-devops#q-how-do-i-authorize-a-secure-file-for-use-in-a-specific-pipeline.
       #
       # This file has a maximum lifetime of one year and the current
-      # file will expire on 2021-07-28 which is also tracked by
+      # file will expire on 2022-07-25 which is also tracked by
       # https://github.com/certbot/certbot/issues/7931. The file will
       # need to be updated before then to prevent automated deploys
       # from breaking.


### PR DESCRIPTION
You can see tests failing with expired credentials [here](https://dev.azure.com/certbot/certbot/_build/results?buildId=4343&view=logs&j=699632ed-b021-590a-8a14-17dad7b1e5b1&s=d729f409-812a-53bb-6569-db2db02f2e2c&t=ec46547f-7bb2-52f7-2cfc-3246f328135f&l=12) and them passing last night with the new credentials [here](https://dev.azure.com/certbot/certbot/_build/results?buildId=4353&view=results).

I already updated the referenced GitHub issue.