### PR TITLE
Add `--cert-filter` option to filter out certain certificates when running `certbot certificates`

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,10 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* With the `--cert-filter` option you can now filter the output of
+  `certbot certificates`. Currently, this is limited to filtering out
+  or only showing staging certificates and filtering out or only showing
+  certain key types (RSA or ECDSA).
 
 ### Changed
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -83,7 +83,7 @@ def certificates(config):
                      ("norsa" in config.certfilter and key_type == "rsa")) or
                     (("ecdsa" in config.certfilter and key_type != "ecdsa") or
                      ("noecdsa" in config.certfilter and key_type == "ecdsa"))):
-                        parsed_certs.append(renewal_candidate)
+                parsed_certs.append(renewal_candidate)
         except Exception as e:  # pylint: disable=broad-except
             logger.warning("Renewal configuration file %s produced an "
                            "unexpected error: %s. Skipping.", renewal_file, e)

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -77,12 +77,15 @@ def certificates(config):
             renewal_candidate = storage.RenewableCert(renewal_file, config)
             crypto_util.verify_renewable_cert(renewal_candidate)
             key_type = renewal_candidate.private_key_type.lower()
+            renewable = renewal_candidate.should_autorenew()
             if not ((("staging" in config.certfilter and not renewal_candidate.is_test_cert) or
                      ("nostaging" in config.certfilter and renewal_candidate.is_test_cert)) or
                     (("rsa" in config.certfilter and key_type != "rsa") or
                      ("norsa" in config.certfilter and key_type == "rsa")) or
                     (("ecdsa" in config.certfilter and key_type != "ecdsa") or
-                     ("noecdsa" in config.certfilter and key_type == "ecdsa"))):
+                     ("noecdsa" in config.certfilter and key_type == "ecdsa")) or
+                    (("renewable" in config.certfilter and not renewable) or
+                     ("norenewable" in config.certfilter and renewable))):
                 parsed_certs.append(renewal_candidate)
         except Exception as e:  # pylint: disable=broad-except
             logger.warning("Renewal configuration file %s produced an "

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -76,7 +76,14 @@ def certificates(config):
         try:
             renewal_candidate = storage.RenewableCert(renewal_file, config)
             crypto_util.verify_renewable_cert(renewal_candidate)
-            parsed_certs.append(renewal_candidate)
+            key_type = renewal_candidate.private_key_type.lower()
+            if not ((("staging" in config.certfilter and not renewal_candidate.is_test_cert) or
+                     ("nostaging" in config.certfilter and renewal_candidate.is_test_cert)) or
+                    (("rsa" in config.certfilter and key_type != "rsa") or
+                     ("norsa" in config.certfilter and key_type == "rsa")) or
+                    (("ecdsa" in config.certfilter and key_type != "ecdsa") or
+                     ("noecdsa" in config.certfilter and key_type == "ecdsa"))):
+                        parsed_certs.append(renewal_candidate)
         except Exception as e:  # pylint: disable=broad-except
             logger.warning("Renewal configuration file %s produced an "
                            "unexpected error: %s. Skipping.", renewal_file, e)

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -23,6 +23,7 @@ from certbot._internal.cli.cli_utils import _DomainsAction
 from certbot._internal.cli.cli_utils import _EncodeReasonAction
 from certbot._internal.cli.cli_utils import _PrefChallAction
 from certbot._internal.cli.cli_utils import _RenewHookAction
+from certbot._internal.cli.cli_utils import _CertFilterAction
 from certbot._internal.cli.cli_utils import _user_agent_comment_type
 from certbot._internal.cli.cli_utils import add_domains
 from certbot._internal.cli.cli_utils import CaseInsensitiveList
@@ -414,6 +415,11 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         "renew", "--no-autorenew", action="store_false",
         default=flag_default("autorenew"), dest="autorenew",
         help="Disable auto renewal of certificates.")
+    helpful.add(
+        "certificates", "--cert-filter", dest="certfilter",
+        metavar="CERTFILTER", action=_CertFilterAction,
+        default=flag_default("certfilter"),
+        help="Filter to apply to the `certbot certificates` output.")
 
     # Deprecated arguments
     helpful.add_deprecated_argument("--os-packages-only", 0)

--- a/certbot/certbot/_internal/cli/cli_utils.py
+++ b/certbot/certbot/_internal/cli/cli_utils.py
@@ -213,6 +213,13 @@ class _RenewHookAction(argparse.Action):
         namespace.renew_hook = values
 
 
+class _CertFilterAction(argparse.Action):
+    """Action class for parsing certificate filters."""
+
+    def __call__(self, parser, namespace, filters, option_string=None):
+        namespace.certfilter = filters.casefold().split(",")
+
+
 def nonnegative_int(value):
     """Converts value to an int and checks that it is not negative.
 

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -76,6 +76,7 @@ CLI_DEFAULTS = dict(
     random_sleep_on_renew=True,
     eab_hmac_key=None,
     eab_kid=None,
+    certfilter=[],
 
     # Subparsers
     num=None,


### PR DESCRIPTION
Mainly just for personal use, but perhaps it might be an interesting function to certbot generally. Let me know what you think of this :)

Currently, only the options `staging`, `nostaging`, `rsa`, `norsa`, `ecdsa`, `noecdsa`, `renewable` and `norenewable` are available with their obvious function.

Todo:
- [ ] Tests
- [ ] Perhaps put all the ugly `(..) or (..)` in a nice function
- [ ] Make it possible to select multiple key types without being mutually exclusive. I.e.: currently `rsa,ecdsa` will show *no* certs, as `rsa` filters out every non-RSA key type and `ecdsa` filters out every non-ECDSA key types, resulting in no certificates at all. It would be nice if `rsa,ecdsa` would filter out everything *but* both, e.g., just filter out EdDSA certs. Note: this is only usefull if there would be three key types possible at all, so no rush I guess..