### PR TITLE
Prep for 1.32.1

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -8,7 +8,7 @@ pr: none
 
 variables:
   dockerTag: ${{variables['Build.SourceBranchName']}}
-  snapBuildTimeout: 5400
+  snapBuildTimeout: 19800
 
 stages:
   - template: templates/stages/test-and-package-stage.yml

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.32.1 - master
+
+### Fixed
+
+* Our snaps and docker images were rebuilt to include updated versions of our dependencies.
+
+This release was not pushed to PyPI since those packages were unaffected.
+
+More details about these changes can be found on our GitHub repo.
+
 ## 1.32.0 - 2022-11-08
 
 ### Added


### PR DESCRIPTION
I wanted to do this because we were notified that https://ubuntu.com/security/notices/USN-5638-3/ affects our snaps. This probably doesn't affect us, but rebuilding to be safe seems worth it to me personally.

I started to just trigger a new v1.32.0 release build, but I don't want to overwrite our 2.0 Docker images under the `latest` tag.

Changelog changes here are similar to what has been done for past point releases like https://github.com/certbot/certbot/pull/8501.

I also cherry picked #9474 to this branch to help the release process pass.

