### PR TITLE
Add subproblems to errors (#7046)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -115,6 +115,7 @@ Authors
 * [Jacob Sachs](https://github.com/jsachs)
 * [Jairo Llopis](https://github.com/Yajo)
 * [Jakub Warmuz](https://github.com/kuba)
+* [James Balazs](https://github.com/jamesbalazs)
 * [James Kasten](https://github.com/jdkasten)
 * [Jason Grinblat](https://github.com/ptychomancer)
 * [Jay Faulkner](https://github.com/jayofdoom)

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -136,6 +136,9 @@ class Error(jose.JSONObjectWithFields, errors.Error):
     :ivar str typ:
     :ivar str title:
     :ivar str detail:
+    :ivar Identifier identifier:
+    :ivar tuple subproblems: An array of ACME Errors which may be present when the CA
+            returns multiple errors related to the same request, `tuple` of `Error`.
 
     """
     typ: str = jose.field('type', omitempty=True, default='about:blank')

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -144,12 +144,13 @@ class Error(jose.JSONObjectWithFields, errors.Error):
         :rtype: List[str]
         """
         codes = []
-        if self.subproblems is None:
-            self.subproblems = []
-
+        subproblems = []
+        if self.subproblems is not None:
+            subproblems = self.subproblems
         if self.code is not None:
             codes.append(self.code)
-        for error in self.subproblems:
+
+        for error in subproblems:
             if error.code:
                 codes.append(error.code)
         if len(codes) > 0:
@@ -157,8 +158,9 @@ class Error(jose.JSONObjectWithFields, errors.Error):
         return None
 
     def __str__(self) -> str:
-        if self.subproblems is None:
-            self.subproblems = []
+        subproblems = []
+        if self.subproblems is not None:
+            subproblems = self.subproblems
 
         result = b' :: '.join(
             part.encode('ascii', 'backslashreplace') for part in
@@ -166,9 +168,9 @@ class Error(jose.JSONObjectWithFields, errors.Error):
             if part is not None).decode()
         if self.identifier:
             result += f' :: {self.identifier}'
-        if len(self.subproblems) > 0:
+        if len(subproblems) > 0:
             result += '\nSub-problems:'
-            for subproblem in self.subproblems:
+            for subproblem in subproblems:
                 result += f'\n{subproblem}'
         return result
 

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -42,6 +42,14 @@ class ErrorTest(unittest.TestCase):
         from acme.messages import Error
         hash(Error.from_json(self.error.to_json()))
 
+    def test_from_json_with_subproblems(self):
+        from acme.messages import Error
+
+        parsed_error = Error.from_json(self.error_with_subproblems.to_json())
+
+        self.assertEqual(1, len(parsed_error.subproblems))
+        self.assertEqual(self.subproblem, parsed_error.subproblems[0])
+
     def test_description(self):
         self.assertEqual('The request message was malformed', self.error.description)
         self.assertIsNone(self.error_custom.description)
@@ -51,13 +59,6 @@ class ErrorTest(unittest.TestCase):
         self.assertEqual('malformed', self.error.code)
         self.assertIsNone(self.error_custom.code)
         self.assertIsNone(Error().code)
-
-    def test_codes(self):
-        from acme.messages import Error
-        self.assertEqual(['malformed'], self.error.codes)
-        self.assertEqual(['malformed', 'caa'], self.error_with_subproblems.codes)
-        self.assertIsNone(self.error_custom.codes)
-        self.assertIsNone(Error().codes)
 
     def test_is_acme_error(self):
         from acme.messages import is_acme_error, Error
@@ -86,8 +87,7 @@ class ErrorTest(unittest.TestCase):
         self.assertEqual(
             str(self.error_with_subproblems),
             (u"{0.typ} :: {0.description} :: {0.detail} :: {0.title}\n"+
-            "Sub-problems:\n"+
-            u"{1.typ} :: {1.description} :: {1.detail} :: {1.title} :: {1.identifier}").format(
+            u"Problem for {1.identifier.value}: {1.typ} :: {1.description} :: {1.detail} :: {1.title}").format(
         self.error_with_subproblems, self.subproblem))
 
 class ConstantTest(unittest.TestCase):

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-* Added RFC8555 subproblems to ACME errors
+* Added support for RFC8555 subproblems to our acme library.
 * Added `--new-key`. When renewing or replacing a certificate that has `--reuse-key`
   set, it will force a new private key to be generated.
   Combining `--reuse-key` and `--new-key` will replace the certificate's private key

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* RFC8555 subproblems to ACME errors
 
 ### Changed
 
@@ -16,7 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Certbot for Windows has been upgraded to use Python 3.9.11, in response to
-  https://www.openssl.org/news/secadv/20220315.txt. 
+  https://www.openssl.org/news/secadv/20220315.txt.
 * Previously, when Certbot was in the process of registering a new ACME account
   and the ACME server did not present any Terms of Service, the user was asked to
   agree with a non-existent Terms of Service ("None"). This bug is now fixed, so

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Added support for RFC8555 subproblems to our acme library.
 
 ### Changed
 
@@ -22,7 +22,6 @@ More details about these changes can be found on our GitHub repo.
 
 ### Added
 
-* Added support for RFC8555 subproblems to our acme library.
 * Added `--new-key`. When renewing or replacing a certificate that has `--reuse-key`
   set, it will force a new private key to be generated, one time.
 


### PR DESCRIPTION
Added an optional `subproblems` field to `acme.messages.Error` and a property `codes` that returns a list of codes for the error, as suggested by @bmw in #7046

Errors now also have an optional `Identifier` which should only be populated for subproblems as in [RFC8555 6.7](https://datatracker.ietf.org/doc/html/rfc8555#section-6.7)

To surface the subproblems in the error trace when an error is returned, I've changed `acme.messages.Error#__str__` - adding a new line to the string for each subproblem, with its own string representation, eg:
  ```
   acme.messages.Error: urn:ietf:params:acme:error:caa :: Certification Authority Authorization (CAA) records forbid the CA from issuing a certificate :: Error finalizing order :: Rechecking CAA for "xxxxx.xxxx.xx" and 1 more identifiers failed. Refer to sub-problems for more information
   Sub-problems:
   [string representation of first sub-problem]
   [string representation of second sub-problem]
  ```
The `Identifier` is tacked onto the end of the subproblems string representation, when present, and itself is represented as `{type}={value}`.

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
