### PR TITLE
Use a different timeout for nightly vs daytime (release and extended) builds

### DIFF
--- a/.azure-pipelines/advanced-test.yml
+++ b/.azure-pipelines/advanced-test.yml
@@ -9,6 +9,7 @@ variables:
   # We don't publish our Docker images in this pipeline, but when building them
   # for testing, let's use the nightly tag.
   dockerTag: nightly
+  snapBuildTimeout: 5400
 
 stages:
   - template: templates/stages/test-and-package-stage.yml

--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -11,6 +11,7 @@ schedules:
 
 variables:
   dockerTag: nightly
+  snapBuildTimeout: 19800
 
 stages:
   - template: templates/stages/test-and-package-stage.yml

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -8,6 +8,7 @@ pr: none
 
 variables:
   dockerTag: ${{variables['Build.SourceBranchName']}}
+  snapBuildTimeout: 5400
 
 stages:
   - template: templates/stages/test-and-package-stage.yml

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -149,7 +149,7 @@ jobs:
           git config --global user.name "$(Build.RequestedFor)"
           mkdir -p ~/.local/share/snapcraft/provider/launchpad
           cp $(credentials.secureFilePath) ~/.local/share/snapcraft/provider/launchpad/credentials
-          python3 tools/snap/build_remote.py ALL --archs ${SNAP_ARCH} --timeout 5400
+          python3 tools/snap/build_remote.py ALL --archs ${SNAP_ARCH} --timeout $(snapBuildTimeout)
         displayName: Build snaps
       - script: |
           set -e


### PR DESCRIPTION
Sometimes nightly tests fail because there's a backlog in the launchpad queue. We want a [lower timeout](https://github.com/certbot/certbot/pull/9320/) when actively monitoring such as during a release, because if it seems stalled we can always restart the build manually. Thus, let's have separate timeouts for these two cases.