### PR TITLE
Remove win2016 from Azure devops pipelines.

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -54,8 +54,12 @@ jobs:
           done
         displayName: Run integration tests for Docker images
   - job: installer_build
-    pool:
-      vmImage: vs2017-win2016
+    strategy:
+      matrix:
+        win-2019:
+          vmImage: windows-2019
+        win-2022:
+          vmImage: windows-2022
     steps:
       - task: UsePythonVersion@0
         inputs:
@@ -87,17 +91,11 @@ jobs:
       matrix:
         win2019:
           imageName: windows-2019
-        win2016:
-          imageName: vs2017-win2016
+        win2022:
+          imageName: windows-2022
     pool:
       vmImage: $(imageName)
     steps:
-      - powershell: |
-          if ($PSVersionTable.PSVersion.Major -ne 5) {
-              throw "Powershell version is not 5.x"
-          }
-        condition: eq(variables['imageName'], 'vs2017-win2016')
-        displayName: Check Powershell 5.x is used in vs2017-win2016
       - task: UsePythonVersion@0
         inputs:
           versionSpec: 3.9

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -13,15 +13,15 @@ jobs:
           PYTHON_VERSION: 3.10
           TOXENV: py310-cover
         windows-py36:
-          IMAGE_NAME: vs2017-win2016
+          IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.6
           TOXENV: py36-win
         windows-py39-cover:
-          IMAGE_NAME: vs2017-win2016
+          IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.9
           TOXENV: py39-cover-win
         windows-integration-certbot:
-          IMAGE_NAME: vs2017-win2016
+          IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.9
           TOXENV: integration-certbot
         linux-oldest-tests-1:

--- a/.azure-pipelines/templates/stages/changelog-stage.yml
+++ b/.azure-pipelines/templates/stages/changelog-stage.yml
@@ -3,7 +3,7 @@ stages:
     jobs:
       - job: prepare
         pool:
-          vmImage: vs2017-win2016
+          vmImage: win2019
         steps:
           # If we change the output filename from `release_notes.md`, it should also be changed in tools/create_github_release.py
           - bash: |


### PR DESCRIPTION
From March 2022, support will be removed.
https://github.com/actions/virtual-environments/issues/4312

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
