### PR TITLE
Use super().__init__ instead of explicitly calling named super-class.

### DIFF
--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -198,7 +198,7 @@ class HTTP01Server(HTTPServer, ACMEServerMixin):
     def __init__(self, server_address: Tuple[str, int], resources: Set[challenges.HTTP01],
                  ipv6: bool = False, timeout: int = 30) -> None:
         super().__init__(
-            self, server_address, HTTP01RequestHandler.partial_init(
+            server_address, HTTP01RequestHandler.partial_init(
                 simple_http_resources=resources, timeout=timeout), ipv6=ipv6)
 
 

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -34,10 +34,9 @@ class TLSServer(socketserver.TCPServer):
         else:
             self.address_family = socket.AF_INET
         self.certs = kwargs.pop("certs", {})
-        self.method = kwargs.pop(
-            "method", crypto_util._DEFAULT_SSL_METHOD)
+        self.method = kwargs.pop("method", crypto_util._DEFAULT_SSL_METHOD)
         self.allow_reuse_address = kwargs.pop("allow_reuse_address", True)
-        socketserver.TCPServer.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _wrap_sock(self) -> None:
         self.socket = crypto_util.SSLSocket(
@@ -190,7 +189,7 @@ class HTTPServer(BaseHTTPServer.HTTPServer):
             self.address_family = socket.AF_INET6
         else:
             self.address_family = socket.AF_INET
-        BaseHTTPServer.HTTPServer.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class HTTP01Server(HTTPServer, ACMEServerMixin):
@@ -198,7 +197,7 @@ class HTTP01Server(HTTPServer, ACMEServerMixin):
 
     def __init__(self, server_address: Tuple[str, int], resources: Set[challenges.HTTP01],
                  ipv6: bool = False, timeout: int = 30) -> None:
-        HTTPServer.__init__(
+        super().__init__(
             self, server_address, HTTP01RequestHandler.partial_init(
                 simple_http_resources=resources, timeout=timeout), ipv6=ipv6)
 
@@ -208,7 +207,7 @@ class HTTP01DualNetworkedServers(BaseDualNetworkedServers):
        affect the other."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        BaseDualNetworkedServers.__init__(self, HTTP01Server, *args, **kwargs)
+        super().__init__(HTTP01Server, *args, **kwargs)
 
 
 class HTTP01RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
@@ -226,7 +225,7 @@ class HTTP01RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.simple_http_resources = kwargs.pop("simple_http_resources", set())
         self._timeout = kwargs.pop('timeout', 30)
-        BaseHTTPServer.BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.server: HTTP01Server
 
     # In parent class BaseHTTPRequestHandler, 'timeout' is a class-level property but we

--- a/acme/tests/standalone_test.py
+++ b/acme/tests/standalone_test.py
@@ -165,7 +165,6 @@ class TLSALPN01ServerTest(unittest.TestCase):
 class BaseDualNetworkedServersTest(unittest.TestCase):
     """Test for acme.standalone.BaseDualNetworkedServers."""
 
-
     class SingleProtocolServer(socketserver.TCPServer):
         """Server that only serves on a single protocol. FreeBSD has this behavior for AF_INET6."""
         def __init__(self, *args, **kwargs):
@@ -175,7 +174,7 @@ class BaseDualNetworkedServersTest(unittest.TestCase):
                 kwargs["bind_and_activate"] = False
             else:
                 self.address_family = socket.AF_INET
-            socketserver.TCPServer.__init__(self, *args, **kwargs)
+            super().__init__(*args, **kwargs)
             if ipv6:
                 # NB: On Windows, socket.IPPROTO_IPV6 constant may be missing.
                 # We use the corresponding value (41) instead.
@@ -201,7 +200,6 @@ class BaseDualNetworkedServersTest(unittest.TestCase):
                 ('', 0), socketserver.BaseRequestHandler)
 
         self.assertEqual(em.exception.errno, EADDRINUSE)
-
 
     def test_ports_equal(self):
         from acme.standalone import BaseDualNetworkedServers

--- a/certbot-nginx/certbot_nginx/_internal/nginxparser.py
+++ b/certbot-nginx/certbot_nginx/_internal/nginxparser.py
@@ -118,7 +118,7 @@ class UnspacedList(list):
 
         # Turn self into a version of the source list that has spaces removed
         # and all sub-lists also UnspacedList()ed
-        list.__init__(self, list_source)
+        super().__init__(list_source)
         for i, entry in reversed(list(enumerate(self))):
             if isinstance(entry, list):
                 sublist = UnspacedList(entry)

--- a/certbot/certbot/_internal/error_handler.py
+++ b/certbot/certbot/_internal/error_handler.py
@@ -167,6 +167,7 @@ class ErrorHandler:
             logger.debug("Calling signal %s", signum)
             os.kill(os.getpid(), signum)
 
+
 class ExitHandler(ErrorHandler):
     """Context manager for running code that must be cleaned up.
 
@@ -175,5 +176,5 @@ class ExitHandler(ErrorHandler):
     regular exit.
     """
     def __init__(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
-        ErrorHandler.__init__(self, func, *args, **kwargs)
+        super().__init__(func, *args, **kwargs)
         self.call_on_regular_exit = True

--- a/certbot/tests/plugins/dns_common_test.py
+++ b/certbot/tests/plugins/dns_common_test.py
@@ -133,7 +133,7 @@ class CredentialsConfigurationTest(test_util.TempDirTestCase):
 
         def __init__(self, *args, **kwargs):
             self.reset()
-            logging.Handler.__init__(self, *args, **kwargs)
+            super().__init__(*args, **kwargs)
 
         def emit(self, record):
             self.messages[record.levelname.lower()].append(record.getMessage())


### PR DESCRIPTION
I think it's largely a question of style/preference. For speed, `super().__init__` is *slower*, but probably more correct if you inherit from those classes.

## Pull Request Checklist

- [X] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [X] Add or update any documentation as needed to support the changes in this PR.
- [X] Include your name in `AUTHORS.md` if you like.
