### PR TITLE
add dns-yandexcloud authentication plugin to third-party plugins

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -316,6 +316,7 @@ dns-lightsail_     Y    N    DNS Authentication using Amazon Lightsail DNS API
 dns-inwx_          Y    Y    DNS Authentication for INWX through the XML API
 dns-azure_         Y    N    DNS Authentication using Azure DNS
 dns-godaddy_       Y    N    DNS Authentication using Godaddy DNS
+dns-yandexcloud_   Y    N    DNS Authentication using Yandex Cloud DNS
 njalla_            Y    N    DNS Authentication for njalla
 DuckDNS_           Y    N    DNS Authentication for DuckDNS
 Porkbun_           Y    N    DNS Authentication for Porkbun
@@ -336,6 +337,7 @@ Infomaniak_        Y    N    DNS Authentication using Infomaniak Domains API
 .. _dns-inwx: https://github.com/oGGy990/certbot-dns-inwx/
 .. _dns-azure: https://github.com/binkhq/certbot-dns-azure
 .. _dns-godaddy: https://github.com/miigotu/certbot-dns-godaddy
+.. _dns-yandexcloud: https://github.com/PykupeJIbc/certbot-dns-yandexcloud
 .. _njalla: https://github.com/chaptergy/certbot-dns-njalla
 .. _DuckDNS: https://github.com/infinityofspace/certbot_dns_duckdns
 .. _Porkbun: https://github.com/infinityofspace/certbot_dns_porkbun


### PR DESCRIPTION
Hi there, I made authenticator plugin for [Yandex Cloud](https://cloud.yandex.ru/) DNS, here link:
https://github.com/PykupeJIbc/certbot-dns-yandexcloud

So I want to add it to third-party plugins in document if there is no problem.

Thank you!

## Pull Request Checklist

- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
