### PR TITLE
Generate a web.config file for IIS to serve properly the challenge files in webroot plugin

### DIFF
--- a/certbot/certbot/_internal/plugins/webroot.py
+++ b/certbot/certbot/_internal/plugins/webroot.py
@@ -242,6 +242,11 @@ to serve all files under specified web root ({0})."""
                 os.remove(validation_path)
                 self.performed[root_path].remove(achall)
 
+                web_config_path = os.path.join(root_path, "web.config")
+                if os.path.exists(web_config_path):
+                    os.remove(web_config_path)
+
+
         not_removed: List[str] = []
         while self._created_dirs:
             path = self._created_dirs.pop()

--- a/certbot/tests/plugins/webroot_test.py
+++ b/certbot/tests/plugins/webroot_test.py
@@ -86,6 +86,16 @@ class AuthenticatorTest(unittest.TestCase):
         self.assertEqual(self.config.webroot_map[self.achall.domain],
                          self.path)
 
+    @unittest.skipIf(filesystem.POSIX_MODE, reason='Test specific to Windows')
+    @test_util.patch_display_util()
+    def test_webroot_webconfig_file(self, mock_get_utility):
+        self.config.webroot_path = []
+        self.config.webroot_map = {"otherthing.com": self.path}
+        mock_display = mock_get_utility()
+        mock_display.menu.return_value = (display_util.OK, 1,)
+        self.auth.perform([self.achall])
+        self.assertTrue(os.path.exists(os.path.join(self.root_challenge_path, "web.config")))
+
     @test_util.patch_display_util()
     def test_webroot_from_list_help_and_cancel(self, mock_get_utility):
         self.config.webroot_path = []


### PR DESCRIPTION
Fixes #9040

This PR makes the webroot plugin generates a `web.config` file in the `.well-known/acme-challenge` directory when the OS is Windows. This `web.config` is used by IIS to allow the challenge files to be served by the webserver despite the fact they do not have a valid file extension.

This relaxed permission is valid only in the `.well-known/acme-challenge` directory and exists only for the lifetime of the directory itself.

In theory this is useful only on IIS while other webservers could be used on Windows. But I think that generated it unconditionally on Windows simplify the implementation, while serving the major use case on this platform. Moreover it is not causing potential issues on other webservers that will just ignore this file, while the file itself do not expose any critical information about the underlying system.