### PR TITLE
Automate determining which PGP key to use

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -30,7 +30,23 @@ echo Releasing production version "$version"...
 nextversion="$2"
 RELEASE_BRANCH="candidate-$version"
 
-RELEASE_GPG_KEY=${RELEASE_GPG_KEY:-A2CFB51FA275A7286234E7B24D17C995CD9775F2}
+# If RELEASE_GPG_KEY isn't set, determine the key to use.
+if [ "$RELEASE_GPG_KEY" = "" ]; then
+    TRUSTED_KEYS="
+        A2CFB51FA275A7286234E7B24D17C995CD9775F2
+    "
+    for key in $TRUSTED_KEYS; do
+        if gpg2 --with-colons --card-status | grep -q "$key"; then
+            RELEASE_GPG_KEY="$key"
+            break
+        fi
+    done
+    if [ "$RELEASE_GPG_KEY" = "" ]; then
+        echo A trusted PGP key was not found on your PGP card.
+        exit 1
+    fi
+fi
+
 # Needed to fix problems with git signatures and pinentry
 export GPG_TTY=$(tty)
 


### PR DESCRIPTION
This is part of https://github.com/certbot/certbot/issues/9039. With this structure, the only change that needs to be made to our release script to use the new signing keys is:
```
diff --git a/tools/_release.sh b/tools/_release.sh
index 22ad7cb28..ed726fa64 100755
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -33,7 +33,9 @@ RELEASE_BRANCH="candidate-$version"
 # If RELEASE_GPG_KEY isn't set, determine the key to use.
 if [ "$RELEASE_GPG_KEY" = "" ]; then
     TRUSTED_KEYS="
-        A2CFB51FA275A7286234E7B24D17C995CD9775F2
+        BF6BCFC89E90747B9A680FD7B6029E8500F7DB16
+        86379B4F0AF371B50CD9E5FF3402831161D1D280
+        20F201346BF8F3F455A73F9A780CC99432A28621
     "
     for key in $TRUSTED_KEYS; do
         if gpg2 --with-colons --card-status | grep -q "$key"; then
```
If this change is accepted, I'll make a similar change to the josepy release script (maybe after we've actually switched to the new keys).