### PR TITLE
Certificate issuing on Window while having web.confing and more then …

### DIFF
--- a/certbot/certbot/_internal/plugins/webroot.py
+++ b/certbot/certbot/_internal/plugins/webroot.py
@@ -217,7 +217,7 @@ to serve all files under specified web root ({0})."""
                 if os.path.exists(web_config_path):
                     logger.info("A web.config file has not been created in "
                                 "%s because another one already exists.", self.full_roots[name])
-                    return
+                    continue
                 logger.info("Creating a web.config file in %s to allow IIS "
                             "to serve challenge files.", self.full_roots[name])
                 with safe_open(web_config_path, mode="w", chmod=0o644) as web_config:


### PR DESCRIPTION

Getting 
```Cleaning up challenges
Not cleaning up the web.config file in C:\inetpub\wwwroot\.well-known\acme-challenge because it is not generated by Certbot.
An unexpected error occurred:
KeyError: 'domain2'
```

https://github.com/certbot/certbot/blob/b1edda8a65cc9d9d143ec67f4d79aafc04670793/certbot/certbot/_internal/plugins/webroot.py#L220

It turns out that if we are trying to set multiple domains (-d domain1 -d domain2) and only one wwwroot for them
certbot end ups with this:

```
Using the webroot path C:\inetpub\wwwroot for all unmatched domains.
A web.config file has not been created in C:\inetpub\wwwroot\.well-known\acme-challenge because another one already exists.
{'domain1': 'C:\\inetpub\\wwwroot\\.well-known\\acme-challenge'}
{'domain1': 'C:\\inetpub\\wwwroot\\.well-known\\acme-challenge'}
```
while it should keep track of both domains

to fix this changed `return` to `continue` so it iterates all the domains instead of exiting 
