### PR TITLE
Don't default to Yes for cert deletion question

### DIFF
--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -108,7 +108,7 @@ def delete(config: configuration.NamespaceConfig) -> None:
         "See https://certbot.org/deleting-certs for information on deleting certificates safely."
     )
     msg.append("\nAre you sure you want to delete the above certificate(s)?")
-    if not display_util.yesno("\n".join(msg), default=True):
+    if not display_util.yesno("\n".join(msg), default=False):
         logger.info("Deletion of certificate(s) canceled.")
         return
     for certname in certnames:


### PR DESCRIPTION
Based on a concern expressed at https://github.com/certbot/certbot/issues/6218#issuecomment-1367869496 that the default when asking the user whether to delete certificates should be no (don't delete) instead of yes (delete).