### PR TITLE
Enable automatic PRs from dependabot

### DIFF
--- a/.azure-pipelines/INSTALL.md
+++ b/.azure-pipelines/INSTALL.md
@@ -17,7 +17,7 @@ During this installation step, warnings describing user access and legal comitme
 !!! ACCESS REQUIRED !!!
 ```
 
-This document suppose that the Azure DevOps organization is named _certbot_, and the Azure DevOps project is also _certbot_.
+This document supposes that the Azure DevOps organization is named _certbot_, and the Azure DevOps project is also _certbot_.
 
 ## Useful links
 
@@ -116,4 +116,4 @@ To set up a variable that is shared between pipelines, follow the instructions
 at
 https://docs.microsoft.com/en-us/azure/devops/pipelines/library/variable-groups.
 When adding variables to a group, don't forget to tick "Keep this value secret"
-if it shouldn't be shared publcily.
+if it shouldn't be shared publicly.

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,98 +15,98 @@ updates:
       - 'dependencies'
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-cloudflare/'
+    directory: '/certbot-dns-cloudflare/'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'
 
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-cloudxns'
+    directory: '/certbot-dns-cloudxns'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-digitalocean'
+    directory: '/certbot-dns-digitalocean'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-dnsimple'
+    directory: '/certbot-dns-dnsimple'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-dnsmadeeasy'
+    directory: '/certbot-dns-dnsmadeeasy'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-gehirn'
+    directory: '/certbot-dns-gehirn'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-google'
+    directory: '/certbot-dns-google'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-linode'
+    directory: '/certbot-dns-linode'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-luadns'
+    directory: '/certbot-dns-luadns'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-nsone'
+    directory: '/certbot-dns-nsone'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-ovh'
+    directory: '/certbot-dns-ovh'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-rfc2136'
+    directory: '/certbot-dns-rfc2136'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-route53'
+    directory: '/certbot-dns-route53'
     schedule:
       interval: 'weekly'
     labels:
       - 'dependencies'  
   
   - package-ecosystem: 'pip'
-    directory: '/certbot/certbot-dns-sakuracloud'
+    directory: '/certbot-dns-sakuracloud'
     schedule:
       interval: 'weekly'
     labels:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,113 @@
+version: 2
+updates:
+  - package-ecosystem: 'pip'
+    directory: '/acme/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'
+
+  - package-ecosystem: 'pip'
+    directory: '/certbot/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-cloudflare/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'
+
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-cloudxns'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-digitalocean'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-dnsimple'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-dnsmadeeasy'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-gehirn'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-google'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-linode'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-luadns'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-nsone'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-ovh'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-rfc2136'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-route53'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  
+  
+  - package-ecosystem: 'pip'
+    directory: '/certbot/certbot-dns-sakuracloud'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'  


### PR DESCRIPTION
It's a proposal to enable dependabot in this repository. It has become an opt-in feature that automatically creates PRs. Since each of the dns plugins is essentially a package, the YAML file is rather long. There are different options that can be set to configure the intervals when the bot creates PRs with dependency updates, as well as labels and reviewers, as well as the maximum number of PRs it can create to avoid being spammed.

I don't think certbot nor the acme library themselves publish many package updates for security issues. All of the DNS plugins depend on these two components, as well as third-party libraries for DNS requests.

Please read the documentation to see if the file can be tweaked 
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
