### PR TITLE
missing trailing '?' in non-interactive checklist

### DIFF
--- a/certbot/certbot/_internal/display/obj.py
+++ b/certbot/certbot/_internal/display/obj.py
@@ -505,7 +505,7 @@ class NoninteractiveDisplay:
 
         """
         if default is None:
-            self._interaction_fail(message, cli_flag, "? ".join(tags))
+            self._interaction_fail(message, cli_flag, "? ".join(tags) + "?")
         return OK, default
 
     def directory_select(self, message, default=None,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/311534/134164206-1c840319-64fc-40ed-becc-0cfd3d6523fd.png)

->

![image](https://user-images.githubusercontent.com/311534/134164248-3804d11f-4d6c-41b4-af67-77dd26cd7137.png)
