### PR TITLE
Encourage people to check in before writing PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 ## Pull Request Checklist
 
+- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
 - [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
 - [ ] Add or update any documentation as needed to support the changes in this PR.
 - [ ] Include your name in `AUTHORS.md` if you like.

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -500,6 +500,9 @@ Submitting a pull request
 
 Steps:
 
+0. We recommend you talk with us in a GitHub issue or :ref:`Mattermost <ask for
+   help>` before writing a pull request to ensure the changes you're making is
+   something we have the time and interest to review.
 1. Write your code! When doing this, you should add :ref:`mypy type annotations
    <type annotations>` for any functions you add or modify. You can check that
    you've done this correctly by running ``tox -e mypy`` on a machine that has


### PR DESCRIPTION
This is based on a conversation the Certbot team recently had privately.

Built Certbot docs look like this and the link works:
![Screen Shot 2022-08-15 at 4 58 08 PM](https://user-images.githubusercontent.com/6504915/184756034-8355b9e7-fb45-4c16-a0ed-05b700d8e435.png)

