### PR TITLE
Allow relative URIs for `Link` headers

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -19,6 +19,7 @@ from typing import List
 from typing import Set
 from typing import Text
 from typing import Union
+from urllib.parse import urljoin
 import warnings
 
 import josepy as jose
@@ -810,7 +811,7 @@ class ClientV2(ClientBase):
         if 'Link' not in response.headers:
             return []
         links = parse_header_links(response.headers['Link'])
-        return [l['url'] for l in links
+        return [urljoin(response.url, l['url']) for l in links
                 if 'rel' in l and 'url' in l and l['rel'] == relation_type]
 
 

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -849,18 +849,39 @@ class ClientV2Test(ClientTestBase):
         updated_orderr = self.orderr.update(body=updated_order,
                                             fullchain_pem=CERT_SAN_PEM,
                                             alternative_fullchains_pem=[CERT_SAN_PEM,
+                                                                        CERT_SAN_PEM,
+                                                                        CERT_SAN_PEM,
+                                                                        CERT_SAN_PEM,
+                                                                        CERT_SAN_PEM,
+                                                                        CERT_SAN_PEM,
                                                                         CERT_SAN_PEM])
         self.response.json.return_value = updated_order.to_json()
         self.response.text = CERT_SAN_PEM
+        self.response.url = 'https://example.com/acme/cert/0'
         self.response.headers['Link'] ='<https://example.com/acme/cert/1>;rel="alternate", ' + \
             '<https://example.com/dir>;rel="index", ' + \
-            '<https://example.com/acme/cert/2>;title="foo";rel="alternate"'
+            '<https://example.com/acme/cert/2>;title="foo";rel="alternate", ' + \
+            '<3>;rel="alternate", ' + \
+            '</acme/cert/4>;rel="alternate", ' + \
+            '<./5>;rel="alternate", ' + \
+            '</acme/./cert/6>;rel="alternate", ' + \
+            '</acme/../acme/cert/7>;rel="alternate"'
 
         deadline = datetime.datetime(9999, 9, 9)
         resp = self.client.finalize_order(self.orderr, deadline, fetch_alternative_chains=True)
         self.net.post.assert_any_call('https://example.com/acme/cert/1',
                                       mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
         self.net.post.assert_any_call('https://example.com/acme/cert/2',
+                                      mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
+        self.net.post.assert_any_call('https://example.com/acme/cert/3',
+                                      mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
+        self.net.post.assert_any_call('https://example.com/acme/cert/4',
+                                      mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
+        self.net.post.assert_any_call('https://example.com/acme/cert/5',
+                                      mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
+        self.net.post.assert_any_call('https://example.com/acme/cert/6',
+                                      mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
+        self.net.post.assert_any_call('https://example.com/acme/cert/7',
                                       mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
         self.assertEqual(resp, updated_orderr)
 

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -854,6 +854,7 @@ class ClientV2Test(ClientTestBase):
                                                                         CERT_SAN_PEM,
                                                                         CERT_SAN_PEM,
                                                                         CERT_SAN_PEM,
+                                                                        CERT_SAN_PEM,
                                                                         CERT_SAN_PEM])
         self.response.json.return_value = updated_order.to_json()
         self.response.text = CERT_SAN_PEM
@@ -865,7 +866,8 @@ class ClientV2Test(ClientTestBase):
             '</acme/cert/4>;rel="alternate", ' + \
             '<./5>;rel="alternate", ' + \
             '</acme/./cert/6>;rel="alternate", ' + \
-            '</acme/../acme/cert/7>;rel="alternate"'
+            '</acme/../acme/cert/7>;rel="alternate", ' + \
+            '<https://example.net/acme/cert/8>;rel="alternate"'
 
         deadline = datetime.datetime(9999, 9, 9)
         resp = self.client.finalize_order(self.orderr, deadline, fetch_alternative_chains=True)
@@ -882,6 +884,8 @@ class ClientV2Test(ClientTestBase):
         self.net.post.assert_any_call('https://example.com/acme/cert/6',
                                       mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
         self.net.post.assert_any_call('https://example.com/acme/cert/7',
+                                      mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
+        self.net.post.assert_any_call('https://example.net/acme/cert/8',
                                       mock.ANY, acme_version=2, new_nonce_url=mock.ANY)
         self.assertEqual(resp, updated_orderr)
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -23,6 +23,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * We removed the dependency on `chardet` from our acme library. Except for when
   downloading a certificate in an alternate format, our acme library now
   assumes all server responses are UTF-8 encoded which is required by RFC 8555.
+* Support for relative URLs in  Link` headers was added to the acme library.
 
 ### Fixed
 


### PR DESCRIPTION
[`urllib.parse.urljoin()`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin) is a very cool function. Almost feels like "if it's too good to be true, it probably is"! What am I missing here? :stuck_out_tongue: 

<s>Maybe write some tests?</s><small>Done.</small>

Fixes #434