### PR TITLE
Make ACMEv1 deprecation warnings scarier

### DIFF
--- a/certbot/certbot/_internal/client.py
+++ b/certbot/certbot/_internal/client.py
@@ -39,8 +39,7 @@ def acme_from_config_key(config, key, regr=None):
                                     user_agent=determine_user_agent(config))
 
     with warnings.catch_warnings():
-        # TODO: full removal of ACMEv1 support: https://github.com/certbot/certbot/issues/6844
-        warnings.simplefilter("ignore", PendingDeprecationWarning)
+        warnings.simplefilter("ignore", DeprecationWarning)
 
         client = acme_client.BackwardsCompatibleClientV2(net, key, config.server)
         if client.acme_version == 1:

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -79,9 +79,9 @@ class HandleAuthorizationsTest(unittest.TestCase):
         self.mock_auth.perform.side_effect = gen_auth_resp
 
         self.mock_account = mock.Mock(key=util.Key("file_path", "PEM"))
-        self.mock_net = mock.MagicMock(spec=acme_client.Client)
+        self.mock_net = mock.MagicMock(spec=acme_client.ClientV2)
         self.mock_net.acme_version = 1
-        self.mock_net.retry_after.side_effect = acme_client.Client.retry_after
+        self.mock_net.retry_after.side_effect = acme_client.ClientV2.retry_after
 
         self.handler = AuthHandler(
             self.mock_auth, self.mock_net, self.mock_account, [])
@@ -165,9 +165,6 @@ class HandleAuthorizationsTest(unittest.TestCase):
         self.assertEqual(len(authzr), 1)
 
     def _test_name3_http_01_3_common(self, combos):
-        self.mock_net.request_domain_challenges.side_effect = functools.partial(
-            gen_dom_authzr, challs=acme_util.CHALLENGES, combos=combos)
-
         authzrs = [gen_dom_authzr(domain="0", challs=acme_util.CHALLENGES),
                    gen_dom_authzr(domain="1", challs=acme_util.CHALLENGES),
                    gen_dom_authzr(domain="2", challs=acme_util.CHALLENGES)]

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -323,12 +323,12 @@ class RevokeTest(test_util.TempDirTestCase):
         self.tmp_cert_path = os.path.abspath(os.path.join(self.tempdir, 'cert_512.pem'))
 
         patches = [
-            mock.patch('acme.client.BackwardsCompatibleClientV2'),
+            mock.patch('certbot._internal.client.acme_client'),
             mock.patch('certbot._internal.client.Client'),
             mock.patch('certbot._internal.main._determine_account'),
             mock.patch('certbot._internal.main.display_ops.success_revocation')
         ]
-        self.mock_acme_client = patches[0].start()
+        self.mock_acme_client = patches[0].start().BackwardsCompatibleClientV2
         patches[1].start()
         self.mock_determine_account = patches[2].start()
         self.mock_success_revoke = patches[3].start()
@@ -708,11 +708,10 @@ class MainTest(test_util.ConfigTestCase):
     @mock.patch('certbot._internal.eff.handle_subscription')
     @mock.patch('certbot._internal.log.post_arg_parse_setup')
     @mock.patch('certbot._internal.main._report_new_cert')
-    @mock.patch('certbot._internal.main.client.acme_client.Client')
     @mock.patch('certbot._internal.main._determine_account')
     @mock.patch('certbot._internal.main.client.Client.obtain_and_enroll_certificate')
     @mock.patch('certbot._internal.main._get_and_save_cert')
-    def test_user_agent(self, gsc, _obt, det, _client, _, __, ___):
+    def test_user_agent(self, gsc, _obt, det, _, __, ___):
         # Normally the client is totally mocked out, but here we need more
         # arguments to automate it...
         args = ["--standalone", "certonly", "-m", "none@none.com",
@@ -720,7 +719,8 @@ class MainTest(test_util.ConfigTestCase):
         det.return_value = mock.MagicMock(), None
         gsc.return_value = mock.MagicMock()
 
-        with mock.patch('certbot._internal.main.client.acme_client.ClientNetwork') as acme_net:
+        with mock.patch('certbot._internal.main.client.acme_client') as acme_client:
+            acme_net = acme_client.ClientNetwork
             self._call_no_clientmock(args)
             os_ver = util.get_os_info_ua()
             ua = acme_net.call_args[1]["user_agent"]
@@ -730,7 +730,8 @@ class MainTest(test_util.ConfigTestCase):
             if "linux" in plat.lower():
                 self.assertIn(util.get_os_info_ua(), ua)
 
-        with mock.patch('certbot._internal.main.client.acme_client.ClientNetwork') as acme_net:
+        with mock.patch('certbot._internal.main.client.acme_client') as acme_client:
+            acme_net = acme_client.ClientNetwork
             ua = "bandersnatch"
             args += ["--user-agent", ua]
             self._call_no_clientmock(args)


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/6844.

This PR does two things:

1. Changes ACMEv1 deprecation warnings from `PendingDeprecationWarning` to `DeprecationWarning`.
2. Changes the ACMEv1 deprecation warnings to be on references to the class themselves. This is the approach taken in https://github.com/certbot/certbot/pull/8989, the PRs linked there, and the `cryptography` code in the code comment. I think this approach warns in more cases and I updated our unit tests to avoid hitting these warnings.