### PR TITLE
Add UI text recommending multi-domain certs

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -23,6 +23,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   next major release of Certbot.
 * The `source_address` argument for `acme.client.ClientNetwork` is deprecated
   and support for it will be removed in the next major release.
+* Add UI text suggesting users create certs for multiple domains, when possible
 
 ### Fixed
 

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -183,7 +183,8 @@ def _filter_names(names: Iterable[str],
     else:
         question = (
             "Which names would you like to activate HTTPS for?\n"
-            "We recommend selecting either all domains, or all domains in a VirtualHost/server block.")
+            "We recommend selecting either all domains, or all domains in a VirtualHost/server "
+            "block.")
     code, names = display_util.checklist(
         question, tags=sorted_names, cli_flag="--domains", force_interactive=True)
     return code, [str(s) for s in names]

--- a/certbot/certbot/display/ops.py
+++ b/certbot/certbot/display/ops.py
@@ -181,7 +181,9 @@ def _filter_names(names: Iterable[str],
     if override_question:
         question = override_question
     else:
-        question = "Which names would you like to activate HTTPS for?"
+        question = (
+            "Which names would you like to activate HTTPS for?\n"
+            "We recommend selecting either all domains, or all domains in a VirtualHost/server block.")
     code, names = display_util.checklist(
         question, tags=sorted_names, cli_flag="--domains", force_interactive=True)
     return code, [str(s) for s in names]


### PR DESCRIPTION
Fixes #8892. This is a far simpler change than was suggested elsewhere in that issue, since it merely adds text to the UI rather than updating how the domain menu groups items.