### PR TITLE
Certbot-specific temp log dir prefix

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* If Certbot exits before setting up its usual log files, the temporary directory created to save logging information will begin with the name `certbot-log-` rather than a generic name. This should not be considered a [stable aspect of Certbot](https://certbot.eff.org/docs/compatibility.html) and may change again in the future.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/log.py
+++ b/certbot/certbot/_internal/log.py
@@ -264,7 +264,7 @@ class TempHandler(logging.StreamHandler):
 
     """
     def __init__(self) -> None:
-        self._workdir = tempfile.mkdtemp(prefix="certbot_log")
+        self._workdir = tempfile.mkdtemp(prefix="certbot-log-")
         self.path = os.path.join(self._workdir, 'log')
         stream = util.safe_open(self.path, mode='w', chmod=0o600)
         super().__init__(stream)

--- a/certbot/certbot/_internal/log.py
+++ b/certbot/certbot/_internal/log.py
@@ -264,7 +264,7 @@ class TempHandler(logging.StreamHandler):
 
     """
     def __init__(self) -> None:
-        self._workdir = tempfile.mkdtemp()
+        self._workdir = tempfile.mkdtemp(prefix="certbot_log")
         self.path = os.path.join(self._workdir, 'log')
         stream = util.safe_open(self.path, mode='w', chmod=0o600)
         super().__init__(stream)


### PR DESCRIPTION
Fixes #9405.

Directories would be called `certbot_logXXXXXXXX`. Of course an extra underscore would be possible to make it `certbot_log_XXXXXXXX` (or something similar/different entirely), but well, why bother. They are meant to be temporary, not permanent, so the actual file name doesn't really matter I think. :)