### PR TITLE
Fixing hanging test farm tests

### DIFF
--- a/certbot-apache/tests/apache-conf-files/apache-conf-test
+++ b/certbot-apache/tests/apache-conf-files/apache-conf-test
@@ -51,9 +51,9 @@ function Cleanup() {
 
 # if our environment asks us to enable modules, do our best!
 if [ "$1" = --debian-modules ] ; then
-    sudo apt-get install -y apache2
-    sudo apt-get install -y libapache2-mod-wsgi-py3
-    sudo apt-get install -y libapache2-mod-macro
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y apache2
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libapache2-mod-wsgi-py3
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libapache2-mod-macro
 
     for mod in  ssl rewrite macro wsgi deflate userdir version mime setenvif ; do
         echo -n enabling $mod

--- a/letstest/scripts/bootstrap_os_packages.sh
+++ b/letstest/scripts/bootstrap_os_packages.sh
@@ -36,7 +36,7 @@ DeterminePythonVersion() {
 BootstrapDebCommon() {
   sudo apt-get update || error apt-get update hit problems but continuing anyway...
 
-  sudo apt-get install -y --no-install-recommends \
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 \
     python3-dev \
     python3-venv \


### PR DESCRIPTION
[Our test farm tests started hanging last night](https://dev.azure.com/certbot/certbot/_build/results?buildId=5151&view=logs&j=23275d9a-33b0-57f8-5f28-197fe2e5b9cd&s=1dfbc15b-7d0f-52a9-b1da-b17592bf94f8). Running the tests locally, the cause was `apt-get install` raised an interactive prompt that wasn't handled well and caused the entire system to restart. Here's a [log of that](https://gist.github.com/fb80d0279306d08e4ffd744e559a3df2).

I fixed this by setting `DEBIAN_FRONTEND=noninteractive` as is commonly done in things like Dockerfiles to avoid this problem.