### PR TITLE
Remove outdated setup.cfg files

### DIFF
--- a/acme/setup.cfg
+++ b/acme/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-apache/setup.cfg
+++ b/certbot-apache/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-compatibility-test/setup.cfg
+++ b/certbot-compatibility-test/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-cloudflare/setup.cfg
+++ b/certbot-dns-cloudflare/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-cloudxns/setup.cfg
+++ b/certbot-dns-cloudxns/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-digitalocean/setup.cfg
+++ b/certbot-dns-digitalocean/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-dnsimple/setup.cfg
+++ b/certbot-dns-dnsimple/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-dnsmadeeasy/setup.cfg
+++ b/certbot-dns-dnsmadeeasy/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-gehirn/setup.cfg
+++ b/certbot-dns-gehirn/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-google/setup.cfg
+++ b/certbot-dns-google/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-linode/setup.cfg
+++ b/certbot-dns-linode/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-luadns/setup.cfg
+++ b/certbot-dns-luadns/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-nsone/setup.cfg
+++ b/certbot-dns-nsone/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-ovh/setup.cfg
+++ b/certbot-dns-ovh/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-rfc2136/setup.cfg
+++ b/certbot-dns-rfc2136/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-dns-route53/setup.cfg
+++ b/certbot-dns-route53/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/certbot-dns-sakuracloud/setup.cfg
+++ b/certbot-dns-sakuracloud/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot-nginx/setup.cfg
+++ b/certbot-nginx/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/certbot/setup.cfg
+++ b/certbot/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-universal = 1
-
-[easy_install]
-zip_ok = false


### PR DESCRIPTION
[Setting `universal = 1` doesn't make sense](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#wheels) because we no longer support Python 2.

I also think we can safely remove the setting for `easy_install` since we only ever did it for the Certbot package and [easy_install is deprecated](https://setuptools.pypa.io/en/latest/deprecated/easy_install.html).
