### PR TITLE
Add `--source-address` option to certbot

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -11,6 +11,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   if the configured target server is not a valid IPv4 or IPv6 address.
 * Our acme library now supports requesting certificates for IP addresses.
   This feature is still unsupported by Certbot and Let's Encrypt.
+* Setting the source address of outward connections is now possible using the 
+  `--source-address` command line option.
 
 ### Changed
 

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -23,6 +23,7 @@ from certbot._internal.cli.cli_utils import _DomainsAction
 from certbot._internal.cli.cli_utils import _EncodeReasonAction
 from certbot._internal.cli.cli_utils import _PrefChallAction
 from certbot._internal.cli.cli_utils import _RenewHookAction
+from certbot._internal.cli.cli_utils import _SourceAddressAction
 from certbot._internal.cli.cli_utils import _user_agent_comment_type
 from certbot._internal.cli.cli_utils import add_domains
 from certbot._internal.cli.cli_utils import CaseInsensitiveList
@@ -414,6 +415,9 @@ def prepare_and_parse_args(plugins, args, detect_defaults=False):
         "renew", "--no-autorenew", action="store_false",
         default=flag_default("autorenew"), dest="autorenew",
         help="Disable auto renewal of certificates.")
+    helpful.add(
+        None, "--source-address", type=str, action=_SourceAddressAction,
+        help="Source IP address to be used for outward connections.")
 
     # Deprecated arguments
     helpful.add_deprecated_argument("--os-packages-only", 0)

--- a/certbot/certbot/_internal/cli/cli_utils.py
+++ b/certbot/certbot/_internal/cli/cli_utils.py
@@ -1,5 +1,6 @@
 """Certbot command line util function"""
 import argparse
+from dns.inet import is_address
 import copy
 import inspect
 
@@ -211,6 +212,17 @@ class _RenewHookAction(argparse.Action):
             raise argparse.ArgumentError(
                 self, "conflicts with --deploy-hook value")
         namespace.renew_hook = values
+
+
+class _SourceAddressAction(argparse.Action):
+    """Action class for parsing preferred challenges."""
+
+    def __call__(self, parser, namespace, source_address, option_string=None):
+        if not is_address(source_address):
+            raise argparse.ArgumentError(self, "'{}' is not a valid source address, only "
+            "valid IPv4 or IPv6 addresses are allowed.".format(source_address))
+        else:
+            namespace.source_address = source_address
 
 
 def nonnegative_int(value):

--- a/certbot/certbot/_internal/cli/cli_utils.py
+++ b/certbot/certbot/_internal/cli/cli_utils.py
@@ -224,11 +224,11 @@ class _SourceAddressAction(argparse.Action):
         try:
             inet_pton(AF_INET, source_address)
             invalid_address = False
-        except Exception:
+        except OSError:
             try:
                 inet_pton(AF_INET6, source_address)
                 invalid_address = False
-            except Exception:
+            except OSError:
                 invalid_address = True
 
         if invalid_address:

--- a/certbot/certbot/_internal/cli/cli_utils.py
+++ b/certbot/certbot/_internal/cli/cli_utils.py
@@ -1,8 +1,10 @@
 """Certbot command line util function"""
 import argparse
-from dns.inet import is_address
 import copy
 import inspect
+from socket import AF_INET
+from socket import AF_INET6
+from socket import inet_pton
 
 from acme import challenges
 from certbot import configuration
@@ -218,7 +220,18 @@ class _SourceAddressAction(argparse.Action):
     """Action class for parsing preferred challenges."""
 
     def __call__(self, parser, namespace, source_address, option_string=None):
-        if not is_address(source_address):
+        invalid_address = True
+        try:
+            inet_pton(AF_INET, source_address)
+            invalid_address = False
+        except Exception:
+            try:
+                inet_pton(AF_INET6, source_address)
+                invalid_address = False
+            except Exception:
+                invalid_address = True
+
+        if invalid_address:
             raise argparse.ArgumentError(self, "'{}' is not a valid source address, only "
             "valid IPv4 or IPv6 addresses are allowed.".format(source_address))
         else:

--- a/certbot/certbot/_internal/client.py
+++ b/certbot/certbot/_internal/client.py
@@ -36,7 +36,8 @@ def acme_from_config_key(config, key, regr=None):
     "Wrangle ACME client construction"
     # TODO: Allow for other alg types besides RS256
     net = acme_client.ClientNetwork(key, account=regr, verify_ssl=(not config.no_verify_ssl),
-                                    user_agent=determine_user_agent(config))
+                                    user_agent=determine_user_agent(config),
+                                    source_address=config.source_address)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -479,6 +479,26 @@ class ParseTest(unittest.TestCase):
             for topic in ['all', 'plugins', 'dns-route53']:
                 self.assertNotIn('certbot-route53:auth', self._help_output([help_flag, topic]))
 
+    def test_source_address_flag_v4(self):
+        namespace = self.parse(["--source-address=192.0.2.1"])
+        self.assertEqual(namespace.source_address, "192.0.2.1")
+        namespace = self.parse(["--source-address", "192.0.2.2"])
+        self.assertEqual(namespace.source_address, "192.0.2.2")
+
+    def test_source_address_flag_v6(self):
+        namespace = self.parse(["--source-address=2001:db8::1"])
+        self.assertEqual(namespace.source_address, "2001:db8::1")
+        namespace = self.parse(["--source-address", "2001:db8::2"])
+        self.assertEqual(namespace.source_address, "2001:db8::2")
+
+    def test_source_address_flag_not_set(self):
+        namespace = self.parse([])
+        self.assertIsNone(namespace.source_address)
+
+    def test_source_address_invalid(self):
+        with self.assertRaises(SystemExit):
+            self.parse(["--source-address", "256.0.0.1"])
+
 
 class DefaultTest(unittest.TestCase):
     """Tests for certbot._internal.cli._Default."""

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -772,5 +772,23 @@ class RollbackTest(unittest.TestCase):
         self._call(1, None)  # Just make sure no exceptions are raised
 
 
+class ClientSourceAddress(test_util.ConfigTestCase):
+    def setUp(self):
+        super().setUp()
+
+    @mock.patch("certbot._internal.client.acme_client.ClientNetwork")
+    def test_source_address(self, mock_clientnetwork):
+        self.config.source_address = "192.0.2.1"
+
+        self.account = mock.MagicMock(**{"key.pem": KEY})
+
+        from certbot._internal.client import Client
+        self.client = Client(
+            config=self.config, account_=self.account,
+            auth=None, installer=None)
+
+        self.assertEqual(mock_clientnetwork.call_args[1]["source_address"], "192.0.2.1")
+
+
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -736,7 +736,7 @@ class MainTest(test_util.ConfigTestCase):
             args += ["--user-agent", ua]
             self._call_no_clientmock(args)
             acme_net.assert_called_once_with(mock.ANY, account=mock.ANY, verify_ssl=True,
-                user_agent=ua)
+                user_agent=ua, source_address=None)
 
     @mock.patch('certbot._internal.main.plug_sel.record_chosen_plugins')
     @mock.patch('certbot._internal.main.plug_sel.pick_installer')


### PR DESCRIPTION
Fixes #3489

Lightly based on #6007.

A few remarks I have:

* Currently, testing for a valid address is done in the argument parser. What about `cli.ini`?
* `acme` raises `ValueError`/`requests.exceptions.ConnectionError` (IPv4 resp. IPv6) if urllib3 cannot bind the source address (ultimately this stack of exceptions starts with an `OSError`). Currently, the `acme` library does not catch these errors. Locally, I modified certbots `client.py` to catch and reraise the errors as OSError, but I'm not sure if this useful at all.. Also, not sure how to write tests for them.. Mock requests or urllib3 and have some kind of mock exception raised? Also, shouldn't that be done in `acme` instead of certbot?
  Edit: my above modification only catches the error when connecting to the ACME API directory. For example, it doesn't catch any errors if an account isn't present and needs to be registered first. So personally it doesn't make sense to catch this at certbots side: it probably should be handled "lower" on the `acme` library side?