### PR TITLE
fix 'NEXT STEPS' being printed to stdout during -q

### DIFF
--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -523,10 +523,12 @@ def _report_next_steps(config: configuration.NamespaceConfig, installer_err: Opt
         return
 
     # TODO: refactor ANSI escapes during https://github.com/certbot/certbot/issues/8848
-    (bold_on, bold_off) = [c if sys.stdout.isatty() and not config.quiet else '' \
-                           for c in (util.ANSI_SGR_BOLD, util.ANSI_SGR_RESET)]
+    (bold_on, nl, bold_off) = [c if sys.stdout.isatty() and not config.quiet else '' \
+                               for c in (util.ANSI_SGR_BOLD, '\n', util.ANSI_SGR_RESET)]
+    print(bold_on, end=nl)
+    display_util.notify("NEXT STEPS:")
+    print(bold_off, end='')
 
-    print(bold_on, '\n', 'NEXT STEPS:', bold_off, sep='')
     for step in steps:
         display_util.notify(f"- {step}")
 

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1934,8 +1934,9 @@ class ReportNextStepsTest(unittest.TestCase):
         _report_next_steps(*args, **kwargs)
 
     def _output(self) -> str:
-        self.mock_notify.assert_called_once()
-        return self.mock_notify.call_args_list[0][0][0]
+        self.assertEqual(self.mock_notify.call_count, 2)
+        self.assertEqual(self.mock_notify.call_args_list[0][0][0], 'NEXT STEPS:')
+        return self.mock_notify.call_args_list[1][0][0]
 
     def test_report(self):
         """No steps for a normal renewal"""


### PR DESCRIPTION
@osirisinferi noticed [in chat](https://opensource.eff.org/eff-open-source/pl/sa85u4n71tywfpc15c1wu59wae) that "NEXT STEPS:" was ignoring `--quiet` and was being printed unconditionally.

I think it ended up being written this way in #8860 because I was trying not to avoid dumping ANSI escapes and newlines into the log file and confused myself in the process. 

This change makes things a bit more explicit in separating presentation/message. That TODO would have helped here :P.