### PR TITLE
resolved #9147 (Remove the restriction for IP address)

### DIFF
--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -551,12 +551,6 @@ def enforce_domain_sanity(domain: Union[str, bytes]) -> str:
                 )
             )
 
-    if is_ipaddress(domain):
-        raise errors.ConfigurationError(
-            "Requested name {0} is an IP address. The Let's Encrypt "
-            "certificate authority will not issue certificates for a "
-            "bare IP address.".format(domain))
-
     # FQDN checks according to RFC 2181: domain name should be less than 255
     # octets (inclusive). And each label is 1 - 63 octets (inclusive).
     # https://tools.ietf.org/html/rfc2181#section-11


### PR DESCRIPTION
If a CA doesn't support IP address format identifier, he can reject new-order request by returns `urn:ietf:params:acme:error:malformed` urn.


## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
