### PR TITLE
windows: upgrade Python to 3.9.11

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Certbot for Windows has been upgraded to use Python 3.9.11, in response to
+  https://www.openssl.org/news/secadv/20220315.txt. 
 
 More details about these changes can be found on our GitHub repo.
 

--- a/windows-installer/windows_installer/construct.py
+++ b/windows-installer/windows_installer/construct.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import time
 
-PYTHON_VERSION = (3, 9, 7)
+PYTHON_VERSION = (3, 9, 11)
 PYTHON_BITNESS = 64
 NSIS_VERSION = '3.06.1'
 


### PR DESCRIPTION
This fixes https://www.openssl.org/news/secadv/20220315.txt for Certbot for Windows.

https://github.com/python/cpython/commits/v3.9.11 shows that the commit upgrading to OpenSSL 1.1.1n is included in this release.

A previous PR which upgraded Python for Windows can be found at #8775.