### PR TITLE
Add extra challenge info to `--debug-challenges`

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,9 +6,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-* When the `--debug-challenges` option is used, Certbot now displays the challenge URLs (for 
-  `http-01` challenges) or FQDNs (for `dns-01` challenges) with their expected values when
-  ran with the `-v` option.
+* When the `--debug-challenges` option is used in combination with `-v`, Certbot
+  now displays the challenge URLs (for `http-01` challenges) or FQDNs (for
+  `dns-01` challenges) and their expected return values.
 *
 
 ### Changed

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,6 +6,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+* When the `--debug-challenges` option is used, Certbot now displays the challenge URLs (for 
+  `http-01` challenges) or FQDNs (for `dns-01` challenges) with their expected values when
+  ran with the `-v` option.
 *
 
 ### Changed

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -103,13 +103,13 @@ class AuthHandler:
                         if http01_achalls:
                             msg.append("\nThe following URLs should be accessible from the world "
                                        "wide web and return the value mentioned:\n")
-                            for uri, token in http01_achalls.items():
-                                msg.append(f"{uri}: {token}")
+                            for uri, key_authz in http01_achalls.items():
+                                msg.append(f"URL: {uri}\nExpected value: {key_authz}")
                         if dns01_achalls:
                             msg.append("\nThe following FQDNs should return a TXT resource "
                                        "record with the value mentioned:\n")
-                            for fqdn, token in dns01_achalls.items():
-                                msg.append(f"{fqdn}: {token}")
+                            for fqdn, key_authz_hash in dns01_achalls.items():
+                                msg.append(f"FQDN: {fqdn}\nExpected value: {key_authz_hash}")
                     else:
                         msg = ['Pass "-v" for more info about challenges.']
                     display_util.notification(

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -349,16 +349,16 @@ class AuthHandler:
                         achall.validation(achall.account_key) + "\n"
                     )
             if http01_achalls:
-                msg.append("\nThe following URLs should be accessible from the "
+                msg.append("The following URLs should be accessible from the "
                            "internet and return the value mentioned:\n")
                 for uri, key_authz in http01_achalls.items():
                     msg.append(f"URL: {uri}\nExpected value: {key_authz}")
             if dns01_achalls:
-                msg.append("\nThe following FQDNs should return a TXT resource "
+                msg.append("The following FQDNs should return a TXT resource "
                            "record with the value mentioned:\n")
                 for fqdn, key_authz_hash in dns01_achalls.items():
                     msg.append(f"FQDN: {fqdn}\nExpected value: {key_authz_hash}")
-            return "\n".join(msg)
+            return "\n" + "\n".join(msg)
         else:
             return 'Pass "-v" for more info about challenges.'
 

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -88,7 +88,7 @@ class AuthHandler:
                 # If debug is on, wait for user input before starting the verification process.
                 if config.debug_challenges:
                     msg = []
-                    if config.namespace.verbose_count > 0:
+                    if config.verbose_count > 0:
                         http01_achalls = {}
                         dns01_achalls = {}
                         for achall in achalls:

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -101,8 +101,8 @@ class AuthHandler:
                                     achall.validation(achall.account_key) + "\n"
                                 )
                         if http01_achalls:
-                            msg.append("\nThe following URLs should be accessible from the world "
-                                       "wide web and return the value mentioned:\n")
+                            msg.append("\nThe following URLs should be accessible from the "
+                                       "internet and return the value mentioned:\n")
                             for uri, key_authz in http01_achalls.items():
                                 msg.append(f"URL: {uri}\nExpected value: {key_authz}")
                         if dns01_achalls:

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -87,34 +87,9 @@ class AuthHandler:
 
                 # If debug is on, wait for user input before starting the verification process.
                 if config.debug_challenges:
-                    msg = []
-                    if config.verbose_count > 0:
-                        http01_achalls = {}
-                        dns01_achalls = {}
-                        for achall in achalls:
-                            if isinstance(achall.chall, challenges.HTTP01):
-                                http01_achalls[achall.chall.uri(achall.domain)] = (
-                                    achall.validation(achall.account_key) + "\n"
-                                )
-                            if isinstance(achall.chall, challenges.DNS01):
-                                dns01_achalls[achall.validation_domain_name(achall.domain)] = (
-                                    achall.validation(achall.account_key) + "\n"
-                                )
-                        if http01_achalls:
-                            msg.append("\nThe following URLs should be accessible from the "
-                                       "internet and return the value mentioned:\n")
-                            for uri, key_authz in http01_achalls.items():
-                                msg.append(f"URL: {uri}\nExpected value: {key_authz}")
-                        if dns01_achalls:
-                            msg.append("\nThe following FQDNs should return a TXT resource "
-                                       "record with the value mentioned:\n")
-                            for fqdn, key_authz_hash in dns01_achalls.items():
-                                msg.append(f"FQDN: {fqdn}\nExpected value: {key_authz_hash}")
-                    else:
-                        msg = ['Pass "-v" for more info about challenges.']
                     display_util.notification(
-                        'Challenges loaded. Press continue to submit to CA.\n' + '\n'.join(msg),
-                        pause=True)
+                        'Challenges loaded. Press continue to submit to CA.\n' +
+                        self._debug_challenges_msg(achalls, config), pause=True)
             except errors.AuthorizationError as error:
                 logger.critical('Failure in setting up challenges.')
                 logger.info('Attempting to clean up outstanding challenges...')
@@ -348,6 +323,44 @@ class AuthHandler:
             msg.append(f"\nHint: {self.auth.auth_hint(failed_achalls)}\n")
 
         display_util.notify("".join(msg))
+
+    def _debug_challenges_msg(self, achalls: List[achallenges.AnnotatedChallenge],
+                              config: configuration.NamespaceConfig) -> str:
+        """Construct message for debug challenges prompt
+
+        :param list achalls: A list of
+            :class:`certbot.achallenges.AnnotatedChallenge`.
+        :param certbot.configuration.NamespaceConfig config: current Certbot configuration
+        :returns: Message containing challenge debug info
+        :rtype: str
+
+        """
+        if config.verbose_count > 0:
+            msg = []
+            http01_achalls = {}
+            dns01_achalls = {}
+            for achall in achalls:
+                if isinstance(achall.chall, challenges.HTTP01):
+                    http01_achalls[achall.chall.uri(achall.domain)] = (
+                        achall.validation(achall.account_key) + "\n"
+                    )
+                if isinstance(achall.chall, challenges.DNS01):
+                    dns01_achalls[achall.validation_domain_name(achall.domain)] = (
+                        achall.validation(achall.account_key) + "\n"
+                    )
+            if http01_achalls:
+                msg.append("\nThe following URLs should be accessible from the "
+                           "internet and return the value mentioned:\n")
+                for uri, key_authz in http01_achalls.items():
+                    msg.append(f"URL: {uri}\nExpected value: {key_authz}")
+            if dns01_achalls:
+                msg.append("\nThe following FQDNs should return a TXT resource "
+                           "record with the value mentioned:\n")
+                for fqdn, key_authz_hash in dns01_achalls.items():
+                    msg.append(f"FQDN: {fqdn}\nExpected value: {key_authz_hash}")
+            return "\n".join(msg)
+        else:
+            return 'Pass "-v" for more info about challenges.'
 
 
 def challb_to_achall(challb: messages.ChallengeBody, account_key: josepy.JWK,

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -264,7 +264,9 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
         [None, "certonly", "run"], "--debug-challenges", action="store_true",
         default=flag_default("debug_challenges"),
         help="After setting up challenges, wait for user input before "
-             "submitting to CA")
+             "submitting to CA. When used in combination with the `-v` "
+             "option, the challenge URLs or FQDNs and their expected "
+             "return values are shown.")
     helpful.add(
         "testing", "--no-verify-ssl", action="store_true",
         help=config_help("no_verify_ssl"),

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -214,8 +214,7 @@ class HandleAuthorizationsTest(unittest.TestCase):
                       self.mock_display.notification.call_args[0][0])
 
     def test_debug_challenges_verbose_http01(self):
-        config = mock.Mock(debug_challenges=True)
-        config.verbose_count = 1
+        config = mock.Mock(debug_challenges=True, verbose_count=1)
         authzrs = [gen_dom_authzr(domain="0", challs=[acme_util.HTTP01])]
         mock_order = mock.MagicMock(authorizations=authzrs)
 

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -202,9 +202,9 @@ class HandleAuthorizationsTest(unittest.TestCase):
         self.assertEqual(self.mock_net.answer_challenge.call_count, 1)
         self.assertEqual(self.mock_display.notification.call_count, 1)
         self.assertIn('Pass "-v" for more info',
-                      self.mock_display.notification.call_args.args[0])
+                      self.mock_display.notification.call_args[0][0])
         self.assertNotIn(f"http://{authzrs[0].body.identifier.value}/.well-known/acme-challenge/",
-                         self.mock_display.notification.call_args.args[0])
+                         self.mock_display.notification.call_args[0][0])
 
     def test_debug_challenges_verbose(self):
         config = mock.Mock(debug_challenges=True)
@@ -221,9 +221,9 @@ class HandleAuthorizationsTest(unittest.TestCase):
         self.assertEqual(self.mock_net.answer_challenge.call_count, 1)
         self.assertEqual(self.mock_display.notification.call_count, 1)
         self.assertNotIn('Pass "-v" for more info',
-                         self.mock_display.notification.call_args.args[0])
+                         self.mock_display.notification.call_args[0][0])
         self.assertIn(f"http://{authzrs[0].body.identifier.value}/.well-known/acme-challenge/",
-                      self.mock_display.notification.call_args.args[0])
+                      self.mock_display.notification.call_args[0][0])
 
     def test_perform_failure(self):
         authzrs = [gen_dom_authzr(domain="0", challs=acme_util.CHALLENGES)]

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -191,7 +191,7 @@ class HandleAuthorizationsTest(unittest.TestCase):
         self._test_name3_http_01_3_common(combos=False)
 
     def test_debug_challenges(self):
-        config = mock.Mock(debug_challenges=True)
+        config = mock.Mock(debug_challenges=True, verbose_count=0)
         config.verbose_count = 0
         authzrs = [gen_dom_authzr(domain="0", challs=[acme_util.HTTP01])]
         mock_order = mock.MagicMock(authorizations=authzrs)

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -73,7 +73,7 @@ class HandleAuthorizationsTest(unittest.TestCase):
         with mock.patch("zope.component.provideUtility"):
             display_obj.set_display(self.mock_display)
 
-        self.mock_auth = mock.MagicMock(name="ApacheConfigurator")
+        self.mock_auth = mock.MagicMock(name="Authenticator")
 
         self.mock_auth.get_chall_pref.return_value = [challenges.HTTP01]
 
@@ -213,7 +213,7 @@ class HandleAuthorizationsTest(unittest.TestCase):
         self.assertNotIn(b64encode(account_key_thumbprint).decode(),
                       self.mock_display.notification.call_args[0][0])
 
-    def test_debug_challenges_verbose(self):
+    def test_debug_challenges_verbose_http01(self):
         config = mock.Mock(debug_challenges=True)
         config.verbose_count = 1
         authzrs = [gen_dom_authzr(domain="0", challs=[acme_util.HTTP01])]
@@ -234,6 +234,30 @@ class HandleAuthorizationsTest(unittest.TestCase):
                       b64encode(authzrs[0].body.challenges[0].chall.token).decode(),
                       self.mock_display.notification.call_args[0][0])
         self.assertIn(b64encode(account_key_thumbprint).decode(),
+                      self.mock_display.notification.call_args[0][0])
+
+    def test_debug_challenges_verbose_dns01(self):
+        config = mock.Mock(debug_challenges=True)
+        config.verbose_count = 1
+        authzrs = [gen_dom_authzr(domain="0", challs=[acme_util.DNS01])]
+        mock_order = mock.MagicMock(authorizations=authzrs)
+
+        account_key_thumbprint = b"foobarbaz"
+        self.mock_account.key.thumbprint.return_value = account_key_thumbprint
+
+        self.mock_net.poll.side_effect = _gen_mock_on_poll()
+
+        self.mock_auth.get_chall_pref.return_value = [challenges.DNS01]
+
+        self.handler.handle_authorizations(mock_order, config)
+
+        self.assertEqual(self.mock_net.answer_challenge.call_count, 1)
+        self.assertEqual(self.mock_display.notification.call_count, 1)
+        self.assertNotIn('Pass "-v" for more info',
+                         self.mock_display.notification.call_args[0][0])
+        self.assertIn(f"_acme-challenge.{authzrs[0].body.identifier.value}",
+                      self.mock_display.notification.call_args[0][0])
+        self.assertIn(authzrs[0].body.challenges[0].validation(self.mock_account.key),
                       self.mock_display.notification.call_args[0][0])
 
     def test_perform_failure(self):

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -191,7 +191,7 @@ class HandleAuthorizationsTest(unittest.TestCase):
 
     def test_debug_challenges(self):
         config = mock.Mock(debug_challenges=True)
-        config.namespace.verbose_count = 0
+        config.verbose_count = 0
         authzrs = [gen_dom_authzr(domain="0", challs=[acme_util.HTTP01])]
         mock_order = mock.MagicMock(authorizations=authzrs)
 
@@ -208,7 +208,7 @@ class HandleAuthorizationsTest(unittest.TestCase):
 
     def test_debug_challenges_verbose(self):
         config = mock.Mock(debug_challenges=True)
-        config.namespace.verbose_count = 1
+        config.verbose_count = 1
         authzrs = [gen_dom_authzr(domain="0", challs=[acme_util.HTTP01])]
         mock_order = mock.MagicMock(authorizations=authzrs)
 

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -192,7 +192,6 @@ class HandleAuthorizationsTest(unittest.TestCase):
 
     def test_debug_challenges(self):
         config = mock.Mock(debug_challenges=True, verbose_count=0)
-        config.verbose_count = 0
         authzrs = [gen_dom_authzr(domain="0", challs=[acme_util.HTTP01])]
         mock_order = mock.MagicMock(authorizations=authzrs)
 


### PR DESCRIPTION
Fixes #6042, I believe.

This PR outputs the URLs (`http-01`) and FQDNs (`dns-01`) used for the challenges and their expected values when Certbot is being run with the `--debug-challenges` option.

This allows users to double/triple-check their challenges before continuing the validation.

Certbot currently does not support the `tls-alpn-01` challenge, so I didn't include it.

<s>Also, it seems the token isn't available in `auth_handler_test.py`. Or at least I can't find it. So I couldn't use the token for the `assertIn()` check, but I'm pretty sure this is enough, right?</s>