### PR TITLE
Actually test everything in test- branches (besides deployment)

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -6,12 +6,10 @@ jobs:
       matrix:
         amd64:
           DOCKER_ARCH: amd64
-        # Do not run the heavy non-amd64 builds for test branches
-        ${{ if not(startsWith(variables['Build.SourceBranchName'], 'test-')) }}:
-          arm32v6:
-            DOCKER_ARCH: arm32v6
-          arm64v8:
-            DOCKER_ARCH: arm64v8
+        arm32v6:
+          DOCKER_ARCH: arm32v6
+        arm64v8:
+          DOCKER_ARCH: arm64v8
     # The default timeout of 60 minutes is a little low for compiling
     # cryptography on ARM architectures.
     timeoutInMinutes: 180
@@ -121,12 +119,10 @@ jobs:
       matrix:
         amd64:
           SNAP_ARCH: amd64
-        # Do not run the heavy non-amd64 builds for test branches
-        ${{ if not(startsWith(variables['Build.SourceBranchName'], 'test-')) }}:
-          armhf:
-            SNAP_ARCH: armhf
-          arm64:
-            SNAP_ARCH: arm64
+        armhf:
+          SNAP_ARCH: armhf
+        arm64:
+          SNAP_ARCH: arm64
     timeoutInMinutes: 0
     steps:
       - script: |


### PR DESCRIPTION
Tests failed last night due to https://github.com/certbot/certbot/pull/9412 despite me running the full test suite because we currently skip some jobs on `test-` branches for performance.

I don't think we should do this anymore. We already have a more limited test suite for PRs and I think the `test-` branches should test everything it can to help us catch problems earlier.