### PR TITLE
Use https: protocol instead of deprecated git: protocol

### DIFF
--- a/tools/snap/README.md
+++ b/tools/snap/README.md
@@ -17,7 +17,7 @@ These steps need to be done once to set up your VM and do not need to be run aga
  5. Add your current user to the lxd group and update your shell to have the new assignment by running `sudo usermod -a -G lxd ${USER} && newgrp lxd`.
  6. Install snapcraft with `sudo snap install --classic snapcraft`.
  7. `cd ~` (or any other directory where you want our source files to be)
- 8. Run `git clone git://github.com/certbot/certbot`
+ 8. Run `git clone https://github.com/certbot/certbot`
  9. `cd certbot` (All further instructions are relative to this directory.)
 
 ### Certbot Snap
@@ -80,7 +80,7 @@ It is easiest to run this from a local machine.
  2. Install git and python with `sudo apt update && sudo apt install -y git python`.
  3. Install snapcraft with `sudo snap install --classic snapcraft`.
  4. `cd ~` (or any other directory where you want our source files to be)
- 5. Run `git clone git://github.com/certbot/certbot`
+ 5. Run `git clone https://github.com/certbot/certbot`
  6. `cd certbot` (All further instructions are relative to this directory.)
  7. To trigger `snapcraft` to request access to your Launchpad account, run
     `snapcraft remote-build --launchpad-accept-public-upload --status`. A URL where you need


### PR DESCRIPTION
👋 This is just a small documentation fix, so hopefully should be quick. GitHub no longer supports the `git://` protocol for cloning, this will fail. Instead, use the HTTPS protocol. See the [GitHub blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/) for more information.