### PR TITLE
Pin readthedocs deps

### DIFF
--- a/acme/readthedocs.org.requirements.txt
+++ b/acme/readthedocs.org.requirements.txt
@@ -9,5 +9,5 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme[docs]

--- a/acme/readthedocs.org.requirements.txt
+++ b/acme/readthedocs.org.requirements.txt
@@ -7,4 +7,7 @@
 # in --editable mode (-e), just "pip install acme[docs]" does not work as
 # expected and "pip install -e acme[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme[docs]

--- a/certbot-dns-cloudflare/readthedocs.org.requirements.txt
+++ b/certbot-dns-cloudflare/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-cloudflare[docs]

--- a/certbot-dns-cloudflare/readthedocs.org.requirements.txt
+++ b/certbot-dns-cloudflare/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-cloudflare[docs]" does not work as
 # expected and "pip install -e certbot-dns-cloudflare[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-cloudflare[docs]

--- a/certbot-dns-cloudxns/readthedocs.org.requirements.txt
+++ b/certbot-dns-cloudxns/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-cloudxns[docs]" does not work as
 # expected and "pip install -e certbot-dns-cloudxns[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-cloudxns[docs]

--- a/certbot-dns-cloudxns/readthedocs.org.requirements.txt
+++ b/certbot-dns-cloudxns/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-cloudxns[docs]

--- a/certbot-dns-digitalocean/readthedocs.org.requirements.txt
+++ b/certbot-dns-digitalocean/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-digitalocean[docs]" does not work as
 # expected and "pip install -e certbot-dns-digitalocean[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-digitalocean[docs]

--- a/certbot-dns-digitalocean/readthedocs.org.requirements.txt
+++ b/certbot-dns-digitalocean/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-digitalocean[docs]

--- a/certbot-dns-dnsimple/readthedocs.org.requirements.txt
+++ b/certbot-dns-dnsimple/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-dnsimple[docs]" does not work as
 # expected and "pip install -e certbot-dns-dnsimple[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-dnsimple[docs]

--- a/certbot-dns-dnsimple/readthedocs.org.requirements.txt
+++ b/certbot-dns-dnsimple/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-dnsimple[docs]

--- a/certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt
+++ b/certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-dnsmadeeasy[docs]" does not work as
 # expected and "pip install -e certbot-dns-dnsmadeeasy[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-dnsmadeeasy[docs]

--- a/certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt
+++ b/certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-dnsmadeeasy[docs]

--- a/certbot-dns-gehirn/readthedocs.org.requirements.txt
+++ b/certbot-dns-gehirn/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-gehirn[docs]

--- a/certbot-dns-gehirn/readthedocs.org.requirements.txt
+++ b/certbot-dns-gehirn/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-gehirn[docs]" does not work as
 # expected and "pip install -e certbot-dns-gehirn[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-gehirn[docs]

--- a/certbot-dns-google/readthedocs.org.requirements.txt
+++ b/certbot-dns-google/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-google[docs]" does not work as
 # expected and "pip install -e certbot-dns-google[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-google[docs]

--- a/certbot-dns-google/readthedocs.org.requirements.txt
+++ b/certbot-dns-google/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-google[docs]

--- a/certbot-dns-linode/readthedocs.org.requirements.txt
+++ b/certbot-dns-linode/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-linode[docs]

--- a/certbot-dns-linode/readthedocs.org.requirements.txt
+++ b/certbot-dns-linode/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-linode[docs]" does not work as
 # expected and "pip install -e certbot-dns-linode[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-linode[docs]

--- a/certbot-dns-luadns/readthedocs.org.requirements.txt
+++ b/certbot-dns-luadns/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-luadns[docs]" does not work as
 # expected and "pip install -e certbot-dns-luadns[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-luadns[docs]

--- a/certbot-dns-luadns/readthedocs.org.requirements.txt
+++ b/certbot-dns-luadns/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-luadns[docs]

--- a/certbot-dns-nsone/readthedocs.org.requirements.txt
+++ b/certbot-dns-nsone/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-nsone[docs]

--- a/certbot-dns-nsone/readthedocs.org.requirements.txt
+++ b/certbot-dns-nsone/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-nsone[docs]" does not work as
 # expected and "pip install -e certbot-dns-nsone[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-nsone[docs]

--- a/certbot-dns-ovh/readthedocs.org.requirements.txt
+++ b/certbot-dns-ovh/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-ovh[docs]

--- a/certbot-dns-ovh/readthedocs.org.requirements.txt
+++ b/certbot-dns-ovh/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-ovh[docs]" does not work as
 # expected and "pip install -e certbot-dns-ovh[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-ovh[docs]

--- a/certbot-dns-rfc2136/readthedocs.org.requirements.txt
+++ b/certbot-dns-rfc2136/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-rfc2136[docs]

--- a/certbot-dns-rfc2136/readthedocs.org.requirements.txt
+++ b/certbot-dns-rfc2136/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-rfc2136[docs]" does not work as
 # expected and "pip install -e certbot-dns-rfc2136[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-rfc2136[docs]

--- a/certbot-dns-route53/readthedocs.org.requirements.txt
+++ b/certbot-dns-route53/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-route53[docs]" does not work as
 # expected and "pip install -e certbot-dns-route53[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-route53[docs]

--- a/certbot-dns-route53/readthedocs.org.requirements.txt
+++ b/certbot-dns-route53/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-route53[docs]

--- a/certbot-dns-sakuracloud/readthedocs.org.requirements.txt
+++ b/certbot-dns-sakuracloud/readthedocs.org.requirements.txt
@@ -7,6 +7,9 @@
 # in --editable mode (-e), just "pip install certbot-dns-sakuracloud[docs]" does not work as
 # expected and "pip install -e certbot-dns-sakuracloud[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-sakuracloud[docs]

--- a/certbot-dns-sakuracloud/readthedocs.org.requirements.txt
+++ b/certbot-dns-sakuracloud/readthedocs.org.requirements.txt
@@ -9,7 +9,7 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot
 -e certbot-dns-sakuracloud[docs]

--- a/certbot/readthedocs.org.requirements.txt
+++ b/certbot/readthedocs.org.requirements.txt
@@ -9,6 +9,6 @@
 
 # We also pin our dependencies for increased stability.
 
--c tools/requirements.txt
+-c ../tools/requirements.txt
 -e acme
 -e certbot[docs]

--- a/certbot/readthedocs.org.requirements.txt
+++ b/certbot/readthedocs.org.requirements.txt
@@ -7,5 +7,8 @@
 # in --editable mode (-e), just "pip install .[docs]" does not work as
 # expected and "pip install -e certbot[docs]" must be used instead
 
+# We also pin our dependencies for increased stability.
+
+-c tools/requirements.txt
 -e acme
 -e certbot[docs]


### PR DESCRIPTION
Our readthedocs builds started failing recently due to https://github.com/readthedocs/readthedocs.org/issues/8616. See logs like https://readthedocs.org/projects/certbot-dns-cloudflare/builds/15177962/.

This PR fixes the problem. You can see them successfully building on readthedocs at https://readthedocs.org/projects/certbot-dns-cloudflare/builds/15177992/.