### PR TITLE
Remove Windows 2016 environment, generate 64 bit installer

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -55,7 +55,7 @@ jobs:
         displayName: Run integration tests for Docker images
   - job: installer_build
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
     steps:
       - task: UsePythonVersion@0
         inputs:
@@ -87,17 +87,9 @@ jobs:
       matrix:
         win2019:
           imageName: windows-2019
-        win2016:
-          imageName: vs2017-win2016
     pool:
       vmImage: $(imageName)
     steps:
-      - powershell: |
-          if ($PSVersionTable.PSVersion.Major -ne 5) {
-              throw "Powershell version is not 5.x"
-          }
-        condition: eq(variables['imageName'], 'vs2017-win2016')
-        displayName: Check Powershell 5.x is used in vs2017-win2016
       - task: UsePythonVersion@0
         inputs:
           versionSpec: 3.9
@@ -116,7 +108,7 @@ jobs:
         displayName: Prepare Certbot-CI
       - script: |
           set PATH=%ProgramFiles(x86)%\Certbot\bin;%PATH%
-          venv\Scripts\python -m pytest certbot-ci\windows_installer_integration_tests --allow-persistent-changes --installer-path $(Build.SourcesDirectory)\bin\certbot-beta-installer-win32.exe
+          venv\Scripts\python -m pytest certbot-ci\windows_installer_integration_tests --allow-persistent-changes --installer-path $(Build.SourcesDirectory)\bin\certbot-beta-installer-win64.exe
         displayName: Run windows installer integration tests
       - script: |
           set PATH=%ProgramFiles(x86)%\Certbot\bin;%PATH%

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -107,11 +107,11 @@ jobs:
           PIP_NO_BUILD_ISOLATION: no
         displayName: Prepare Certbot-CI
       - script: |
-          set PATH=%ProgramFiles(x86)%\Certbot\bin;%PATH%
+          set PATH=%ProgramFiles%\Certbot\bin;%PATH%
           venv\Scripts\python -m pytest certbot-ci\windows_installer_integration_tests --allow-persistent-changes --installer-path $(Build.SourcesDirectory)\bin\certbot-beta-installer-win_amd64.exe
         displayName: Run windows installer integration tests
       - script: |
-          set PATH=%ProgramFiles(x86)%\Certbot\bin;%PATH%
+          set PATH=%ProgramFiles%\Certbot\bin;%PATH%
           venv\Scripts\python -m pytest certbot-ci\certbot_integration_tests\certbot_tests -n 4
         displayName: Run certbot integration tests
   - job: snaps_build

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -108,7 +108,7 @@ jobs:
         displayName: Prepare Certbot-CI
       - script: |
           set PATH=%ProgramFiles(x86)%\Certbot\bin;%PATH%
-          venv\Scripts\python -m pytest certbot-ci\windows_installer_integration_tests --allow-persistent-changes --installer-path $(Build.SourcesDirectory)\bin\certbot-beta-installer-win64.exe
+          venv\Scripts\python -m pytest certbot-ci\windows_installer_integration_tests --allow-persistent-changes --installer-path $(Build.SourcesDirectory)\bin\certbot-beta-installer-win_amd64.exe
         displayName: Run windows installer integration tests
       - script: |
           set PATH=%ProgramFiles(x86)%\Certbot\bin;%PATH%

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -60,7 +60,7 @@ jobs:
       - task: UsePythonVersion@0
         inputs:
           versionSpec: 3.9
-          architecture: x86
+          architecture: x64
           addToPath: true
       - script: |
           python -m venv venv

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -12,16 +12,16 @@ jobs:
           IMAGE_NAME: macOS-10.15
           PYTHON_VERSION: 3.10
           TOXENV: py310-cover
-        windows-py37:
-          IMAGE_NAME: vs2017-win2016
+        windows-py36:
+          IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.7
           TOXENV: py37-win
         windows-py39-cover:
-          IMAGE_NAME: vs2017-win2016
+          IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.9
           TOXENV: py39-cover-win
         windows-integration-certbot:
-          IMAGE_NAME: vs2017-win2016
+          IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.9
           TOXENV: integration-certbot
         linux-oldest-tests-1:

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -12,7 +12,7 @@ jobs:
           IMAGE_NAME: macOS-10.15
           PYTHON_VERSION: 3.10
           TOXENV: py310-cover
-        windows-py36:
+        windows-py37:
           IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.7
           TOXENV: py37-win

--- a/.azure-pipelines/templates/stages/changelog-stage.yml
+++ b/.azure-pipelines/templates/stages/changelog-stage.yml
@@ -3,7 +3,7 @@ stages:
     jobs:
       - job: prepare
         pool:
-          vmImage: vs2017-win2016
+          vmImage: windows-2019
         steps:
           # If we change the output filename from `release_notes.md`, it should also be changed in tools/create_github_release.py
           - bash: |

--- a/certbot-ci/windows_installer_integration_tests/conftest.py
+++ b/certbot-ci/windows_installer_integration_tests/conftest.py
@@ -20,9 +20,9 @@ def pytest_addoption(parser):
     """
     parser.addoption('--installer-path',
                      default=os.path.join(ROOT_PATH, 'windows-installer', 'build',
-                                          'nsis', 'certbot-beta-installer-win32.exe'),
+                                          'nsis', 'certbot-beta-installer-win64.exe'),
                      help='set the path of the windows installer to use, default to '
-                          'CERTBOT_ROOT_PATH\\windows-installer\\build\\nsis\\certbot-beta-installer-win32.exe')  # pylint: disable=line-too-long
+                          'CERTBOT_ROOT_PATH\\windows-installer\\build\\nsis\\certbot-beta-installer-win64.exe')  # pylint: disable=line-too-long
     parser.addoption('--allow-persistent-changes', action='store_true',
                      help='needs to be set, and confirm that the test will make persistent changes on this machine')  # pylint: disable=line-too-long
 

--- a/certbot-ci/windows_installer_integration_tests/conftest.py
+++ b/certbot-ci/windows_installer_integration_tests/conftest.py
@@ -20,9 +20,9 @@ def pytest_addoption(parser):
     """
     parser.addoption('--installer-path',
                      default=os.path.join(ROOT_PATH, 'windows-installer', 'build',
-                                          'nsis', 'certbot-beta-installer-win64.exe'),
+                                          'nsis', 'certbot-beta-installer-win_amd64.exe'),
                      help='set the path of the windows installer to use, default to '
-                          'CERTBOT_ROOT_PATH\\windows-installer\\build\\nsis\\certbot-beta-installer-win64.exe')  # pylint: disable=line-too-long
+                          'CERTBOT_ROOT_PATH\\windows-installer\\build\\nsis\\certbot-beta-installer-win_amd64.exe')  # pylint: disable=line-too-long
     parser.addoption('--allow-persistent-changes', action='store_true',
                      help='needs to be set, and confirm that the test will make persistent changes on this machine')  # pylint: disable=line-too-long
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -56,7 +56,7 @@ More details about these changes can be found on our GitHub repo.
 ### Changed
 
 * Dropped 32 bit support for the Windows beta installer
-* Windows beta installer is now distributed as "certbot-beta-installer-win64.exe"
+* Windows beta installer is now distributed as "certbot-beta-installer-win_amd64.exe"
 
 ### Fixed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -55,7 +55,8 @@ More details about these changes can be found on our GitHub repo.
 
 ### Changed
 
-*
+* Dropped 32 bit support for the Windows beta installer
+* Windows beta installer is now distributed as "certbot-beta-installer-win64.exe"
 
 ### Fixed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Dropped 32 bit support for the Windows beta installer
+* Windows beta installer is now distributed as "certbot-beta-installer-win_amd64.exe".
+  Users of the Windows beta should uninstall the old version before running this.
 
 ### Fixed
 
@@ -55,8 +57,7 @@ More details about these changes can be found on our GitHub repo.
 
 ### Changed
 
-* Dropped 32 bit support for the Windows beta installer
-* Windows beta installer is now distributed as "certbot-beta-installer-win_amd64.exe"
+*
 
 ### Fixed
 

--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -135,7 +135,7 @@ def create_github_release(github_access_token, tempdir, version):
 
     # Upload windows installer to release
     print("Uploading windows installer")
-    release.upload_asset(tempdir + '/windows-installer/certbot-beta-installer-win32.exe')
+    release.upload_asset(tempdir + '/windows-installer/certbot-beta-installer-win64.exe')
     release.update_release(release.title, release.body, draft=False)
 
 

--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -135,7 +135,7 @@ def create_github_release(github_access_token, tempdir, version):
 
     # Upload windows installer to release
     print("Uploading windows installer")
-    release.upload_asset(tempdir + '/windows-installer/certbot-beta-installer-win64.exe')
+    release.upload_asset(tempdir + '/windows-installer/certbot-beta-installer-win_amd64.exe')
     release.update_release(release.title, release.body, draft=False)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ source_paths = acme/acme certbot/certbot certbot-apache/certbot_apache certbot-c
 passenv =
     CERTBOT_NO_PIN
 platform =
-    win: win32
-    posix: ^(?!.*win32).*$
+    win: win64
+    posix: ^(?!.*win64).*$
 commands_pre = python {toxinidir}/tools/pipstrap.py
 commands =
     !cover-win: {[base]install_and_test} {[base]win_all_packages}

--- a/windows-installer/windows_installer/construct.py
+++ b/windows-installer/windows_installer/construct.py
@@ -94,7 +94,7 @@ def _generate_pynsist_config(repo_path, build_path):
     certbot_version = subprocess.check_output([sys.executable, '-c', 'import certbot; print(certbot.__version__)'],
                                               universal_newlines=True, cwd=certbot_pkg_path).strip()
 
-    # If we change the installer name from `certbot-beta-installer-win64.exe`, it should
+    # If we change the installer name from `certbot-beta-installer-win_amd64.exe`, it should
     # also be changed in tools/create_github_release.py
     with open(installer_cfg_path, 'w') as file_h:
         file_h.write('''\
@@ -124,7 +124,7 @@ files=run.bat
 entry_point=certbot.main:main
 extra_preamble=preamble.py
 '''.format(certbot_version=certbot_version,
-           installer_suffix='win64',
+           installer_suffix='win_amd64',
            python_bitness=PYTHON_BITNESS,
            python_version='.'.join(str(item) for item in PYTHON_VERSION)))
 

--- a/windows-installer/windows_installer/construct.py
+++ b/windows-installer/windows_installer/construct.py
@@ -94,7 +94,7 @@ def _generate_pynsist_config(repo_path, build_path):
     certbot_version = subprocess.check_output([sys.executable, '-c', 'import certbot; print(certbot.__version__)'],
                                               universal_newlines=True, cwd=certbot_pkg_path).strip()
 
-    # If we change the installer name from `certbot-beta-installer-win32.exe`, it should
+    # If we change the installer name from `certbot-beta-installer-win64.exe`, it should
     # also be changed in tools/create_github_release.py
     with open(installer_cfg_path, 'w') as file_h:
         file_h.write('''\
@@ -124,7 +124,7 @@ files=run.bat
 entry_point=certbot.main:main
 extra_preamble=preamble.py
 '''.format(certbot_version=certbot_version,
-           installer_suffix='win_amd64' if PYTHON_BITNESS == 64 else 'win32',
+           installer_suffix='win64',
            python_bitness=PYTHON_BITNESS,
            python_version='.'.join(str(item) for item in PYTHON_VERSION)))
 

--- a/windows-installer/windows_installer/construct.py
+++ b/windows-installer/windows_installer/construct.py
@@ -8,7 +8,7 @@ import sys
 import time
 
 PYTHON_VERSION = (3, 9, 7)
-PYTHON_BITNESS = 32
+PYTHON_BITNESS = 64
 NSIS_VERSION = '3.06.1'
 
 

--- a/windows-installer/windows_installer/construct.py
+++ b/windows-installer/windows_installer/construct.py
@@ -124,7 +124,7 @@ files=run.bat
 entry_point=certbot.main:main
 extra_preamble=preamble.py
 '''.format(certbot_version=certbot_version,
-           installer_suffix='win_amd64',
+           installer_suffix='win_amd64' if PYTHON_BITNESS == 64 else 'win32',
            python_bitness=PYTHON_BITNESS,
            python_version='.'.join(str(item) for item in PYTHON_VERSION)))
 


### PR DESCRIPTION
## Pull Request Checklist

Addresses #9176 

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.

I'm still not super familiar with the CI pipeline, and I haven't worked w/ python on Windows, so it's totally possible I missed something here. Also, note that once this is merged/the installer is built, we'll need to update the `dl.eff.org` CI to pull the win64 exe, and also update the Windows installer docs on certbot.eff.org.