### PR TITLE
Propagate requirement that ACME responses are UTF-8

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1160,6 +1160,9 @@ class ClientNetwork:
                 "Accept" in kwargs["headers"]):
             debug_content = base64.b64encode(response.content)
         else:
+            # We set response.encoding so requests.text knows the response is
+            # UTF-8 encoded instead of trying to guess the encoding that was
+            # used which is error prone.
             response.encoding = "utf-8"
             debug_content = response.text
         logger.debug('Received response:\nHTTP %d\n%s\n\n%s',

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1160,9 +1160,10 @@ class ClientNetwork:
                 "Accept" in kwargs["headers"]):
             debug_content = base64.b64encode(response.content)
         else:
-            # We set response.encoding so requests.text knows the response is
+            # We set response.encoding so response.text knows the response is
             # UTF-8 encoded instead of trying to guess the encoding that was
-            # used which is error prone.
+            # used which is error prone. This setting affects all future
+            # accesses of .text made on the returned response object as well.
             response.encoding = "utf-8"
             debug_content = response.text
         logger.debug('Received response:\nHTTP %d\n%s\n\n%s',

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -6,10 +6,6 @@ from setuptools import setup
 version = '1.19.0.dev0'
 
 install_requires = [
-    # This dependency just exists to ensure that chardet is installed along
-    # with requests so it will use it instead of charset_normalizer. See
-    # https://github.com/certbot/certbot/issues/8964 for more info.
-    'chardet',
     'cryptography>=2.1.4',
     # formerly known as acme.jose:
     # 1.1.0+ is required to avoid the warnings described at

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * `zope` based interfaces in `certbot.interfaces` module are deprecated and will
   be removed in a future release of Certbot. Any import of these interfaces will
   emit a warning to prepare the transition for developers.
+* We removed the dependency on `chardet` from our acme library.
 
 ### Fixed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,7 +16,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * `zope` based interfaces in `certbot.interfaces` module are deprecated and will
   be removed in a future release of Certbot. Any import of these interfaces will
   emit a warning to prepare the transition for developers.
-* We removed the dependency on `chardet` from our acme library.
+* We removed the dependency on `chardet` from our acme library. Except for when
+  downloading a certificate in an alternate format, our acme library now
+  assumes all server responses are UTF-8 encoded which is required by RFC 8555.
 
 ### Fixed
 


### PR DESCRIPTION
I think this fixes https://github.com/certbot/certbot/issues/8968.

The only other calls with `requests` we make in our code outside of our tests that I could find are:

1. [Here](https://github.com/certbot/certbot/blob/a8a8a39ff18ee33936d385b5ac403daa81b7ed31/certbot/certbot/_internal/eff.py#L91) where we assume the response is JSON and I think [requests behavior](https://github.com/psf/requests/blob/db575eeedcfdb03bf31285afd3033e301df8b685/requests/models.py#L891-L896) is sane.
2. [Here](https://github.com/certbot/certbot/blob/a8a8a39ff18ee33936d385b5ac403daa81b7ed31/certbot/certbot/ocsp.py#L190) where we know the response contains binary data.

I think this is a pretty minor change because we were already assuming the response was UTF-8 in the code here when logging it which I think is a valid assumption because the spec says that [all content should be UTF-8 encoded](https://datatracker.ietf.org/doc/html/rfc8555#section-5).

I added the check for the `Accept` header due to the text [here](https://datatracker.ietf.org/doc/html/rfc8555#section-7.4.2) saying that it can be used to request the certificate in an alternate format such as DER. We currently set the Accept header in our own ACMEv1 client code before downloading the DER certificate, but this isn't required according to [the closest thing I think we have to an ACMEv1 spec](https://github.com/letsencrypt/boulder/blob/f1894f8d1d91c250d8193be02cb08b22d849f641/docs/acme-divergences-v1.md#section-742) so I left the content type check with a comment that it can be removed in the future.

You can see all tests passing with these changes at https://dev.azure.com/certbot/certbot/_build/results?buildId=4446&view=results (on commit https://github.com/certbot/certbot/commit/dca8f345cba652309732b1fb012669b156402f52 before I added a little more documentation).