### PR TITLE
Update generate_dnsplugins_snapcraft.sh

### DIFF
--- a/tools/snap/generate_dnsplugins_snapcraft.sh
+++ b/tools/snap/generate_dnsplugins_snapcraft.sh
@@ -7,7 +7,7 @@ set -e
 
 PLUGIN_PATH=$1
 PLUGIN=$(basename "${PLUGIN_PATH}")
-DESCRIPTION=$(grep description "${PLUGIN_PATH}/setup.py" | sed -E 's|\s+description="(.*)",|\1|g')
+DESCRIPTION=$(sed -E -n "/[[:space:]]+description=/ s/[[:space:]]+description=['\"](.*)['\"],/\1/ p" "${PLUGIN_PATH}/setup.py")
 mkdir -p "${PLUGIN_PATH}/snap"
 cat <<EOF > "${PLUGIN_PATH}/snap/snapcraft.yaml"
 # This file is generated automatically and should not be edited manually.


### PR DESCRIPTION
Fix for #9397 .

There is no need for two interconneced (pipe) processes. (optional improvement)

The regular expression in the grep part is not strict enough in some cases (presence of long_description.
sed does not seem to support perl regular expressions ("\s").

Some Python developers prefer single quotes to double qoutes. Some even go so far as to adapt generated templates (setup.py).

This update will (hopefully) fix this all.

The updated generator was successfully tested on Ubuntu 20.04.5 LTS (Focal Fossa) and macOS 12.5.1 (Monterey).