### PR TITLE
dns-ovh: increase default propagation timeout to 120s

### DIFF
--- a/certbot-dns-ovh/certbot_dns_ovh/_internal/dns_ovh.py
+++ b/certbot-dns-ovh/certbot_dns_ovh/_internal/dns_ovh.py
@@ -32,7 +32,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
     @classmethod
     def add_parser_arguments(cls, add: Callable[..., None],
-                             default_propagation_seconds: int = 30) -> None:
+                             default_propagation_seconds: int = 120) -> None:
         super().add_parser_arguments(add, default_propagation_seconds)
         add('credentials', help='OVH credentials INI file.')
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* The default propagation timeout for the OVH DNS plugin (`--dns-ovh-propagation-seconds`)
+  has been increased from 30 seconds to 120 seconds, based on user feedback.
 
 ### Fixed
 


### PR DESCRIPTION
Besides [this comment](https://github.com/certbot/certbot/issues/9065#issuecomment-1072968488), there are a couple of forum threads and GitHub issues in other projects that suggest the current 30s duration is too low.