### PR TITLE
Change certbot.org links to point to new certbot.eff.org locations

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -156,6 +156,7 @@ Authors
 * [Luca Beltrame](https://github.com/lbeltrame)
 * [Luca Ebach](https://github.com/lucebac)
 * [Luca Olivetti](https://github.com/olivluca)
+* [Luke Mitchell](https://github.com/lpmitchell)
 * [Luke Rogers](https://github.com/lukeroge)
 * [Maarten](https://github.com/mrtndwrd)
 * [Mads Jensen](https://github.com/atombrella)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Updated help links to use certbot.eff.org
 
 ### Fixed
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -105,7 +105,8 @@ def delete(config: configuration.NamespaceConfig) -> None:
         "\nWARNING: Before continuing, ensure that the listed certificates are not being used "
         "by any installed server software (e.g. Apache, nginx, mail servers). Deleting a "
         "certificate that is still being used will cause the server software to stop working. "
-        "See https://certbot.eff.org/deleting-certs for information on deleting certificates safely."
+        "See https://certbot.eff.org/deleting-certs for information on deleting certificates "
+        "safely."
     )
     msg.append("\nAre you sure you want to delete the above certificate(s)?")
     if not display_util.yesno("\n".join(msg), default=True):

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -105,7 +105,7 @@ def delete(config: configuration.NamespaceConfig) -> None:
         "\nWARNING: Before continuing, ensure that the listed certificates are not being used "
         "by any installed server software (e.g. Apache, nginx, mail servers). Deleting a "
         "certificate that is still being used will cause the server software to stop working. "
-        "See https://certbot.org/deleting-certs for information on deleting certificates safely."
+        "See https://certbot.eff.org/deleting-certs for information on deleting certificates safely."
     )
     msg.append("\nAre you sure you want to delete the above certificate(s)?")
     if not display_util.yesno("\n".join(msg), default=True):

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -538,7 +538,7 @@ def _report_next_steps(config: configuration.NamespaceConfig, installer_err: Opt
                 "The certificate will need to be renewed before it expires. Certbot can "
                 "automatically renew the certificate in the background, but you may need "
                 "to take steps to enable that functionality. "
-                "See https://certbot.org/renewal-setup for instructions.")
+                "See https://certbot.eff.org/renewal-setup for instructions.")
 
     if not steps:
         return

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -1961,7 +1961,7 @@ class ReportNextStepsTest(unittest.TestCase):
         """No --preconfigured-renewal needs manual cron setup"""
         self.config.preconfigured_renewal = False
         self._call(self.config, None, None)
-        self.assertIn("https://certbot.org/renewal-setup", self._output())
+        self.assertIn("https://certbot.eff.org/renewal-setup", self._output())
 
 
 class UpdateAccountTest(test_util.ConfigTestCase):


### PR DESCRIPTION
# Fix broken https://certbot.org links

The certbot.org certificate expired on the 30th January 2022.

Certbot will still prompt users to visit https://certbot.org/ addresses to read up on certain topics - this will cause an invalid certificate warning in the user's browser.

This PR simply changes the links to point to the new EFF subdomain equivalents to avoid this issue.

The new links that Certbot will output are:
- https://certbot.eff.org/deleting-certs
- https://certbot.eff.org/renewal-setup

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
