### PR TITLE
Upgrade Certbot on Windows to Python 3.9

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: 3.8
+          versionSpec: 3.9
           architecture: x86
           addToPath: true
       - script: |
@@ -100,7 +100,7 @@ jobs:
         displayName: Check Powershell 5.x is used in vs2017-win2016
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: 3.8
+          versionSpec: 3.9
           addToPath: true
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -16,13 +16,13 @@ jobs:
           IMAGE_NAME: vs2017-win2016
           PYTHON_VERSION: 3.6
           TOXENV: py36-win
-        windows-py38-cover:
+        windows-py39-cover:
           IMAGE_NAME: vs2017-win2016
-          PYTHON_VERSION: 3.8
-          TOXENV: py38-cover-win
+          PYTHON_VERSION: 3.9
+          TOXENV: py39-cover-win
         windows-integration-certbot:
           IMAGE_NAME: vs2017-win2016
-          PYTHON_VERSION: 3.8
+          PYTHON_VERSION: 3.9
           TOXENV: integration-certbot
         linux-oldest-tests-1:
           IMAGE_NAME: ubuntu-18.04

--- a/windows-installer/windows_installer/construct.py
+++ b/windows-installer/windows_installer/construct.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import time
 
-PYTHON_VERSION = (3, 8, 9)
+PYTHON_VERSION = (3, 9, 7)
 PYTHON_BITNESS = 32
 NSIS_VERSION = '3.06.1'
 


### PR DESCRIPTION
It seems that all required pre-compiled wheels to install Certbot on Python 3.9 on Windows are present.

This PR upgrades Windows tests on Python 3.9 and repackages the installer on this version of Python.
