### PR TITLE
Reimplement zope interfaces into abc in compatibility tests

### DIFF
--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
@@ -4,8 +4,6 @@ import shutil
 import subprocess
 from unittest import mock
 
-import zope.interface
-
 from certbot import errors as le_errors, configuration
 from certbot import util as certbot_util
 from certbot_apache._internal import entrypoint
@@ -15,7 +13,6 @@ from certbot_compatibility_test import util
 from certbot_compatibility_test.configurators import common as configurators_common
 
 
-@zope.interface.implementer(interfaces.IConfiguratorProxy)
 class Proxy(configurators_common.Proxy):
     """A common base for Apache test configurators"""
 

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/apache/common.py
@@ -8,7 +8,6 @@ from certbot import errors as le_errors, configuration
 from certbot import util as certbot_util
 from certbot_apache._internal import entrypoint
 from certbot_compatibility_test import errors
-from certbot_compatibility_test import interfaces
 from certbot_compatibility_test import util
 from certbot_compatibility_test.configurators import common as configurators_common
 

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
@@ -4,8 +4,10 @@ import logging
 import os
 import shutil
 import tempfile
+from typing import Optional
 
 from certbot._internal import constants
+from certbot.interfaces import Plugin
 from certbot_compatibility_test import interfaces
 from certbot_compatibility_test import errors
 from certbot_compatibility_test import util
@@ -22,6 +24,7 @@ class Proxy(interfaces.ConfiguratorProxy):
 
     def __init__(self, args):
         """Initializes the plugin with the given command line args"""
+        super().__init__(args)
         self._temp_dir = tempfile.mkdtemp()
         # tempfile.mkdtemp() creates folders with too restrictive permissions to be accessible
         # to an Apache worker, leading to HTTP challenge failures. Let's fix that.
@@ -35,7 +38,7 @@ class Proxy(interfaces.ConfiguratorProxy):
         self.args = args
         self.http_port = 80
         self.https_port = 443
-        self._configurator = None
+        self._configurator: interfaces.Configurator
         self._all_names = None
         self._test_names = None
 

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
@@ -1,17 +1,19 @@
 """Provides a common base for configurator proxies"""
+from abc import abstractmethod
 import logging
 import os
 import shutil
 import tempfile
 
 from certbot._internal import constants
+from certbot_compatibility_test import interfaces
 from certbot_compatibility_test import errors
 from certbot_compatibility_test import util
 
 logger = logging.getLogger(__name__)
 
 
-class Proxy:
+class Proxy(interfaces.ConfiguratorProxy):
     """A common base for compatibility test configurators"""
 
     @classmethod
@@ -37,20 +39,11 @@ class Proxy:
         self._all_names = None
         self._test_names = None
 
-    def __getattr__(self, name):
-        """Wraps the configurator methods"""
-        if self._configurator is None:
-            raise AttributeError()
-
-        method = getattr(self._configurator, name, None)
-        if callable(method):
-            return method
-        raise AttributeError()
-
     def has_more_configs(self):
         """Returns true if there are more configs to test"""
         return bool(self._configs)
 
+    @abstractmethod
     def cleanup_from_tests(self):
         """Performs any necessary cleanup from running plugin tests"""
 
@@ -99,3 +92,47 @@ class Proxy:
             raise ValueError("Configurator plugin is not set.")
         self._configurator.deploy_cert(
             domain, cert_path, key_path, chain_path, fullchain_path)
+
+
+    def cleanup(self, achalls):
+        self._configurator.cleanup(achalls)
+
+    def config_test(self):
+        self._configurator.config_test()
+
+    def enhance(self, domain, enhancement, options = None):
+        self._configurator.enhance(domain, enhancement, options)
+
+    def get_all_names(self):
+        return self._configurator.get_all_names()
+
+    def get_chall_pref(self, domain):
+        return self._configurator.get_chall_pref(domain)
+
+    @classmethod
+    def inject_parser_options(cls, parser, name):
+        pass
+
+    def more_info(self):
+        return self._configurator.more_info()
+
+    def perform(self, achalls):
+        return self._configurator.perform(achalls)
+
+    def prepare(self):
+        self._configurator.prepare()
+
+    def recovery_routine(self):
+        self._configurator.recovery_routine()
+
+    def restart(self):
+        self._configurator.restart()
+
+    def rollback_checkpoints(self, rollback = 1):
+        self._configurator.rollback_checkpoints(rollback)
+
+    def save(self, title = None, temporary = False):
+        self._configurator.save(title, temporary)
+
+    def supported_enhancements(self):
+        return self._configurator.supported_enhancements()

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/common.py
@@ -4,10 +4,8 @@ import logging
 import os
 import shutil
 import tempfile
-from typing import Optional
 
 from certbot._internal import constants
-from certbot.interfaces import Plugin
 from certbot_compatibility_test import interfaces
 from certbot_compatibility_test import errors
 from certbot_compatibility_test import util

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/nginx/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/nginx/common.py
@@ -4,8 +4,6 @@ import shutil
 import subprocess
 from typing import Set
 
-import zope.interface
-
 from certbot import configuration
 from certbot_compatibility_test import errors
 from certbot_compatibility_test import interfaces
@@ -15,7 +13,6 @@ from certbot_nginx._internal import configurator
 from certbot_nginx._internal import constants
 
 
-@zope.interface.implementer(interfaces.IConfiguratorProxy)
 class Proxy(configurators_common.Proxy):
     """A common base for Nginx test configurators"""
 

--- a/certbot-compatibility-test/certbot_compatibility_test/configurators/nginx/common.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/configurators/nginx/common.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import subprocess
+from typing import cast
 from typing import Set
 
 from certbot import configuration
@@ -45,9 +46,12 @@ class Proxy(configurators_common.Proxy):
             setattr(self.le_config, "nginx_" + k, constants.os_constant(k))
 
         conf = configuration.NamespaceConfig(self.le_config)
-        self._configurator = configurator.NginxConfigurator(
-            config=conf, name="nginx")
+        self._configurator = cast(interfaces.Configurator, configurator.NginxConfigurator(
+            config=conf, name="nginx"))
         self._configurator.prepare()
+
+    def cleanup_from_tests(self):
+        """Performs any necessary cleanup from running plugin tests"""
 
 
 def _get_server_root(config):

--- a/certbot-compatibility-test/certbot_compatibility_test/interfaces.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/interfaces.py
@@ -2,17 +2,17 @@
 from abc import ABCMeta
 from abc import abstractmethod
 
-import certbot.interfaces
+from certbot import interfaces
 
 
-class PluginProxy(metaclass=ABCMeta):
+class PluginProxy(interfaces.Plugin, metaclass=ABCMeta):
     """Wraps a Certbot plugin"""
 
     http_port: int = NotImplemented
-    "The port to connect to on localhost for HTTP traffic"
+    """The port to connect to on localhost for HTTP traffic"""
 
     https_port: int = NotImplemented
-    "The port to connect to on localhost for HTTPS traffic"
+    """The port to connect to on localhost for HTTPS traffic"""
 
     @classmethod
     @abstractmethod
@@ -22,7 +22,7 @@ class PluginProxy(metaclass=ABCMeta):
     @abstractmethod
     def __init__(self, args):
         """Initializes the plugin with the given command line args"""
-        super().__init__()
+        super().__init__(args, 'proxy')
 
     @abstractmethod
     def cleanup_from_tests(self):  # type: ignore
@@ -45,11 +45,11 @@ class PluginProxy(metaclass=ABCMeta):
         """Returns the domain names that can be used in testing"""
 
 
-class AuthenticatorProxy(PluginProxy, certbot.interfaces.Authenticator, metaclass=ABCMeta):
+class AuthenticatorProxy(PluginProxy, interfaces.Authenticator, metaclass=ABCMeta):
     """Wraps a Certbot authenticator"""
 
 
-class InstallerProxy(PluginProxy, certbot.interfaces.Installer, metaclass=ABCMeta):
+class InstallerProxy(PluginProxy, interfaces.Installer, metaclass=ABCMeta):
     """Wraps a Certbot installer"""
 
     @abstractmethod
@@ -61,5 +61,5 @@ class ConfiguratorProxy(AuthenticatorProxy, InstallerProxy, metaclass=ABCMeta):
     """Wraps a Certbot configurator"""
 
 
-class Configurator(certbot.interfaces.Installer, certbot.interfaces.Authenticator):
+class Configurator(interfaces.Installer, interfaces.Authenticator, metaclass=ABCMeta):
     """Represents a plugin that has both Installer and Authenticator capabilities"""

--- a/certbot-compatibility-test/certbot_compatibility_test/interfaces.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/interfaces.py
@@ -1,26 +1,29 @@
 """Certbot compatibility test interfaces"""
-import zope.interface
+from abc import ABCMeta
+from abc import abstractmethod
 
 import certbot.interfaces
 
-# pylint: disable=no-self-argument,no-method-argument
 
-
-class IPluginProxy(zope.interface.Interface):  # pylint: disable=inherit-non-class
+class PluginProxy(metaclass=ABCMeta):
     """Wraps a Certbot plugin"""
 
-    http_port = zope.interface.Attribute(
-        "The port to connect to on localhost for HTTP traffic")
+    http_port = NotImplemented
+    "The port to connect to on localhost for HTTP traffic"
 
-    https_port = zope.interface.Attribute(
-        "The port to connect to on localhost for HTTPS traffic")
+    https_port = NotImplemented
+    "The port to connect to on localhost for HTTPS traffic"
 
+    @abstractmethod
     def add_parser_arguments(cls, parser):
         """Adds command line arguments needed by the parser"""
 
-    def __init__(args):  # pylint: disable=super-init-not-called
+    @abstractmethod
+    def __init__(args):
         """Initializes the plugin with the given command line args"""
+        super().__init__()
 
+    @abstractmethod
     def cleanup_from_tests():  # type: ignore
         """Performs any necessary cleanup from running plugin tests.
 
@@ -28,26 +31,30 @@ class IPluginProxy(zope.interface.Interface):  # pylint: disable=inherit-non-cla
 
         """
 
+    @abstractmethod
     def has_more_configs():  # type: ignore
         """Returns True if there are more configs to test"""
 
+    @abstractmethod
     def load_config():  # type: ignore
         """Loads the next config and returns its name"""
 
+    @abstractmethod
     def get_testable_domain_names():  # type: ignore
         """Returns the domain names that can be used in testing"""
 
 
-class IAuthenticatorProxy(IPluginProxy, certbot.interfaces.IAuthenticator):
+class AuthenticatorProxy(PluginProxy, certbot.interfaces.Authenticator):
     """Wraps a Certbot authenticator"""
 
 
-class IInstallerProxy(IPluginProxy, certbot.interfaces.IInstaller):
+class InstallerProxy(PluginProxy, certbot.interfaces.Installer):
     """Wraps a Certbot installer"""
 
+    @abstractmethod
     def get_all_names_answer():  # type: ignore
         """Returns all names that should be found by the installer"""
 
 
-class IConfiguratorProxy(IAuthenticatorProxy, IInstallerProxy):
+class ConfiguratorProxy(AuthenticatorProxy, InstallerProxy):
     """Wraps a Certbot configurator"""

--- a/certbot-compatibility-test/certbot_compatibility_test/interfaces.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/interfaces.py
@@ -8,23 +8,24 @@ import certbot.interfaces
 class PluginProxy(metaclass=ABCMeta):
     """Wraps a Certbot plugin"""
 
-    http_port = NotImplemented
+    http_port: int = NotImplemented
     "The port to connect to on localhost for HTTP traffic"
 
-    https_port = NotImplemented
+    https_port: int = NotImplemented
     "The port to connect to on localhost for HTTPS traffic"
 
+    @classmethod
     @abstractmethod
     def add_parser_arguments(cls, parser):
         """Adds command line arguments needed by the parser"""
 
     @abstractmethod
-    def __init__(args):
+    def __init__(self, args):
         """Initializes the plugin with the given command line args"""
         super().__init__()
 
     @abstractmethod
-    def cleanup_from_tests():  # type: ignore
+    def cleanup_from_tests(self):  # type: ignore
         """Performs any necessary cleanup from running plugin tests.
 
         This is guaranteed to be called before the program exits.
@@ -32,29 +33,33 @@ class PluginProxy(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def has_more_configs():  # type: ignore
+    def has_more_configs(self):  # type: ignore
         """Returns True if there are more configs to test"""
 
     @abstractmethod
-    def load_config():  # type: ignore
+    def load_config(self):  # type: ignore
         """Loads the next config and returns its name"""
 
     @abstractmethod
-    def get_testable_domain_names():  # type: ignore
+    def get_testable_domain_names(self):  # type: ignore
         """Returns the domain names that can be used in testing"""
 
 
-class AuthenticatorProxy(PluginProxy, certbot.interfaces.Authenticator):
+class AuthenticatorProxy(PluginProxy, certbot.interfaces.Authenticator, metaclass=ABCMeta):
     """Wraps a Certbot authenticator"""
 
 
-class InstallerProxy(PluginProxy, certbot.interfaces.Installer):
+class InstallerProxy(PluginProxy, certbot.interfaces.Installer, metaclass=ABCMeta):
     """Wraps a Certbot installer"""
 
     @abstractmethod
-    def get_all_names_answer():  # type: ignore
+    def get_all_names_answer(self):  # type: ignore
         """Returns all names that should be found by the installer"""
 
 
-class ConfiguratorProxy(AuthenticatorProxy, InstallerProxy):
+class ConfiguratorProxy(AuthenticatorProxy, InstallerProxy, metaclass=ABCMeta):
     """Wraps a Certbot configurator"""
+
+
+class Configurator(certbot.interfaces.Installer, certbot.interfaces.Authenticator):
+    """Represents a plugin that has both Installer and Authenticator capabilities"""

--- a/certbot-compatibility-test/setup.py
+++ b/certbot-compatibility-test/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import find_packages
 from setuptools import setup
 
@@ -9,13 +7,7 @@ install_requires = [
     'certbot',
     'certbot-apache',
     'requests',
-    'zope.interface',
 ]
-
-if sys.version_info < (2, 7, 9):
-    # For secure SSL connexion with Python 2.7 (InsecurePlatformWarning)
-    install_requires.append('ndg-httpsclient')
-    install_requires.append('pyasn1')
 
 
 setup(


### PR DESCRIPTION
This PR is a follow-up of #8950, it reimplements the zope interfaces used in compatibility tests into abc.