### PR TITLE
If an installer is provided to certonly, restart after cert issuance

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -273,6 +273,7 @@ Authors
 * [Wilfried Teiken](https://github.com/wteiken)
 * [Willem Fibbe](https://github.com/fibbers)
 * [William Budington](https://github.com/Hainish)
+* [Will Greenberg](https://github.com/wgreenberg)
 * [Will Newby](https://github.com/willnewby)
 * [Will Oller](https://github.com/willoller)
 * [Yan](https://github.com/diracdeltas)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -45,6 +45,9 @@ More details about these changes can be found on our GitHub repo.
 
 ## 1.23.0 - 2022-02-08
 
+* When `certonly` is run with an installer specified (e.g.  `--nginx`),
+  `certonly` will now also run `restart` for that installer
+
 ### Added
 
 * Added `show_account` subcommand, which will fetch the account information

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1572,7 +1572,7 @@ def certonly(config: configuration.NamespaceConfig, plugins: plugins_disco.Plugi
     # run `installer.restart()` to load the newly issued certificate
     installer_err: Optional[errors.Error] = None
     if lineage and installer and not config.dry_run:
-        logger.info("Reloading % server after certificate issuance", config.installer)
+        logger.info("Reloading %s server after certificate issuance", config.installer)
         try:
             installer.restart()
         except errors.Error as e:

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -538,8 +538,8 @@ def _report_next_steps(config: configuration.NamespaceConfig, installer_err: Opt
         # run the "installer" (i.e. reloading the nginx/apache config)
         if config.verb == 'certonly':
             steps.append(
-                "The certificate was saved, but was not successfully loaded by the installer"
-                f"({config.installer}) due to the installer failing to reload."
+                "The certificate was saved, but was not successfully loaded by the installer "
+                f"({config.installer}) due to the installer failing to reload. "
                 f"After fixing the error shown below, try reloading {config.installer} manually."
             )
         else:
@@ -1584,6 +1584,8 @@ def certonly(config: configuration.NamespaceConfig, plugins: plugins_disco.Plugi
     _report_new_cert(config, cert_path, fullchain_path, key_path)
     _report_next_steps(config, installer_err, lineage,
                        new_or_renewed_cert=should_get_cert and not config.dry_run)
+    if installer_err:
+        raise installer_err
     _suggest_donation_if_appropriate(config)
     eff.handle_subscription(config, le_client.account)
 

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1559,6 +1559,12 @@ def certonly(config: configuration.NamespaceConfig, plugins: plugins_disco.Plugi
 
     lineage = _get_and_save_cert(le_client, config, domains, certname, lineage)
 
+    # If a new cert was issued and we were passed an installer, we can safely
+    # run `installer.restart()` to load the newly issued certificate
+    if lineage and installer and not config.dry_run:
+        display_util.notify(f"Reloading {config.installer} server after certificate issuance")
+        installer.restart()
+
     cert_path = lineage.cert_path if lineage else None
     fullchain_path = lineage.fullchain_path if lineage else None
     key_path = lineage.key_path if lineage else None

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1673,7 +1673,7 @@ def main(cli_args: List[str] = None) -> Optional[Union[str, int]]:
     if not cli_args:
         cli_args = sys.argv[1:]
 
-    log.pre_arg_parse_setup() 
+    log.pre_arg_parse_setup()
 
     if os.environ.get('CERTBOT_SNAPPED') == 'True':
         cli_args = snap_config.prepare_env(cli_args)

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -538,8 +538,9 @@ def _report_next_steps(config: configuration.NamespaceConfig, installer_err: Opt
         # run the "installer" (i.e. reloading the nginx/apache config)
         if config.verb == 'certonly':
             steps.append(
-                f"The certificate was saved, but the plugin {config.installer} failed"
-                "to reload. After fixing the error shown below, try reloading manually."
+                "The certificate was saved, but was not successfully loaded by the installer"
+                f"({config.installer}) due to the installer failing to reload."
+                f"After fixing the error shown below, try reloading {config.installer} manually."
             )
         else:
             steps.append(
@@ -1571,7 +1572,7 @@ def certonly(config: configuration.NamespaceConfig, plugins: plugins_disco.Plugi
     # run `installer.restart()` to load the newly issued certificate
     installer_err: Optional[errors.Error] = None
     if lineage and installer and not config.dry_run:
-        logger.info(f"Reloading {config.installer} server after certificate issuance")
+        logger.info("Reloading % server after certificate issuance", config.installer)
         try:
             installer.restart()
         except errors.Error as e:
@@ -1672,7 +1673,7 @@ def main(cli_args: List[str] = None) -> Optional[Union[str, int]]:
     if not cli_args:
         cli_args = sys.argv[1:]
 
-    log.pre_arg_parse_setup()
+    log.pre_arg_parse_setup() 
 
     if os.environ.get('CERTBOT_SNAPPED') == 'True':
         cli_args = snap_config.prepare_env(cli_args)

--- a/certbot/certbot/_internal/plugins/selection.py
+++ b/certbot/certbot/_internal/plugins/selection.py
@@ -250,10 +250,16 @@ def choose_configurator_plugins(config: configuration.NamespaceConfig,
         if need_auth:
             authenticator = pick_authenticator(config, req_auth, plugins)
 
+    # Report on any failures
+    if need_inst and not installer:
+        diagnose_configurator_problem("installer", req_inst, plugins)
+    if need_auth and not authenticator:
+        diagnose_configurator_problem("authenticator", req_auth, plugins)
+
     # As a special case for certonly, if a user selected apache or nginx, set
     # the relevant installer (unless the user specifically specified no
     # installer)
-    if verb == "certonly":
+    if verb == "certonly" and authenticator is not None:
         # user specified --nginx or --apache on CLI
         selected_configurator = config.nginx or config.apache
         # user didn't request an authenticator, and so interactively chose nginx
@@ -263,12 +269,6 @@ def choose_configurator_plugins(config: configuration.NamespaceConfig,
         if selected_configurator or interactively_selected:
             installer = cast(Optional[interfaces.Installer], authenticator)
     logger.debug("Selected authenticator %s and installer %s", authenticator, installer)
-
-    # Report on any failures
-    if need_inst and not installer:
-        diagnose_configurator_problem("installer", req_inst, plugins)
-    if need_auth and not authenticator:
-        diagnose_configurator_problem("authenticator", req_auth, plugins)
 
     record_chosen_plugins(config, plugins, authenticator, installer)
     return installer, authenticator

--- a/certbot/certbot/_internal/plugins/selection.py
+++ b/certbot/certbot/_internal/plugins/selection.py
@@ -249,6 +249,13 @@ def choose_configurator_plugins(config: configuration.NamespaceConfig,
             installer = pick_installer(config, req_inst, plugins, installer_question)
         if need_auth:
             authenticator = pick_authenticator(config, req_auth, plugins)
+
+    # As a special case for certonly, if the user interactively selected nginx
+    # or apache as an authenticator, make sure we set the appropriate installer
+    # to allow us to safely reload after retrieving a cert
+    if verb == "certonly" and authenticator and not installer:
+        if authenticator.name in ("nginx", "apache"):
+            installer = cast(Optional[interfaces.Installer], authenticator)
     logger.debug("Selected authenticator %s and installer %s", authenticator, installer)
 
     # Report on any failures

--- a/certbot/certbot/_internal/plugins/selection.py
+++ b/certbot/certbot/_internal/plugins/selection.py
@@ -250,11 +250,17 @@ def choose_configurator_plugins(config: configuration.NamespaceConfig,
         if need_auth:
             authenticator = pick_authenticator(config, req_auth, plugins)
 
-    # As a special case for certonly, if the user interactively selected nginx
-    # or apache as an authenticator, make sure we set the appropriate installer
-    # to allow us to safely reload after retrieving a cert
-    if verb == "certonly" and authenticator and not installer:
-        if authenticator.name in ("nginx", "apache"):
+    # As a special case for certonly, if a user selected apache or nginx, set
+    # the relevant installer (unless the user specifically specified no
+    # installer)
+    if verb == "certonly":
+        # user specified --nginx or --apache on CLI
+        selected_configurator = config.nginx or config.apache
+        # user didn't request an authenticator, and so interactively chose nginx
+        # or apache
+        interactively_selected = req_auth is None and authenticator.name in ("nginx", "apache")
+
+        if selected_configurator or interactively_selected:
             installer = cast(Optional[interfaces.Installer], authenticator)
     logger.debug("Selected authenticator %s and installer %s", authenticator, installer)
 

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -304,6 +304,36 @@ class CertonlyTest(unittest.TestCase):
                 mock.ANY, mock.ANY, mock.ANY, new_or_renewed_cert=False)
             mock_report_next_steps.reset_mock()
 
+    @mock.patch('certbot._internal.main._report_next_steps')
+    @mock.patch('certbot._internal.main._report_new_cert')
+    @mock.patch('certbot._internal.main._find_cert')
+    @mock.patch('certbot._internal.main._get_and_save_cert')
+    @mock.patch('certbot._internal.plugins.selection.choose_configurator_plugins')
+    def test_installer_runs_restart(self, mock_sel, mock_get_cert, mock_find_cert,
+                                    unused_report_new, unused_report_next):
+        mock_installer = mock.MagicMock()
+        mock_sel.return_value = (mock_installer, None)
+        mock_get_cert.return_value = mock.MagicMock()
+        mock_find_cert.return_value = (True, None)
+
+        self._call('certonly --nginx -d example.com'.split())
+        mock_installer.restart.assert_called_once()
+
+    @mock.patch('certbot._internal.main._report_next_steps')
+    @mock.patch('certbot._internal.main._report_new_cert')
+    @mock.patch('certbot._internal.main._find_cert')
+    @mock.patch('certbot._internal.main._get_and_save_cert')
+    @mock.patch('certbot._internal.plugins.selection.choose_configurator_plugins')
+    def test_dryrun_installer_doesnt_restart(self, mock_sel, mock_get_cert, mock_find_cert,
+                                             unused_report_new, unused_report_next):
+        mock_installer = mock.MagicMock()
+        mock_sel.return_value = (mock_installer, None)
+        mock_get_cert.return_value = mock.MagicMock()
+        mock_find_cert.return_value = (True, None)
+
+        self._call('certonly --nginx -d example.com --dry-run'.split())
+        mock_installer.restart.assert_not_called()
+
 
 class FindDomainsOrCertnameTest(unittest.TestCase):
     """Tests for certbot._internal.main._find_domains_or_certname."""


### PR DESCRIPTION
Fixes #8912. I wasn't sure if any docs needed updating for this, since it sounded like this change was making `--nginx` and `--apache` behave closer to how they're described in the docs in the `certonly` case. Let me know if that's not the case!

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
