### PR TITLE
Consul kv

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -187,6 +187,7 @@ Authors
 * [mrstanwell](https://github.com/mrstanwell)
 * [Nav Aulakh](https://github.com/Nav)
 * [Nelson Elhage](https://github.com/nelhage)
+* [Nicholas Cioli](https://github.com/nicholascioli)
 * [Nick Fong](https://github.com/nickfong)
 * [Nick Le Mouton](https://github.com/NoodlesNZ)
 * [Nikos Roussos](https://github.com/comzeradd)

--- a/certbot-consul/_internal/CertMapping.py
+++ b/certbot-consul/_internal/CertMapping.py
@@ -1,0 +1,22 @@
+"""
+Certificate Mappings
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List
+
+class CertType(Enum):
+    """Valid certificate types"""
+
+    CHAIN = "chain"
+    FULL_CHAIN = "fullchain"
+    PRIVATE_KEY = "privkey"
+    CERTIFICATE = "cert"
+
+@dataclass
+class CertMapping:
+    """Class for keeping track of the mappings between a consul key and its cert contents"""
+
+    key: str
+    contents: List[CertType] = field(default_factory=list)

--- a/certbot-consul/_internal/ConsulHelper.py
+++ b/certbot-consul/_internal/ConsulHelper.py
@@ -1,0 +1,130 @@
+"""
+Consul Helper class
+"""
+
+from secrets import token_hex
+from typing import List
+
+from certbot import errors
+from consul import Consul
+
+class ConsulHelper:
+    """Helper for interfacing with Consul
+
+    ConsulHelper makes sure to wrap any and all Consul errors in a PluginError
+    so that the certbot cli command can handle those errors appropriately.
+
+    """
+    def __init__(self, client: Consul, root: str):
+        self.client = client
+        self.root = root
+
+        # Ensure that the consul backend is accessable
+        self.test_consul_read_write()
+
+    def _get_rooted_path(self, key: str) -> str:
+        """Prepends the root KV path to a key, if set.
+
+        :param str key: The key to save to in Consul's KV store.
+
+        :returns: The key prepended with the saved root KV path.
+        :rtype: str
+
+        """
+        # Make sure that we only append to the root if it is not empty.
+        # This is because the consul client does not allow a leading /
+        return key if self.root == '' else f'{self.root}/{key}'
+
+    def get_keys(self, root: str) -> List[str]:
+        """Fetch the available keys in the specified root
+
+        :param str root: The root path in which to list all keys.
+
+        :returns: A list of keys in the specified root path.
+            Keys are stripped of the saved root KV path.
+
+        :rtype: List[str]
+
+        """
+        path = self._get_rooted_path(root)
+
+        try:
+            (_, values) = self.client.kv.get(path, keys=True)
+
+            # Strip the root from the prefix
+            prefix = self._get_rooted_path('')
+            values = [x[x.startswith(prefix) and len(prefix):] for x in values]
+
+            return values
+        except Exception as e:
+            raise errors.PluginError(
+                "Could not get keys at path '{0}': {1}".format(path, e)
+            )
+
+    def get_key(self, key: str, default=None) -> str:
+        """Fetch a key's value from consul and return the default value is the key does not exist
+
+        :param str key: The key in Consul KV to read.
+        :param str default: The default value to use if the key does not exist.
+
+        :returns: The value of the specified key in Consul's KV store.
+            Returns the default value if not found.
+
+        :rtype: str
+
+        """
+        path = self._get_rooted_path(key)
+
+        try:
+            # Get the actual value
+            (_, value) = self.client.kv.get(path)
+
+            return value['Value'] if value is not None else default
+        except Exception as e:
+            raise errors.PluginError(
+                "Could not read key '{0}': {1}".format(path, e)
+            )
+
+    def put_key(self, key: str, content: str) -> None:
+        """Put a value into consul's KV store
+
+        :param str key: The key in Consul's KV in which to store.
+        :param str content: The content to store at key location in Consul's KV store.
+
+        :returns: Nothing
+        :rtype: None
+
+        """
+        path = self._get_rooted_path(key)
+
+        try:
+            # Push the value to consul
+            self.client.kv.put(path, content)
+        except Exception as e:
+            raise errors.PluginError(
+                "Could not put key '{0}': '{1}".format(path, e)
+            )
+
+    def test_consul_read_write(self) -> None:
+        """Test that the consul backend can be read from / written to at the specified root"""
+
+        # First, we try to read the root.
+        try:
+            self.client.kv.get(self.root, keys=True)
+        except Exception as e:
+            raise errors.PluginError(
+                "Consul backend does not support 'read' at root '{0}': {1}".format(self.root, e)
+            )
+
+        # Try writing to the kv a temporary file, and then remove it
+        # Note: We use a random key name to help minimize collisions
+        key = ".CERTBOT_TEST_CONSUL_KEY_" + token_hex(8)
+        path = self._get_rooted_path(key)
+
+        try:
+            self.client.kv.put(path, "REMOVE ME")
+            self.client.kv.delete(path)
+        except Exception as e:
+            raise errors.PluginError(
+                "Consul backend does not support 'write' at root '{0}': {1}".format(self.root, e)
+            )

--- a/certbot-consul/_internal/__init__.py
+++ b/certbot-consul/_internal/__init__.py
@@ -1,0 +1,1 @@
+"""Certbot consul plugin internal implementation"""

--- a/certbot-consul/_internal/constants.py
+++ b/certbot-consul/_internal/constants.py
@@ -1,0 +1,10 @@
+"""consul plugin constants."""
+
+ARG_DATA_CENTER = "data-center"
+ARG_KV_ROOT = "kv-root"
+ARG_MAPPING = "mapping"
+ARG_NO_VERIFY_SSL = "no-verify-ssl"
+
+ARG_DATA_CENTER_DEFAULT = "dc1"
+ARG_KV_ROOT_DEFAULT = "certbot"
+ARG_NO_VERIFY_SSL_DEFAULT = False

--- a/certbot-consul/cert_consul.py
+++ b/certbot-consul/cert_consul.py
@@ -1,0 +1,174 @@
+"""Consul Certbot Plugins
+
+Stores certificates into a Consul KV store for use in cluster applications.
+
+"""
+import consul
+from functools import reduce
+from typing import Callable, Iterable, List, Optional, Set, Union
+
+from certbot import errors, interfaces
+from certbot import util
+from certbot.plugins import common
+
+from _internal import constants
+from _internal.CertMapping import CertMapping, CertType
+from _internal.ConsulHelper import ConsulHelper
+
+class Installer(common.Plugin, interfaces.Installer):
+    """Installer using the Consul KV store."""
+
+    description = "Install certificates to a Consul KV store."
+
+    # Class properties
+    _consul_helper: ConsulHelper
+
+    # Cert info
+    _mappings: List[CertMapping] = []
+
+    #######################
+    # Plugin overrides
+    #######################
+    @classmethod
+    def add_parser_arguments(cls, add: Callable):
+        add(
+            constants.ARG_MAPPING,
+            action = "append",
+            type = str,
+            help = "Mapping between consul key and cert components." +
+                "(Ex. test.example.com:fullchain,privkey)",
+        )
+        add(
+            constants.ARG_KV_ROOT,
+            default = constants.ARG_KV_ROOT_DEFAULT,
+            type = str,
+            help = "The root path in conul's KV store in which to save the certificates.",
+        )
+        add(
+            constants.ARG_NO_VERIFY_SSL,
+            default = constants.ARG_NO_VERIFY_SSL_DEFAULT,
+            action = "store_true",
+            help="Skip SSL verification when communicating with consul.",
+        )
+        add(
+            constants.ARG_DATA_CENTER,
+            default = constants.ARG_DATA_CENTER_DEFAULT,
+            type = str,
+            help="The consul data center.",
+        )
+
+    def more_info(self) -> str:
+        """Human-readable string to help understand the module"""
+
+        return (
+            "Save certificates to a Consul KV store."
+        )
+
+    def prepare(self) -> None:
+        """Prepare the plugin
+
+        Checks the existance of the consul server and that the KV is present.
+        Needed environment variables are the same as those needed by consul:
+        - CONSUL_HTTP_ADDR: The HTTP address (with the protocol and port)
+        - CONSUL_HTTP_TOKEN: The token (if needed) with the relevant ACL permissions
+
+        This also creates a key containing the metadata for the certs installed by this tool.
+
+        """
+
+        # Fetch configuration options
+        dc = self.conf(constants.ARG_DATA_CENTER)
+        verify = not self.conf(constants.ARG_NO_VERIFY_SSL)
+        root = self.conf(constants.ARG_KV_ROOT)
+
+        # Create our consul client
+        client = consul.Consul(
+            dc=dc,
+            verify=verify,
+        )
+
+        # Construct our consul helper.
+        # Note: This will raise an exception on error due to missing permissions
+        self._consul_helper = ConsulHelper(client, root)
+
+        # Make sure that we have valid mappings
+        self._mappings = [
+            CertMapping(key = x.split(':')[0], contents = x.split(':')[1].split(','))
+            for x in self.conf("mapping")
+        ]
+
+        if self._mappings is None or len(self._mappings) == 0:
+            raise errors.PluginError("No valid mappings found! Specify them with --consul-mappings")
+
+    #######################
+    # Installer Overrides
+    #######################
+    def get_all_names(self) -> Iterable[str]:
+        """Returns all names found in the Consul KV store.
+
+        :returns: All ServerNames, ServerAliases, and reverse DNS entries for
+                  virtual host addresses
+        :rtype: set
+
+        """
+        # Fetch the names of all of the files from consul
+        all_names: Set[str] = set(self._consul_helper.get_keys(''))
+
+        return util.get_filtered_names(all_names)
+
+    def deploy_cert(
+        self, domain: str, cert_path: str, key_path: str,
+        chain_path: str, fullchain_path: str
+    ) -> None:
+        """Deploy a cert to Consul's KV store."""
+
+        # Find the corresponding mapping corresponding to the domain
+        mapping = [x for x in self._mappings if x.key == domain]
+
+        # Make sure that there is a mapping and that it is unique
+        if len(mapping) == 0:
+            raise errors.PluginError(f"No mapping found for domain: {domain}")
+        elif len(mapping) > 1:
+            raise errors.PluginError(f"Multiple mappings found for the same domain: {domain}")
+
+        # Get the files needed for the mappings
+        mapping_to_file = {
+            CertType.CHAIN.value: chain_path,
+            CertType.FULL_CHAIN.value: fullchain_path,
+            CertType.PRIVATE_KEY.value: key_path,
+            CertType.CERTIFICATE.value: cert_path,
+        }
+        files = [mapping_to_file[x] for x in mapping[0].contents]
+
+        # Read in the files into the overall content
+        def file_reducer(acc: str, next_file: str):
+            result = acc
+            with open(next_file, 'r') as file:
+                result += '\n' + file.read()
+
+            return result
+
+        content = reduce(file_reducer, files, "")
+
+        # Save the mapped content into consul
+        # Note: This will raise any error from consul
+        self._consul_helper.put_key(domain, content)
+
+    # Disabled overrides below
+    def supported_enhancements(self) -> List[str]:
+        return []
+    def enhance(
+        self, domain: str, enhancement: str,
+        options: Optional[Union[List[str], str]] = None
+    ) -> None:
+        pass
+    def rollback_checkpoints(self, rollback: int = 1) -> None:
+        pass
+    def restart(self) -> None:
+        pass
+    def config_test(self) -> None:
+        pass
+    def recovery_routine(self) -> None:
+        pass
+    def save(self, title: Optional[str] = None, temporary: bool = False) -> None:
+        pass

--- a/certbot-consul/setup.py
+++ b/certbot-consul/setup.py
@@ -1,0 +1,22 @@
+"""Setup script for certbot-consul"""
+
+from setuptools import find_packages, setup
+
+version = '1.22.0.dev0'
+
+setup(
+    name='certbot-consul',
+    version=version,
+    packages=find_packages(),
+    python_requires='>=3.6',
+    install_requires=[
+        f'certbot>={version}',
+        'python-consul>=1.1.0',
+        'setuptools>=39.0.1',
+    ],
+    entry_points={
+        'certbot.plugins': [
+            'consul = cert_consul:Installer',
+        ],
+    },
+)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,6 +10,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * The function certbot.util.parse_loose_version was added to parse version
   strings in the same way as the now deprecated distutils.version.LooseVersion
   class from the Python standard library.
+* Support for saving certificates directly to a Consul KV was added to Certbot
+  using the `certbot-consul` plugin.
 
 ### Changed
 


### PR DESCRIPTION
Some load balancers can leverage Consul's KV store for hosting
certificates in a highly available fashion. This commit allows for
installing generated certificates directly to Consul.

An example use case is `fabio` which expects a certificate to be of the
format fullchain + privkey. For this use-case, the corresponding certbot
command would be:

```sh
certbot run -a standalone -i consul -d test.example.com --consul-mapping test.example.com:fullchain,privkey
```

Valid options for a consul mapping are:
* fullchain
* cert
* chain
* privkey

Other valid options include:
* `--consul-no-verify-ssl` Disables verifying the Consul API certificate.
* `--consul-kv-root` Specifies the base KV path in Consul in which to save certificates.
* `--consul-data-center` Specifies the Consul data center in which to connect.

## Pull Request Checklist

- [X] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [X] Add or update any documentation as needed to support the changes in this PR.
- [X] Include your name in `AUTHORS.md` if you like.
