### PR TITLE
Deprecate Python 3.6 support

### DIFF
--- a/acme/acme/__init__.py
+++ b/acme/acme/__init__.py
@@ -6,6 +6,7 @@ This module is an implementation of the `ACME protocol`_.
 
 """
 import sys
+import warnings
 
 # This code exists to keep backwards compatibility with people using acme.jose
 # before it became the standalone josepy package.
@@ -19,3 +20,11 @@ for mod in list(sys.modules):
     # preserved (acme.jose.* is josepy.*)
     if mod == 'josepy' or mod.startswith('josepy.'):
         sys.modules['acme.' + mod.replace('josepy', 'jose', 1)] = sys.modules[mod]
+
+
+if sys.version_info[:2] == (3, 6):
+    warnings.warn(
+            "Python 3.6 support will be dropped in the next release of "
+            "acme. Please upgrade your Python version.",
+            PendingDeprecationWarning,
+    )  # pragma: no cover

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -9,6 +9,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Added `show_account` subcommand, which will fetch the account information
   from the ACME server and show the account details (account URL and, if
   applicable, email address or addresses)
+* We deprecated support for Python 3.6 in Certbot and its ACME library.
+  Support for Python 3.6 will be removed in the next major release of Certbot.
 
 ### Changed
 

--- a/certbot/certbot/__init__.py
+++ b/certbot/certbot/__init__.py
@@ -1,3 +1,13 @@
 """Certbot client."""
 # version number like 1.2.3a0, must have at least 2 parts, like 1.2
+import sys
+import warnings
+
 __version__ = '1.23.0.dev0'
+
+if sys.version_info[:2] == (3, 6):
+    warnings.warn(
+            "Python 3.6 support will be dropped in the next release of "
+            "certbot. Please upgrade your Python version.",
+            PendingDeprecationWarning,
+    )  # pragma: no cover

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1673,6 +1673,10 @@ def main(cli_args: List[str] = None) -> Optional[Union[str, int]]:
     zope.component.provideUtility(report, interfaces.IReporter)
     util.atexit_register(report.print_messages)
 
+    if sys.version_info[:2] == (3, 6):
+        logger.warning("Python 3.6 support will be dropped in the next release "
+                       "of Certbot - please upgrade your Python version.")
+
     with make_displayer(config) as displayer:
         display_obj.set_display(displayer)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,8 @@
 # 7) botocore's default TLS settings raise deprecation warnings in Python
 #    3.10+, but their values are sane from a security perspective. See
 #    https://github.com/boto/botocore/issues/2550.
+# 8) Ignore our own PendingDeprecationWarning about Python 3.6 soon to be dropped.
+#    See https://github.com/certbot/certbot/pull/9160.
 filterwarnings =
     error
     ignore:The external mock module:PendingDeprecationWarning
@@ -36,3 +38,4 @@ filterwarnings =
     ignore:decodestring\(\) is a deprecated alias:DeprecationWarning:dns
     ignore:_SixMetaPathImporter.:ImportWarning
     ignore:ssl.PROTOCOL_TLS:DeprecationWarning:botocore
+    ignore:Python 3.6 support will be dropped:PendingDeprecationWarning


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8983

Python 3.6 is now EOL: https://endoflife.date/python

This is normally a good time to create warnings about Python 3.6 deprecation the Certbot upcoming release 1.23.0 so that its support is removed in 1.24.0.

We have to say here that EPEL maintainers asked us to keep maintaining support of Python 3.6 because Python 3.7 will never be shipped to CentOS 7. This support would be needed in theory up to 2 more years, basically until CentOS 7 EOL in 2024-06-30. It has been said that we could support as a best effort until a reasonable need on Certbot side requires to drop Python 3.6. See https://github.com/certbot/certbot/issues/8983 for more information.

However some of us (including me) consider that there is already a reasonable need right now. Indeed, keeping the support on Python 3.6 while the Python community globally moves away from it will pin implicitly some Certbot dependencies to the last version of these dependencies supporting Python 3.6 as the upstream maintainers decide to make the move. At any point in a future time, one of these dependencies could require an urgent upgrade (typically a critical uncovered vulnerability): then we would require to drop Python 3.6 immediately without further notice instead of following an organized deprecation path.

This reason motivates to proactively deprecate then drop the Python versions once they are EOL. You can see the discussion in Mattermost starting from [this post](https://opensource.eff.org/eff-open-source/pl/ntzs9zy1fprjmkso3xrqspnoce) to get more elements about the reasoning.

