### PR TITLE
stop using deprecated jose abstractclassmethod

### DIFF
--- a/certbot/certbot/plugins/common.py
+++ b/certbot/certbot/plugins/common.py
@@ -1,12 +1,12 @@
 """Plugin common functions."""
 from abc import ABCMeta
+from abc import abstractmethod
 import logging
 import re
 import shutil
 import tempfile
 from typing import List
 
-from josepy import util as jose_util
 import pkg_resources
 
 from certbot import achallenges
@@ -48,7 +48,8 @@ class Plugin(AbstractPlugin, metaclass=ABCMeta):
         self.config = config
         self.name = name
 
-    @jose_util.abstractclassmethod
+    @classmethod
+    @abstractmethod
     def add_parser_arguments(cls, add):
         """Add plugin arguments to the CLI argument parser.
 


### PR DESCRIPTION
The josepy 1.10.0 release deprecated this decorator and [caused the nightly `nopin` test to break](https://dev.azure.com/certbot/certbot/_build/results?buildId=4548&view=logs&j=ce03f7c1-1e3f-5d55-28be-f084e7c62a50&t=597fea95-d44e-53a2-5b71-76ed20bd4dde).

---

We don't need to bump josepy to 1.10.0 for this, right?