### PR TITLE
Fix certbot plugins output

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Interfaces which plugins register themselves as implementing without inheriting from them now show up in `certbot plugins` output.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/_internal/plugins/disco.py
+++ b/certbot/certbot/_internal/plugins/disco.py
@@ -24,25 +24,9 @@ from certbot.errors import Error
 
 logger = logging.getLogger(__name__)
 
-PREFIX_FREE_DISTRIBUTIONS = [
-    "certbot",
-    "certbot-apache",
-    "certbot-dns-cloudflare",
-    "certbot-dns-digitalocean",
-    "certbot-dns-dnsimple",
-    "certbot-dns-dnsmadeeasy",
-    "certbot-dns-gehirn",
-    "certbot-dns-google",
-    "certbot-dns-linode",
-    "certbot-dns-luadns",
-    "certbot-dns-nsone",
-    "certbot-dns-ovh",
-    "certbot-dns-rfc2136",
-    "certbot-dns-route53",
-    "certbot-dns-sakuracloud",
-    "certbot-nginx",
-]
-"""Distributions for which prefix will be omitted."""
+
+PLUGIN_INTERFACES = [interfaces.Authenticator, interfaces.Installer, interfaces.Plugin]
+"""Interfaces that should be listed in `certbot plugins` output"""
 
 
 class PluginEntryPoint:
@@ -165,8 +149,8 @@ class PluginEntryPoint:
             "* {0}".format(self.name),
             "Description: {0}".format(self.plugin_cls.description),
             "Interfaces: {0}".format(", ".join(
-                cls.__name__ for cls in self.plugin_cls.mro()
-                if cls.__module__ == 'certbot.interfaces'
+                iface.__name__ for iface in PLUGIN_INTERFACES
+                if issubclass(self.plugin_cls, iface)
             )),
             "Entry point: {0}".format(self.entry_point),
         ]

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -152,6 +152,12 @@ class PluginEntryPointTest(unittest.TestCase):
         self.assertIs(self.plugin_ep.misconfigured, False)
         self.assertIs(self.plugin_ep.available, False)
 
+    def test_str(self):
+        output = str(self.plugin_ep)
+        self.assertIn("Authenticator", output)
+        self.assertNotIn("Installer", output)
+        self.assertIn("Plugin", output)
+
     def test_repr(self):
         self.assertEqual("PluginEntryPoint#sa", repr(self.plugin_ep))
 


### PR DESCRIPTION
This fixes the bug that Alex identified at https://github.com/certbot/certbot/issues/9485#issuecomment-1332006395. I considered a few different ways of generating the list of interfaces to check against, but having a static list of interfaces we want shown in user output seemed simple and sane enough to me personally.

While doing this, I also noticed that `PREFIX_FREE_DISTRIBUTIONS` is unused cruft and can be removed.