### PR TITLE
deprecate certbot-dns-cloudxns

### DIFF
--- a/certbot-dns-cloudxns/certbot_dns_cloudxns/__init__.py
+++ b/certbot-dns-cloudxns/certbot_dns_cloudxns/__init__.py
@@ -1,4 +1,11 @@
 """
+.. danger::
+   The certbot-dns-cloudxns plugin is deprecated and will be removed in the next major
+   release of Certbot. The CloudXNS DNS service is defunct and we recommend uninstalling
+   the plugin.
+
+----------
+
 The `~certbot_dns_cloudxns.dns_cloudxns` plugin automates the process of
 completing a ``dns-01`` challenge (`~acme.challenges.DNS01`) by creating, and
 subsequently removing, TXT records using the CloudXNS API.

--- a/certbot-dns-cloudxns/certbot_dns_cloudxns/_internal/dns_cloudxns.py
+++ b/certbot-dns-cloudxns/certbot_dns_cloudxns/_internal/dns_cloudxns.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 from typing import Callable
 from typing import Optional
+import warnings
 
 from lexicon.providers import cloudxns
 from requests import HTTPError
@@ -27,6 +28,11 @@ class Authenticator(dns_common.DNSAuthenticator):
     ttl = 60
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "The CloudXNS authenticator is deprecated and will be removed in the "
+            "next major release of Certbot. The CloudXNS DNS service is defunct and "
+            "we recommend removing the plugin."
+        )
         super().__init__(*args, **kwargs)
         self.credentials: Optional[CredentialsConfiguration] = None
 

--- a/certbot-dns-cloudxns/tests/dns_cloudxns_test.py
+++ b/certbot-dns-cloudxns/tests/dns_cloudxns_test.py
@@ -8,6 +8,7 @@ except ImportError: # pragma: no cover
     from unittest import mock # type: ignore
 from requests.exceptions import HTTPError
 from requests.exceptions import RequestException
+import warnings
 
 from certbot.compat import os
 from certbot.plugins import dns_test_common
@@ -36,7 +37,9 @@ class AuthenticatorTest(test_util.TempDirTestCase,
         self.config = mock.MagicMock(cloudxns_credentials=path,
                                      cloudxns_propagation_seconds=0)  # don't wait during tests
 
-        self.auth = Authenticator(self.config, "cloudxns")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning)
+            self.auth = Authenticator(self.config, "cloudxns")
 
         self.mock_client = mock.MagicMock()
         # _get_cloudxns_client | pylint: disable=protected-access

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* The `certbot-dns-cloudxns` plugin is now deprecated and will be removed in the
+  next major release of Certbot.
 
 ### Fixed
 


### PR DESCRIPTION
Per the plan in #9361 comments.

----

<img width="733" alt="image" src="https://user-images.githubusercontent.com/311534/181651571-97b03608-387e-4040-96aa-cbcb8d933050.png">

The CLI warning only comes up when actually using the authenticator:

<img width="1447" alt="image" src="https://user-images.githubusercontent.com/311534/181651651-807d1a60-6205-4f4a-a55c-48bf7675c4be.png">
