### PR TITLE
Make display classes implement IDisplay

### DIFF
--- a/certbot/certbot/_internal/display/obj.py
+++ b/certbot/certbot/_internal/display/obj.py
@@ -33,6 +33,9 @@ class _DisplayService:
 _SERVICE = _DisplayService()
 
 
+# This use of IDisplay can be removed when this class is no longer accessible
+# through the public API in certbot.display.util.
+@zope.interface.implementer(interfaces.IDisplay)
 class FileDisplay:
     """File-based display."""
     # see https://github.com/certbot/certbot/issues/3915
@@ -381,6 +384,9 @@ class FileDisplay:
         return util.OK, selection
 
 
+# This use of IDisplay can be removed when this class is no longer accessible
+# through the public API in certbot.display.util.
+@zope.interface.implementer(interfaces.IDisplay)
 class NoninteractiveDisplay:
     """An iDisplay implementation that never asks for interactive user input"""
 


### PR DESCRIPTION
If from the root of our repo on our `master` branch you activate our dev env and run:
```
git checkout v1.17.0 certbot-apache
rm pytest.ini  # To avoid errors about deprecation warnings
pytest certbot-apache
```
Many tests fail because these classes no longer implement a zope interface.

If you do the same on this branch, the only tests that should fail are in `certbot-apache/tests/debian_test.py` which fail due to the problem described [here](https://github.com/certbot/certbot/pull/8835#discussion_r645687370) which I personally don't think we should worry about.