### PR TITLE
docs: update the intersphinx URL for the certbot project

### DIFF
--- a/certbot-dns-cloudflare/docs/conf.py
+++ b/certbot-dns-cloudflare/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-cloudxns/docs/conf.py
+++ b/certbot-dns-cloudxns/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-digitalocean/docs/conf.py
+++ b/certbot-dns-digitalocean/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-dnsimple/docs/conf.py
+++ b/certbot-dns-dnsimple/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-dnsmadeeasy/docs/conf.py
+++ b/certbot-dns-dnsmadeeasy/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-gehirn/docs/conf.py
+++ b/certbot-dns-gehirn/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-google/docs/conf.py
+++ b/certbot-dns-google/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-linode/docs/conf.py
+++ b/certbot-dns-linode/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-luadns/docs/conf.py
+++ b/certbot-dns-luadns/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-nsone/docs/conf.py
+++ b/certbot-dns-nsone/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-ovh/docs/conf.py
+++ b/certbot-dns-ovh/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-rfc2136/docs/conf.py
+++ b/certbot-dns-rfc2136/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-route53/docs/conf.py
+++ b/certbot-dns-route53/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-sakuracloud/docs/conf.py
+++ b/certbot-dns-sakuracloud/docs/conf.py
@@ -177,5 +177,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
-    'certbot': ('https://certbot.eff.org/docs/', None),
+    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/tools/sphinx-quickstart.sh
+++ b/tools/sphinx-quickstart.sh
@@ -12,7 +12,7 @@ yes "n" | sphinx-quickstart --dot _ --project $PROJECT --author "Certbot Project
 cd $PROJECT/docs
 sed -i -e "s|\# import os|import os|" conf.py
 sed -i -e "s|\# needs_sphinx = '1.0'|needs_sphinx = '1.0'|" conf.py
-sed -i -e "s|intersphinx_mapping = {'https://docs.python.org/': None}|intersphinx_mapping = {\n    'python': ('https://docs.python.org/', None),\n    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),\n    'certbot': ('https://certbot.eff.org/docs/', None),\n}|" conf.py
+sed -i -e "s|intersphinx_mapping = {'https://docs.python.org/': None}|intersphinx_mapping = {\n    'python': ('https://docs.python.org/', None),\n    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),\n    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),\n}|" conf.py
 sed -i -e "s|html_theme = 'alabaster'|\n# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally\n# on_rtd is whether we are on readthedocs.org\non_rtd = os.environ.get('READTHEDOCS', None) == 'True'\nif not on_rtd:  # only import and set the theme if we're building docs locally\n    import sphinx_rtd_theme\n    html_theme = 'sphinx_rtd_theme'\n    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]\n# otherwise, readthedocs.org uses their theme by default, so no need to specify it|" conf.py
 sed -i -e "s|# Add any paths that contain templates here, relative to this directory.|autodoc_member_order = 'bysource'\nautodoc_default_flags = ['show-inheritance']\n\n# Add any paths that contain templates here, relative to this directory.|" conf.py
 sed -i -e "s|# The name of the Pygments (syntax highlighting) style to use.|default_role = 'py:obj'\n\n# The name of the Pygments (syntax highlighting) style to use.|" conf.py


### PR DESCRIPTION
Fixes the sphinx builds. 

We might want to update other references to the former docs URL (`https://certbot.eff.org/docs/`), but this is just to make `master` pass.