### PR TITLE
Add filename to dns_common.py configuration errors

### DIFF
--- a/certbot/certbot/plugins/dns_common.py
+++ b/certbot/certbot/plugins/dns_common.py
@@ -272,8 +272,18 @@ class CredentialsConfiguration:
         try:
             self.confobj = configobj.ConfigObj(filename)
         except configobj.ConfigObjError as e:
-            logger.debug("Error parsing credentials configuration: %s", e, exc_info=True)
-            raise errors.PluginError("Error parsing credentials configuration: {0}".format(e))
+            logger.debug(
+                "Error parsing credentials configuration '%s': %s",
+                filename,
+                e,
+                exc_info=True
+            )
+            raise errors.PluginError(
+                "Error parsing credentials configuration '{}': {}".format(
+                    filename,
+                    e
+                )
+            )
 
         self.mapper = mapper
 


### PR DESCRIPTION
Fixes #9500

Also print the path to the file with errors for the error "Error parsing credentials configuration" of `dns_common.py`. This makes debugging this error much easier.

## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
