### PR TITLE
Optionally sign the SOA query for dns_rfc2136

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,6 +10,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * The function certbot.util.parse_loose_version was added to parse version
   strings in the same way as the now deprecated distutils.version.LooseVersion
   class from the Python standard library.
+* Optionally sign the SOA query for dns-rfc2136, which can help with split-view
+  DNS setups.
 
 ### Changed
 


### PR DESCRIPTION
This should help folks running split views in their nameserver, which
can leverage the TSIG key to figure out *which* view to query and
update.

This helps the _query_soa function "find" the authorative view.

P.s: I am a developer, just not a python developer -- someone please double check this :)