### PR TITLE
disable donation prompt during --quiet

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -27,6 +27,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Fixed parsing of `Define`d values in the Apache plugin to allow for `=` in the value.
+* Fixed a relatively harmless crash when issuing a certificate with `--quiet`/`-q`.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -66,9 +66,12 @@ def _suggest_donation_if_appropriate(config):
     :rtype: None
 
     """
+    # don't prompt for donation if:
+    # - renewing
+    # - using the staging server (--staging or --dry-run)
+    # - running with --quiet (display fd won't be available during atexit calls #8995)
     assert config.verb != "renew"
-    if config.staging:
-        # --dry-run implies --staging
+    if config.staging or config.quiet:
         return
     util.atexit_register(
         display_util.notification,


### PR DESCRIPTION
Issuing a certificate with --quiet was crashing during the donation
atexit call because it was trying to use the /dev/null fd after the
displayer context manager had already closed it.


----

Fixes #8995.

This felt a bit tricky to fix due to the [design of the displayer context manager](https://github.com/certbot/certbot/blob/b7bde05aee7b43996fe88bc399518b802cc596a7/certbot/certbot/_internal/main.py#L1480-L1509) and my previous attempt to fix some fd leaks in #8747. 

Practically speaking, it's only this one atexit call that invokes displayer, so this workaround should be totally effective.

Long term, something else is probably better, like to rethink how the `/dev/null` fd is managed in the context manager, or move the donation prompt off `display_util`. 

I'd really love for this to get into 1.19.0 but I understand with the long weekend if it's not possible to review it in time.