### PR TITLE
draft / proof-of-concept: remove python-requests

### DIFF
--- a/acme/acme/errors.py
+++ b/acme/acme/errors.py
@@ -6,7 +6,6 @@ from typing import Mapping
 from typing import Set
 
 from josepy import errors as jose_errors
-import requests
 
 # We import acme.messages only during type check to avoid circular dependencies. Type references
 # to acme.message.* must be quoted to be lazily initialized and avoid compilation errors.
@@ -56,17 +55,17 @@ class MissingNonce(NonceError):
     Replay-Nonce header field in each successful response to a POST it
     provides to a client (...)".
 
-    :ivar requests.Response ~.response: HTTP Response
+    :ivar headers: Mapping of HTTP headers
 
     """
-    def __init__(self, response: requests.Response, *args: Any) -> None:
+    def __init__(self, headers: Mapping, *args: Any) -> None:
         super().__init__(*args)
-        self.response = response
+        self.headers = dict(headers)
 
     def __str__(self) -> str:
-        return ('Server {0} response did not include a replay '
-                'nonce, headers: {1} (This may be a service outage)'.format(
-                    self.response.request.method, self.response.headers))
+        return ('Server response did not include a replay '
+                'nonce, headers: {0} (This may be a service outage)'.format(
+                    self.headers))
 
 
 class PollError(ClientError):

--- a/acme/acme/mureq.py
+++ b/acme/acme/mureq.py
@@ -1,0 +1,343 @@
+"""
+mureq is a replacement for python-requests, intended to be vendored
+in-tree by Linux systems software and other lightweight applications.
+
+This is mureq version 0.1.0.
+
+mureq is copyright 2021 by its contributors and is released under the
+0BSD ("zero-clause BSD") license.
+"""
+import contextlib
+import io
+import os.path
+import socket
+import ssl
+import sys
+import urllib.parse
+from http.client import HTTPConnection, HTTPSConnection, HTTPMessage, HTTPException
+
+__all__ = ['HTTPException', 'TooManyRedirects', 'Response',
+           'yield_response', 'request', 'get', 'post', 'head', 'put', 'patch', 'delete']
+
+DEFAULT_TIMEOUT=15.0
+
+# e.g. "Python 3.8.10"
+DEFAULT_UA = "Python " + sys.version.split()[0]
+
+
+def request(method, url, read_limit=None, **kwargs):
+    """request performs an HTTP request and reads the entire response body.
+
+    :param method: HTTP method to request (e.g. 'GET', 'POST')
+    :param url: URL to request
+    :param read_limit: maximum number of bytes to read from the body, or None for no limit
+    :param **kwargs: optional arguments defined by yield_response
+    :return: Response object
+    :rtype: mureq.Response
+    :raises: HTTPException
+    """
+    with yield_response(method, url, **kwargs) as response:
+        try:
+            body = response.read(read_limit)
+        except IOError as e:
+            if isinstance(e, HTTPException):
+                raise
+            else:
+                raise HTTPException(str(e)) from e
+        return Response(response.status, _prepare_incoming_headers(response.headers), body)
+
+def get(url, **kwargs):
+    """get performs a HTTP GET request."""
+    return request('GET', url=url, **kwargs)
+
+def post(url, body=None, **kwargs):
+    """post performs a HTTP POST request."""
+    return request('POST', url=url, body=body, **kwargs)
+
+def head(url, **kwargs):
+    """head performs a HTTP HEAD request."""
+    return request('HEAD', url=url, **kwargs)
+
+def put(url, body=None, **kwargs):
+    """put performs a HTTP PUT request."""
+    return request('PUT', url=url, body=body, **kwargs)
+
+def patch(url, body=None, **kwargs):
+    """patch performs a HTTP PATCH request."""
+    return request('PATCH', url=url, body=body, **kwargs)
+
+def delete(url, **kwargs):
+    """delete performs a HTTP DELETE request."""
+    return request('DELETE', url=url, **kwargs)
+
+@contextlib.contextmanager
+def yield_response(method, url, *, unix_socket=None, timeout=DEFAULT_TIMEOUT, headers=None, params=None, body=None, form=None, json=None, verify=True, source_address=None, max_redirects=None, ssl_context=None):
+    """yield_response is a low-level API that exposes the actual
+    http.client.HTTPResponse via a contextmanager.
+
+    Note that unlike mureq.Response, http.client.HTTPResponse does not
+    automatically canonicalize multiple appearances of the same header by
+    joining them together with a comma delimiter. To retrieve canonicalized
+    headers from the response, use response.getheader():
+    https://docs.python.org/3/library/http.client.html#http.client.HTTPResponse.getheader
+
+    :param method: HTTP method to request (e.g. 'GET', 'POST')
+    :param url: URL to request
+    :param unix_socket: path to Unix domain socket to query, or None for a normal TCP request
+    :param timeout: timeout in seconds, or None for no timeout (default: 15 seconds)
+    :param headers: HTTP headers as a mapping or list of key-value pairs
+    :param params: parameters to be URL-encoded and added to the query string, as a mapping or list of key-value pairs
+    :param body: payload body of the request; must be bytes
+    :param form: parameters to be form-encoded and sent as the payload body, as a mapping or list of key-value pairs
+    :param json: str or bytes containing serialized JSON data to be sent as the payload body
+    :param verify: bool, whether to verify TLS certificates (default: True)
+    :param source_address: source address to bind to for TCP: str, (str, int) pair, or None for default
+    :param max_redirects: int, maximum number of redirects to follow, or None (the default) to not follow any redirects
+    :param ssl_context: ssl.SSLContext object to control certificate validation, or None to use the default context
+    :return: http.client.HTTPResponse (yielded as context manager)
+    :rtype: http.client.HTTPResponse
+    :raises: HTTPException
+    """
+    method = method.upper()
+    headers = _prepare_outgoing_headers(headers)
+    enc_params = _prepare_params(params)
+    body = _prepare_body(body, form, json, headers)
+
+    redirected_urls = [url]
+
+    while max_redirects is None or (len(redirected_urls) - 1) <= max_redirects:
+        conn, path = _prepare_request(method, url, enc_params=enc_params, timeout=timeout, unix_socket=unix_socket, verify=verify, source_address=source_address, ssl_context=ssl_context)
+        try:
+            try:
+                conn.request(method, path, headers=headers, body=body)
+                response = conn.getresponse()
+            except IOError as e:
+                if isinstance(e, HTTPException):
+                    raise
+                else:
+                    # wrap any IOError that is not already an HTTPException
+                    # in HTTPException, exposing a uniform API for remote errors
+                    raise HTTPException(str(e)) from e
+            redirect_url = _check_redirect(url, response.status, response.headers)
+            if max_redirects is None or redirect_url is None:
+                yield response
+                return
+            else:
+                redirected_urls.append(redirect_url)
+                url = redirect_url
+                if response.status == 303:
+                    # 303 See Other: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
+                    method = 'GET'
+        finally:
+            conn.close()
+
+    raise TooManyRedirects(redirected_urls)
+
+
+class Response:
+    """Response bundles together the elements of a completely consumed HTTP
+    response: the status code (`status_code`, int), the headers
+    (`headers`, http.client.HTTPMessage), and the payload body
+    (`body`, bytes)."""
+
+    __slots__ = ('status_code', 'headers', 'body')
+
+    def __init__(self, status_code, headers, body):
+        self.status_code, self.headers, self.body = status_code, headers, body
+
+    def __repr__(self):
+        return "Response(status_code=%d)" % (self.status_code,)
+
+    @property
+    def ok(self):
+        """ok returns whether the response had a successful status code
+        (anything other than a 40x or 50x)."""
+        return not (400 <= self.status_code and self.status_code < 600)
+
+    @property
+    def content(self):
+        """content returns the response body (the `body` member). This is an
+        alias for compatibility with requests.Response."""
+        # alias for compatibility with requests.Response:
+        return self.body
+
+    def _debugstr(self):
+        buf = io.StringIO()
+        print("HTTP", self.status_code, file=buf)
+        for k, v in self.headers.items():
+            print("%s: %s" % (k, v), file=buf)
+        print(file=buf)
+        try:
+            print(self.body.decode('utf-8'), file=buf)
+        except UnicodeDecodeError:
+            print("<%d bytes binary data>" % (len(self.body),), file=buf)
+        return buf.getvalue()
+
+
+class TooManyRedirects(HTTPException):
+    """TooManyRedirects is raised when automatic following of redirects was
+    enabled, but the server redirected too many times without completing."""
+    pass
+
+
+# end public API, begin internal implementation details
+
+_JSON_CONTENTTYPE = 'application/json'
+_FORM_CONTENTTYPE = 'application/x-www-form-urlencoded'
+
+
+class UnixHTTPConnection(HTTPConnection):
+    """UnixHTTPConnection is a subclass of HTTPConnection that connects to a
+    Unix domain stream socket instead of a TCP address.
+    """
+
+    def __init__(self, path, timeout=DEFAULT_TIMEOUT):
+        super(UnixHTTPConnection, self).__init__('localhost', timeout=timeout)
+        self._unix_path = path
+
+    def connect(self):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.settimeout(self.timeout)
+            sock.connect(self._unix_path)
+        except:
+            sock.close()
+            raise
+        self.sock = sock
+
+def _check_redirect(url, status, response_headers):
+    """Return the URL to redirect to, or None for no redirection."""
+    if status not in (301, 302, 303, 307, 308):
+        return None
+    location = response_headers.get('Location')
+    if not location:
+        return None
+    parsed_location = urllib.parse.urlparse(location)
+    if parsed_location.scheme:
+        # absolute URL
+        return location
+
+    old_url = urllib.parse.urlparse(url)
+    if location.startswith('/'):
+        # absolute path on old hostname
+        return urllib.parse.urlunparse((old_url.scheme, old_url.netloc,
+            parsed_location.path, parsed_location.params, parsed_location.query, parsed_location.fragment))
+
+    # relative path on old hostname
+    old_dir, _old_file = os.path.split(old_url.path)
+    new_path = os.path.join(old_dir, location)
+    return urllib.parse.urlunparse((old_url.scheme, old_url.netloc,
+        new_path, parsed_location.params, parsed_location.query, parsed_location.fragment))
+
+def _prepare_outgoing_headers(headers):
+    if headers is None:
+        headers = HTTPMessage()
+    elif not isinstance(headers, HTTPMessage):
+        new_headers = HTTPMessage()
+        if hasattr(headers, 'items'):
+            iterator = headers.items()
+        else:
+            iterator = iter(headers)
+        for k, v in iterator:
+            new_headers[k] = v
+        headers = new_headers
+    _setdefault_header(headers, 'User-Agent', DEFAULT_UA)
+    return headers
+
+# XXX join multi-headers together so that get(), __getitem__(),
+# etc. behave intuitively, then stuff them back in an HTTPMessage.
+def _prepare_incoming_headers(headers):
+    headers_dict = {}
+    for k, v in headers.items():
+        headers_dict.setdefault(k, []).append(v)
+    result = HTTPMessage()
+    # note that iterating over headers_dict preserves the original
+    # insertion order in all versions since Python 3.6:
+    for k, vlist in headers_dict.items():
+        result[k] = ','.join(vlist)
+    return result
+
+def _setdefault_header(headers, name, value):
+    if name not in headers:
+        headers[name] = value
+
+def _prepare_body(body, form, json, headers):
+    if body is not None:
+        if not isinstance(body, bytes):
+            raise TypeError('body must be bytes or None', type(body))
+        return body
+
+    if json is not None:
+        if isinstance(json, bytes):
+            _setdefault_header(headers, 'Content-Type', _JSON_CONTENTTYPE)
+            return json
+        elif isinstance(json, str):
+            _setdefault_header(headers, 'Content-Type', _JSON_CONTENTTYPE)
+            return json.encode('utf-8')
+        else:
+            raise TypeError('json must be str, bytes, or None', type(json))
+
+    if form is not None:
+        _setdefault_header(headers, 'Content-Type', _FORM_CONTENTTYPE)
+        return urllib.parse.urlencode(form, doseq=True)
+
+    return None
+
+def _prepare_params(params):
+    if params is None:
+        return ''
+    return urllib.parse.urlencode(params, doseq=True)
+
+def _prepare_request(method, url, *, enc_params='', timeout=DEFAULT_TIMEOUT, source_address=None, unix_socket=None, verify=True, ssl_context=None):
+    """Parses the URL, returns the path and the right HTTPConnection subclass."""
+    parsed_url = urllib.parse.urlparse(url)
+
+    is_unix = (unix_socket is not None)
+    scheme = parsed_url.scheme.lower()
+    if scheme.endswith('+unix'):
+        scheme = scheme[:-5]
+        is_unix = True
+        if scheme == 'https':
+            raise ValueError("https+unix is not implemented")
+
+    if scheme not in ('http', 'https'):
+        raise ValueError("unrecognized scheme", scheme)
+
+    is_https = (scheme == 'https')
+    host = parsed_url.hostname
+    port = 443 if is_https else 80
+    if parsed_url.port:
+        port = parsed_url.port
+
+    if is_unix and unix_socket is None:
+        unix_socket = urllib.parse.unquote(parsed_url.netloc)
+
+    path = parsed_url.path
+    if parsed_url.query:
+        if enc_params:
+            path = '%s?%s&%s' % (path, parsed_url.query, enc_params)
+        else:
+            path = '%s?%s' % (path, parsed_url.query)
+    else:
+        if enc_params:
+            path = '%s?%s' % (path, enc_params)
+        else:
+            pass # just parsed_url.path in this case
+
+    if isinstance(source_address, str):
+        source_address = (source_address, 0)
+
+    if is_unix:
+        conn = UnixHTTPConnection(unix_socket, timeout=timeout)
+    elif is_https:
+        if ssl_context is None:
+            ssl_context = ssl.create_default_context()
+            if not verify:
+                ssl_context.check_hostname = False
+                ssl_context.verify_mode = ssl.CERT_NONE
+        conn = HTTPSConnection(host, port, source_address=source_address, timeout=timeout,
+                               context=ssl_context)
+    else:
+        conn = HTTPConnection(host, port, source_address=source_address, timeout=timeout)
+
+    return conn, path

--- a/acme/acme/util.py
+++ b/acme/acme/util.py
@@ -1,4 +1,5 @@
 """ACME utilities."""
+import re
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -8,3 +9,53 @@ from typing import Mapping
 def map_keys(dikt: Mapping[Any, Any], func: Callable[[Any], Any]) -> Dict[Any, Any]:
     """Map dictionary keys."""
     return {func(key): value for key, value in dikt.items()}
+
+
+# this is taken from python-requests:
+def parse_header_links(value):
+    """Return a list of parsed link headers proxies.
+
+    i.e. Link: <http:/.../front.jpeg>; rel=front; type="image/jpeg",<http://.../back.jpeg>; rel=back;type="image/jpeg"
+
+    :rtype: list
+    """
+
+    links = []
+
+    replace_chars = ' \'"'
+
+    value = value.strip(replace_chars)
+    if not value:
+        return links
+
+    for val in re.split(', *<', value):
+        try:
+            url, params = val.split(';', 1)
+        except ValueError:
+            url, params = val, ''
+
+        link = {'url': url.strip('<> \'"')}
+
+        for param in params.split(';'):
+            try:
+                key, value = param.split('=')
+            except ValueError:
+                break
+
+            link[key.strip(replace_chars)] = value.strip(replace_chars)
+
+        links.append(link)
+
+    return links
+
+def extract_links(response):
+    result = {}
+    value = response.headers.get('Link')
+    if not value:
+        return result
+    links = parse_header_links(value)
+    for link in links:
+        key = link.get('rel')
+        if key:
+            result[key] = link
+    return result

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import find_packages
 from setuptools import setup
 
@@ -11,8 +9,6 @@ install_requires = [
     'PyOpenSSL>=17.3.0',
     'pyrfc3339',
     'pytz',
-    'requests>=2.14.2',
-    'requests-toolbelt>=0.3.0',
     'setuptools>=39.0.1',
 ]
 

--- a/acme/tests/errors_test.py
+++ b/acme/tests/errors_test.py
@@ -19,13 +19,10 @@ class MissingNonceTest(unittest.TestCase):
 
     def setUp(self):
         from acme.errors import MissingNonce
-        self.response = mock.MagicMock(headers={})
-        self.response.request.method = 'FOO'
-        self.error = MissingNonce(self.response)
+        self.error = MissingNonce({'X-Test': 'FOO', 'Content-Type': 'application/json'})
 
     def test_str(self):
         self.assertIn("FOO", str(self.error))
-        self.assertIn("{}", str(self.error))
 
 
 class PollErrorTest(unittest.TestCase):

--- a/acme/tests/standalone_test.py
+++ b/acme/tests/standalone_test.py
@@ -8,11 +8,11 @@ from typing import Set
 from unittest import mock
 
 import josepy as jose
-import requests
 
 from acme import challenges
 from acme import crypto_util
 from acme import errors
+from acme import mureq
 
 import test_util
 
@@ -56,14 +56,14 @@ class HTTP01ServerTest(unittest.TestCase):
         self.thread.join()
 
     def test_index(self):
-        response = requests.get(
+        response = mureq.get(
             'http://localhost:{0}'.format(self.port), verify=False)
         self.assertEqual(
-            response.text, 'ACME client standalone challenge solver')
+            response.body.decode('utf-8'), 'ACME client standalone challenge solver')
         self.assertTrue(response.ok)
 
     def test_404(self):
-        response = requests.get(
+        response = mureq.get(
             'http://localhost:{0}/foo'.format(self.port), verify=False)
         self.assertEqual(response.status_code, http_client.NOT_FOUND)
 
@@ -237,14 +237,14 @@ class HTTP01DualNetworkedServersTest(unittest.TestCase):
         self.servers.shutdown_and_server_close()
 
     def test_index(self):
-        response = requests.get(
+        response = mureq.get(
             'http://localhost:{0}'.format(self.port), verify=False)
         self.assertEqual(
-            response.text, 'ACME client standalone challenge solver')
+            response.body.decode('utf-8'), 'ACME client standalone challenge solver')
         self.assertTrue(response.ok)
 
     def test_404(self):
-        response = requests.get(
+        response = mureq.get(
             'http://localhost:{0}/foo'.format(self.port), verify=False)
         self.assertEqual(response.status_code, http_client.NOT_FOUND)
 

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -10,12 +10,12 @@ from typing import Tuple
 from typing import Type
 
 import josepy
-from requests.models import Response
 
 from acme import challenges
 from acme import client
 from acme import errors as acme_errors
 from acme import messages
+from acme import mureq
 from certbot import achallenges
 from certbot import configuration
 from certbot import errors
@@ -152,7 +152,7 @@ class AuthHandler:
             raise errors.Error("No ACME client defined, cannot poll authorizations.")
 
         authzrs_to_check: Dict[int, Tuple[messages.AuthorizationResource,
-                                          Optional[Response]]] = {index: (authzr, None)
+                                          Optional[mureq.Response]]] = {index: (authzr, None)
                             for index, authzr in enumerate(authzrs)}
         authzrs_failed_to_report = []
         # Give an initial second to the ACME CA server to check the authorizations

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -1,26 +1,12 @@
 """Module configuring Certbot in a snap environment"""
+import json
 import logging
-import socket
-from typing import Iterable
 from typing import List
-from typing import Optional
 
-from requests import Session
-from requests.adapters import HTTPAdapter
-from requests.exceptions import HTTPError
-from requests.exceptions import RequestException
+from acme import mureq
 
 from certbot.compat import os
 from certbot.errors import Error
-
-try:
-    from urllib3.connection import HTTPConnection
-    from urllib3.connectionpool import HTTPConnectionPool
-except ImportError:
-    # Stub imports for oldest requirements, that will never be used in snaps.
-    HTTPConnection = object
-    HTTPConnectionPool = object
-
 
 _ARCH_TRIPLET_MAP = {
     'arm64': 'aarch64-linux-gnu',
@@ -50,24 +36,23 @@ def prepare_env(cli_args: List[str]) -> List[str]:
     os.environ['CERTBOT_AUGEAS_PATH'] = '{0}/usr/lib/{1}/libaugeas.so.0'.format(
         os.environ.get('SNAP'), _ARCH_TRIPLET_MAP[snap_arch])
 
-    with Session() as session:
-        session.mount('http://snapd/', _SnapdAdapter())
 
-        try:
-            response = session.get('http://snapd/v2/connections?snap=certbot&interface=content')
-            response.raise_for_status()
-        except RequestException as e:
-            if isinstance(e, HTTPError) and e.response.status_code == 404:
-                LOGGER.error('An error occurred while fetching Certbot snap plugins: '
-                             'your version of snapd is outdated.')
-                LOGGER.error('Please run "sudo snap install core; sudo snap refresh core" '
-                             'in your terminal and try again.')
-            else:
-                LOGGER.error('An error occurred while fetching Certbot snap plugins: '
-                             'make sure the snapd service is running.')
-            raise e
+    try:
+        response = mureq.get('http://snapd/v2/connections?snap=certbot&interface=content', unix_socket='/run/snapd.socket')
+    except mureq.HTTPException:
+        LOGGER.error('An error occurred while fetching Certbot snap plugins: '
+                     'make sure the snapd service is running.')
+        raise
+    if not response.ok:
+        if response.status_code == 404:
+            LOGGER.error('An error occurred while fetching Certbot snap plugins: '
+                         'your version of snapd is outdated.')
+            LOGGER.error('Please run "sudo snap install core; sudo snap refresh core" '
+                         'in your terminal and try again.')
+        raise IOError("Bad HTTP status code from snapd", response.status_code)
 
-    data = response.json()
+
+    data = json.loads(response.body)
     connections = ['/snap/{0}/current/lib/python3.8/site-packages/'.format(item['slot']['snap'])
                    for item in data.get('result', {}).get('established', [])
                    if item.get('plug', {}).get('plug') == 'plugin'
@@ -78,27 +63,3 @@ def prepare_env(cli_args: List[str]) -> List[str]:
     cli_args.append('--preconfigured-renewal')
 
     return cli_args
-
-
-class _SnapdConnection(HTTPConnection):
-    def __init__(self) -> None:
-        super().__init__("localhost")
-        self.sock: Optional[socket.socket] = None
-
-    def connect(self) -> None:
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.sock.connect("/run/snapd.socket")
-
-
-class _SnapdConnectionPool(HTTPConnectionPool):
-    def __init__(self) -> None:
-        super().__init__("localhost")
-
-    def _new_conn(self) -> _SnapdConnection:
-        return _SnapdConnection()
-
-
-class _SnapdAdapter(HTTPAdapter):
-    def get_connection(self, url: str,
-                       proxies: Optional[Iterable[str]] = None) -> _SnapdConnectionPool:
-        return _SnapdConnectionPool()

--- a/certbot/certbot/ocsp.py
+++ b/certbot/certbot/ocsp.py
@@ -16,7 +16,8 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509 import ocsp
 import pytz
-import requests
+
+from acme import mureq
 
 from certbot import crypto_util
 from certbot import errors
@@ -170,10 +171,10 @@ def _check_ocsp_cryptography(cert_path: str, chain_path: str, url: str, timeout:
     request = builder.build()
     request_binary = request.public_bytes(serialization.Encoding.DER)
     try:
-        response = requests.post(url, data=request_binary,
+        response = mureq.post(url, body=request_binary,
                                  headers={'Content-Type': 'application/ocsp-request'},
                                  timeout=timeout)
-    except requests.exceptions.RequestException:
+    except mureq.HTTPException:
         logger.info("OCSP check failed for %s (are we offline?)", cert_path, exc_info=True)
         return False
     if response.status_code != 200:

--- a/certbot/certbot/plugins/dns_common_lexicon.py
+++ b/certbot/certbot/plugins/dns_common_lexicon.py
@@ -6,9 +6,6 @@ from typing import Mapping
 from typing import Optional
 from typing import Union
 
-from requests.exceptions import HTTPError
-from requests.exceptions import RequestException
-
 from certbot import errors
 from certbot.plugins import dns_common
 
@@ -20,9 +17,12 @@ from certbot.plugins import dns_common
 try:
     from lexicon.config import ConfigResolver
     from lexicon.providers.base import Provider
+    from requests.exceptions import HTTPError
+    from requests.exceptions import RequestException
 except ImportError:
     ConfigResolver = None
     Provider = None
+    HTTPError, RequestException = None
 
 logger = logging.getLogger(__name__)
 

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -297,7 +297,7 @@ def _ocsp_mock(certificate_status, response_status,
     with mock.patch('certbot.ocsp.ocsp.load_der_ocsp_response') as mock_response:
         mock_response.return_value = _construct_mock_ocsp_response(
             certificate_status, response_status)
-        with mock.patch('certbot.ocsp.requests.post') as mock_post:
+        with mock.patch('certbot.ocsp.mureq.post') as mock_post:
             mock_post.return_value = mock.Mock(status_code=http_status_code)
             with mock.patch('certbot.ocsp.crypto_util.verify_signed_payload') \
                 as mock_check:


### PR DESCRIPTION
This isn't intended as a merge-ready pull request (it doesn't follow the style guide and I didn't fix all the test mocks). It's more a working proof of concept for a feature request: would certbot be interested in removing the dependency on python-requests? (I tested that this branch can successfully request a certificate from the staging server, without pulling in python-requests; the output from `pip freeze` looks like [this](https://gist.github.com/slingamn/321cb789005c5b0199c85ce8269a9138)).

The benefits to certbot are mainly in shrinking the size of the snap and the memory footprint. (For example, despite #9001, a copy of chardet still ships in v1.22.0 of the snap, under the path `/snap/certbot/${num}/lib/python3.8/site-packages/pip/_vendor`.)

mureq has its own writeup here: https://github.com/slingamn/mureq

but the main precedents for this change are individual patches I've sent to open-source projects aimed at breaking the dependency of the Ubuntu base system on python3-requests:

1. https://code.launchpad.net/~slingamn/ssh-import-id/+git/ssh-import-id/+merge/389139
2. https://bugs.launchpad.net/ubuntu/+source/apport/+bug/1903605
3. https://code.launchpad.net/~ddstreet/software-properties/+git/software-properties/+merge/396926
4. https://github.com/OpenPrinting/system-config-printer/pull/247

These efforts have been successful in that Ubuntu Server 21.04 and later can run without python3-requests installed (after removing cloud-init and then autoremoving its dependencies).

Thanks very much for your time.