### PR TITLE
Separate cover environment to workaround tox bug

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,13 +30,9 @@ platform =
     posix: ^(?!.*win32).*$
 commands_pre = python {toxinidir}/tools/pipstrap.py
 commands =
-    !cover-win: {[base]install_and_test} {[base]win_all_packages}
-    !cover-!win: {[base]install_and_test} {[base]all_packages}
-    !cover: python tests/lock_test.py
-
-    cover-win: {[base]pip_install} {[base]win_all_packages}
-    cover-!win: {[base]pip_install} {[base]all_packages} certbot-apache[dev]
-    cover: python tox.cover.py
+    win: {[base]install_and_test} {[base]win_all_packages}
+    !win: {[base]install_and_test} {[base]all_packages}
+    python tests/lock_test.py
 # We always recreate the virtual environment to avoid problems like
 # https://github.com/certbot/certbot/issues/7745.
 recreate = true
@@ -111,6 +107,12 @@ commands =
     python tests/lock_test.py
 setenv =
     {[testenv:oldest]setenv}
+
+[testenv:cover{,-win,-posix}]
+commands =
+    win: {[base]pip_install} {[base]win_all_packages}
+    !win: {[base]pip_install} {[base]all_packages} certbot-apache[dev]
+    python tox.cover.py
 
 [testenv:lint{,-win,-posix}]
 basepython = python3


### PR DESCRIPTION
This is a workaround https://github.com/tox-dev/tox/issues/2747 by taking the same approach for `cover` as we do for `lint` and `mypy`.