### PR TITLE
snap: revert to checking snapctl file existence

### DIFF
--- a/snap/hooks/prepare-plug-plugin
+++ b/snap/hooks/prepare-plug-plugin
@@ -7,9 +7,9 @@
 SNAPCTL_CORE="/snap/core/current/usr/bin/snapctl"
 SNAPCTL_SNAPD="/snap/snapd/current/usr/bin/snapctl"
 SNAPCTL="snapctl"
-if $SNAPCTL_CORE get x 2>/dev/null; then
+if [ -x $SNAPCTL_CORE ]; then
     SNAPCTL=$SNAPCTL_CORE
-elif $SNAPCTL_SNAPD get x 2>/dev/null; then
+elif [ -x $SNAPCTL_SNAPD ]; then
     SNAPCTL=$SNAPCTL_SNAPD
 fi
 


### PR DESCRIPTION
While the previous approach of testing the functionality of snapctl
worked, the snapd developers told us they could not guarantee its
reliability.

---

As with #8955, I tested this on Debian 9, 10 and CentOS 7, 8, Stream.