### PR TITLE
changelog: clarify --new-key entry

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -7,9 +7,10 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 * Added `--new-key`. When renewing or replacing a certificate that has `--reuse-key`
-  set, it will force a new private key to be generated.
-  Combining `--reuse-key` and `--new-key` will replace the certificate's private key
-  and then reuse it for future renewals.
+  set, it will force a new private key to be generated, one time.
+
+  As before, `--reuse-key` and `--no-reuse-key` can be used to enable and disable key
+  reuse.
 
 ### Changed
 


### PR DESCRIPTION
@osirisinferi pointed out [in chat](https://opensource.eff.org/eff-open-source/pl/y5whp5ny378wuedi8gd7995qbo) that the way this entry was written, suggested that `--new-key` might affect whether `--reuse-key` is set or not.

I think the second sentence was the main culprit, so I've nixed it and replaced it with a reminder about our other flags.

This maybe calls out more for a documentation section but let's fix this quickly before the release.