### PR TITLE
Add documentation on interactions between multiple views in BIND and the dns_rfc2136 plugin

### DIFF
--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
@@ -148,7 +148,7 @@ AmKd7ak51vWKgSl12ib86oQRPkpDjg==";
      zone "example.com." IN {
        in-view external;
      };
-   }
+   };
 
 Examples
 --------

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
@@ -111,14 +111,26 @@ AmKd7ak51vWKgSl12ib86oQRPkpDjg==";
 Special considerations for multiple views in BIND
 '''''''''''''''''''''''''''''''''''''''''''''''''
 
-If your BIND configuration leverages multiple views, certbot may fail with an ``Unable to determine base domain for _acme-challenge.example.com`` error.  This error occurs when certbot isn't able to communicate with an authorative nameserver for the zone, one that answers with the AA (Authorative Answer) flag set in the response.
+If your BIND configuration leverages multiple views, certbot may fail with an
+``Unable to determine base domain for _acme-challenge.example.com`` error.
+This error occurs when certbot isn't able to communicate with an authorative
+nameserver for the zone, one that answers with the AA (Authorative Answer) flag
+set in the response.
 
-A common multiple view configuration with two views, external and internal, can cause this error.  If the zone is only present in the external view, and the credentials_ ``dns_rfc2136_server`` setting is set (e.g. 127.0.0.1) so the DNS server's ``match-clients`` view option causes the DNS server to route certbot's query to the internal view; the internal view doesn't contain the zone, so the response won't have the AA flag set.
+A common multiple view configuration with two views, external and internal,
+can cause this error.  If the zone is only present in the external view, and
+the credentials_ ``dns_rfc2136_server`` setting is set (e.g. 127.0.0.1) so the
+DNS server's ``match-clients`` view option causes the DNS server to route
+certbot's query to the internal view; the internal view doesn't contain the
+zone, so the response won't have the AA flag set.
 
-One solution is to logically place the zone into the view certbot is sending queries to, with an `in-view <https://bind9.readthedocs.io/en/latest/reference.html#multiple-views>`_ zone option.  The zone will be then visible in both zones with exactly the same content.
+One solution is to logically place the zone into the view certbot is sending
+queries to, with an `in-view <https://bind9.readthedocs.io/en/latest/reference.html#multiple-views>`_
+zone option.  The zone will be then visible in both zones with exactly the same content.
 
 .. note::
-   Order matters in BIND views, the ``in-view`` zone option must refer to a view defined preceeding it, it cannot refer to a view defined later in the configuration file.
+   Order matters in BIND views, the ``in-view`` zone option must refer to a
+view defined preceeding it, it cannot refer to a view defined later in the configuration file.
 
 .. code-block:: none
    :caption: Split-view BIND configuration

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
@@ -108,6 +108,48 @@ AmKd7ak51vWKgSl12ib86oQRPkpDjg==";
    <https://bind9.readthedocs.io/en/latest/reference.html#dynamic-update-policies>`_
    for details.
 
+Special considerations for multiple views in BIND
+'''''''''''''''''''''''''''''''''''''''''''''''''
+
+If your BIND configuration leverages multiple views, certbot may fail with an ``Unable to determine base domain for _acme-challenge.example.com`` error.  This error occurs when certbot isn't able to communicate with an authorative nameserver for the zone, one that answers with the AA (Authorative Answer) flag set in the response.
+
+A common multiple view configuration with two views, external and internal, can cause this error.  If the zone is only present in the external view, and the credentials_ ``dns_rfc2136_server`` setting is set (e.g. 127.0.0.1) so the DNS server's ``match-clients`` view option causes the DNS server to route certbot's query to the internal view; the internal view doesn't contain the zone, so the response won't have the AA flag set.
+
+One solution is to logically place the zone into the view certbot is sending queries to, with an `in-view <https://bind9.readthedocs.io/en/latest/reference.html#multiple-views>`_ zone option.  The zone will be then visible in both zones with exactly the same content.
+
+.. note::
+   Order matters in BIND views, the ``in-view`` zone option must refer to a view defined preceeding it, it cannot refer to a view defined later in the configuration file.
+
+.. code-block:: none
+   :caption: Split-view BIND configuration
+
+   key "keyname." {
+     algorithm hmac-sha512;
+     secret "4q4wM/2I180UXoMyN4INVhJNi8V9BCV+jMw2mXgZw/CSuxUT8C7NKKFs \
+AmKd7ak51vWKgSl12ib86oQRPkpDjg==";
+   };
+
+   // adjust internal-addresses to suit your needs
+   acl internal-address { 127.0.0.0/8; 10.0.0.0/8; 192.168.0.0/16; 172.16.0.0/12; };
+
+   view "external" {
+     match-clients { !internal-addresses; any; };
+
+     zone "example.com." IN {
+       type master;
+       file "named.example.com";
+       update-policy {
+         grant keyname. name _acme-challenge.example.com. txt;
+       };
+     };
+   };
+
+   view "internal" {
+     zone "example.com." IN {
+       in-view external;
+     };
+   }
+
 Examples
 --------
 

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
@@ -143,9 +143,9 @@ AmKd7ak51vWKgSl12ib86oQRPkpDjg==";
 Special considerations for multiple views in BIND
 '''''''''''''''''''''''''''''''''''''''''''''''''
 
-If your BIND configuration leverages multiple views, certbot may fail with an
+If your BIND configuration leverages multiple views, Certbot may fail with an
 ``Unable to determine base domain for _acme-challenge.example.com`` error.
-This error occurs when certbot isn't able to communicate with an authorative
+This error occurs when Certbot isn't able to communicate with an authorative
 nameserver for the zone, one that answers with the AA (Authorative Answer) flag
 set in the response.
 
@@ -153,17 +153,17 @@ A common multiple view configuration with two views, external and internal,
 can cause this error.  If the zone is only present in the external view, and
 the credentials_ ``dns_rfc2136_server`` setting is set (e.g. 127.0.0.1) so the
 DNS server's ``match-clients`` view option causes the DNS server to route
-certbot's query to the internal view; the internal view doesn't contain the
+Certbot's query to the internal view; the internal view doesn't contain the
 zone, so the response won't have the AA flag set.
 
-One solution is to logically place the zone into the view certbot is sending
+One solution is to logically place the zone into the view Certbot is sending
 queries to, with an
 `in-view <https://bind9.readthedocs.io/en/latest/reference.html#multiple-views>`_
 zone option.  The zone will be then visible in both zones with exactly the same content.
 
 .. note::
    Order matters in BIND views, the ``in-view`` zone option must refer to a
-view defined preceeding it, it cannot refer to a view defined later in the configuration file.
+   view defined preceeding it, it cannot refer to a view defined later in the configuration file.
 
 .. code-block:: none
    :caption: Split-view BIND configuration

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
@@ -65,6 +65,38 @@ file. This warning will be emitted each time Certbot uses the credentials file,
 including for renewal, and cannot be silenced except by addressing the issue
 (e.g., by using a command like ``chmod 600`` to restrict access to the file).
 
+Examples
+--------
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``
+
+   certbot certonly \\
+     --dns-rfc2136 \\
+     --dns-rfc2136-credentials ~/.secrets/certbot/rfc2136.ini \\
+     -d example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com``
+
+   certbot certonly \\
+     --dns-rfc2136 \\
+     --dns-rfc2136-credentials ~/.secrets/certbot/rfc2136.ini \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com``, waiting 30 seconds
+             for DNS propagation
+
+   certbot certonly \\
+     --dns-rfc2136 \\
+     --dns-rfc2136-credentials ~/.secrets/certbot/rfc2136.ini \\
+     --dns-rfc2136-propagation-seconds 30 \\
+     -d example.com
+
+
 Sample BIND configuration
 '''''''''''''''''''''''''
 
@@ -125,7 +157,8 @@ certbot's query to the internal view; the internal view doesn't contain the
 zone, so the response won't have the AA flag set.
 
 One solution is to logically place the zone into the view certbot is sending
-queries to, with an `in-view <https://bind9.readthedocs.io/en/latest/reference.html#multiple-views>`_
+queries to, with an
+`in-view <https://bind9.readthedocs.io/en/latest/reference.html#multiple-views>`_
 zone option.  The zone will be then visible in both zones with exactly the same content.
 
 .. note::
@@ -161,36 +194,5 @@ AmKd7ak51vWKgSl12ib86oQRPkpDjg==";
        in-view external;
      };
    };
-
-Examples
---------
-
-.. code-block:: bash
-   :caption: To acquire a certificate for ``example.com``
-
-   certbot certonly \\
-     --dns-rfc2136 \\
-     --dns-rfc2136-credentials ~/.secrets/certbot/rfc2136.ini \\
-     -d example.com
-
-.. code-block:: bash
-   :caption: To acquire a single certificate for both ``example.com`` and
-             ``www.example.com``
-
-   certbot certonly \\
-     --dns-rfc2136 \\
-     --dns-rfc2136-credentials ~/.secrets/certbot/rfc2136.ini \\
-     -d example.com \\
-     -d www.example.com
-
-.. code-block:: bash
-   :caption: To acquire a certificate for ``example.com``, waiting 30 seconds
-             for DNS propagation
-
-   certbot certonly \\
-     --dns-rfc2136 \\
-     --dns-rfc2136-credentials ~/.secrets/certbot/rfc2136.ini \\
-     --dns-rfc2136-propagation-seconds 30 \\
-     -d example.com
 
 """


### PR DESCRIPTION
Follow up to https://github.com/certbot/certbot/pull/9106 :

This is a documentation only pull request, describing how multiple views in BIND can cause certbot to be unable to find the authorative nameserver for a zone, with an example configuration that causes BIND to respond correctly with the AA (authorative answer) flag set for the dns_rfc2136 plugin.