### PR TITLE
Disable poetry's cache

### DIFF
--- a/tools/pinning/common/export-pinned-dependencies.sh
+++ b/tools/pinning/common/export-pinned-dependencies.sh
@@ -37,7 +37,10 @@ if [ -f poetry.lock ]; then
     rm poetry.lock
 fi
 
-poetry lock >&2
+# If you're running this with different Python versions (say to update both our
+# "current" and "oldest" pinnings), poetry's cache can become corrupted causing
+# poetry to hang indefinitely. --no-cache avoids this.
+poetry lock --no-cache >&2
 trap 'rm poetry.lock' EXIT
 
 # We need to remove local packages from the output.


### PR DESCRIPTION
I unfortunately haven't found a reliable way to reproduce the problem, but this seems to fix it.

I use `pyenv` to switch between Python versions as desired (and running this script with different Python versions is now needed due to the change I commented on at https://github.com/certbot/certbot/pull/9438#issue-1417336933). Sometimes after doing that the script modified here hangs indefinitely.

I've found `poetry cache clear pypi --all` fixes it, however, that command is interactive (even with the `--no-interactive` flag). Based on that, it seems like `--no-cache` should also work and I haven't hit the problem since adding this flag.