### PR TITLE
Fix race condition and uncaught exception

### DIFF
--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -122,7 +122,7 @@ class SSLSocket:  # pylint: disable=too-few-public-methods
             # OpenSSL.SSL.Connection.shutdown doesn't accept any args
             try:
                 return self._wrapped.shutdown()
-            except SSL.error as error:
+            except SSL.Error as error:
                 # We wrap the error so we raise the same error type as sockets
                 # in the standard library. This is useful when this object is
                 # used by code which expects a standard socket such as

--- a/acme/acme/standalone.py
+++ b/acme/acme/standalone.py
@@ -153,8 +153,11 @@ class TLSALPN01Server(TLSServer, ACMEServerMixin):
                  certs: List[Tuple[crypto.PKey, crypto.X509]],
                  challenge_certs: Mapping[str, Tuple[crypto.PKey, crypto.X509]],
                  ipv6: bool = False) -> None:
+        # We don't need to implement a request handler here because the work
+        # (including logging) is being done by wrapped socket set up in the
+        # parent TLSServer class.
         TLSServer.__init__(
-            self, server_address, _BaseRequestHandlerWithLogging, certs=certs,
+            self, server_address, socketserver.BaseRequestHandler, certs=certs,
             ipv6=ipv6)
         self.challenge_certs = challenge_certs
 
@@ -303,16 +306,3 @@ class HTTP01RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         return functools.partial(
             cls, simple_http_resources=simple_http_resources,
             timeout=timeout)
-
-
-class _BaseRequestHandlerWithLogging(socketserver.BaseRequestHandler):
-    """BaseRequestHandler with logging."""
-
-    def log_message(self, format: str, *args: Any) -> None:  # pylint: disable=redefined-builtin
-        """Log arbitrary message."""
-        logger.debug("%s - - %s", self.client_address[0], format % args)
-
-    def handle(self) -> None:
-        """Handle request."""
-        self.log_message("Incoming request")
-        socketserver.BaseRequestHandler.handle(self)


### PR DESCRIPTION
This PR should fix two things in our tests:

1. [Spurious macOS coverage failure](https://opensource.eff.org/eff-open-source/pl/hboep33c17dxfyw5t8hzfpbp6y)
2. [Uncaught exception we see in `pytest`'s warnings output](https://dev.azure.com/certbot/certbot/_build/results?buildId=5379&view=logs&j=78dafcda-217b-566d-2514-79d72c721887&t=b03566bc-9a5d-5f73-5ce8-34a18de28148&l=760)

Tracking this down was a bit tricky. To do so, [I modified our TLSALPN server and its socket to print the current call stack every time either is accessed](https://github.com/certbot/certbot/compare/master...test-macos-race). I then ran this in CI until the race condition occurred. Grabbing that output and cleaning it up a bit, here is the relevant output from a successful and failed run: https://gist.github.com/bmw/cf3b05f2a49db5ed5f35849e775fefa8. Looking at the diff between the two and examining https://github.com/python/cpython/blob/v3.10.3/Lib/socketserver.py, I think I was able to track down the problem.

Problem 1 is caused by all of the work necessary for TLSALPN happening in `acme.crypto_util.SSLSocket.accept` called from [here](https://github.com/python/cpython/blob/v3.10.3/Lib/socketserver.py#L499) before our request handler that was sometimes missing coverage gets a chance to run. If that `accept` call raises an error, perhaps due to the connecting client closing its connection, [the error is swallowed](https://github.com/python/cpython/blob/v3.10.3/Lib/socketserver.py#L310-L313) and our request handler never runs. To fix this, I just removed our custom request handler since all did was log the request which is already being done in `acme.crypto_util.SSLSocket.accept`.

Problem 2 is more straightforward. [`socketserver` expects an `OSError` to be raised if there is a problem shutting down in the connection](https://github.com/python/cpython/blob/v3.10.3/Lib/socketserver.py#L503-L508). I used `socket.error` since [its an alias for `OSError`](https://docs.python.org/3/library/socket.html#socket.error) and its the error type we currently use in our code. Since our `shutdown` method didn't raise that exception type, we get the uncaught exception which I fixed by wrapping the error in the expected type.