### PR TITLE
docs: use modern tsig-keygen util in certbot-dns-rfc2136

### DIFF
--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/__init__.py
@@ -107,12 +107,11 @@ permission to issue updates on the target DNS zone.
 .. code-block:: bash
    :caption: Generate a new SHA512 TSIG key
 
-   dnssec-keygen -a HMAC-SHA512 -b 512 -n HOST keyname.
+   tsig-keygen -a HMAC-SHA512 keyname.
 
 .. note::
-   There are a few tools shipped with BIND that can all generate TSIG keys;
-   ``dnssec-keygen``, ``rndc-confgen``, and ``ddns-confgen``. Try and use the
-   most secure algorithm supported by your DNS server.
+   Prior to BIND version 9.10.0, you will need to use ``dnssec-keygen`` to generate
+   TSIG keys. Try and use the most secure algorithm supported by your DNS server.
 
 .. code-block:: none
    :caption: Sample BIND configuration


### PR DESCRIPTION
Fixes #7206.

I think it's about time we did this:

- `dnssec-keygen` on new distros doesn't support the HMAC algorithms anymore, so our instructions don't work.
- The oldest distros we support are Debian Buster (`9.11.5.P4+dfsg-5.1+deb10u7`) and CentOS 7 (`9.11.4-26.P2.el7_9.9`), which ship `tsig-keygen` and support `HMAC-SHA512`.

I am not sure why the linked issue suggests that we have to wait for Bind 9.13.

Before:

<img width="738" alt="image" src="https://user-images.githubusercontent.com/311534/193734528-b100831c-acf6-4c6c-8285-7925febd0420.png">

After:

<img width="739" alt="image" src="https://user-images.githubusercontent.com/311534/193734562-0a81041e-31bc-4bbb-854a-b5ada48147ee.png">

