### PR TITLE
acme: move setuptools from install_requires to setup_requires

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -20,7 +20,6 @@ install_requires = [
     'pytz',
     'requests>=2.14.2',
     'requests-toolbelt>=0.3.0',
-    'setuptools>=39.0.1',
 ]
 
 docs_extras = [
@@ -63,4 +62,5 @@ setup(
         'docs': docs_extras,
         'test': test_extras,
     },
+    setup_requires=['setuptools>=39.0.1'],
 )


### PR DESCRIPTION
## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.


Hi,

I didn't touch the changelog because I wasn't sure this was worth listing as the majority downstream consumers won't notice it. Please let me know if I need to add an entry there.

The change may also apply to other components. Generally speaking, I don't think any of the code needs setuptools at runtime, it is just required during installation.