### PR TITLE
Update oldest pyproject.toml comments

### DIFF
--- a/tools/pinning/oldest/pyproject.toml
+++ b/tools/pinning/oldest/pyproject.toml
@@ -35,7 +35,7 @@ certbot = {path = "../../../certbot", extras = ["test"]}
 acme = {path = "../../../acme", extras = ["test"]}
 
 # Oldest dependencies
-# We specify the oldest versions our dependencies that we're trying to keep
+# We specify the oldest versions of our dependencies that we keep
 # support for below. We should only update these packages as needed to make use
 # of features in newer versions of our dependencies. Keeping compatibility with
 # older packages makes it much easier for OS maintainers to update their

--- a/tools/pinning/oldest/pyproject.toml
+++ b/tools/pinning/oldest/pyproject.toml
@@ -41,8 +41,8 @@ acme = {path = "../../../acme", extras = ["test"]}
 # older packages makes it much easier for OS maintainers to update their
 # Certbot packages if needed or desired.
 #
-# When updating these dependencies, we should ideally try to only update them
-# to the oldest version of the dependency found in CentOS/RHEL 8 + EPEL (or
+# When updating these dependencies, we should try to update them no further
+# than the oldest version of the dependency found in CentOS/RHEL 8 + EPEL (or
 # newer versions of CentOS/RHEL + EPEL) as our Certbot packages there see
 # frequent updates. If the dependency being updated is a direct dependency of
 # one of our own packages, the minimum required version of that dependency

--- a/tools/pinning/oldest/pyproject.toml
+++ b/tools/pinning/oldest/pyproject.toml
@@ -36,84 +36,59 @@ acme = {path = "../../../acme", extras = ["test"]}
 
 # Oldest dependencies
 # We specify the oldest versions our dependencies that we're trying to keep
-# support for below. Usually these version numbers are taken from the packages
-# of our dependencies available in popular LTS Linux distros. Keeping
-# compatibility with those versions makes it much easier for OS maintainers to
-# update their Certbot packages.
+# support for below. We should only update these packages as needed to make use
+# of features in newer versions of our dependencies. Keeping compatibility with
+# older packages makes it much easier for OS maintainers to update their
+# Certbot packages if needed or desired.
 #
 # When updating these dependencies, we should ideally try to only update them
-# to the oldest version of the dependency that is found in a non-EOL'd version
-# of CentOS, Debian, or Ubuntu that has Certbot packages in their OS
-# repositories using a version of Python we support. If the distro is EOL'd or
-# using a version of Python we don't support, it can be ignored. If the
-# dependency being updated is a direct dependency of one of our own packages,
-# the minimum required version of that dependency should be updated in our
-# setup.py files as well to communicate this information to our users.
+# to the oldest version of the dependency found in CentOS/RHEL 8 + EPEL (or
+# newer versions of CentOS/RHEL + EPEL) as our Certbot packages there see
+# frequent updates. If the dependency being updated is a direct dependency of
+# one of our own packages, the minimum required version of that dependency
+# should be updated in our setup.py files as well to communicate this
+# information to our users.
 
-# CentOS/RHEL 7 EPEL dependencies
-# Some of these dependencies may be stricter than necessary because they
-# initially referred to the Python 2 packages in CentOS/RHEL 7 with EPEL.
+ConfigArgParse = "0.10.0"
+apacheconfig = "0.3.2"
+asn1crypto = "0.24.0"
+boto3 = "1.4.7"
+botocore = "1.7.41"
 cffi = "1.9.1"
 chardet = "2.2.1"
+cloudflare = "1.5.1"
+configobj = "5.0.6"
+cryptography = "2.1.4"
+distro = "1.0.1"
+dns-lexicon = "3.2.1"
+funcsigs = "0.4"
+google-api-python-client = "1.5.5"
+httplib2 = "0.9.2"
+idna = "2.6"
 ipaddress = "1.0.16"
 mock = "1.0.1"
 ndg-httpsclient = "0.3.2"
+oauth2client = "4.0.0"
+parsedatetime = "2.4"
+pbr = "1.8.0"
 ply = "3.4"
 pyOpenSSL = "17.3.0"
+pyRFC3339 = "1.0"
 pyasn1 = "0.1.9"
 pycparser = "2.14"
-pyRFC3339 = "1.0"
+pyparsing = "2.2.0"
 python-augeas = "0.5.0"
-oauth2client = "4.0.0"
+python-digitalocean = "1.11"
+pytz = "2012rc0"
 requests = "2.14.2"
+setuptools = "39.0.1"
+six = "1.11.0"
 urllib3 = "1.10.2"
 # Package names containing "." need to be quoted.
 "zope.component" = "4.1.0"
 "zope.event" = "4.0.3"
-"zope.interface" = "4.0.5"
-
-# Debian Jessie Backports dependencies
-# Debian Jessie has reached end of life so these dependencies can probably be
-# updated as needed or desired.
-pbr = "1.8.0"
-pytz = "2012rc0"
-
-# Debian Buster dependencies
-google-api-python-client = "1.5.5"
-pyparsing = "2.2.0"
-
-# Our setup.py dependencies
-apacheconfig = "0.3.2"
-cloudflare = "1.5.1"
-python-digitalocean = "1.11"
-
-# Ubuntu Xenial dependencies
-# Ubuntu Xenial only has versions of Python which we do not support available
-# so these dependencies can probably be updated as needed or desired.
-ConfigArgParse = "0.10.0"
-funcsigs = "0.4"
-# Package names containing "." need to be quoted.
 "zope.hookable" = "4.0.4"
-
-# Ubuntu Bionic dependencies.
-cryptography = "2.1.4"
-distro = "1.0.1"
-httplib2 = "0.9.2"
-idna = "2.6"
-setuptools = "39.0.1"
-six = "1.11.0"
-
-# Ubuntu Focal dependencies
-asn1crypto = "0.24.0"
-configobj = "5.0.6"
-parsedatetime = "2.4"
-
-# Plugin dependencies
-# These aren't necessarily the oldest versions we need to support
-# Tracking at https://github.com/certbot/certbot/issues/6473
-boto3 = "1.4.7"
-botocore = "1.7.41"
-dns-lexicon = "3.2.1"
+"zope.interface" = "4.0.5"
 
 # Build dependencies
 # Since there doesn't appear to


### PR DESCRIPTION
I think this fixes https://github.com/certbot/certbot/issues/8956.

I updated the comment based on the Mattermost discussion linked in the issue and put all oldest dependencies in a single section because we're no longer tracking things for other distros.