### PR TITLE
tests: remove Boulder v1 endpoint from certbot-ci and azure

### DIFF
--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -26,58 +26,30 @@ jobs:
           CERTBOT_NO_PIN: 1
         linux-external-mock:
           TOXENV: external-mock
-        linux-boulder-v1-integration-certbot-oldest:
-          PYTHON_VERSION: 3.6
-          TOXENV: integration-certbot-oldest
-          ACME_SERVER: boulder-v1
         linux-boulder-v2-integration-certbot-oldest:
           PYTHON_VERSION: 3.6
           TOXENV: integration-certbot-oldest
           ACME_SERVER: boulder-v2
-        linux-boulder-v1-integration-nginx-oldest:
-          PYTHON_VERSION: 3.6
-          TOXENV: integration-nginx-oldest
-          ACME_SERVER: boulder-v1
         linux-boulder-v2-integration-nginx-oldest:
           PYTHON_VERSION: 3.6
           TOXENV: integration-nginx-oldest
           ACME_SERVER: boulder-v2
-        linux-boulder-v1-py36-integration:
-          PYTHON_VERSION: 3.6
-          TOXENV: integration
-          ACME_SERVER: boulder-v1
         linux-boulder-v2-py36-integration:
           PYTHON_VERSION: 3.6
           TOXENV: integration
           ACME_SERVER: boulder-v2
-        linux-boulder-v1-py37-integration:
-          PYTHON_VERSION: 3.7
-          TOXENV: integration
-          ACME_SERVER: boulder-v1
         linux-boulder-v2-py37-integration:
           PYTHON_VERSION: 3.7
           TOXENV: integration
           ACME_SERVER: boulder-v2
-        linux-boulder-v1-py38-integration:
-          PYTHON_VERSION: 3.8
-          TOXENV: integration
-          ACME_SERVER: boulder-v1
         linux-boulder-v2-py38-integration:
           PYTHON_VERSION: 3.8
           TOXENV: integration
           ACME_SERVER: boulder-v2
-        linux-boulder-v1-py39-integration:
-          PYTHON_VERSION: 3.9
-          TOXENV: integration
-          ACME_SERVER: boulder-v1
         linux-boulder-v2-py39-integration:
           PYTHON_VERSION: 3.9
           TOXENV: integration
           ACME_SERVER: boulder-v2
-        linux-boulder-v1-py310-integration:
-          PYTHON_VERSION: 3.10
-          TOXENV: integration
-          ACME_SERVER: boulder-v1
         linux-boulder-v2-py310-integration:
           PYTHON_VERSION: 3.10
           TOXENV: integration

--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -512,7 +512,7 @@ def test_default_curve_type(context: IntegrationTestsContext) -> None:
     # Curve name, Curve class, ACME servers to skip
     ('secp256r1', SECP256R1, []),
     ('secp384r1', SECP384R1, []),
-    ('secp521r1', SECP521R1, ['boulder-v1', 'boulder-v2'])]
+    ('secp521r1', SECP521R1, ['boulder-v2'])]
 )
 def test_ecdsa_curves(context: IntegrationTestsContext, curve: str, curve_cls: Type[EllipticCurve],
                       skip_servers: Iterable[str]) -> None:
@@ -689,9 +689,6 @@ def test_revoke_multiple_lineages(context: IntegrationTestsContext) -> None:
 
 def test_wildcard_certificates(context: IntegrationTestsContext) -> None:
     """Test wildcard certificate issuance."""
-    if context.acme_server == 'boulder-v1':
-        pytest.skip('Wildcard certificates are not supported on ACME v1')
-
     certname = context.get_domain('wild')
 
     context.certbot([

--- a/certbot-ci/certbot_integration_tests/conftest.py
+++ b/certbot-ci/certbot_integration_tests/conftest.py
@@ -21,9 +21,9 @@ def pytest_addoption(parser):
     :param parser: current pytest parser that will be used on the CLI
     """
     parser.addoption('--acme-server', default='pebble',
-                     choices=['boulder-v1', 'boulder-v2', 'pebble'],
-                     help='select the ACME server to use (boulder-v1, boulder-v2, '
-                          'pebble), defaulting to pebble')
+                     choices=['boulder-v2', 'pebble'],
+                     help='select the ACME server to use (boulder-v2, pebble), '
+                          'defaulting to pebble')
     parser.addoption('--dns-server', default='challtestsrv',
                      choices=['bind', 'challtestsrv'],
                      help='select the DNS server to use (bind, challtestsrv), '

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -47,7 +47,7 @@ class ACMEServer:
                  http_01_port: int = DEFAULT_HTTP_01_PORT) -> None:
         """
         Create an ACMEServer instance.
-        :param str acme_server: the type of acme server used (boulder-v1, boulder-v2 or pebble)
+        :param str acme_server: the type of acme server used (boulder-v2 or pebble)
         :param list nodes: list of node names that will be setup by pytest xdist
         :param bool http_proxy: if False do not start the HTTP proxy
         :param bool stdout: if True stream all subprocesses stdout to standard stdout
@@ -130,8 +130,7 @@ class ACMEServer:
         if acme_server == 'pebble':
             acme_xdist['directory_url'] = PEBBLE_DIRECTORY_URL
         else:  # boulder
-            acme_xdist['directory_url'] = BOULDER_V2_DIRECTORY_URL \
-                if acme_server == 'boulder-v2' else BOULDER_V1_DIRECTORY_URL
+            acme_xdist['directory_url'] = BOULDER_V2_DIRECTORY_URL
 
         acme_xdist['http_port'] = {
             node: port for (node, port) in  # pylint: disable=unnecessary-comprehension
@@ -267,9 +266,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description='CLI tool to start a local instance of Pebble or Boulder CA server.')
     parser.add_argument('--server-type', '-s',
-                        choices=['pebble', 'boulder-v1', 'boulder-v2'], default='pebble',
-                        help='type of CA server to start: can be Pebble or Boulder '
-                             '(in ACMEv1 or ACMEv2 mode), Pebble is used if not set.')
+                        choices=['pebble', 'boulder-v2'], default='pebble',
+                        help='type of CA server to start: can be Pebble or Boulder. '
+                             'Pebble is used if not set.')
     parser.add_argument('--dns-server', '-d',
                         help='specify the DNS server as `IP:PORT` to use by '
                              'Pebble; if not specified, a local mock DNS server will be used to '

--- a/certbot-ci/certbot_integration_tests/utils/constants.py
+++ b/certbot-ci/certbot_integration_tests/utils/constants.py
@@ -2,7 +2,6 @@
 DEFAULT_HTTP_01_PORT = 5002
 TLS_ALPN_01_PORT = 5001
 CHALLTESTSRV_PORT = 8055
-BOULDER_V1_DIRECTORY_URL = 'http://localhost:4000/directory'
 BOULDER_V2_DIRECTORY_URL = 'http://localhost:4001/directory'
 PEBBLE_DIRECTORY_URL = 'https://localhost:14000/dir'
 PEBBLE_MANAGEMENT_URL = 'https://localhost:15000'


### PR DESCRIPTION
Boulder is removing the v1 WFE from its code and no longer exposes the endpoint since https://github.com/letsencrypt/boulder/commit/5c02deabfb5aa4d43f708389187973bc84a69943, causing our extended test suite to fail.

This change removes references to the Boulder v1 endpoint from Certbot's tests.

You can see the full test suite passing at https://dev.azure.com/certbot/certbot/_build/results?buildId=4894&view=results.