### PR TITLE
cli: fix help text for --no-autorenew

### DIFF
--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -438,7 +438,7 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
     helpful.add(
         "renew", "--no-autorenew", action="store_false",
         default=flag_default("autorenew"), dest="autorenew",
-        help="Disable auto renewal of certificates.")
+        help="Disable auto renewal of certificates. (default: False)")
 
     # Deprecated arguments
     helpful.add_deprecated_argument("--os-packages-only", 0)


### PR DESCRIPTION
Fixes #9311.

---

This is a dumb quirk with how `--no-autorenew` is set up in the CLI parser:

https://github.com/certbot/certbot/blob/d13131e30337cf0be5ba2196132437a67632a429/certbot/certbot/_internal/cli/__init__.py#L438-L441

The fix is the same one that is used for `--no-directory-hooks`:

https://github.com/certbot/certbot/blob/d13131e30337cf0be5ba2196132437a67632a429/certbot/certbot/_internal/cli/__init__.py#L425-L429

Before:

<img width="774" alt="image" src="https://user-images.githubusercontent.com/311534/171967370-d8ef6542-4dc7-403c-bf0a-b8c9d55dd675.png">


After:

<img width="778" alt="image" src="https://user-images.githubusercontent.com/311534/171967353-a15306e3-17a8-4013-8f3a-7c563ca8b195.png">
