### PR TITLE
docs: redirect macOS users to different cron guide

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -818,8 +818,13 @@ scheduled task to automatically renew your certificates in the background. If yo
 whether your system has a pre-installed scheduled task for Certbot, it is safe to follow these
 instructions to create one.
 
-If you're using Windows, these instructions are not neccessary as Certbot on Windows comes with
-a scheduled task for automated renewal pre-installed.
+.. note::
+   If you're using Windows, these instructions are not neccessary as Certbot on Windows comes with
+   a scheduled task for automated renewal pre-installed.
+
+   If you are using macOS and installed Certbot using Homebrew, follow the instructions at
+   https://certbot.eff.org/instructions to set up automated renewal. The instructions below
+   are not applicable on macOS.
 
 Run the following line, which will add a cron job to `/etc/crontab`:
 


### PR DESCRIPTION
Due to macOS having some complications about Certbot from Homebrew being
in the PATH, the instructions we have in the Automated Renewal section
do not work for them. Instead, send those users to the instruction
generator.

----

Fixes https://github.com/certbot/certbot/issues/8974.

Don't merge until:

- [x] https://github.com/certbot/website/pull/729 is merged

![image](https://user-images.githubusercontent.com/311534/131308925-e24e5d65-7f1a-4139-8760-5e612b64484a.png)
