### PR TITLE
certbot-dns-rfc2136: catch error when a hostname is being used for `dns_rfc2136_server`

### DIFF
--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
@@ -33,7 +33,7 @@ different to HMAC-MD5.
    :name: credentials.ini
    :caption: Example credentials file:
 
-   # Target DNS server
+   # Target DNS server (IPv4 or IPv6 address, not a hostname)
    dns_rfc2136_server = 192.0.2.1
    # Target DNS port
    dns_rfc2136_port = 53

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/dns_rfc2136.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/dns_rfc2136.py
@@ -212,6 +212,9 @@ class _RFC2136Client:
         try:
             try:
                 response = dns.query.tcp(request, self.server, self._default_timeout, self.port)
+            except ValueError:
+                raise errors.PluginError('Please enter an IP address for the `dns_rfc2136_server` '
+                                         'option instead of a hostname.')
             except (OSError, dns.exception.Timeout) as e:
                 logger.debug('TCP query failed, fallback to UDP: %s', e)
                 response = dns.query.udp(request, self.server, self._default_timeout, self.port)

--- a/certbot-dns-rfc2136/tests/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/tests/dns_rfc2136_test.py
@@ -74,6 +74,27 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
         self.auth.perform([self.achall])
 
+    def test_invalid_server_raises(self):
+        config = VALID_CONFIG.copy()
+        config["rfc2136_server"] = "example.com"
+        dns_test_common.write(config, self.config.rfc2136_credentials)
+
+        self.assertRaises(errors.PluginError,
+                          self.auth.perform,
+                          [self.achall])
+
+    @test_util.patch_display_util()
+    def test_valid_server_passes(self, unused_mock_get_utility):
+        config = VALID_CONFIG.copy()
+        dns_test_common.write(config, self.config.rfc2136_credentials)
+
+        self.auth.perform([self.achall])
+
+        config["rfc2136_server"] = "2001:db8:3333:4444:cccc:dddd:eeee:ffff"
+        dns_test_common.write(config, self.config.rfc2136_credentials)
+
+        self.auth.perform([self.achall])
+
 
 class RFC2136ClientTest(unittest.TestCase):
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* The certbot-dns-rfc2136 plugin always assumed the use of an IP address as the
+  target server, but this was never checked. Until now. The plugin raises an error
+  if the configured target server is not a valid IPv4 or IPv6 address.
 
 ### Changed
 


### PR DESCRIPTION
Currently, if a hostname is used for `dns_rfc2136_server`, dnspython raises a `dns.exception.SyntaxError` internally in `ipv4.py` which is propogated to certbot-dns-rfc2136 through a `ValueError` in `inet.py`. Previously, this was catched by the generic exception at the end of `_query_soa()` without providing much information to the user.

This small PR adds a separate check for the `ValueError` raised by dnspython when a hostname has been entered instead of the required IP address. You can see in the [dns.query.tcp() documentation](https://dnspython.readthedocs.io/en/latest/query.html#tcp) an IP address is required.

I thought about adding a test for this, but I was unsure on how to proceed: in the current `dns_rfc2136_test.py` the `dns.query.tcp()` function is mocked out and consequently hardcoding a mocked exception and checking for that same exception doesn't make much sense to me..

Sort of fixes #7295 ?