### PR TITLE
Add 1.24.x changelog

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.24.1 - master
+
+### Fixed
+
+* The packages used in our snaps were updated in response to
+  https://ubuntu.com/security/notices/USN-5320-1.
+
+This release was only done for our snaps, however, our Docker images were
+rebuilt as well due to pipeline automation. No other distribution mechanisms
+were affected.
+
+More details about these changes can be found on our GitHub repo.
+
 ## 1.24.0 - 2022-03-01
 
 ### Added

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -9,9 +9,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * The packages used in our snaps were updated in response to
   https://ubuntu.com/security/notices/USN-5320-1.
 
-This release was only done for our snaps, however, our Docker images were
-rebuilt as well due to pipeline automation. No other distribution mechanisms
-were affected.
+This release was only done for our snaps, however, all of our distribution
+mechanisms were updated.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -9,8 +9,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * The packages used in our snaps were updated in response to
   https://ubuntu.com/security/notices/USN-5320-1.
 
-This release was only done for our snaps, however, all of our distribution
-mechanisms were updated.
+While this release was built and pushed to all of our normal distribution
+channels, the release was only done for the sake of updating the Certbot snaps.
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
See https://opensource.eff.org/eff-open-source/pl/8tepfnrdt7r5jxryz43d6y9z6r for more info.

The changelog says `master` because it is changed to the current date in the release script. This is what we've done before in PRs like https://github.com/certbot/certbot/pull/7511.