### PR TITLE
Make EFF newsletter signup not default to alerting email

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -72,6 +72,7 @@ Authors
 * [David cz](https://github.com/dave-cz)
 * [David Dworken](https://github.com/ddworken)
 * [David Kreitschmann](https://kreitschmann.de)
+* [David Stein](https://github.com/davidbstein)
 * [David Xia](https://github.com/davidxia)
 * [Devin Howard](https://github.com/devvmh)
 * [dokazaki](https://github.com/dokazaki)

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -181,6 +181,10 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
                 action="store_false", default=flag_default("eff_email"), dest="eff_email",
                 help="Don't share your e-mail address with EFF")
     helpful.add(
+        ["register", "update_account", "automation"], "--eff-email-address",
+        dest="eff_email_address", help="Set the contact email to be shared with the EFF."
+    )
+    helpful.add(
         ["automation", "certonly", "run"],
         "--keep-until-expiring", "--keep", "--reinstall",
         dest="reinstall", action="store_true", default=flag_default("reinstall"),

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -37,6 +37,7 @@ CLI_DEFAULTS: Dict[str, Any] = dict(  # noqa
     register_unsafely_without_email=False,
     email=None,
     eff_email=None,
+    eff_email_address=None,
     reinstall=False,
     expand=False,
     renew_by_default=False,

--- a/certbot/certbot/_internal/eff.py
+++ b/certbot/certbot/_internal/eff.py
@@ -89,6 +89,9 @@ def _get_subscription_email() -> str:
 
     :raises errors.Error: if the user cancels
     """
+    reuse_email_msg = "would you like to re-use your email address (" + config.email + ") for the EFF newsletter?"
+    if display_util.yesno(reuse_email_msg, default=False):
+        return config.email
     msg = "Enter email address you'd like to share with the EFF\n"
     try:
         code, email = display_util.input_text(msg, force_interactive=True)

--- a/certbot/certbot/_internal/eff.py
+++ b/certbot/certbot/_internal/eff.py
@@ -30,9 +30,9 @@ def prepare_subscription(config: configuration.NamespaceConfig, acc: Account) ->
     if config.eff_email is False:
         return
     if config.eff_email is True or _want_subscription():
-        if not config.eff_email_addresss:
+        if not config.eff_email_address:
             config.eff_email_address = _get_subscription_email()
-        while not config.eff_email_addresss or not util.safe_email(config.eff_email_address):
+        while not config.eff_email_address or not util.safe_email(config.eff_email_address):
             if not _want_subscription(True):
                 return
             config.eff_email_address = _get_subscription_email(True)

--- a/certbot/docs/cli-help.txt
+++ b/certbot/docs/cli-help.txt
@@ -393,6 +393,7 @@ register:
                         comma to register multiple emails, ex:
                         u1@example.com,u2@example.com. (default: Ask).
   --eff-email           Share your e-mail address with EFF (default: None)
+  --eff-email-address   Set the email address to be shared with the EFF.
   --no-eff-email        Don't share your e-mail address with EFF (default:
                         None)
 

--- a/certbot/tests/eff_test.py
+++ b/certbot/tests/eff_test.py
@@ -32,7 +32,7 @@ class SubscriptionTest(test_util.ConfigTestCase):
                 creation_host='test.certbot.org',
                 creation_dt=datetime.datetime(
                     2015, 7, 4, 14, 4, 10, tzinfo=pytz.UTC)))
-        self.config.email = 'certbot@example.org'
+        self.config.eff_email_address = 'certbot@example.org'
         self.config.eff_email = None
 
 
@@ -45,7 +45,7 @@ class PrepareSubscriptionTest(SubscriptionTest):
     @test_util.patch_display_util()
     @mock.patch("certbot._internal.eff.display_util.notify")
     def test_failure(self, mock_notify, mock_get_utility):
-        self.config.email = None
+        self.config.eff_email_address = None
         self.config.eff_email = True
         self._call()
         actual = mock_notify.call_args[0][0]
@@ -65,7 +65,7 @@ class PrepareSubscriptionTest(SubscriptionTest):
         self.config.eff_email = True
         self._call()
         self._assert_no_get_utility_calls(mock_get_utility)
-        self.assertEqual(self.account.meta.register_to_eff, self.config.email)
+        self.assertEqual(self.account.meta.register_to_eff, self.config.eff_email_address)
 
     @test_util.patch_display_util()
     def test_will_not_subscribe_with_prompt(self, mock_get_utility):
@@ -81,7 +81,7 @@ class PrepareSubscriptionTest(SubscriptionTest):
         self._call()
         self.assertFalse(mock_get_utility().add_message.called)
         self._assert_correct_yesno_call(mock_get_utility)
-        self.assertEqual(self.account.meta.register_to_eff, self.config.email)
+        self.assertEqual(self.account.meta.register_to_eff, self.config.eff_email_address)
 
     def _assert_no_get_utility_calls(self, mock_get_utility):
         self.assertFalse(mock_get_utility().yesno.called)
@@ -109,10 +109,10 @@ class HandleSubscriptionTest(SubscriptionTest):
 
     @mock.patch('certbot._internal.eff.subscribe')
     def test_subscribe(self, mock_subscribe):
-        self.account.meta = self.account.meta.update(register_to_eff=self.config.email)
+        self.account.meta = self.account.meta.update(register_to_eff=self.config.eff_email_address)
         self._call()
         self.assertTrue(mock_subscribe.called)
-        self.assertEqual(mock_subscribe.call_args[0][0], self.config.email)
+        self.assertEqual(mock_subscribe.call_args[0][0], self.config.eff_email_address)
 
 
 class SubscribeTest(unittest.TestCase):


### PR DESCRIPTION
addresses #9462 

## Pull Request Checklist

- ❌ The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
