### PR TITLE
Cleanup renewer defaults

### DIFF
--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -151,13 +151,9 @@ DEFAULT_LOGGING_LEVEL = logging.WARNING
 """Default logging level to use when not in quiet mode."""
 
 RENEWER_DEFAULTS = {
-    "renewer_enabled": "yes",
     "renew_before_expiry": "30 days",
-    # This value should ensure that there is never a deployment delay by
-    # default.
-    "deploy_before_expiry": "99 years",
 }
-"""Defaults for renewer script."""
+"""Defaults for `certbot renew`."""
 
 ARCHIVE_DIR = "archive"
 """Archive directory, relative to `certbot.configuration.NamespaceConfig.config_dir`."""

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -461,7 +461,6 @@ class RenewableCertTests(BaseRenewableCertTest):
         ]:
             sometime = datetime.datetime.utcfromtimestamp(current_time)
             mock_datetime.datetime.utcnow.return_value = sometime
-            self.test_rc.configuration["deploy_before_expiry"] = interval
             self.test_rc.configuration["renew_before_expiry"] = interval
             self.assertEqual(self.test_rc.should_autorenew(), result)
 


### PR DESCRIPTION
I noticed this while looking into https://github.com/certbot/certbot/issues/9261.

The key-value pairs deleted here are never used anywhere in Certbot so let's delete them.