### PR TITLE
Remove outdated example

### DIFF
--- a/acme/examples/standalone/README
+++ b/acme/examples/standalone/README
@@ -1,2 +1,0 @@
-python -m acme.standalone -p 1234
-curl -k https://localhost:1234

--- a/acme/examples/standalone/localhost/cert.pem
+++ b/acme/examples/standalone/localhost/cert.pem
@@ -1,1 +1,0 @@
-../../../acme/testdata/rsa2048_cert.pem

--- a/acme/examples/standalone/localhost/key.pem
+++ b/acme/examples/standalone/localhost/key.pem
@@ -1,1 +1,0 @@
-../../../acme/testdata/rsa2048_key.pem


### PR DESCRIPTION
There are a couple problems with these files.

1. `python -m acme.standalone` from the README hasn't worked since https://github.com/certbot/certbot/pull/7483.
2. The symlinks for the PEM files have been broken since https://github.com/certbot/certbot/pull/7600.

Because of this and the fact [these example files are causing snap build failures](https://dev.azure.com/certbot/certbot/_build/results?buildId=4395&view=logs&j=f44d40a4-7318-5ffe-762c-ae4557889284&t=07786725-57f8-5198-4d13-ea77f640bd5c&l=78), let's delete it.