### PR TITLE
Update packaging docs to mention dl.eff.org

### DIFF
--- a/certbot/docs/packaging.rst
+++ b/certbot/docs/packaging.rst
@@ -40,9 +40,12 @@ PGP keys:
 - ``86379B4F0AF371B50CD9E5FF3402831161D1D280``
 - ``20F201346BF8F3F455A73F9A780CC99432A28621``
 
+These keys can be found on major key servers and at
+https://dl.eff.org/certbot.pub.
+
 Releases before 1.21.0 were signed by the PGP key
-``A2CFB51FA275A7286234E7B24D17C995CD9775F2``. All of these keys can be found on
-major key servers.
+``A2CFB51FA275A7286234E7B24D17C995CD9775F2`` which can still be found on major
+key servers.
 
 Notes for package maintainers
 =============================


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/9038. The new keys are being hosted on the site now.