### PR TITLE
Upgrade base docker image

### DIFF
--- a/tools/docker/core/Dockerfile
+++ b/tools/docker/core/Dockerfile
@@ -1,6 +1,6 @@
 # Docker Arch (amd64, arm32v6, ...)
 ARG TARGET_ARCH
-FROM ${TARGET_ARCH}/python:3.8-alpine3.12
+FROM ${TARGET_ARCH}/python:3.10-alpine3.16
 
 # Qemu Arch (x86_64, arm, ...)
 ARG QEMU_ARCH


### PR DESCRIPTION
This fixes the test failures last night caused by https://github.com/certbot/certbot/pull/9412. The problem was our [rust version was too old](https://dev.azure.com/certbot/certbot/_build/results?buildId=5872&view=logs&j=fdd3565a-f3c6-5154-eca9-9ae03666f7bd&t=5dbd9851-46a4-524f-73a8-4028241afcde&l=545) which is fixed by upgrading our Docker images. 

I also opened https://github.com/certbot/certbot/pull/9414 to try to help avoid problems like this slipping through in the future. I ran a combination of these two PRs testing the problematic builds at https://dev.azure.com/certbot/certbot/_build/results?buildId=5874&view=results.