### PR TITLE
snap_config: set a timeout when talking to snapd

### DIFF
--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -54,7 +54,8 @@ def prepare_env(cli_args: List[str]) -> List[str]:
         session.mount('http://snapd/', _SnapdAdapter())
 
         try:
-            response = session.get('http://snapd/v2/connections?snap=certbot&interface=content')
+            response = session.get('http://snapd/v2/connections?snap=certbot&interface=content',
+                                   timeout=30.0)
             response.raise_for_status()
         except RequestException as e:
             if isinstance(e, HTTPError) and e.response.status_code == 404:


### PR DESCRIPTION
Fixes #8475.

---

I came across another thread which looked suspiciously like a hung snapd process. Having a timeout here seems wise anyway.