### PR TITLE
Fix Windows webroot crash when multiple domains have the same webroot

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -20,6 +20,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Fixed an issue on Windows where the `web.config` created by Certbot would sometimes
   conflict with preexisting configurations (#9088).
+* Fixed an issue on Windows where the `webroot` plugin would crash when multiple domains
+  had the same webroot. This affected Certbot 1.21.0.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/_internal/plugins/webroot.py
+++ b/certbot/certbot/_internal/plugins/webroot.py
@@ -217,7 +217,7 @@ to serve all files under specified web root ({0})."""
                 if os.path.exists(web_config_path):
                     logger.info("A web.config file has not been created in "
                                 "%s because another one already exists.", self.full_roots[name])
-                    return
+                    continue
                 logger.info("Creating a web.config file in %s to allow IIS "
                             "to serve challenge files.", self.full_roots[name])
                 with safe_open(web_config_path, mode="w", chmod=0o644) as web_config:


### PR DESCRIPTION
This issue is related to the changes introduced in #9054.

Fixes #9091.
Closes #9090.