### PR TITLE
Inline dict creation in _assert_valid_call.

### DIFF
--- a/certbot/certbot/tests/util.py
+++ b/certbot/certbot/tests/util.py
@@ -410,10 +410,11 @@ def _create_display_util_mock_with_stdout(stdout: IO) -> FreezableMock:
 def _assert_valid_call(*args: Any, **kwargs: Any) -> None:
     assert_args = [args[0] if args else kwargs['message']]
 
-    assert_kwargs = {}
-    assert_kwargs['default'] = kwargs.get('default', None)
-    assert_kwargs['cli_flag'] = kwargs.get('cli_flag', None)
-    assert_kwargs['force_interactive'] = kwargs.get('force_interactive', False)
+    assert_kwargs = {
+        'default': kwargs.get('default', None),
+        'cli_flag': kwargs.get('cli_flag', None),
+        'force_interactive': kwargs.get('force_interactive', False),
+    }
 
     display_util.assert_valid_call(*assert_args, **assert_kwargs)
 


### PR DESCRIPTION
PyCharm has this check, and it's the only one it could find. It'll cut off valuable nanoseconds off the test suite run :smile: 

## Pull Request Checklist

- [X] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [X] Add or update any documentation as needed to support the changes in this PR.
- [X] Include your name in `AUTHORS.md` if you like.
