### PR TITLE
Mention Python 3.6 support plan change

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -13,7 +13,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* We previously said we'd drop Python 3.6 support in this release. This release
+  still supports Python 3.6, however, support is still deprecated and we plan
+  to completely remove support in a future release.
 
 ### Fixed
 


### PR DESCRIPTION
I have https://github.com/certbot/certbot/pull/9216, however, I see no real reason to rush things. I would like one of these two PRs to land before the release tomorrow.