### PR TITLE
Remove outdated pylint comments

### DIFF
--- a/certbot-apache/certbot_apache/_internal/http_01.py
+++ b/certbot-apache/certbot_apache/_internal/http_01.py
@@ -9,7 +9,7 @@ from certbot import errors
 from certbot.compat import filesystem
 from certbot.compat import os
 from certbot.plugins import common
-from certbot_apache._internal.obj import VirtualHost  # pylint: disable=unused-import
+from certbot_apache._internal.obj import VirtualHost
 from certbot_apache._internal.parser import get_aug_path
 
 if TYPE_CHECKING:

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -28,7 +28,7 @@ from certbot_nginx._internal import constants
 from certbot_nginx._internal import display_ops
 from certbot_nginx._internal import http_01
 from certbot_nginx._internal import nginxparser
-from certbot_nginx._internal import obj  # pylint: disable=unused-import
+from certbot_nginx._internal import obj
 from certbot_nginx._internal import parser
 
 NAME_RANK = 0

--- a/certbot/certbot/_internal/account.py
+++ b/certbot/certbot/_internal/account.py
@@ -20,7 +20,7 @@ import pytz
 
 from acme import fields as acme_fields
 from acme import messages
-from acme.client import ClientBase  # pylint: disable=unused-import
+from acme.client import ClientBase
 from certbot import configuration
 from certbot import errors
 from certbot import interfaces
@@ -125,6 +125,7 @@ class AccountMemoryStorage(interfaces.AccountStorage):
         except KeyError:
             raise errors.AccountNotFound(account_id)
 
+
 class RegistrationResourceWithNewAuthzrURI(messages.RegistrationResource):
     """A backwards-compatible RegistrationResource with a new-authz URI.
 
@@ -135,6 +136,7 @@ class RegistrationResourceWithNewAuthzrURI(messages.RegistrationResource):
        clients don't crash in that scenario.
     """
     new_authzr_uri = jose.Field('new_authzr_uri')
+
 
 class AccountFileStorage(interfaces.AccountStorage):
     """Accounts file storage.

--- a/certbot/certbot/ocsp.py
+++ b/certbot/certbot/ocsp.py
@@ -22,7 +22,7 @@ from certbot import crypto_util
 from certbot import errors
 from certbot import util
 from certbot.compat.os import getenv
-from certbot.interfaces import RenewableCert  # pylint: disable=unused-import
+from certbot.interfaces import RenewableCert
 
 
 logger = logging.getLogger(__name__)

--- a/certbot/tests/display/completer_test.py
+++ b/certbot/tests/display/completer_test.py
@@ -10,9 +10,9 @@ import string
 import sys
 import unittest
 
-from certbot.compat import filesystem  # pylint: disable=ungrouped-imports
-from certbot.compat import os  # pylint: disable=ungrouped-imports
-import certbot.tests.util as test_util  # pylint: disable=ungrouped-imports
+from certbot.compat import filesystem
+from certbot.compat import os
+import certbot.tests.util as test_util
 
 try:
     import mock

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -529,7 +529,6 @@ class DeleteIfAppropriateTest(test_util.ConfigTestCase):
     def test_opt_in_deletion(self, mock_get_utility, mock_delete,
             mock_cert_path_to_lineage, mock_full_archive_dir,
             mock_match_and_check_overlaps, mock_renewal_file_for_certname):
-        # pylint: disable = unused-argument
         config = self.config
         config.namespace.delete_after_revoke = True
         config.cert_path = "/some/reasonable/path"

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -18,7 +18,7 @@ import pytz
 
 from certbot import crypto_util, configuration
 from certbot import errors
-from certbot import interfaces  # pylint: disable=unused-import
+from certbot import interfaces
 from certbot import util
 from certbot._internal import account
 from certbot._internal import cli

--- a/certbot/tests/plugins/standalone_test.py
+++ b/certbot/tests/plugins/standalone_test.py
@@ -7,10 +7,10 @@ from typing import Tuple
 import unittest
 
 import josepy as jose
-import OpenSSL.crypto  # pylint: disable=unused-import
+import OpenSSL.crypto
 
 from acme import challenges
-from acme import standalone as acme_standalone  # pylint: disable=unused-import
+from acme import standalone as acme_standalone
 from certbot import achallenges
 from certbot import errors
 from certbot.tests import acme_util
@@ -20,7 +20,6 @@ try:
     import mock
 except ImportError: # pragma: no cover
     from unittest import mock
-
 
 
 class ServerManagerTest(unittest.TestCase):


### PR DESCRIPTION
@adferrand I think you forgot to remove those `# pylint: disable=unused-import` when you added type annotations to those areas :) I found a couple more that seem safe to remove, as tests/linting passes.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
