### PR TITLE
Remove zope from plugin example

### DIFF
--- a/certbot/examples/plugins/setup.py
+++ b/certbot/examples/plugins/setup.py
@@ -5,7 +5,6 @@ setup(
     package='certbot_example_plugins.py',
     install_requires=[
         'certbot',
-        'zope.interface',
     ],
     entry_points={
         'certbot.plugins': [


### PR DESCRIPTION
I noticed this while reviewing https://github.com/certbot/certbot/pull/8997 and figured we could save an iteration on a PR by just fixing it myself while I'm here as opposed to me asking Adrien to make the change and reviewing the change again later.