### PR TITLE
plugins: remove support for dist:plugin plugin names

### DIFF
--- a/certbot/certbot/_internal/plugins/disco.py
+++ b/certbot/certbot/_internal/plugins/disco.py
@@ -219,13 +219,13 @@ class PluginsRegistry(Mapping):
             pkg_resources.iter_entry_points(
                 constants.OLD_SETUPTOOLS_PLUGINS_ENTRY_POINT),)
         for entry_point in entry_points:
-            _ = cls._load_entry_point(entry_point, plugins)
+            cls._load_entry_point(entry_point, plugins)
 
         return cls(plugins)
 
     @classmethod
     def _load_entry_point(cls, entry_point: pkg_resources.EntryPoint,
-                          plugins: Dict[str, PluginEntryPoint]) -> PluginEntryPoint:
+                          plugins: Dict[str, PluginEntryPoint]) -> None:
         plugin_ep = PluginEntryPoint(entry_point)
         if plugin_ep.name in plugins:
             other_ep = plugins[plugin_ep.name]
@@ -238,8 +238,6 @@ class PluginsRegistry(Mapping):
         else:  # pragma: no cover
             logger.warning(
                 "%r does not inherit from Plugin, skipping", plugin_ep)
-
-        return plugin_ep
 
     def __getitem__(self, name: str) -> PluginEntryPoint:
         return self._plugins[name]

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -60,11 +60,9 @@ class PluginEntryPointTest(unittest.TestCase):
 
         for entry_point, name in names.items():
             self.assertEqual(
-                name, PluginEntryPoint.entry_point_to_plugin_name(entry_point, with_prefix=False))
+                name, PluginEntryPoint.entry_point_to_plugin_name(entry_point))
 
     def test_entry_point_to_plugin_name_prefixed(self):
-        from certbot._internal.plugins.disco import PluginEntryPoint
-
         names = {
             self.ep1: "p1:ep1",
             self.ep1prim: "p2:ep1",
@@ -74,7 +72,7 @@ class PluginEntryPointTest(unittest.TestCase):
 
         for entry_point, name in names.items():
             self.assertEqual(
-                name, PluginEntryPoint.entry_point_to_plugin_name(entry_point, with_prefix=True))
+                name, f"{entry_point.dist.key}:{entry_point.name}")
 
     def test_description(self):
         self.assertIn("temporary webserver", self.plugin_ep.description)
@@ -232,8 +230,7 @@ class PluginsRegistryTest(unittest.TestCase):
         self.assertIs(plugins["wr"].entry_point, EP_WR)
         self.assertIs(plugins["ep1"].plugin_cls, null.Installer)
         self.assertIs(plugins["ep1"].entry_point, self.ep1)
-        self.assertIs(plugins["p1:ep1"].plugin_cls, null.Installer)
-        self.assertIs(plugins["p1:ep1"].entry_point, self.ep1)
+        self.assertNotIn("p1:ep1", plugins)
 
     def test_getitem(self):
         self.assertEqual(self.plugin_ep, self.reg["mock"])

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -62,18 +62,6 @@ class PluginEntryPointTest(unittest.TestCase):
             self.assertEqual(
                 name, PluginEntryPoint.entry_point_to_plugin_name(entry_point))
 
-    def test_entry_point_to_plugin_name_prefixed(self):
-        names = {
-            self.ep1: "p1:ep1",
-            self.ep1prim: "p2:ep1",
-            self.ep2: "p2:ep2",
-            self.ep3: "p3:ep3",
-        }
-
-        for entry_point, name in names.items():
-            self.assertEqual(
-                name, f"{entry_point.dist.key}:{entry_point.name}")
-
     def test_description(self):
         self.assertIn("temporary webserver", self.plugin_ep.description)
 


### PR DESCRIPTION
Fixes #9305.

----

- [x] Need to check exactly what the fallout is if users have not updated to the short version by the time this lands.
    - Doing nothing.