### PR TITLE
Ignore parallel coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ poetry.lock
 
 # coverage
 .coverage
+.coverage.*
 /htmlcov/
 
 /.vagrant


### PR DESCRIPTION
As described in the [--help output for --parallel-mode](https://coverage.readthedocs.io/en/6.3.2/cmd.html?highlight=parallel#execution-coverage-run), coverage will create `.coverage` files with more data appended to the filename when collecting data from multiple processes.

Alex and I have noticed this on macOS machines. I've also noticed it on Linux after setting the environment variable `PYTEST_ADDOPTS="--numprocesses 2"` to override [the default value in tox.ini](https://github.com/certbot/certbot/blob/2017669544b1d296f10339321f5f66b6b5f158bf/tox.ini#L44) which masks this behavior on my VPSes because I don't have enough CPU cores for `--numprocesses auto` to default to running tests in parallel.