### PR TITLE
Use the git CLI with cargo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,9 @@ parts:
       - python3-dev
       - cargo
     build-environment:
+      # We set this environment variable while building to try and increase the
+      # stability of fetching the rust crates needed to build the cryptography
+      # library.
       - CARGO_NET_GIT_FETCH_WITH_CLI: true
       - SNAPCRAFT_PYTHON_VENV_ARGS: --upgrade
       # Constraints are passed through the environment variable PIP_CONSTRAINTS instead of using the

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,7 @@ parts:
       - python3-dev
       - cargo
     build-environment:
+      - CARGO_NET_GIT_FETCH_WITH_CLI: true
       - SNAPCRAFT_PYTHON_VENV_ARGS: --upgrade
       # Constraints are passed through the environment variable PIP_CONSTRAINTS instead of using the
       # parts.[part_name].constraints option available in snapcraft.yaml when the Python plugin is

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,7 +83,7 @@ parts:
       # We set this environment variable while building to try and increase the
       # stability of fetching the rust crates needed to build the cryptography
       # library.
-      - CARGO_NET_GIT_FETCH_WITH_CLI: true
+      - CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       - SNAPCRAFT_PYTHON_VENV_ARGS: --upgrade
       # Constraints are passed through the environment variable PIP_CONSTRAINTS instead of using the
       # parts.[part_name].constraints option available in snapcraft.yaml when the Python plugin is

--- a/tools/docker/core/Dockerfile
+++ b/tools/docker/core/Dockerfile
@@ -26,6 +26,10 @@ RUN apk add --no-cache --virtual .certbot-deps \
         ca-certificates \
         binutils
 
+# We set this environment variable and install git while building to try and
+# increase the stability of fetching the rust crates needed to build the
+# cryptography library
+ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 # Install certbot from sources
 RUN apk add --no-cache --virtual .build-deps \
         gcc \
@@ -35,6 +39,7 @@ RUN apk add --no-cache --virtual .build-deps \
         libffi-dev \
         python3-dev \
         cargo \
+        git \
     && python tools/pipstrap.py \
     && python tools/pip_install.py --no-cache-dir \
             --editable src/acme \

--- a/tools/snap/generate_dnsplugins_snapcraft.sh
+++ b/tools/snap/generate_dnsplugins_snapcraft.sh
@@ -30,7 +30,7 @@ parts:
       # We set this environment variable while building to try and increase the
       # stability of fetching the rust crates needed to build the cryptography
       # library.
-      - CARGO_NET_GIT_FETCH_WITH_CLI: true
+      - CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       # Constraints are passed through the environment variable PIP_CONSTRAINTS instead of using the
       # parts.[part_name].constraints option available in snapcraft.yaml when the Python plugin is
       # used. This is done to let these constraints be applied not only on the certbot package

--- a/tools/snap/generate_dnsplugins_snapcraft.sh
+++ b/tools/snap/generate_dnsplugins_snapcraft.sh
@@ -27,6 +27,10 @@ parts:
         snapcraftctl pull
         snapcraftctl set-version \`grep ^version \$SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"\`
     build-environment:
+      # We set this environment variable while building to try and increase the
+      # stability of fetching the rust crates needed to build the cryptography
+      # library.
+      - CARGO_NET_GIT_FETCH_WITH_CLI: true
       # Constraints are passed through the environment variable PIP_CONSTRAINTS instead of using the
       # parts.[part_name].constraints option available in snapcraft.yaml when the Python plugin is
       # used. This is done to let these constraints be applied not only on the certbot package


### PR DESCRIPTION
Hopefully this makes things more stable. This is based on Alex's suggestion [here](https://opensource.eff.org/eff-open-source/pl/ouf996zuxjnkdxwq81bihxak7e). I'm testing building the snaps and docker images for all architectures with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=5227&view=results.