### PR TITLE
Drop the snap build tiemout to 90 minutes

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -149,7 +149,7 @@ jobs:
           git config --global user.name "$(Build.RequestedFor)"
           mkdir -p ~/.local/share/snapcraft/provider/launchpad
           cp $(credentials.secureFilePath) ~/.local/share/snapcraft/provider/launchpad/credentials
-          python3 tools/snap/build_remote.py ALL --archs ${SNAP_ARCH} --timeout 19800
+          python3 tools/snap/build_remote.py ALL --archs ${SNAP_ARCH} --timeout 5400
         displayName: Build snaps
       - script: |
           set -e


### PR DESCRIPTION
It was previously 5.5 hours, which was just to have an exception thrown
before Azure's 6 hour timeout. Generally we aren't seeing this step take
more than 45 minutes, so 90 minutes seems like more than enough.