### PR TITLE
Document appending behaviour of `max-log-backups = 0` in User Guide

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -1151,7 +1151,8 @@ certbot will begin rotating logs once there are 1000 logs in the log directory.
 Meaning that once 1000 files are in ``/var/log/letsencrypt`` Certbot will delete
 the oldest one to make room for new logs. The number of subsequent logs can be
 changed by passing the desired number to the command line flag
-``--max-log-backups``.
+``--max-log-backups``. Setting this flag to 0 disables log rotation entirely,
+causing certbot to always append to the same log file.
 
 .. note:: Some distributions, including Debian and Ubuntu, disable
    certbot's internal log rotation in favor of a more traditional


### PR DESCRIPTION
In https://github.com/certbot/certbot/pull/4907 a nice clear helpful text was incorporated in the introduction of the `max-log-backups` option, specifically the behaviour of certbot when it is set to `0`: _appending_ to a single file instead of overwriting/rotating.

In https://github.com/certbot/certbot/pull/4942 a few words about log rotating was added to the User Guide, including mentioning of the `max-log-backups` option. However, its behaviour when set to `0` is not mentioned.

[Yesterday](https://community.letsencrypt.org/t/new-logfile-after-69-lines/167933) I made the error in believing certbot couldn't do log file appending, but just rotating/overwriting. It didn't help that [recently certbots `--help` was broken](https://github.com/certbot/certbot/issues/9129) and the User Guide did not incorporate the helpful text in the command line options section at all, so the log rotate part was the only mentioning of `max-log-backups` option. 

This PR "fixes" the lack of mentioning of the log **appending** behaviour of certbot when ``max-log-backups` is set to `0` in the log rotate paragraph of the User Guide.

I understand that this just places two identical sentences at just two different places, but personally I think it would also be benificial in the log rotate section, as that's the only time `max-log-backups` is mentioned besides the complete command line options output at the bottom. Feel free to close the PR if this is not what you have in mind :)