### PR TITLE
Fix egg-info cleanup

### DIFF
--- a/tools/pinning/common/export-pinned-dependencies.sh
+++ b/tools/pinning/common/export-pinned-dependencies.sh
@@ -29,7 +29,7 @@ fi
 # Old eggs can cause outdated dependency information to be used by poetry so we
 # delete them before generating the lock file. See
 # https://github.com/python-poetry/poetry/issues/4103 for more info.
-rm -rf ${REPO_ROOT}/*.egg-info
+rm -rf ${REPO_ROOT}/*/*.egg-info
 
 cd "${WORK_DIR}"
 


### PR DESCRIPTION
In https://github.com/certbot/certbot/pull/8934 I changed:
```
# Old eggs can cause outdated dependency information to be used by poetry so we
# delete them before generating the lock file. See
# https://github.com/python-poetry/poetry/issues/4103 for more info.
cd "${REPO_ROOT}"
rm -rf */*.egg-info
```
in the deleted  `tools/pinning/pin.sh` script to
```
# Old eggs can cause outdated dependency information to be used by poetry so we
# delete them before generating the lock file. See
# https://github.com/python-poetry/poetry/issues/4103 for more info.
rm -rf ${REPO_ROOT}/*.egg-info
```
in `tools/pinning/common/export-pinned-dependencies.sh`.

This wasn't right.