### PR TITLE
dns-linode: fix confusing credentials example

### DIFF
--- a/certbot-dns-linode/certbot_dns_linode/__init__.py
+++ b/certbot-dns-linode/certbot_dns_linode/__init__.py
@@ -40,7 +40,7 @@ Tokens page (legacy) <https://manager.linode.com/profile/api>`_ or `Applications
 
    # Linode API credentials used by Certbot
    dns_linode_key = 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ64
-   dns_linode_version = [<blank>|3|4]
+   dns_linode_version = 4
 
 The path to this file can be provided interactively or using the
 ``--dns-linode-credentials`` command-line argument. Certbot records the path


### PR DESCRIPTION
https://community.letsencrypt.org/t/getting-valueerror-invalid-literal-for-int-with-base-10-3-4/188915

I think, anybody who needs the deprecated API v3 for whatever reason, will figure it out. Nobody else needs to care.