### PR TITLE
Use f-strings in DNS plugins.

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1142,8 +1142,7 @@ class ClientNetwork:
                     'response', response_ct)
 
             if content_type == cls.JSON_CONTENT_TYPE and jobj is None:
-                raise errors.ClientError(
-                    'Unexpected response Content-Type: {0}'.format(response_ct))
+                raise errors.ClientError(f'Unexpected response Content-Type: {response_ct}')
 
         return response
 
@@ -1196,7 +1195,7 @@ class ClientNetwork:
             if m is None:
                 raise  # pragma: no cover
             host, path, _err_no, err_msg = m.groups()
-            raise ValueError("Requesting {0}{1}:{2}".format(host, path, err_msg))
+            raise ValueError(f"Requesting {host}{path}:{err_msg}")
 
         # If the Content-Type is DER or an Accept header was sent in the
         # request, the response may not be UTF-8 encoded. In this case, we
@@ -1217,8 +1216,7 @@ class ClientNetwork:
             debug_content = response.text
         logger.debug('Received response:\nHTTP %d\n%s\n\n%s',
                      response.status_code,
-                     "\n".join("{0}: {1}".format(k, v)
-                                for k, v in response.headers.items()),
+                     "\n".join(f"{k}: {v}" for k, v in response.headers.items()),
                      debug_content)
         return response
 

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/dns_cloudflare.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/dns_cloudflare.py
@@ -47,22 +47,24 @@ class Authenticator(dns_common.DNSAuthenticator):
         key = credentials.conf('api-key')
         if token:
             if email or key:
-                raise errors.PluginError('{}: dns_cloudflare_email and dns_cloudflare_api_key are '
-                                         'not needed when using an API Token'
-                                         .format(credentials.confobj.filename))
+                raise errors.PluginError(
+                    f'{credentials.confobj.filename}: dns_cloudflare_email and '
+                    'dns_cloudflare_api_key are not needed when using an API Token')
         elif email or key:
             if not email:
-                raise errors.PluginError('{}: dns_cloudflare_email is required when using a Global '
-                                         'API Key. (should be email address associated with '
-                                         'Cloudflare account)'.format(credentials.confobj.filename))
+                raise errors.PluginError(
+                    f'{credentials.confobj.filename}: dns_cloudflare_email is required when '
+                    'using a Global API Key. (should be email address associated with '
+                    'Cloudflare account)')
             if not key:
-                raise errors.PluginError('{}: dns_cloudflare_api_key is required when using a '
-                                         'Global API Key. (see {})'
-                                         .format(credentials.confobj.filename, ACCOUNT_URL))
+                raise errors.PluginError(
+                    f'{credentials.confobj.filename}: dns_cloudflare_api_key is required when '
+                    f'using a Global API Key. (see {ACCOUNT_URL})')
         else:
-            raise errors.PluginError('{}: Either dns_cloudflare_api_token (recommended), or '
-                                     'dns_cloudflare_email and dns_cloudflare_api_key are required.'
-                                     ' (see {})'.format(credentials.confobj.filename, ACCOUNT_URL))
+            raise errors.PluginError(
+                f'{credentials.confobj.filename}: Either dns_cloudflare_api_token (recommended), '
+                'or dns_cloudflare_email and dns_cloudflare_api_key are required.'
+                f' (see {ACCOUNT_URL})')
 
     def _setup_credentials(self) -> None:
         self.credentials = self._configure_credentials(
@@ -124,8 +126,10 @@ class _CloudflareClient:
                 hint = 'Does your API token have "Zone:DNS:Edit" permissions?'
 
             logger.error('Encountered CloudFlareAPIError adding TXT record: %d %s', e, e)
-            raise errors.PluginError('Error communicating with the Cloudflare API: {0}{1}'
-                                     .format(e, ' ({0})'.format(hint) if hint else ''))
+            hint_disp = f' ({hint})' if hint else ''
+            raise errors.PluginError(
+                f'Error communicating with the Cloudflare API: {e}{hint_disp}'
+            )
 
         record_id = self._find_txt_record_id(zone_id, record_name, record_content)
         logger.debug('Successfully added TXT record with record_id: %s', record_id)
@@ -190,19 +194,23 @@ class _CloudflareClient:
                 hint = None
 
                 if code == 6003:
-                    hint = ('Did you copy your entire API token/key? To use Cloudflare tokens, '
-                            'you\'ll need the python package cloudflare>=2.3.1.{}'
-                    .format(' This certbot is running cloudflare ' + str(CloudFlare.__version__)
-                    if hasattr(CloudFlare, '__version__') else ''))
+                    version_disp = (
+                        f" This certbot is running cloudflare {str(CloudFlare.__version__)}"
+                    ) if hasattr(CloudFlare, '__version__') else ""
+                    hint = (
+                        "Did you copy your entire API token/key? To use Cloudflare tokens, "
+                        f"you'll need the python package cloudflare>=2.3.1.{version_disp}"
+                    )
                 elif code == 9103:
                     hint = 'Did you enter the correct email address and Global key?'
                 elif code == 9109:
                     hint = 'Did you enter a valid Cloudflare Token?'
 
                 if hint:
-                    raise errors.PluginError('Error determining zone_id: {0} {1}. Please confirm '
-                                  'that you have supplied valid Cloudflare API credentials. ({2})'
-                                                                         .format(code, msg, hint))
+                    raise errors.PluginError(
+                        f'Error determining zone_id: {code} {msg}. Please confirm '
+                        f'that you have supplied valid Cloudflare API credentials. ({hint})'
+                    )
                 else:
                     logger.debug('Unrecognised CloudFlareAPIError while finding zone_id: %d %s. '
                                  'Continuing with next zone guess...', e, e)
@@ -214,20 +222,24 @@ class _CloudflareClient:
 
         if msg is not None:
             if 'com.cloudflare.api.account.zone.list' in msg:
-                raise errors.PluginError('Unable to determine zone_id for {0} using zone names: '
-                                         '{1}. Please confirm that the domain name has been '
-                                         'entered correctly and your Cloudflare Token has access '
-                                         'to the domain.'.format(domain, zone_name_guesses))
+                raise errors.PluginError(
+                    f'Unable to determine zone_id for {domain} using zone names: '
+                    f'{zone_name_guesses}. Please confirm that the domain name has been '
+                    'entered correctly and your Cloudflare Token has access '
+                    'to the domain.'
+                )
             else:
-                raise errors.PluginError('Unable to determine zone_id for {0} using zone names: '
-                                         '{1}. The error from Cloudflare was: {2} {3}.'
-                                         .format(domain, zone_name_guesses, code, msg))
+                raise errors.PluginError(
+                    f'Unable to determine zone_id for {domain} using zone names: '
+                    f'{zone_name_guesses}. The error from Cloudflare was: {code} {msg}.'
+                )
         else:
-            raise errors.PluginError('Unable to determine zone_id for {0} using zone names: '
-                                     '{1}. Please confirm that the domain name has been '
-                                     'entered correctly and is already associated with the '
-                                     'supplied Cloudflare account.'
-                                     .format(domain, zone_name_guesses))
+            raise errors.PluginError(
+                f'Unable to determine zone_id for {domain} using zone names: '
+                f'{zone_name_guesses}. Please confirm that the domain name has been '
+                'entered correctly and is already associated with the '
+                'supplied Cloudflare account.'
+            )
 
     def _find_txt_record_id(self, zone_id: str, record_name: str,
                             record_content: str) -> Optional[str]:

--- a/certbot-dns-cloudxns/certbot_dns_cloudxns/_internal/dns_cloudxns.py
+++ b/certbot-dns-cloudxns/certbot_dns_cloudxns/_internal/dns_cloudxns.py
@@ -45,9 +45,8 @@ class Authenticator(dns_common.DNSAuthenticator):
             'credentials',
             'CloudXNS credentials INI file',
             {
-                'api-key': 'API key for CloudXNS account, obtained from {0}'.format(ACCOUNT_URL),
-                'secret-key': 'Secret key for CloudXNS account, obtained from {0}'
-                              .format(ACCOUNT_URL)
+                'api-key': f'API key for CloudXNS account, obtained from {ACCOUNT_URL}',
+                'secret-key': f'Secret key for CloudXNS account, obtained from {ACCOUNT_URL}',
             }
         )
 

--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
@@ -93,8 +93,10 @@ class _DigitalOceanClient:
                 hint = 'Did you provide a valid API token?'
 
             logger.debug('Error finding domain using the DigitalOcean API: %s', e)
-            raise errors.PluginError('Error finding domain using the DigitalOcean API: {0}{1}'
-                                     .format(e, ' ({0})'.format(hint) if hint else ''))
+            hint_disp = f' ({hint})' if hint else ''
+            raise errors.PluginError(
+                f'Error finding domain using the DigitalOcean API: {e}{hint_disp}'
+            )
 
         try:
             result = domain.create_new_domain_record(
@@ -108,8 +110,7 @@ class _DigitalOceanClient:
             logger.debug('Successfully added TXT record with id: %d', record_id)
         except digitalocean.Error as e:
             logger.debug('Error adding TXT record using the DigitalOcean API: %s', e)
-            raise errors.PluginError('Error adding TXT record using the DigitalOcean API: {0}'
-                                     .format(e))
+            raise errors.PluginError(f'Error adding TXT record using the DigitalOcean API: {e}')
 
     def del_txt_record(self, domain_name: str, record_name: str, record_content: str) -> None:
         """

--- a/certbot-dns-dnsimple/certbot_dns_dnsimple/_internal/dns_dnsimple.py
+++ b/certbot-dns-dnsimple/certbot_dns_dnsimple/_internal/dns_dnsimple.py
@@ -45,7 +45,7 @@ class Authenticator(dns_common.DNSAuthenticator):
             'credentials',
             'DNSimple credentials INI file',
             {
-                'token': 'User access token for DNSimple v2 API. (See {0}.)'.format(ACCOUNT_URL)
+                'token': f'User access token for DNSimple v2 API. (See {ACCOUNT_URL}.)'
             }
         )
 

--- a/certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy/_internal/dns_dnsmadeeasy.py
+++ b/certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy/_internal/dns_dnsmadeeasy.py
@@ -46,10 +46,8 @@ class Authenticator(dns_common.DNSAuthenticator):
             'credentials',
             'DNS Made Easy credentials INI file',
             {
-                'api-key': 'API key for DNS Made Easy account, obtained from {0}'
-                           .format(ACCOUNT_URL),
-                'secret-key': 'Secret key for DNS Made Easy account, obtained from {0}'
-                              .format(ACCOUNT_URL)
+                'api-key': f'API key for DNS Made Easy account, obtained from {ACCOUNT_URL}',
+                'secret-key': f'Secret key for DNS Made Easy account, obtained from {ACCOUNT_URL}',
             }
         )
 

--- a/certbot-dns-dnsmadeeasy/tests/dns_dnsmadeeasy_test.py
+++ b/certbot-dns-dnsmadeeasy/tests/dns_dnsmadeeasy_test.py
@@ -43,8 +43,8 @@ class AuthenticatorTest(test_util.TempDirTestCase,
 
 class DNSMadeEasyLexiconClientTest(unittest.TestCase,
                                    dns_test_common_lexicon.BaseLexiconClientTest):
-    DOMAIN_NOT_FOUND = HTTPError('404 Client Error: Not Found for url: {0}.'.format(DOMAIN))
-    LOGIN_ERROR = HTTPError('403 Client Error: Forbidden for url: {0}.'.format(DOMAIN))
+    DOMAIN_NOT_FOUND = HTTPError(f'404 Client Error: Not Found for url: {DOMAIN}.')
+    LOGIN_ERROR = HTTPError(f'403 Client Error: Forbidden for url: {DOMAIN}.')
 
     def setUp(self):
         from certbot_dns_dnsmadeeasy._internal.dns_dnsmadeeasy import _DNSMadeEasyLexiconClient

--- a/certbot-dns-gehirn/certbot_dns_gehirn/_internal/dns_gehirn.py
+++ b/certbot-dns-gehirn/certbot_dns_gehirn/_internal/dns_gehirn.py
@@ -47,10 +47,14 @@ class Authenticator(dns_common.DNSAuthenticator):
             'credentials',
             'Gehirn Infrastructure Service credentials file',
             {
-                'api-token': 'API token for Gehirn Infrastructure Service ' + \
-                             'API obtained from {0}'.format(DASHBOARD_URL),
-                'api-secret': 'API secret for Gehirn Infrastructure Service ' + \
-                              'API obtained from {0}'.format(DASHBOARD_URL),
+                'api-token': (
+                    'API token for Gehirn Infrastructure Service ' +
+                    f'API obtained from {DASHBOARD_URL}'
+                ),
+                'api-secret': (
+                    'API secret for Gehirn Infrastructure Service '
+                    f'API obtained from {DASHBOARD_URL}'
+                ),
             }
         )
 

--- a/certbot-dns-gehirn/tests/dns_gehirn_test.py
+++ b/certbot-dns-gehirn/tests/dns_gehirn_test.py
@@ -42,8 +42,8 @@ class AuthenticatorTest(test_util.TempDirTestCase,
 
 
 class GehirnLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexiconClientTest):
-    DOMAIN_NOT_FOUND = HTTPError('404 Client Error: Not Found for url: {0}.'.format(DOMAIN))
-    LOGIN_ERROR = HTTPError('401 Client Error: Unauthorized for url: {0}.'.format(DOMAIN))
+    DOMAIN_NOT_FOUND = HTTPError(f'404 Client Error: Not Found for url: {DOMAIN}.')
+    LOGIN_ERROR = HTTPError(f'401 Client Error: Unauthorized for url: {DOMAIN}.')
 
     def setUp(self):
         from certbot_dns_gehirn._internal.dns_gehirn import _GehirnLexiconClient

--- a/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
@@ -37,9 +37,11 @@ class Authenticator(dns_common.DNSAuthenticator):
                              default_propagation_seconds: int = 60) -> None:
         super().add_parser_arguments(add, default_propagation_seconds=60)
         add('credentials',
-            help=('Path to Google Cloud DNS service account JSON file. (See {0} for' +
-                  'information about creating a service account and {1} for information about the' +
-                  'required permissions.)').format(ACCT_URL, PERMISSIONS_URL),
+            help=(
+                f'Path to Google Cloud DNS service account JSON file. (See {ACCT_URL} for '
+                'information about creating a service account and {PERMISSIONS_URL} '
+                'for information about the required permissions.)'
+            ),
             default=None)
 
     def more_info(self) -> str:
@@ -88,8 +90,7 @@ class _GoogleClient:
                 with open(account_json) as account:
                     self.project_id = json.load(account)['project_id']
             except Exception as e:
-                raise errors.PluginError(
-                    "Error parsing credentials file '{}': {}".format(account_json, e))
+                raise errors.PluginError(f"Error parsing credentials file '{account_json}': {e}")
         else:
             credentials = None
             self.project_id = self.get_project_id()
@@ -135,7 +136,7 @@ class _GoogleClient:
                 {
                     "kind": "dns#resourceRecordSet",
                     "type": "TXT",
-                    "name": record_name + ".",
+                    "name": f"{record_name}.",
                     "rrdatas": add_records,
                     "ttl": record_ttl,
                 },
@@ -148,7 +149,7 @@ class _GoogleClient:
                 {
                     "kind": "dns#resourceRecordSet",
                     "type": "TXT",
-                    "name": record_name + ".",
+                    "name": f"{record_name}.",
                     "rrdatas": record_contents["rrdatas"],
                     "ttl": record_contents["ttl"],
                 },
@@ -168,8 +169,7 @@ class _GoogleClient:
                 status = response['status']
         except googleapiclient_errors.Error as e:
             logger.error('Encountered error adding TXT record: %s', e)
-            raise errors.PluginError('Error communicating with the Google Cloud DNS API: {0}'
-                                     .format(e))
+            raise errors.PluginError(f'Error communicating with the Google Cloud DNS API: {e}')
 
     def del_txt_record(self, domain: str, record_name: str, record_content: str,
                        record_ttl: int) -> None:
@@ -281,8 +281,7 @@ class _GoogleClient:
                 response = request.execute()
                 zones = response['managedZones']
             except googleapiclient_errors.Error as e:
-                raise errors.PluginError('Encountered error finding managed zone: {0}'
-                                         .format(e))
+                raise errors.PluginError(f'Encountered error finding managed zone: {e}')
 
             for zone in zones:
                 zone_id = zone['id']
@@ -290,8 +289,10 @@ class _GoogleClient:
                     logger.debug('Found id of %s for %s using name %s', zone_id, domain, zone_name)
                     return zone_id
 
-        raise errors.PluginError('Unable to determine managed zone for {0} using zone names: {1}.'
-                                 .format(domain, zone_dns_name_guesses))
+        raise errors.PluginError(
+            f'Unable to determine managed zone for {domain} using '
+            f'zone names: {zone_dns_name_guesses}.'
+        )
 
     @staticmethod
     def get_project_id() -> str:
@@ -304,13 +305,13 @@ class _GoogleClient:
         :raises ValueError: Server is found, but response code is not 200
         :returns: project id
         """
-        url = '{0}project/project-id'.format(METADATA_URL)
+        url = f'{METADATA_URL}project/project-id'
 
         # Request an access token from the metadata server.
         http = httplib2.Http()
         r, content = http.request(url, headers=METADATA_HEADERS)
-        if r.status != 200:
-            raise ValueError("Invalid status code: {0}".format(r))
+        if r.status != :
+            raise ValueError(f"Invalid status code: {r}")
 
         if isinstance(content, bytes):
             return content.decode()

--- a/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/dns_google.py
@@ -310,7 +310,7 @@ class _GoogleClient:
         # Request an access token from the metadata server.
         http = httplib2.Http()
         r, content = http.request(url, headers=METADATA_HEADERS)
-        if r.status != :
+        if r.status != 200:
             raise ValueError(f"Invalid status code: {r}")
 
         if isinstance(content, bytes):

--- a/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
@@ -47,8 +47,8 @@ class Authenticator(dns_common.DNSAuthenticator):
             'credentials',
             'Linode credentials INI file',
             {
-                'key': 'API key for Linode account, obtained from {0} or {1}'
-                        .format(API_KEY_URL, API_KEY_URL_V4)
+                'key': f'API key for Linode account, obtained from {API_KEY_URL} '
+                       f'or {API_KEY_URL_V4}'
             }
         )
 
@@ -103,8 +103,9 @@ class _LinodeLexiconClient(dns_common_lexicon.LexiconClient):
 
             self.provider = linode4.Provider(config)
         else:
-            raise errors.PluginError('Invalid api version specified: {0}. (Supported: 3, 4)'
-                                     .format(api_version))
+            raise errors.PluginError(
+                f'Invalid api version specified: {api_version}. (Supported: 3, 4)'
+            )
 
     def _handle_general_error(self, e: Exception, domain_name: str) -> Optional[errors.PluginError]:
         if not str(e).startswith('Domain not found'):

--- a/certbot-dns-luadns/certbot_dns_luadns/_internal/dns_luadns.py
+++ b/certbot-dns-luadns/certbot_dns_luadns/_internal/dns_luadns.py
@@ -46,7 +46,7 @@ class Authenticator(dns_common.DNSAuthenticator):
             'LuaDNS credentials INI file',
             {
                 'email': 'email address associated with LuaDNS account',
-                'token': 'API token for LuaDNS account, obtained from {0}'.format(ACCOUNT_URL)
+                'token': f'API token for LuaDNS account, obtained from {ACCOUNT_URL}'
             }
         )
 

--- a/certbot-dns-nsone/certbot_dns_nsone/_internal/dns_nsone.py
+++ b/certbot-dns-nsone/certbot_dns_nsone/_internal/dns_nsone.py
@@ -45,7 +45,7 @@ class Authenticator(dns_common.DNSAuthenticator):
             'credentials',
             'NS1 credentials file',
             {
-                'api-key': 'API key for NS1 API, obtained from {0}'.format(ACCOUNT_URL)
+                'api-key': f'API key for NS1 API, obtained from {ACCOUNT_URL}'
             }
         )
 

--- a/certbot-dns-nsone/tests/dns_nsone_test.py
+++ b/certbot-dns-nsone/tests/dns_nsone_test.py
@@ -39,8 +39,8 @@ class AuthenticatorTest(test_util.TempDirTestCase,
 
 
 class NS1LexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexiconClientTest):
-    DOMAIN_NOT_FOUND = HTTPError('404 Client Error: Not Found for url: {0}.'.format(DOMAIN))
-    LOGIN_ERROR = HTTPError('401 Client Error: Unauthorized for url: {0}.'.format(DOMAIN))
+    DOMAIN_NOT_FOUND = HTTPError(f'404 Client Error: Not Found for url: {DOMAIN}.')
+    LOGIN_ERROR = HTTPError(f'401 Client Error: Unauthorized for url: {DOMAIN}.')
 
     def setUp(self):
         from certbot_dns_nsone._internal.dns_nsone import _NS1LexiconClient

--- a/certbot-dns-ovh/certbot_dns_ovh/_internal/dns_ovh.py
+++ b/certbot-dns-ovh/certbot_dns_ovh/_internal/dns_ovh.py
@@ -46,12 +46,9 @@ class Authenticator(dns_common.DNSAuthenticator):
             'OVH credentials INI file',
             {
                 'endpoint': 'OVH API endpoint (ovh-eu or ovh-ca)',
-                'application-key': 'Application key for OVH API, obtained from {0}'
-                .format(TOKEN_URL),
-                'application-secret': 'Application secret for OVH API, obtained from {0}'
-                .format(TOKEN_URL),
-                'consumer-key': 'Consumer key for OVH API, obtained from {0}'
-                .format(TOKEN_URL),
+                'application-key': f'Application key for OVH API, obtained from {TOKEN_URL}',
+                'application-secret': f'Application secret for OVH API, obtained from {TOKEN_URL}',
+                'consumer-key': f'Consumer key for OVH API, obtained from {TOKEN_URL}',
             }
         )
 

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/dns_rfc2136.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/dns_rfc2136.py
@@ -61,12 +61,13 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _validate_credentials(self, credentials: CredentialsConfiguration) -> None:
         server = credentials.conf('server')
         if not is_ipaddress(server):
-            raise errors.PluginError("The configured target DNS server ({0}) is not a valid IPv4 "
-                                     "or IPv6 address. A hostname is not allowed.".format(server))
+            raise errors.PluginError(
+                f"The configured target DNS server ({server}) is not a valid IPv4 "
+                "or IPv6 address. A hostname is not allowed.")
         algorithm = credentials.conf('algorithm')
         if algorithm:
             if not self.ALGORITHMS.get(algorithm.upper()):
-                raise errors.PluginError("Unknown algorithm: {0}.".format(algorithm))
+                raise errors.PluginError(f"Unknown algorithm: {algorithm}.")
 
     def _setup_credentials(self) -> None:
         self.credentials = self._configure_credentials(
@@ -136,15 +137,13 @@ class _RFC2136Client:
         try:
             response = dns.query.tcp(update, self.server, self._default_timeout, self.port)
         except Exception as e:
-            raise errors.PluginError('Encountered error adding TXT record: {0}'
-                                     .format(e))
+            raise errors.PluginError(f'Encountered error adding TXT record: {e}')
         rcode = response.rcode()  # type: ignore[attr-defined]
 
         if rcode == dns.rcode.NOERROR:
             logger.debug('Successfully added TXT record %s', record_name)
         else:
-            raise errors.PluginError('Received response from server: {0}'
-                                     .format(dns.rcode.to_text(rcode)))
+            raise errors.PluginError(f'Received response from server: {dns.rcode.to_text(rcode)}')
 
     def del_txt_record(self, record_name: str, record_content: str) -> None:
         """
@@ -171,15 +170,13 @@ class _RFC2136Client:
         try:
             response = dns.query.tcp(update, self.server, self._default_timeout, self.port)
         except Exception as e:
-            raise errors.PluginError('Encountered error deleting TXT record: {0}'
-                                     .format(e))
+            raise errors.PluginError(f'Encountered error deleting TXT record: {e}')
         rcode = response.rcode()  # type: ignore[attr-defined]
 
         if rcode == dns.rcode.NOERROR:
             logger.debug('Successfully deleted TXT record %s', record_name)
         else:
-            raise errors.PluginError('Received response from server: {0}'
-                                     .format(dns.rcode.to_text(rcode)))
+            raise errors.PluginError(f'Received response from server: {dns.rcode.to_text(rcode)}')
 
     def _find_domain(self, record_name: str) -> str:
         """
@@ -198,8 +195,9 @@ class _RFC2136Client:
             if self._query_soa(guess):
                 return guess
 
-        raise errors.PluginError('Unable to determine base domain for {0} using names: {1}.'
-                                 .format(record_name, domain_name_guesses))
+        raise errors.PluginError(
+            f'Unable to determine base domain for {record_name} using names: '
+            f'{domain_name_guesses}.')
 
     def _query_soa(self, domain_name: str) -> bool:
         """
@@ -236,5 +234,4 @@ class _RFC2136Client:
             logger.debug('No authoritative SOA record found for %s', domain_name)
             return False
         except Exception as e:
-            raise errors.PluginError('Encountered error when making query: {0}'
-                                     .format(e))
+            raise errors.PluginError(f'Encountered error when making query: {e}')

--- a/certbot-dns-route53/certbot_dns_route53/_internal/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/_internal/dns_route53.py
@@ -92,9 +92,7 @@ class Authenticator(dns_common.DNSAuthenticator):
                     zones.append((zone["Name"], zone["Id"]))
 
         if not zones:
-            raise errors.PluginError(
-                "Unable to find a Route53 hosted zone for {0}".format(domain)
-            )
+            raise errors.PluginError(f"Unable to find a Route53 hosted zone for {domain}")
 
         # Order the zones that are suffixes for our desired to domain by
         # length, this puts them in an order like:
@@ -107,7 +105,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         zone_id = self._find_zone_id_for_domain(validation_domain_name)
 
         rrecords = self._resource_records[validation_domain_name]
-        challenge = {"Value": '"{0}"'.format(validation)}
+        challenge = {"Value": f'"{validation}"'}
         if action == "DELETE":
             # Remove the record being deleted from the list of tracked records
             rrecords.remove(challenge)
@@ -149,5 +147,6 @@ class Authenticator(dns_common.DNSAuthenticator):
                 return
             time.sleep(5)
         raise errors.PluginError(
-            "Timed out waiting for Route53 change. Current status: %s" %
-            response["ChangeInfo"]["Status"])
+            "Timed out waiting for Route53 change. "
+            f'Current status: {response["ChangeInfo"]["Status"]}'
+        )

--- a/certbot-dns-route53/tests/dns_route53_test.py
+++ b/certbot-dns-route53/tests/dns_route53_test.py
@@ -213,7 +213,7 @@ class ClientTest(unittest.TestCase):
             return_value={"ChangeInfo": {"Id": 1}})
 
         validation = "some-value"
-        validation_record = {"Value": '"{0}"'.format(validation)}
+        validation_record = {"Value": f'"{validation}"'}
         self.client._resource_records[DOMAIN] = [validation_record]
 
         self.client._change_txt_record("DELETE", DOMAIN, validation)

--- a/certbot-dns-sakuracloud/tests/dns_sakuracloud_test.py
+++ b/certbot-dns-sakuracloud/tests/dns_sakuracloud_test.py
@@ -43,8 +43,8 @@ class AuthenticatorTest(test_util.TempDirTestCase,
 
 class SakuraCloudLexiconClientTest(unittest.TestCase,
                                    dns_test_common_lexicon.BaseLexiconClientTest):
-    DOMAIN_NOT_FOUND = HTTPError('404 Client Error: Not Found for url: {0}.'.format(DOMAIN))
-    LOGIN_ERROR = HTTPError('401 Client Error: Unauthorized for url: {0}.'.format(DOMAIN))
+    DOMAIN_NOT_FOUND = HTTPError(f'404 Client Error: Not Found for url: {DOMAIN}.')
+    LOGIN_ERROR = HTTPError(f'401 Client Error: Unauthorized for url: {DOMAIN}.')
 
     def setUp(self):
         from certbot_dns_sakuracloud._internal.dns_sakuracloud import _SakuraCloudLexiconClient


### PR DESCRIPTION
It probably should have been included in #9225 Anyway, everything matching has been replaced with f-strings. Just for the sake of curiosity, I ran a small test with `ipython`, and they're roughly 2-2.5x faster.

```bash
grep -r -E "\.format" certbot-dns*
```

There are still a lot matching this. 
```bash
grep -r -E "\.format" certbot*   
```

I think switching to f-strings is one small step in the right direction of the black/flake8 adoption.

## Pull Request Checklist

- [X] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [X] Add or update any documentation as needed to support the changes in this PR.
- [X] Include your name in `AUTHORS.md` if you like.
