### PR TITLE
letstest: replace ubuntu 21.10 with 22.04

### DIFF
--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -6,8 +6,8 @@
 targets:
   #-----------------------------------------------------------------------------
   #Ubuntu
-  - ami: ami-0c2d5393cb5b518f6
-    name: ubuntu21.10
+  - ami: ami-051dcca84f1edfff1
+    name: ubuntu22.04
     type: ubuntu
     virt: hvm
     user: ubuntu


### PR DESCRIPTION
as ubuntu 21.10 is now EOL


