### PR TITLE
docs: add BunnyDNS to list of 3rd-party plugins

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -178,6 +178,7 @@ Authors
 * [Mathieu Leduc-Hamel](https://github.com/mlhamel)
 * [Matt Bostock](https://github.com/mattbostock)
 * [Matthew Ames](https://github.com/SuperMatt)
+* [Matthew W. Thomas](https://github.com/mwt)
 * [Michael Schumacher](https://github.com/schumaml)
 * [Michael Strache](https://github.com/Jarodiv)
 * [Michael Sverdlin](https://github.com/sveder)

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -317,6 +317,7 @@ dns-inwx_          Y    Y    DNS Authentication for INWX through the XML API
 dns-azure_         Y    N    DNS Authentication using Azure DNS
 dns-godaddy_       Y    N    DNS Authentication using Godaddy DNS
 dns-yandexcloud_   Y    N    DNS Authentication using Yandex Cloud DNS
+dns-bunny_         Y    N    DNS Authentication using BunnyDNS
 njalla_            Y    N    DNS Authentication for njalla
 DuckDNS_           Y    N    DNS Authentication for DuckDNS
 Porkbun_           Y    N    DNS Authentication for Porkbun
@@ -338,6 +339,7 @@ Infomaniak_        Y    N    DNS Authentication using Infomaniak Domains API
 .. _dns-azure: https://github.com/binkhq/certbot-dns-azure
 .. _dns-godaddy: https://github.com/miigotu/certbot-dns-godaddy
 .. _dns-yandexcloud: https://github.com/PykupeJIbc/certbot-dns-yandexcloud
+.. _dns-bunny: https://github.com/mwt/certbot-dns-bunny
 .. _njalla: https://github.com/chaptergy/certbot-dns-njalla
 .. _DuckDNS: https://github.com/infinityofspace/certbot_dns_duckdns
 .. _Porkbun: https://github.com/infinityofspace/certbot_dns_porkbun


### PR DESCRIPTION
You can find the plugin here:
https://github.com/mwt/certbot-dns-bunny
It's for [BunnyDNS](https://bunny.net/dns/).

closes #9374

## Pull Request Checklist

- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
