### PR TITLE
Cleanup some useless type ignore directives

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -7,10 +7,10 @@ import logging
 import socket
 from typing import Type
 
-from cryptography.hazmat.primitives import hashes  # type: ignore
+from cryptography.hazmat.primitives import hashes
 import josepy as jose
 from OpenSSL import crypto
-from OpenSSL import SSL  # type: ignore # https://github.com/python/typeshed/issues/2052
+from OpenSSL import SSL
 import requests
 
 from acme import crypto_util

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -11,7 +11,7 @@ from typing import Union
 
 import josepy as jose
 from OpenSSL import crypto
-from OpenSSL import SSL  # type: ignore # https://github.com/python/typeshed/issues/2052
+from OpenSSL import SSL
 
 from acme import errors
 
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 # https://www.openssl.org/docs/ssl/SSLv23_method.html). _serve_sni
 # should be changed to use "set_options" to disable SSLv2 and SSLv3,
 # in case it's used for things other than probing/serving!
-_DEFAULT_SSL_METHOD = SSL.SSLv23_METHOD  # type: ignore
+_DEFAULT_SSL_METHOD = SSL.SSLv23_METHOD
 
 
 class _DefaultCertSelection:
@@ -169,7 +169,7 @@ def probe_sni(name, host, port=443, timeout=300, # pylint: disable=too-many-argu
             ) if any(source_address) else ""
         )
         socket_tuple: Tuple[str, int] = (host, port)
-        sock = socket.create_connection(socket_tuple, **socket_kwargs)  # type: ignore
+        sock = socket.create_connection(socket_tuple, **socket_kwargs)
     except socket.error as error:
         raise errors.Error(error)
 

--- a/acme/acme/magic_typing.py
+++ b/acme/acme/magic_typing.py
@@ -6,7 +6,7 @@ available. This code is being kept for now for backwards compatibility.
 """
 import warnings
 from typing import *  # pylint: disable=wildcard-import, unused-wildcard-import
-from typing import Collection, IO  # type: ignore
+from typing import Collection, IO
 
 warnings.warn("acme.magic_typing is deprecated and will be removed in a future release.",
               DeprecationWarning)

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -126,7 +126,7 @@ class Error(jose.JSONObjectWithFields, errors.Error):
             if part is not None).decode()
 
 
-class _Constant(jose.JSONDeSerializable, Hashable):  # type: ignore
+class _Constant(jose.JSONDeSerializable, Hashable):
     """ACME constant."""
     __slots__ = ('name',)
     POSSIBLE_NAMES: Dict[str, '_Constant'] = NotImplemented

--- a/certbot-compatibility-test/certbot_compatibility_test/interfaces.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/interfaces.py
@@ -25,7 +25,7 @@ class PluginProxy(interfaces.Plugin, metaclass=ABCMeta):
         super().__init__(args, 'proxy')
 
     @abstractmethod
-    def cleanup_from_tests(self):  # type: ignore
+    def cleanup_from_tests(self):
         """Performs any necessary cleanup from running plugin tests.
 
         This is guaranteed to be called before the program exits.
@@ -33,15 +33,15 @@ class PluginProxy(interfaces.Plugin, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def has_more_configs(self):  # type: ignore
+    def has_more_configs(self):
         """Returns True if there are more configs to test"""
 
     @abstractmethod
-    def load_config(self):  # type: ignore
+    def load_config(self):
         """Loads the next config and returns its name"""
 
     @abstractmethod
-    def get_testable_domain_names(self):  # type: ignore
+    def get_testable_domain_names(self):
         """Returns the domain names that can be used in testing"""
 
 
@@ -53,7 +53,7 @@ class InstallerProxy(PluginProxy, interfaces.Installer, metaclass=ABCMeta):
     """Wraps a Certbot installer"""
 
     @abstractmethod
-    def get_all_names_answer(self):  # type: ignore
+    def get_all_names_answer(self):
         """Returns all names that should be found by the installer"""
 
 

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -458,7 +458,7 @@ def set_by_cli(var):
         detector = set_by_cli.detector = prepare_and_parse_args(  # type: ignore
             plugins, reconstructed_args, detect_defaults=True)
         # propagate plugin requests: eg --standalone modifies config.authenticator
-        detector.authenticator, detector.installer = (  # type: ignore
+        detector.authenticator, detector.installer = (
             plugin_selection.cli_plugin_requests(detector))
 
     if not isinstance(getattr(detector, var), _Default):

--- a/certbot/certbot/_internal/client.py
+++ b/certbot/certbot/_internal/client.py
@@ -6,8 +6,7 @@ from typing import List, Optional, Union
 import warnings
 
 from cryptography.hazmat.backends import default_backend
-# See https://github.com/pyca/cryptography/issues/4275
-from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key  # type: ignore
+from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
 import josepy as jose
 import OpenSSL
 

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1382,7 +1382,7 @@ def renew_cert(config, plugins, lineage):
         # In case of a renewal, reload server to pick up new certificate.
         updater.run_renewal_deployer(config, renewed_lineage, installer)
         display_util.notify(f"Reloading {config.installer} server after certificate renewal")
-        installer.restart() # type: ignore
+        installer.restart()
 
 
 def certonly(config, plugins):

--- a/certbot/certbot/_internal/plugins/disco.py
+++ b/certbot/certbot/_internal/plugins/disco.py
@@ -148,9 +148,7 @@ class PluginEntryPoint:
             raise ValueError("Plugin is not initialized.")
         if self._prepared is None:
             try:
-                # TODO: remove type ignore once the interface becomes a proper
-                #  abstract class (using abc) that mypy understands.
-                self._initialized.prepare()  # type: ignore
+                self._initialized.prepare()
             except errors.MisconfigurationError as error:
                 logger.debug("Misconfigured %r: %s", self, error, exc_info=True)
                 self._prepared = error

--- a/certbot/certbot/compat/filesystem.py
+++ b/certbot/certbot/compat/filesystem.py
@@ -166,10 +166,7 @@ def check_owner(file_path: str) -> bool:
     :return: True if given file is owned by current user, False otherwise.
     """
     if POSIX_MODE:
-        # On Windows, os.getuid does not exist. This is checked through POSIX_MODE value,
-        # but MyPy/PyLint does not know it and raises an error here on Windows.
-        # We disable specifically the check to fix the issue.
-        return os.stat(file_path).st_uid == os.getuid()  # type: ignore
+        return os.stat(file_path).st_uid == os.getuid()
 
     # Get owner sid of the file
     security = win32security.GetFileSecurity(file_path, win32security.OWNER_SECURITY_INFORMATION)

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -11,8 +11,7 @@ from typing import List
 from typing import Set
 import warnings
 
-# See https://github.com/pyca/cryptography/issues/4275
-from cryptography import x509  # type: ignore
+from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
@@ -25,7 +24,7 @@ from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import NoEncryption
 from cryptography.hazmat.primitives.serialization import PrivateFormat
 from OpenSSL import crypto
-from OpenSSL import SSL  # type: ignore
+from OpenSSL import SSL
 import pyrfc3339
 import zope.component
 

--- a/certbot/certbot/ocsp.py
+++ b/certbot/certbot/ocsp.py
@@ -12,8 +12,7 @@ from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
-# See https://github.com/pyca/cryptography/issues/4275
-from cryptography.hazmat.primitives import hashes  # type: ignore
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 import pytz
 import requests

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -482,7 +482,7 @@ Those imports should look like this:
 .. code-block:: python
 
   from OpenSSL import crypto
-  from OpenSSL import SSL # type: ignore # https://github.com/python/typeshed/issues/2052
+  from OpenSSL import SSL
 
 .. _mypy: https://mypy.readthedocs.io
 .. _added in comments: https://mypy.readthedocs.io/en/latest/cheat_sheet.html

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -54,7 +54,7 @@ class PreArgParseSetupTest(unittest.TestCase):
             handler = call[0][0]
             if memory_handler is None and isinstance(handler, logging.handlers.MemoryHandler):
                 memory_handler = handler
-                target = memory_handler.target  # type: ignore
+                target = memory_handler.target
             else:
                 self.assertIsInstance(handler, logging.StreamHandler)
         self.assertIsInstance(target, logging.StreamHandler)

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -9,7 +9,7 @@ from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes  # type: ignore
+from cryptography.hazmat.primitives import hashes
 import pytz
 
 from certbot import errors

--- a/certbot/tests/reporter_test.py
+++ b/certbot/tests/reporter_test.py
@@ -16,7 +16,7 @@ class ReporterTest(unittest.TestCase):
         from certbot._internal import reporter
         self.reporter = reporter.Reporter(mock.MagicMock(quiet=False))
 
-        self.old_stdout = sys.stdout  # type: ignore
+        self.old_stdout = sys.stdout
         sys.stdout = io.StringIO()
 
     def tearDown(self):
@@ -25,32 +25,32 @@ class ReporterTest(unittest.TestCase):
     def test_multiline_message(self):
         self.reporter.add_message("Line 1\nLine 2", self.reporter.LOW_PRIORITY)
         self.reporter.print_messages()
-        output = sys.stdout.getvalue()  # type: ignore
+        output = sys.stdout.getvalue()
         self.assertIn("Line 1\n", output)
         self.assertIn("Line 2", output)
 
     def test_tty_print_empty(self):
-        sys.stdout.isatty = lambda: True  # type: ignore
+        sys.stdout.isatty = lambda: True
         self.test_no_tty_print_empty()
 
     def test_no_tty_print_empty(self):
         self.reporter.print_messages()
-        self.assertEqual(sys.stdout.getvalue(), "")  # type: ignore
+        self.assertEqual(sys.stdout.getvalue(), "")
         try:
             raise ValueError
         except ValueError:
             self.reporter.print_messages()
-        self.assertEqual(sys.stdout.getvalue(), "")  # type: ignore
+        self.assertEqual(sys.stdout.getvalue(), "")
 
     def test_tty_successful_exit(self):
-        sys.stdout.isatty = lambda: True  # type: ignore
+        sys.stdout.isatty = lambda: True
         self._successful_exit_common()
 
     def test_no_tty_successful_exit(self):
         self._successful_exit_common()
 
     def test_tty_unsuccessful_exit(self):
-        sys.stdout.isatty = lambda: True  # type: ignore
+        sys.stdout.isatty = lambda: True
         self._unsuccessful_exit_common()
 
     def test_no_tty_unsuccessful_exit(self):
@@ -59,7 +59,7 @@ class ReporterTest(unittest.TestCase):
     def _successful_exit_common(self):
         self._add_messages()
         self.reporter.print_messages()
-        output = sys.stdout.getvalue()  # type: ignore
+        output = sys.stdout.getvalue()
         self.assertIn("IMPORTANT NOTES:", output)
         self.assertIn("High", output)
         self.assertIn("Med", output)
@@ -71,7 +71,7 @@ class ReporterTest(unittest.TestCase):
             raise ValueError
         except ValueError:
             self.reporter.print_messages()
-        output = sys.stdout.getvalue()  # type: ignore
+        output = sys.stdout.getvalue()
         self.assertIn("IMPORTANT NOTES:", output)
         self.assertIn("High", output)
         self.assertNotIn("Med", output)

--- a/tests/lock_test.py
+++ b/tests/lock_test.py
@@ -12,9 +12,7 @@ import tempfile
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-# TODO: once mypy has cryptography types bundled, type: ignore can be removed.
-# See https://github.com/pyca/cryptography/issues/4275
-from cryptography.hazmat.primitives import hashes  # type: ignore
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 


### PR DESCRIPTION
With the recent upgrades of mypy, types and migration of interfaces on ABC, some `# type: ignore` directives are not useful anymore, and some other were not useful in the first place. This PR removes these directives.