### PR TITLE
Unpin pip used in the oldest tests

### DIFF
--- a/tools/oldest_constraints.txt
+++ b/tools/oldest_constraints.txt
@@ -2,9 +2,10 @@
 # that script.
 apacheconfig==0.3.2
 asn1crypto==0.24.0
-astroid==2.5.6; python_version >= "3.6" and python_version < "4.0"
+astroid==2.6.6; python_version >= "3.6" and python_version < "4.0"
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0"
 attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+backports.entry-points-selectable==1.1.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
 bcrypt==3.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 boto3==1.4.7
 botocore==1.7.41
@@ -17,7 +18,8 @@ configargparse==0.10.0
 configobj==5.0.6
 coverage==5.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.6"
 cryptography==2.1.4
-cython==0.29.23; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
+cython==0.29.24; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
+distlib==0.3.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
 distro==1.0.1
 dns-lexicon==3.2.1
 dnspython==2.1.0; python_version >= "3.6"
@@ -28,13 +30,14 @@ dockerpty==0.4.1; python_version >= "3.6" and python_full_version < "3.0.0" or p
 docopt==0.6.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 docutils==0.17.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 execnet==1.9.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-filelock==3.0.12; python_version >= "3.6"
+filelock==3.0.12; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0" or python_version >= "3.6" or python_version >= "3.6" and python_full_version >= "3.5.0"
 funcsigs==0.4
 future==0.18.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 google-api-python-client==1.5.5
 httplib2==0.9.2
 idna==2.6
-importlib-metadata==4.5.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8" or python_version < "3.8" and python_version >= "3.6"
+importlib-metadata==4.6.4; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8" or python_version < "3.8" and python_version >= "3.6" or python_version >= "3.6" and python_full_version >= "3.5.0" and python_version < "3.8"
+importlib-resources==5.2.2; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.7" or python_version >= "3.6" and python_full_version >= "3.5.0" and python_version < "3.7"
 iniconfig==1.1.1; python_version >= "3.6"
 ipaddress==1.0.16
 isort==5.8.0; python_version >= "3.6" and python_version < "4.0"
@@ -49,18 +52,19 @@ mypy-extensions==0.4.3; python_version >= "3.6"
 mypy==0.910; python_version >= "3.6"
 ndg-httpsclient==0.3.2
 oauth2client==4.0.0
-packaging==20.9; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+packaging==21.0; python_version >= "3.6"
 paramiko==2.4.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 parsedatetime==2.4
 pbr==1.8.0
-pip==20.2.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+pip==21.2.4; python_version >= "3.6"
+platformdirs==2.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
 pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 ply==3.4
 py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6" or python_full_version >= "3.5.0" and python_version >= "3.6"
 pyasn1-modules==0.0.10; python_version >= "3.6"
 pyasn1==0.1.9
 pycparser==2.14
-pylint==2.8.3; python_version >= "3.6" and python_version < "4.0"
+pylint==2.9.6; python_version >= "3.6" and python_version < "4.0"
 pynacl==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pyopenssl==17.3.0
 pyparsing==2.2.0
@@ -71,7 +75,7 @@ pytest-forked==1.3.0; python_version >= "3.6" and python_full_version < "3.0.0" 
 pytest-xdist==2.3.0; python_version >= "3.6" or python_version >= "3.6"
 pytest==6.2.4; python_version >= "3.6" or python_version >= "3.6" or python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 python-augeas==0.5.0
-python-dateutil==2.8.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
+python-dateutil==2.8.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 python-digitalocean==1.11
 pytz==2012c
 pywin32==301; sys_platform == "win32" and python_version >= "3.6" or sys_platform == "win32" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6")
@@ -85,15 +89,28 @@ setuptools==39.0.1; (python_version >= "2.7" and python_full_version < "3.0.0") 
 six==1.11.0
 texttable==0.9.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tldextract==3.1.0; python_version >= "3.6"
-toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6" or python_full_version >= "3.5.0" and python_version >= "3.6" or python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.3.0"
+toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6" or python_full_version >= "3.5.0" and python_version >= "3.6" or python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.3.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
+tox==3.12.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
 typed-ast==1.4.3; python_version >= "3.6" and python_version < "3.8" or implementation_name == "cpython" and python_version < "3.8" and python_version >= "3.6"
+types-cryptography==3.3.5; python_version >= "3.6"
+types-enum34==0.1.8; python_version >= "3.6"
+types-ipaddress==0.1.5; python_version >= "3.6"
+types-mock==0.1.5; python_version >= "3.6"
+types-pyopenssl==20.0.5; python_version >= "3.6"
+types-pyrfc3339==0.1.2; python_version >= "3.6"
+types-python-dateutil==0.1.6; python_version >= "3.6"
+types-pytz==2021.1.2; python_version >= "3.6"
+types-requests==2.25.6; python_version >= "3.6"
+types-setuptools==57.0.2; python_version >= "3.6"
+types-six==1.16.0; python_version >= "3.6"
 typing-extensions==3.10.0.0; python_version >= "3.6" or python_version < "3.8" and python_version >= "3.6"
 uritemplate==3.0.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 urllib3==1.10.2
+virtualenv==20.7.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
 websocket-client==0.59.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 wheel==0.33.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 wrapt==1.12.1; python_version >= "3.6" and python_version < "4.0"
-zipp==3.4.1; python_version < "3.8" and python_version >= "3.6"
+zipp==3.5.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.7" or python_version >= "3.6" and python_full_version >= "3.5.0" and python_version < "3.7" or python_version < "3.8" and python_version >= "3.6"
 zope.component==4.1.0
 zope.event==4.0.3
 zope.hookable==4.0.4

--- a/tools/pinning/oldest/pyproject.toml
+++ b/tools/pinning/oldest/pyproject.toml
@@ -129,11 +129,6 @@ cython = "*"
 # We add any dependencies that must be specified in this file for any another
 # reason below.
 
-# pip's new dependency resolver fails on local packages that depend on each
-# other when those packages are requested with extras such as 'certbot[dev]' so
-# let's pin it back for now. See https://github.com/pypa/pip/issues/9204.
-pip = "20.2.4"
-
 # wheel 0.34.1+ does not support the version of setuptools pinned above (and
 # wheel 0.34.0 is buggy).
 wheel = "<0.34.0"


### PR DESCRIPTION
This is just an oldest tests version of https://github.com/certbot/certbot/pull/8993.

You can see all oldest tests passing with these changes at https://dev.azure.com/certbot/certbot/_build/results?buildId=4442&view=results.