### PR TITLE
Deprecate source address

### DIFF
--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -32,7 +32,11 @@ import OpenSSL
 import requests
 from requests.adapters import HTTPAdapter
 from requests.utils import parse_header_links
-from requests_toolbelt.adapters.source import SourceAddressAdapter
+# We're capturing the warnings described at
+# https://github.com/requests/toolbelt/issues/331 until we can remove this
+# dependency in Certbot 2.0.
+with warnings.catch_warnings():
+    from requests_toolbelt.adapters.source import SourceAddressAdapter
 
 from acme import challenges
 from acme import crypto_util
@@ -1049,6 +1053,8 @@ class ClientNetwork:
         adapter = HTTPAdapter()
 
         if source_address is not None:
+            warnings.warn("Support for source_address is deprecated and will be "
+                          "removed soon.", DeprecationWarning, stacklevel=2)
             adapter = SourceAddressAdapter(source_address)
 
         self.session.mount("http://", adapter)

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -1037,7 +1037,8 @@ class ClientNetwork:
     :param bool verify_ssl: Whether to verify certificates on SSL connections.
     :param str user_agent: String to send as User-Agent header.
     :param float timeout: Timeout for requests.
-    :param source_address: Optional source address to bind to when making requests.
+    :param source_address: Optional source address to bind to when making
+        requests. (deprecated since 1.30.0)
     :type source_address: str or tuple(str, int)
     """
     def __init__(self, key: jose.JWK, account: Optional[messages.RegistrationResource] = None,

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -36,6 +36,8 @@ from requests.utils import parse_header_links
 # https://github.com/requests/toolbelt/issues/331 until we can remove this
 # dependency in Certbot 2.0.
 with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", "'urllib3.contrib.pyopenssl",
+                            DeprecationWarning)
     from requests_toolbelt.adapters.source import SourceAddressAdapter
 
 from acme import challenges

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -8,7 +8,6 @@ import json
 import unittest
 from typing import Dict
 from unittest import mock
-import warnings
 
 import josepy as jose
 import OpenSSL
@@ -1344,10 +1343,10 @@ class ClientNetworkSourceAddressBindingTest(unittest.TestCase):
 
     def test_source_address_set(self):
         from acme.client import ClientNetwork
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', '.*source_address',
-                                    DeprecationWarning)
+        with mock.patch('warnings.warn') as mock_warn:
             net = ClientNetwork(key=None, alg=None, source_address=self.source_address)
+            mock_warn.assert_called_once()
+            self.assertIn('source_address', mock_warn.call_args[0][0])
         for adapter in net.session.adapters.values():
             self.assertIn(self.source_address, adapter.source_address)
 

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -8,6 +8,7 @@ import json
 import unittest
 from typing import Dict
 from unittest import mock
+import warnings
 
 import josepy as jose
 import OpenSSL
@@ -1343,7 +1344,8 @@ class ClientNetworkSourceAddressBindingTest(unittest.TestCase):
 
     def test_source_address_set(self):
         from acme.client import ClientNetwork
-        net = ClientNetwork(key=None, alg=None, source_address=self.source_address)
+        with warnings.catch_warnings():
+            net = ClientNetwork(key=None, alg=None, source_address=self.source_address)
         for adapter in net.session.adapters.values():
             self.assertIn(self.source_address, adapter.source_address)
 

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -1345,6 +1345,8 @@ class ClientNetworkSourceAddressBindingTest(unittest.TestCase):
     def test_source_address_set(self):
         from acme.client import ClientNetwork
         with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', '.*source_address',
+                                    DeprecationWarning)
             net = ClientNetwork(key=None, alg=None, source_address=self.source_address)
         for adapter in net.session.adapters.values():
             self.assertIn(self.source_address, adapter.source_address)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -12,6 +12,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * The `certbot-dns-cloudxns` plugin is now deprecated and will be removed in the
   next major release of Certbot.
+* The `source_address` argument for `acme.client.ClientNetwork` is deprecated
+  and support for it will be removed in the next major release.
 
 ### Fixed
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,11 +22,8 @@
 #    the certbot.display.util module.
 # 5) A deprecation warning is raised in dnspython==1.15.0 in the oldest tests for
 #    certbot-dns-rfc2136.
-# 6) The vendored version of six in botocore causes ImportWarnings in Python
-#    3.10+. See https://github.com/boto/botocore/issues/2548.
-# 7) botocore's default TLS settings raise deprecation warnings in Python
-#    3.10+, but their values are sane from a security perspective. See
-#    https://github.com/boto/botocore/issues/2550.
+# 6) botocore is currently using deprecated urllib3 functionality. See
+#    https://github.com/boto/botocore/issues/2744.
 filterwarnings =
     error
     ignore:The external mock module:PendingDeprecationWarning
@@ -34,5 +31,4 @@ filterwarnings =
     ignore:.*attribute in certbot.interfaces module is deprecated:DeprecationWarning
     ignore:.*attribute in certbot.display.util module is deprecated:DeprecationWarning
     ignore:decodestring\(\) is a deprecated alias:DeprecationWarning:dns
-    ignore:_SixMetaPathImporter.:ImportWarning
-    ignore:ssl.PROTOCOL_TLS:DeprecationWarning:botocore
+    ignore:'urllib3.contrib.pyopenssl:DeprecationWarning:botocore


### PR DESCRIPTION
This PR fixes our nightly tests per the conversation at https://github.com/certbot/certbot/pull/9381.

The changes to `pytest.ini` were also needed to make tests pass. Without these changes, the unpinned tests would have failed later when testing our route53 plugin. I also took the opportunity to delete a couple botocore warnings from `pytest.ini` that are no longer raised.

I created https://github.com/certbot/certbot/issues/9390 to track ripping this code out.