### PR TITLE
Use a longer timeout for releases

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -8,7 +8,7 @@ pr: none
 
 variables:
   dockerTag: ${{variables['Build.SourceBranchName']}}
-  snapBuildTimeout: 5400
+  snapBuildTimeout: 19800
 
 stages:
   - template: templates/stages/test-and-package-stage.yml


### PR DESCRIPTION
This is in response to the thread starting at https://github.com/certbot/certbot/pull/9330#issuecomment-1320416069.

In addition to this, I plan to add the following text to the step of the release instructions that tells you to wait until Azure Pipelines for the release has finished running:

> Some jobs such as building our snaps can take a long time to complete, however, if the process seems hung, you can cancel the build and then rerun the failed jobs. To do this, click on the build for the release in the link above, make sure you're logged into Azure Pipelines, and then use the cancel/rerun buttons in the top right of the web page.