### PR TITLE
certbot.interfaces: reintroduce empty zope interfaces

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,12 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* `IPluginFactory`, `IPlugin`, `IAuthenticator` and `IInstaller` have been re-added to
+  `certbot.interfaces`.
+    - This is to fix compatibility with a number of third-party DNS plugins which may
+      have started erroring with `AttributeError` in Certbot v2.0.0.
+    - Plugin authors can find more information about Certbot 2.x compatibility
+      [here]().
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -19,7 +19,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
     - This is to fix compatibility with a number of third-party DNS plugins which may
       have started erroring with `AttributeError` in Certbot v2.0.0.
     - Plugin authors can find more information about Certbot 2.x compatibility
-      [here]().
+      [here](https://github.com/certbot/certbot/wiki/Certbot-v2.x-Plugin-Compatibility).
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/interfaces.py
+++ b/certbot/certbot/interfaces.py
@@ -16,6 +16,11 @@ from acme.client import ClientV2
 from certbot import configuration
 from certbot.achallenges import AnnotatedChallenge
 
+try:
+    from zope.interface import Interface as ZopeInterface
+except ImportError:
+    ZopeInterface = object
+
 if TYPE_CHECKING:
     from certbot._internal.account import Account
 
@@ -465,3 +470,16 @@ class RenewDeployer(metaclass=ABCMeta):
         :type lineage: RenewableCert
 
         """
+
+
+class IPluginFactory(ZopeInterface):
+    """Compatibility shim for plugins that still use Certbot's old zope.interface classes."""
+
+class IPlugin(ZopeInterface):
+    """Compatibility shim for plugins that still use Certbot's old zope.interface classes."""
+
+class IAuthenticator(IPlugin):
+    """Compatibility shim for plugins that still use Certbot's old zope.interface classes."""
+
+class IInstaller(IPlugin):
+    """Compatibility shim for plugins that still use Certbot's old zope.interface classes."""


### PR DESCRIPTION
Fixes #9485.