### PR TITLE
Change `query_registration()` to use `_get_v2_account()`

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -646,7 +646,7 @@ class ClientV2(ClientBase):
             Resource.
 
         """
-        self.net.account = self._get_v2_account(regr)
+        self.net.account = self._get_v2_account(regr, True)
 
         return self.net.account
 
@@ -667,12 +667,14 @@ class ClientV2(ClientBase):
         new_regr = self._get_v2_account(regr)
         return super().update_registration(new_regr, update)
 
-    def _get_v2_account(self, regr: messages.RegistrationResource) -> messages.RegistrationResource:
+    def _get_v2_account(self, regr: messages.RegistrationResource, update_body: bool = False
+                       ) -> messages.RegistrationResource:
         self.net.account = None
         only_existing_reg = regr.body.update(only_return_existing=True)
         response = self._post(self.directory['newAccount'], only_existing_reg)
         updated_uri = response.headers['Location']
-        new_regr = regr.update(body=messages.Registration.from_json(response.json()),
+        new_regr = regr.update(body=messages.Registration.from_json(response.json())
+                               if update_body else regr.body,
                                uri=updated_uri)
         self.net.account = new_regr
         return new_regr

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -646,12 +646,8 @@ class ClientV2(ClientBase):
             Resource.
 
         """
-        self.net.account = regr  # See certbot/certbot#6258
-        # ACME v2 requires to use a POST-as-GET request (POST an empty JWS) here.
-        # This is done by passing None instead of an empty UpdateRegistration to _post().
-        response = self._post(regr.uri, None)
-        self.net.account = self._regr_from_response(response, uri=regr.uri,
-                                                    terms_of_service=regr.terms_of_service)
+        self.net.account = self._get_v2_account(regr)
+
         return self.net.account
 
     def update_registration(self, regr: messages.RegistrationResource,
@@ -676,7 +672,8 @@ class ClientV2(ClientBase):
         only_existing_reg = regr.body.update(only_return_existing=True)
         response = self._post(self.directory['newAccount'], only_existing_reg)
         updated_uri = response.headers['Location']
-        new_regr = regr.update(uri=updated_uri)
+        new_regr = regr.update(body=messages.Registration.from_json(response.json()),
+                               uri=updated_uri)
         self.net.account = new_regr
         return new_regr
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -8,6 +8,7 @@ import datetime
 from email.utils import parsedate_tz
 import heapq
 import http.client as http_client
+import json
 import logging
 import re
 import sys
@@ -672,7 +673,19 @@ class ClientV2(ClientBase):
         only_existing_reg = regr.body.update(only_return_existing=True)
         response = self._post(self.directory['newAccount'], only_existing_reg)
         updated_uri = response.headers['Location']
-        new_regr = regr.update(body=messages.Registration.from_json(response.json()),
+
+        # Check for an empty `regr.body` by using the `json_dumps()` method to remove all the
+        # `None` fields from the `regr.body` (subclass of `jose.JSONObjectWithFields`) object
+        # which only leaves a `contact` field if everything else is `None`. The `contact` field
+        # contains an empty list if the `regr.body` is empty.
+        regr_body = json.loads(regr.body.json_dumps())
+        regr_body_empty = bool(len(regr_body) == 1 and not regr_body['contact'])
+
+        # If the original `regr.body` was empty, populate it with info received from the
+        # ACME server. If it isn't empty, pass through the original body, as it might be
+        # an updated body in `certbot.main.update_account()`.
+        new_regr = regr.update(body=messages.Registration.from_json(response.json())
+                               if regr_body_empty else regr.body,
                                uri=updated_uri)
         self.net.account = new_regr
         return new_regr

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -140,6 +140,7 @@ class BackwardsCompatibleClientV2Test(ClientTestBase):
         self.response.json.return_value = DIRECTORY_V2.to_json()
         client = self._init()
         self.response.json.return_value = self.regr.body.to_json()
+        self.response.headers = {'Location': 'https://www.letsencrypt-demo.org/acme/reg/1'}
         self.assertEqual(self.regr, client.query_registration(self.regr))
 
     def test_forwarding(self):

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,7 +16,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* The `show_account` now uses the "newAccount" ACME endpoint to fetch the account data, so it
+  doesn't rely on the account URL. This fixes situations where Certbot would use old ACMEv1
+  registration information.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* The `show_account` subcommand now uses the "newAccount" ACME endpoint to fetch the account
+  data, so it doesn't rely on the locally stored account URL. This fixes situations where Certbot
+  would use old ACMEv1 registration info with non-functional account URLs.
 
 More details about these changes can be found on our GitHub repo.
 
@@ -32,9 +34,7 @@ More details about these changes can be found on our GitHub repo.
 
 ### Fixed
 
-* The `show_account` now uses the "newAccount" ACME endpoint to fetch the account data, so it
-  doesn't rely on the account URL. This fixes situations where Certbot would use old ACMEv1
-  registration information.
+*
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
Fixes #9306.

I also needed to update `_get_v2_account()` to include the registrations resources body.

It seems the `terms_of_service=regr.terms_of_service` part in the original code isn't necessary any longer. With these changes, when I set `terms_of_service` to a random value in `query_registration()` before the call to `_get_v2_account()` it still is that random value *after* the call.. So I guess it's not required. Not sure if the unittests also check this.

Another thing: maybe `regr = self._regr_from_response(response)` makes more sense in `_get_v2_account()` too, instead of the `regr.update()` currently used?