### PR TITLE
docs: give webroot and standalone better descriptions

### DIFF
--- a/certbot/certbot/_internal/plugins/standalone.py
+++ b/certbot/certbot/_internal/plugins/standalone.py
@@ -124,7 +124,9 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
     rely on any existing server program.
     """
 
-    description = "Spin up a temporary webserver"
+    description = """Runs an HTTP server locally which serves the necessary validation files \
+under the /.well-known/acme-challenge/ request path. Suitable if there is no HTTP server already \
+running. HTTP challenge only (wildcards not supported)."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/certbot/certbot/_internal/plugins/webroot.py
+++ b/certbot/certbot/_internal/plugins/webroot.py
@@ -56,7 +56,10 @@ _WEB_CONFIG_SHA256SUMS = [
 class Authenticator(common.Plugin, interfaces.Authenticator):
     """Webroot Authenticator."""
 
-    description = "Place files in webroot directory"
+    description = """\
+Saves the necessary validation files to a .well-known/acme-challenge/ directory within the \
+nominated webroot path. A seperate HTTP server must be running and serving files from the \
+webroot path. HTTP challenge only (wildcards not supported)."""
 
     MORE_INFO = """\
 Authenticator plugin that performs http-01 challenge by saving

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -58,7 +58,7 @@ class PluginEntryPointTest(unittest.TestCase):
                 name, PluginEntryPoint.entry_point_to_plugin_name(entry_point))
 
     def test_description(self):
-        self.assertIn("temporary webserver", self.plugin_ep.description)
+        self.assertIn("server locally", self.plugin_ep.description)
 
     def test_description_with_name(self):
         self.plugin_ep.plugin_cls = mock.MagicMock(description="Desc")


### PR DESCRIPTION
When thinking about https://community.letsencrypt.org/t/please-document-the-webroot-well-known-request-path/191024, I realized that the descriptions for these plugins could be more useful.

The changes will be reflected in the HTML (for CLI output, not for the user guide copy. That will be in the docs rework) and `man` docs, and `certbot --help {all,webroot,standalone}`.

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/311534/211953741-0fcfeafe-ac9b-48a6-a540-652407e28e4f.png">

<img width="941" alt="image" src="https://user-images.githubusercontent.com/311534/211954256-9ca048cb-939d-41b4-9503-f194c1e50406.png">
