### PR TITLE
Revert "Remove win2016 from Azure devops pipelines. (#9145)"

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -54,12 +54,8 @@ jobs:
           done
         displayName: Run integration tests for Docker images
   - job: installer_build
-    strategy:
-      matrix:
-        win-2019:
-          vmImage: windows-2019
-        win-2022:
-          vmImage: windows-2022
+    pool:
+      vmImage: vs2017-win2016
     steps:
       - task: UsePythonVersion@0
         inputs:
@@ -91,11 +87,17 @@ jobs:
       matrix:
         win2019:
           imageName: windows-2019
-        win2022:
-          imageName: windows-2022
+        win2016:
+          imageName: vs2017-win2016
     pool:
       vmImage: $(imageName)
     steps:
+      - powershell: |
+          if ($PSVersionTable.PSVersion.Major -ne 5) {
+              throw "Powershell version is not 5.x"
+          }
+        condition: eq(variables['imageName'], 'vs2017-win2016')
+        displayName: Check Powershell 5.x is used in vs2017-win2016
       - task: UsePythonVersion@0
         inputs:
           versionSpec: 3.9

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -13,15 +13,15 @@ jobs:
           PYTHON_VERSION: 3.10
           TOXENV: py310-cover
         windows-py36:
-          IMAGE_NAME: windows-2019
+          IMAGE_NAME: vs2017-win2016
           PYTHON_VERSION: 3.6
           TOXENV: py36-win
         windows-py39-cover:
-          IMAGE_NAME: windows-2019
+          IMAGE_NAME: vs2017-win2016
           PYTHON_VERSION: 3.9
           TOXENV: py39-cover-win
         windows-integration-certbot:
-          IMAGE_NAME: windows-2019
+          IMAGE_NAME: vs2017-win2016
           PYTHON_VERSION: 3.9
           TOXENV: integration-certbot
         linux-oldest-tests-1:

--- a/.azure-pipelines/templates/stages/changelog-stage.yml
+++ b/.azure-pipelines/templates/stages/changelog-stage.yml
@@ -3,7 +3,7 @@ stages:
     jobs:
       - job: prepare
         pool:
-          vmImage: win2019
+          vmImage: vs2017-win2016
         steps:
           # If we change the output filename from `release_notes.md`, it should also be changed in tools/create_github_release.py
           - bash: |


### PR DESCRIPTION
In order to quick fix the full test suite, I propose to simply revert #9145 for now, until we decide the appropriate strategy to upgrade the Windows agents used in the pipelines. I made some propositions here: https://github.com/certbot/certbot/pull/9145#issuecomment-1004291274