### PR TITLE
pinning: update current awscli pin

### DIFF
--- a/tools/pinning/current/pyproject.toml
+++ b/tools/pinning/current/pyproject.toml
@@ -43,7 +43,7 @@ windows-installer = {path = "../../../windows-installer"}
 # versions of awscli on PyPI so this process takes too long. Providing a high
 # minimum version here prevents poetry from searching this path and it fairly
 # quickly resolves the dependency conflict in another way.
-awscli = ">=1.19.62"
+awscli = ">=1.22.76"
 # As of writing this, cython is a build dependency of pyyaml. Since there
 # doesn't appear to be a good way to automatically track down and pin build
 # dependencies in Python (see


### PR DESCRIPTION
On my laptop, this reduces the runtime of `tools/pinning/current/repin.sh` from 252s to 23s, which is a ~90% reduction.

Is there a way to express a constraint that says "the highest available version?". Alternatively, who wants to volunteer to write a GitHub bot to open a monthly PR?

Another thought is that `repin.sh` could dynamically look up the highest published version (`requests.get('https://pypi.org/pypi/awscli/json').json()['info']['version']`) and substitute it just before running `poetry`.