### PR TITLE
Prompt for username in finish_release.py

### DIFF
--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -83,7 +83,7 @@ def publish_windows(css):
     :param str css: CSS host name
 
     """
-    username = getpass.getuser()
+    username = input("CSS username (usually EFF username): ")
     host = css
     command = "ssh -t {}@{} bash /opt/certbot-misc/css/venv.sh".format(username,host)
     


### PR DESCRIPTION
The local machine's username may not be the same as the one on the CSS, so let's prompt for it instead.