### PR TITLE
CentOS & RHEL test farm fixes

### DIFF
--- a/letstest/scripts/bootstrap_os_packages.sh
+++ b/letstest/scripts/bootstrap_os_packages.sh
@@ -117,8 +117,9 @@ BootstrapRpmPython3() {
     python3-devel
   "
 
+  # We only expect this branch to be taken on RHEL 7.
   if ! sudo $TOOL list 'python3*-devel' >/dev/null 2>&1; then
-    sudo yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-REGION-rhel-server-optional
+    sudo yum-config-manager --enable rhel-7-server-rhui-extras-rpms rhel-7-server-rhui-optional-rpms
   fi
 
   BootstrapRpmCommonBase "$python_pkgs"

--- a/letstest/targets/apache2_targets.yaml
+++ b/letstest/targets/apache2_targets.yaml
@@ -30,6 +30,8 @@ targets:
     user: admin
   #-----------------------------------------------------------------------------
   # CentOS
+  # This AMI was found on
+  # https://web.archive.org/web/20211126215532/https://wiki.centos.org/Cloud/AWS.
   - ami: ami-00e87074e52e6c9f9
     name: centos7
     type: centos

--- a/letstest/targets/apache2_targets.yaml
+++ b/letstest/targets/apache2_targets.yaml
@@ -30,7 +30,7 @@ targets:
     user: admin
   #-----------------------------------------------------------------------------
   # CentOS
-  - ami: ami-9887c6e7
+  - ami: ami-00e87074e52e6c9f9
     name: centos7
     type: centos
     virt: hvm

--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -32,7 +32,9 @@ targets:
     user: admin
     machine_type: a1.medium
   #-----------------------------------------------------------------------------
-  # Other Redhat Distros
+  # RHEL
+  # These AMIs were found using the commands given at
+  # https://web.archive.org/web/20220129184532/https://access.redhat.com/solutions/15356.
   - ami: ami-005b7876121b7244d
     name: RHEL7
     type: centos
@@ -45,6 +47,8 @@ targets:
     user: ec2-user
   #-----------------------------------------------------------------------------
   # CentOS
+  # These AMIs were found on
+  # https://web.archive.org/web/20211126215532/https://wiki.centos.org/Cloud/AWS.
   - ami: ami-00e87074e52e6c9f9
     name: centos7
     type: centos

--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -33,7 +33,7 @@ targets:
     machine_type: a1.medium
   #-----------------------------------------------------------------------------
   # Other Redhat Distros
-  - ami: ami-0916c408cb02e310b
+  - ami: ami-005b7876121b7244d
     name: RHEL7
     type: centos
     virt: hvm

--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -52,7 +52,7 @@ targets:
     type: centos
     virt: hvm
     user: centos
-  - ami: ami-01ca03df4a6012157
+  - ami: ami-05d7cb15bfbf13b6d
     name: centos8
     type: centos
     virt: hvm

--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -45,15 +45,13 @@ targets:
     user: ec2-user
   #-----------------------------------------------------------------------------
   # CentOS
-  # These Marketplace AMIs must, irritatingly, have their terms manually
-  # agreed to on the AWS marketplace site for any new AWS account using them...
-  - ami: ami-9887c6e7
+  - ami: ami-00e87074e52e6c9f9
     name: centos7
     type: centos
     virt: hvm
     user: centos
-  - ami: ami-05d7cb15bfbf13b6d
-    name: centos8
+  - ami: ami-0ee70e88eed976a1b
+    name: centos_stream8
     type: centos
     virt: hvm
     user: centos


### PR DESCRIPTION
This PR fixes a number of problems that are causing our nightly tests to fail.

1. Our RHEL 7 AMI has been repeatedly failing to connect to RHEL's repos. This has been happening for a number of days, but here is [one example](https://dev.azure.com/certbot/certbot/_build/results?buildId=5060&view=logs&j=23275d9a-33b0-57f8-5f28-197fe2e5b9cd&t=6b259d66-5a71-5486-aac1-c5dfab50d0ea&l=1136). I fixed this problem by updating to a newer RHEL 7 AMI.
2. The names of the RHEL 7 repos we enable were updated to reflect the change described [here](https://access.redhat.com/articles/4599971).
3. While I was working on this PR, CentOS 8 shut down their repos to reflect the CentOS 8 EOL as described [here](https://www.centos.org/centos-linux-eol/). As a replacement, I switched our CentOS 8 test to CentOS Stream 8.

Finally, the deleted comment about marketplace AMIs isn't true for the new image so I removed the comment and also updated the CentOS 7 to a non-marketplace AMI.