### PR TITLE
Point pip to filesystem packages rather than local HTTP server

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -157,29 +157,25 @@ done
 mkdir "dist.$version"
 for pkg_dir in $SUBPKGS
 do
-  mv $pkg_dir/dist "dist.$version/$pkg_dir/"
+  mv $pkg_dir/dist/* "dist.$version"
 done
 
 echo "Testing packages"
 cd "dist.$version"
-# start local PyPI
-python -m http.server $PORT &
 # cd .. is NOT done on purpose: we make sure that all subpackages are
-# installed from local PyPI rather than current directory (repo root)
+# installed from local archives rather than current directory (repo root)
 VIRTUALENV_NO_DOWNLOAD=1 virtualenv ../venv
 . ../venv/bin/activate
 pip install -U setuptools
 pip install -U pip
-# Now, use our local PyPI. Disable cache so we get the correct KGS even if we
-# (or our dependencies) have conditional dependencies implemented with if
-# statements in setup.py and we have cached wheels lying around that would
-# cause those ifs to not be evaluated.
+# Now, use our local archives. Disable cache so we get the correct packages even if
+# we (or our dependencies) have conditional dependencies implemented with if
+# statements in setup.py and we have cached wheels lying around that would cause
+# those ifs to not be evaluated.
 python ../tools/pip_install.py \
   --no-cache-dir \
-  --extra-index-url http://localhost:$PORT \
+  --find-links . \
   $SUBPKGS
-# stop local PyPI
-kill $!
 cd ~-
 
 # get a snapshot of the CLI help for the docs


### PR DESCRIPTION
This gets rid of the pip warnings about missing doctypes, and based on the pip docs on installation order (or lack thereof), I think this shouldn't the package installation process at all:

> pip looks for packages in a number of places: on PyPI (if not disabled via --no-index), in the local filesystem, and in any additional repositories specified via --find-links or --index-url. There is no ordering in the locations that are searched. Rather they are all checked, and the “best” match for the requirements (in terms of version number - see [PEP 440](https://www.python.org/dev/peps/pep-0440) for details) is selected.

https://pip.pypa.io/en/stable/cli/pip_install/#finding-packages