### PR TITLE
cli: minor copy changes to `renew` help text

### DIFF
--- a/certbot/certbot/_internal/cli/verb_help.py
+++ b/certbot/certbot/_internal/cli/verb_help.py
@@ -23,14 +23,14 @@ VERB_HELP = [
     }),
     ("renew", {
         "short": "Renew all certificates (or one specified with --cert-name)",
-        "opts": ("The 'renew' subcommand will attempt to renew all"
-                 " certificates (or more precisely, certificate lineages) you have"
+        "opts": ("The 'renew' subcommand will attempt to renew any certificates"
                  " previously obtained if they are close to expiry, and print a"
-                 " summary of the results. By default, 'renew' will reuse the options"
-                 " used to create obtain or most recently successfully renew each"
-                 " certificate lineage. You can try it with `--dry-run` first. For"
-                 " more fine-grained control, you can renew individual lineages with"
-                 " the `certonly` subcommand. Hooks are available to run commands"
+                 " summary of the results. By default, 'renew' will reuse the"
+                 " plugins and options used to obtain or most recently renew each"
+                 " certificate. You can test whether future renewals will succeed"
+                 " with `--dry-run`."
+                 " Individual certificates can be renewed with the `--cert-name`"
+                 " option. Hooks are available to run commands"
                  " before and after renewal; see"
                  " https://certbot.eff.org/docs/using.html#renewal for more"
                  " information on these."),


### PR DESCRIPTION
Fixes #9009.

---

IMO it didn't seem super appropriate to also include information on `certonly` here. 

I would like to separately improve the "Renewing Certificates" part of the user guide, though.

![image](https://user-images.githubusercontent.com/311534/132611295-d778373f-400d-4bcb-8de0-e004d3994aee.png)
