### PR TITLE
certbot-dns-rfc2136: correctly declare dependency on dnspython > 2.0

### DIFF
--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 version = '1.20.0.dev0'
 
 install_requires = [
-    'dnspython',
+    'dnspython>=2.0',
     'setuptools>=39.0.1',
 ]
 


### PR DESCRIPTION
Since commit 295dc5a2 (#8990) the plugin uses dnspython's `is_address()` helper function which was added in dnspython 2.0 ([commit 037dfe7f](https://github.com/rthalley/dnspython/commit/037dfe7f71f21e37fade0e3a203e38b675a1aa43)).

This change is just a quick fix to get the correct dependencies. Actually the problem for CentOS is that RHEL 8 ships python3-dns 1.15.0-10.el8 in base which means upgrading that dependency is close to impossible. I filed #9033 for a discussion that issue.