### PR TITLE
Increase minimum of josepy version to use and update the oldest contraints

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -7,10 +7,7 @@ version = '1.20.0.dev0'
 
 install_requires = [
     'cryptography>=2.1.4',
-    # formerly known as acme.jose:
-    # 1.1.0+ is required to avoid the warnings described at
-    # https://github.com/certbot/josepy/issues/13.
-    'josepy>=1.1.0',
+    'josepy>=1.9.0',
     'PyOpenSSL>=17.3.0',
     'pyrfc3339',
     'pytz',

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -52,9 +52,7 @@ install_requires = [
     'configobj>=5.0.6',
     'cryptography>=2.1.4',
     'distro>=1.0.1',
-    # 1.1.0+ is required to avoid the warnings described at
-    # https://github.com/certbot/josepy/issues/13.
-    'josepy>=1.1.0',
+    'josepy>=1.9.0',
     'parsedatetime>=2.4',
     'pyrfc3339',
     'pytz',

--- a/tools/oldest_constraints.txt
+++ b/tools/oldest_constraints.txt
@@ -2,7 +2,7 @@
 # that script.
 apacheconfig==0.3.2
 asn1crypto==0.24.0
-astroid==2.6.6; python_version >= "3.6" and python_version < "4.0"
+astroid==2.7.3; python_version >= "3.6" and python_version < "4.0"
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0"
 attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 backports.entry-points-selectable==1.1.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
@@ -30,19 +30,19 @@ dockerpty==0.4.1; python_version >= "3.6" and python_full_version < "3.0.0" or p
 docopt==0.6.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 docutils==0.17.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 execnet==1.9.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-filelock==3.0.12; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0" or python_version >= "3.6" or python_version >= "3.6" and python_full_version >= "3.5.0"
+filelock==3.0.12; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0" or python_version >= "3.6"
 funcsigs==0.4
 future==0.18.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 google-api-python-client==1.5.5
 httplib2==0.9.2
 idna==2.6
-importlib-metadata==4.6.4; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8" or python_version < "3.8" and python_version >= "3.6" or python_version >= "3.6" and python_full_version >= "3.5.0" and python_version < "3.8"
+importlib-metadata==4.8.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_version >= "3.6" and python_full_version >= "3.5.0" and python_version < "3.8" or python_version < "3.8" and python_version >= "3.6"
 importlib-resources==5.2.2; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.7" or python_version >= "3.6" and python_full_version >= "3.5.0" and python_version < "3.7"
 iniconfig==1.1.1; python_version >= "3.6"
 ipaddress==1.0.16
 isort==5.8.0; python_version >= "3.6" and python_version < "4.0"
 jmespath==0.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
-josepy==1.8.0; python_version >= "3.6"
+josepy==1.9.0; python_version >= "3.6"
 jsonschema==2.6.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 lazy-object-proxy==1.6.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.6.0"
 logger==1.4; python_version >= "3.6"
@@ -57,14 +57,14 @@ paramiko==2.4.3; python_version >= "3.6" and python_full_version < "3.0.0" or py
 parsedatetime==2.4
 pbr==1.8.0
 pip==21.2.4; python_version >= "3.6"
-platformdirs==2.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"
-pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+platformdirs==2.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0" or python_version >= "3.6" and python_version < "4.0"
+pluggy==1.0.0; python_version >= "3.6"
 ply==3.4
 py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6" or python_full_version >= "3.5.0" and python_version >= "3.6"
 pyasn1-modules==0.0.10; python_version >= "3.6"
 pyasn1==0.1.9
 pycparser==2.14
-pylint==2.9.6; python_version >= "3.6" and python_version < "4.0"
+pylint==2.10.2; python_version >= "3.6" and python_version < "4.0"
 pynacl==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pyopenssl==17.3.0
 pyparsing==2.2.0
@@ -73,7 +73,7 @@ pyrfc3339==1.0
 pytest-cov==2.12.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 pytest-forked==1.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 pytest-xdist==2.3.0; python_version >= "3.6" or python_version >= "3.6"
-pytest==6.2.4; python_version >= "3.6" or python_version >= "3.6" or python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+pytest==6.2.5; python_version >= "3.6" or python_version >= "3.6" or python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 python-augeas==0.5.0
 python-dateutil==2.8.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 python-digitalocean==1.11
@@ -88,22 +88,22 @@ s3transfer==0.1.13; python_version >= "3.6"
 setuptools==39.0.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 six==1.11.0
 texttable==0.9.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
-tldextract==3.1.0; python_version >= "3.6"
-toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6" or python_full_version >= "3.5.0" and python_version >= "3.6" or python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.3.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
-tox==3.12.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
+tldextract==3.1.2; python_version >= "3.6"
+toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6" or python_full_version >= "3.5.0" and python_version >= "3.6" or python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.3.0"
+tox==1.9.2; python_version >= "3.6"
 typed-ast==1.4.3; python_version >= "3.6" and python_version < "3.8" or implementation_name == "cpython" and python_version < "3.8" and python_version >= "3.6"
 types-cryptography==3.3.5; python_version >= "3.6"
-types-enum34==0.1.8; python_version >= "3.6"
-types-ipaddress==0.1.5; python_version >= "3.6"
-types-mock==0.1.5; python_version >= "3.6"
-types-pyopenssl==20.0.5; python_version >= "3.6"
+types-enum34==1.1.0; python_version >= "3.6"
+types-ipaddress==1.0.0; python_version >= "3.6"
+types-mock==4.0.1; python_version >= "3.6"
+types-pyopenssl==20.0.6; python_version >= "3.6"
 types-pyrfc3339==0.1.2; python_version >= "3.6"
-types-python-dateutil==0.1.6; python_version >= "3.6"
+types-python-dateutil==2.8.0; python_version >= "3.6"
 types-pytz==2021.1.2; python_version >= "3.6"
 types-requests==2.25.6; python_version >= "3.6"
 types-setuptools==57.0.2; python_version >= "3.6"
-types-six==1.16.0; python_version >= "3.6"
-typing-extensions==3.10.0.0; python_version >= "3.6" or python_version < "3.8" and python_version >= "3.6"
+types-six==1.16.1; python_version >= "3.6"
+typing-extensions==3.10.0.2; python_version >= "3.6" or python_version < "3.8" and python_version >= "3.6"
 uritemplate==3.0.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 urllib3==1.10.2
 virtualenv==20.7.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.5.0"


### PR DESCRIPTION
As a follow-up to #9027, this PR increases the minimum version of `josepy` to use and updates the oldest constraints accordingly.