### PR TITLE
Upgrade CI OS

### DIFF
--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -2,7 +2,7 @@ jobs:
   - job: extended_test
     variables:
       - name: IMAGE_NAME
-        value: ubuntu-18.04
+        value: ubuntu-22.04
       - name: PYTHON_VERSION
         value: 3.10
       - group: certbot-common
@@ -47,13 +47,13 @@ jobs:
         nginx-compat:
           TOXENV: nginx_compat
         linux-integration-rfc2136:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.8
           TOXENV: integration-dns-rfc2136
         docker-dev:
           TOXENV: docker_dev
         le-modification:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           TOXENV: modification
         farmtest-apache2:
           PYTHON_VERSION: 3.8

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: docker_build
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-22.04
     strategy:
       matrix:
         amd64:
@@ -37,7 +37,7 @@ jobs:
   - job: docker_run
     dependsOn: docker_build
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-22.04
     steps:
       - task: DownloadPipelineArtifact@2
         inputs:
@@ -116,7 +116,7 @@ jobs:
         displayName: Run certbot integration tests
   - job: snaps_build
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-22.04
     strategy:
       matrix:
         amd64:
@@ -164,7 +164,7 @@ jobs:
   - job: snap_run
     dependsOn: snaps_build
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-22.04
     steps:
       - task: UsePythonVersion@0
         inputs:
@@ -194,7 +194,7 @@ jobs:
   - job: snap_dns_run
     dependsOn: snaps_build
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-22.04
     steps:
       - script: |
           set -e

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -25,42 +25,42 @@ jobs:
           PYTHON_VERSION: 3.9
           TOXENV: integration-certbot
         linux-oldest-tests-1:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.7
           TOXENV: '{acme,apache,apache-v2,certbot}-oldest'
         linux-oldest-tests-2:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.7
           TOXENV: '{dns,nginx}-oldest'
         linux-py37:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.7
           TOXENV: py37
         linux-py310-cover:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.10
           TOXENV: py310-cover
         linux-py310-lint:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.10
           TOXENV: lint-posix
         linux-py310-mypy:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.10
           TOXENV: mypy-posix
         linux-integration:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.8
           TOXENV: integration
           ACME_SERVER: pebble
         apache-compat:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           TOXENV: apache_compat
         apacheconftest:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           TOXENV: apacheconftest-with-pebble
         nginxroundtrip:
-          IMAGE_NAME: ubuntu-18.04
+          IMAGE_NAME: ubuntu-22.04
           TOXENV: nginxroundtrip
     pool:
       vmImage: $(IMAGE_NAME)

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -5,11 +5,11 @@ jobs:
     strategy:
       matrix:
         macos-py37-cover:
-          IMAGE_NAME: macOS-10.15
+          IMAGE_NAME: macOS-12
           PYTHON_VERSION: 3.7
           TOXENV: py37-cover
         macos-py310-cover:
-          IMAGE_NAME: macOS-10.15
+          IMAGE_NAME: macOS-12
           PYTHON_VERSION: 3.10
           TOXENV: py310-cover
         windows-py37:

--- a/.azure-pipelines/templates/stages/deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/deploy-stage.yml
@@ -35,7 +35,7 @@ stages:
       # more info.
       - job: publish_snap
         pool:
-          vmImage: ubuntu-18.04
+          vmImage: ubuntu-22.04
         variables:
           - group: certbot-common
         strategy:
@@ -71,7 +71,7 @@ stages:
             displayName: Publish to Snap store
       - job: publish_docker
         pool:
-          vmImage: ubuntu-18.04
+          vmImage: ubuntu-22.04
         strategy:
           matrix:
             amd64:

--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -12,7 +12,7 @@ steps:
       set -e
       sudo apt-get update
       sudo apt-get install -y --no-install-recommends \
-        python-dev \
+        python3-dev \
         gcc \
         libaugeas0 \
         libssl-dev \
@@ -36,8 +36,8 @@ steps:
     # problems with its lack of real dependency resolution.
   - bash: |
       set -e
-      python tools/pipstrap.py
-      python tools/pip_install.py -I tox virtualenv
+      python3 tools/pipstrap.py
+      python3 tools/pip_install.py -I tox virtualenv
     displayName: Install runtime dependencies
   - task: DownloadSecureFile@1
     name: testFarmPem
@@ -49,7 +49,7 @@ steps:
       export TARGET_BRANCH="`echo "${BUILD_SOURCEBRANCH}" | sed -E 's!refs/(heads|tags)/!!g'`"
       [ -z "${SYSTEM_PULLREQUEST_TARGETBRANCH}" ] || export TARGET_BRANCH="${SYSTEM_PULLREQUEST_TARGETBRANCH}"
       env
-      python -m tox
+      python3 -m tox
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
       AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)


### PR DESCRIPTION
This gets rid of all the warnings you can see on pages like https://dev.azure.com/certbot/certbot/_build/results?buildId=5748&view=results. More info about Azure Pipeline's supported images and deprecations can be found at https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml.