### PR TITLE
Add `show_account` subcommand to retrieve account info from ACME server

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,10 +6,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-* Added `fetch_account` subcommand, which will fetch the account information from the ACME
-  server. By default it will display the contact information associated with the ACME account.
-  When the `--verbose` option is used, it will also show the ACME account URI and the ACME
-  account thumbprint.
+* Added `show_account` subcommand, which will fetch the account information
+  from the ACME server and show the account details (account URL and, if
+  applicable, email address or addresses)
 
 ### Changed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,10 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Added `fetch_account` subcommand, which will fetch the account information from the ACME
+  server. By default it will display the contact information associated with the ACME account.
+  When the `--verbose` option is used, it will also show the ACME account URI and the ACME
+  account thumbprint.
 
 ### Changed
 
@@ -28,8 +31,6 @@ More details about these changes can be found on our GitHub repo.
   class from the Python standard library.
 * Added `--issuance-timeout`. This option specifies how long (in seconds) Certbot will wait
   for the server to issue a certificate.
-* Added `fetch_account` subcommand, which will fetch the account information from the ACME
-  server and display the stored contact information.
 
 ### Changed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -12,6 +12,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   class from the Python standard library.
 * Added `--issuance-timeout`. This option specifies how long (in seconds) Certbot will wait
   for the server to issue a certificate.
+* Added `fetch_account` subcommand, which will fetch the account information from the ACME
+  server and display the stored contact information.
 
 ### Changed
 

--- a/certbot/certbot/_internal/cli/cli_constants.py
+++ b/certbot/certbot/_internal/cli/cli_constants.py
@@ -43,7 +43,7 @@ manage your account:
     register        Create an ACME account
     unregister      Deactivate an ACME account
     update_account  Update an ACME account
-    fetch_account   Fetch ACME account data from server and print the contact info
+    show_account    Display account details
   --agree-tos       Agree to the ACME server's Subscriber Agreement
    -m EMAIL         Email address for important account notifications
 """

--- a/certbot/certbot/_internal/cli/cli_constants.py
+++ b/certbot/certbot/_internal/cli/cli_constants.py
@@ -43,6 +43,7 @@ manage your account:
     register        Create an ACME account
     unregister      Deactivate an ACME account
     update_account  Update an ACME account
+    fetch_account   Fetch ACME account data from server and print the contact info
   --agree-tos       Agree to the ACME server's Subscriber Agreement
    -m EMAIL         Email address for important account notifications
 """

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -56,7 +56,7 @@ class HelpfulArgumentParser:
             "plugins": main.plugins_cmd,
             "register": main.register,
             "update_account": main.update_account,
-            "fetch_account": main.fetch_account,
+            "show_account": main.show_account,
             "unregister": main.unregister,
             "renew": main.renew,
             "revoke": main.revoke,

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -56,6 +56,7 @@ class HelpfulArgumentParser:
             "plugins": main.plugins_cmd,
             "register": main.register,
             "update_account": main.update_account,
+            "fetch_account": main.fetch_account,
             "unregister": main.unregister,
             "renew": main.renew,
             "revoke": main.revoke,

--- a/certbot/certbot/_internal/cli/paths_parser.py
+++ b/certbot/certbot/_internal/cli/paths_parser.py
@@ -46,5 +46,5 @@ def _paths_parser(helpful: "helpful.HelpfulArgumentParser") -> None:
         help=config_help("work_dir"))
     add("paths", "--logs-dir", default=flag_default("logs_dir"),
         help="Logs directory.")
-    add("paths", "--server", default=flag_default("server"),
+    add(["paths", "show_account"], "--server", default=flag_default("server"),
         help=config_help("server"))

--- a/certbot/certbot/_internal/cli/verb_help.py
+++ b/certbot/certbot/_internal/cli/verb_help.py
@@ -97,6 +97,11 @@ VERB_HELP = [
                  "to already existing configuration."),
         "usage": "\n\n  certbot enhance [options]\n\n"
     }),
+    ("show_account", {
+        "short": "Show account details from an ACME server",
+        "opts": 'Options useful for the "show_account" subcommand:',
+        "usage": "\n\n  certbot show_account [options]\n\n"
+    }),
 ]
 
 

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -846,7 +846,7 @@ def register(config: configuration.NamespaceConfig,
     :param unused_plugins: List of plugins (deprecated)
     :type unused_plugins: plugins_disco.PluginsRegistry
 
-    :returns: `None` or a string indicating and error
+    :returns: `None` or a string indicating an error
     :rtype: None or str
 
     """
@@ -877,7 +877,7 @@ def update_account(config: configuration.NamespaceConfig,
     :param unused_plugins: List of plugins (deprecated)
     :type unused_plugins: plugins_disco.PluginsRegistry
 
-    :returns: `None` or a string indicating and error
+    :returns: `None` or a string indicating an error
     :rtype: None or str
 
     """
@@ -931,7 +931,7 @@ def show_account(config: configuration.NamespaceConfig,
     :param unused_plugins: List of plugins (deprecated)
     :type unused_plugins: plugins_disco.PluginsRegistry
 
-    :returns: `None` or a string indicating and error
+    :returns: `None` or a string indicating an error
     :rtype: None or str
 
     """

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -811,7 +811,7 @@ def unregister(config: configuration.NamespaceConfig,
     accounts = account_storage.find_all()
 
     if not accounts:
-        return "Could not find existing account to deactivate."
+        return f"Could not find existing account for server {config.server}."
     prompt = ("Are you sure you would like to irrevocably deactivate "
               "your account?")
     wants_deactivate = display_util.yesno(prompt, yes_label='Deactivate', no_label='Abort',
@@ -887,7 +887,7 @@ def update_account(config: configuration.NamespaceConfig,
     accounts = account_storage.find_all()
 
     if not accounts:
-        return "Could not find an existing account to update."
+        return f"Could not find an existing account for server {config.server}."
     if config.email is None and not config.register_unsafely_without_email:
         config.email = display_ops.get_email(optional=False)
 
@@ -941,7 +941,7 @@ def show_account(config: configuration.NamespaceConfig,
     accounts = account_storage.find_all()
 
     if not accounts:
-        return "Could not find an existing account to show."
+        return f"Could not find an existing account for server {config.server}."
 
     acc, acme = _determine_account(config)
     cb_client = client.Client(config, acc, None, None, acme=acme)

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -953,18 +953,12 @@ def show_account(config: configuration.NamespaceConfig,
     output = [f"Account details for server {config.server}:",
               f"  Account URL: {regr.uri}"]
 
-    #phones = []
     emails = []
 
     for contact in regr.body.contact:
-        #if contact.startswith('tel:'):
-        #    phones.append(contact[4:])
         if contact.startswith('mailto:'):
             emails.append(contact[7:])
 
-    #output.append("Phone number{} associated with account: {}".format(
-    #                        "s" if len(phones) > 1 else "",
-    #                        ", ".join(phones) if len(phones) > 0 else "none"))
     output.append("  Email contact{}: {}".format(
                             "s" if len(emails) > 1 else "",
                             ", ".join(emails) if len(emails) > 0 else "none"))

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -15,6 +15,7 @@ from typing import TypeVar
 from typing import Union
 
 import configobj
+from cryptography.hazmat.primitives.hashes import SHA256
 import josepy as jose
 import zope.component
 import zope.interface
@@ -950,6 +951,13 @@ def fetch_account(config: configuration.NamespaceConfig,
         raise errors.Error("ACME client is not set.")
 
     regr = cb_client.acme.query_registration(acc.regr)
+
+    if config.verbose_count > 0:
+        display_util.notify(f"Account URI: {regr.uri}")
+
+        thumbprint = jose.b64encode(regr.body.key.thumbprint(
+            hash_function=SHA256)).decode()
+        display_util.notify(f"Account thumbprint: {thumbprint}")
 
     phones = []
     emails = []

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -2071,7 +2071,7 @@ class UpdateAccountTest(test_util.ConfigTestCase):
 
 
 class ShowAccountTest(test_util.ConfigTestCase):
-    """Tests for certbot._internal.main.fetch_account"""
+    """Tests for certbot._internal.main.show_account"""
 
     def setUp(self):
         patches = {
@@ -2105,7 +2105,7 @@ class ShowAccountTest(test_util.ConfigTestCase):
         mock_account.regr.body = mock_regr.body
         self.mocks['determine_account'].return_value = (mock_account, mock.MagicMock())
 
-    def _test_fetch_account(self, contact):
+    def _test_show_account(self, contact):
         self._prepare_mock_account()
         mock_client = mock.MagicMock()
         mock_regr = mock.MagicMock()
@@ -2141,7 +2141,7 @@ class ShowAccountTest(test_util.ConfigTestCase):
             self.assertEqual('ACME client is not set.', str(e))
 
     def test_no_contacts(self):
-        self._test_fetch_account(())
+        self._test_show_account(())
 
         self.assertEqual(self.mocks['notify'].call_count, 1)
         self.mocks['notify'].assert_has_calls([
@@ -2151,7 +2151,7 @@ class ShowAccountTest(test_util.ConfigTestCase):
 
     def test_single_email(self):
         contact = ('mailto:foo@example.com',)
-        self._test_fetch_account(contact)
+        self._test_show_account(contact)
 
         self.assertEqual(self.mocks['notify'].call_count, 1)
         self.mocks['notify'].assert_has_calls([
@@ -2161,7 +2161,7 @@ class ShowAccountTest(test_util.ConfigTestCase):
 
     def test_double_email(self):
         contact = ('mailto:foo@example.com', 'mailto:bar@example.com')
-        self._test_fetch_account(contact)
+        self._test_show_account(contact)
 
         self.assertEqual(self.mocks['notify'].call_count, 1)
         self.mocks['notify'].assert_has_calls([

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1595,10 +1595,11 @@ class UnregisterTest(unittest.TestCase):
         self.mocks['client'].Client.return_value = cb_client
 
         config = mock.MagicMock()
+        config.server = "https://acme.example.com/directory"
         unused_plugins = mock.MagicMock()
 
         res = main.unregister(config, unused_plugins)
-        m = "Could not find existing account to deactivate."
+        m = "Could not find existing account for server https://acme.example.com/directory."
         self.assertEqual(res, m)
         self.assertIs(cb_client.acme.deactivate_registration.called, False)
 
@@ -2025,7 +2026,8 @@ class UpdateAccountTest(test_util.ConfigTestCase):
         mock_storage.find_all.return_value = []
         self.mocks['account'].AccountFileStorage.return_value = mock_storage
         self.assertEqual(self._call(['update_account', '--email', 'user@example.org']),
-                         'Could not find an existing account to update.')
+                         'Could not find an existing account for server'
+                         ' https://acme-v02.api.letsencrypt.org/directory.')
 
     def test_update_account_remove_email(self):
         """Test that --register-unsafely-without-email is handled as no email"""
@@ -2127,7 +2129,8 @@ class ShowAccountTest(test_util.ConfigTestCase):
         mock_storage.find_all.return_value = []
         self.mocks['account'].AccountFileStorage.return_value = mock_storage
         self.assertEqual(self._call(['show_account']),
-                         'Could not find an existing account to show.')
+                         'Could not find an existing account for server'
+                         ' https://acme-v02.api.letsencrypt.org/directory.')
 
     def test_no_existing_client(self):
         """Test that issues with the ACME client are handled correctly"""

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -2132,6 +2132,17 @@ class FetchAccountTest(test_util.ConfigTestCase):
         self.assertEqual(self._call(['fetch_account']),
                          'Could not find an existing account to fetch.')
 
+    def test_no_existing_client(self):
+        """Test that issues with the ACME client are handled correctly"""
+        self._prepare_mock_account()
+        mock_client = mock.MagicMock()
+        mock_client.acme = None
+        self.mocks['client'].Client.return_value = mock_client
+        try:
+            self._call(['fetch_account'])
+        except errors.Error as e:
+            self.assertEqual('ACME client is not set.', str(e))
+
     def test_no_contacts(self):
         self._test_fetch_account(())
 

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -2070,5 +2070,133 @@ class UpdateAccountTest(test_util.ConfigTestCase):
             'Your e-mail address was updated to user@example.com,user@example.org.')
 
 
+class FetchAccountTest(test_util.ConfigTestCase):
+    """Tests for certbot._internal.main.fetch_account"""
+
+    def setUp(self):
+        patches = {
+            'account': mock.patch('certbot._internal.main.account'),
+            'atexit': mock.patch('certbot.util.atexit'),
+            'client': mock.patch('certbot._internal.main.client'),
+            'determine_account': mock.patch('certbot._internal.main._determine_account'),
+            'notify': mock.patch('certbot._internal.main.display_util.notify'),
+            'util': test_util.patch_display_util()
+        }
+        self.mocks = { k: patches[k].start() for k in patches }
+        for patch in patches.values():
+            self.addCleanup(patch.stop)
+
+        return super().setUp()
+
+    def _call(self, args):
+        with mock.patch('certbot._internal.main.sys.stdout'), \
+             mock.patch('certbot._internal.main.sys.stderr'):
+            args = ['--config-dir', self.config.config_dir,
+                    '--work-dir', self.config.work_dir,
+                    '--logs-dir', self.config.logs_dir, '--text'] + args
+            return main.main(args[:]) # NOTE: parser can alter its args!
+
+    def _prepare_mock_account(self):
+        mock_storage = mock.MagicMock()
+        mock_account = mock.MagicMock()
+        mock_regr = mock.MagicMock()
+        mock_storage.find_all.return_value = [mock_account]
+        self.mocks['account'].AccountFileStorage.return_value = mock_storage
+        mock_account.regr.body = mock_regr.body
+        self.mocks['determine_account'].return_value = (mock_account, mock.MagicMock())
+
+    def _test_fetch_account(self, contact):
+        self._prepare_mock_account()
+        mock_client = mock.MagicMock()
+        mock_regr = mock.MagicMock()
+        mock_regr.body.contact = contact
+        mock_client.acme.query_registration.return_value = mock_regr
+        self.mocks['client'].Client.return_value = mock_client
+
+        self._call(['fetch_account'])
+
+        self.assertEqual(mock_client.acme.query_registration.call_count, 1)
+
+    def test_no_existing_accounts(self):
+        """Test that no existing account is handled correctly"""
+        mock_storage = mock.MagicMock()
+        mock_storage.find_all.return_value = []
+        self.mocks['account'].AccountFileStorage.return_value = mock_storage
+        self.assertEqual(self._call(['fetch_account']),
+                         'Could not find an existing account to fetch.')
+
+    def test_no_contacts(self):
+        self._test_fetch_account(())
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone number associated with account: none'),
+            mock.call('Email address associated with account: none')])
+
+    def test_single_email(self):
+        contact = ('mailto:foo@example.com',)
+        self._test_fetch_account(contact)
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone number associated with account: none'),
+            mock.call('Email address associated with account: foo@example.com')])
+
+    def test_double_email(self):
+        contact = ('mailto:foo@example.com', 'mailto:bar@example.com')
+        self._test_fetch_account(contact)
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone number associated with account: none'),
+            mock.call('Email addresses associated with account: foo@example.com, bar@example.com')])
+
+    def test_single_phone(self):
+        contact = ('tel:+1-415-555-0101',)
+        self._test_fetch_account(contact)
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone number associated with account: +1-415-555-0101'),
+            mock.call('Email address associated with account: none')])
+
+    def test_double_phone(self):
+        contact = ('tel:+1-415-555-0101', 'tel:+1-415-555-0102')
+        self._test_fetch_account(contact)
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone numbers associated with account: +1-415-555-0101, +1-415-555-0102'),
+            mock.call('Email address associated with account: none')])
+
+    def test_combined_single_mail_and_single_phone(self):
+        contact = ('mailto:foo@example.com', 'tel:+1-415-555-0101')
+        self._test_fetch_account(contact)
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone number associated with account: +1-415-555-0101'),
+            mock.call('Email address associated with account: foo@example.com')])
+
+    def test_combined_double_mail_and_single_phone(self):
+        contact = ('mailto:foo@example.com', 'mailto:bar@example.com', 'tel:+1-415-555-0101')
+        self._test_fetch_account(contact)
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone number associated with account: +1-415-555-0101'),
+            mock.call('Email addresses associated with account: foo@example.com, bar@example.com')])
+
+    def test_combined_single_mail_and_double_phone(self):
+        contact = ('mailto:foo@example.com', 'tel:+1-415-555-0101', 'tel:+1-415-555-0102')
+        self._test_fetch_account(contact)
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone numbers associated with account: +1-415-555-0101, +1-415-555-0102'),
+            mock.call('Email address associated with account: foo@example.com')])
+
+    def test_combined_double_mail_and_double_phone(self):
+        contact = ('mailto:foo@example.com', 'mailto:bar@example.com',
+                   'tel:+1-415-555-0101', 'tel:+1-415-555-0102')
+        self._test_fetch_account(contact)
+
+        self.mocks['notify'].assert_has_calls([
+            mock.call('Phone numbers associated with account: +1-415-555-0101, +1-415-555-0102'),
+            mock.call('Email addresses associated with account: foo@example.com, bar@example.com')])
+
+
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
On the Community, a user wanted to know which contact info was used during the registration of the ACME account. (See https://community.letsencrypt.org/t/determining-the-parameters-of-my-account/166915.) Unfortunately, the info was not stored in `regr.json`. And certbot currently does not have the capability to fetch the account info from the ACME server.

This PR introduces a new subcommand called `fetch_account` which will fetch the account info from the ACME server and return it to the user.

Note that RFC 8555 has the possibility to include a phone number as contact info. Even though Let's Encrypt does not support this, I've included this in the code, as I do not want to have a "vendor lockin" to LE only. (Although I do not know if other ACME endpoints actually support a phone number as contact info though..)

<s>Also note that I did not set `only_return_existing` to `True`. I did try to set that to `True` in the account registration for the ACME client, but somewhere down the line it was completely ignored for some reason..?</s> Nevermind, `query_registration()` uses the account URI to retrieve the registration and `only_return_existing` is not an option for that endpoint. Only for the newAccount endpoint, which isn't used at all..

(And yes, I borrowed/stole the basic test premise from the `update_account` tests :stuck_out_tongue: and yes it probably could have been written in some fancy loop, looping around the different scenarios and automatically adjust the expected responses.. But now there are different test functions which can fail individually! :joy:)