### PR TITLE
Use win32 as platform in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ source_paths = acme/acme certbot/certbot certbot-apache/certbot_apache certbot-c
 passenv =
     CERTBOT_NO_PIN
 platform =
-    win: win64
-    posix: ^(?!.*win64).*$
+    win: win32
+    posix: ^(?!.*win32).*$
 commands_pre = python {toxinidir}/tools/pipstrap.py
 commands =
     !cover-win: {[base]install_and_test} {[base]win_all_packages}


### PR DESCRIPTION
This is used to match against sys.platform, which for windows is
win32 regardless of bitness