### PR TITLE
Disable random sleep in lock_test.py

### DIFF
--- a/tests/lock_test.py
+++ b/tests/lock_test.py
@@ -134,7 +134,7 @@ def set_up_command(config_dir: str, logs_dir: str, work_dir: str, nginx_dir: str
     return (
         'certbot --cert-path {0} --key-path {1} --config-dir {2} '
         '--logs-dir {3} --work-dir {4} --nginx-server-root {5} --debug '
-        '--force-renewal --nginx -vv '.format(
+        '--force-renewal --nginx -vv --no-random-sleep-on-renew '.format(
             test_util.vector_path('cert.pem'),
             test_util.vector_path('rsa512_key.pem'),
             config_dir, logs_dir, work_dir, nginx_dir).split())


### PR DESCRIPTION
Check out logs like https://dev.azure.com/certbot/certbot/_build/results?buildId=6260&view=logs&j=e15079d9-b790-527b-6052-e71d7388e6ca&t=08a6496d-7c88-596f-9edc-35ba97363e90&l=1317 after enabling timestamps in the Azure Pipelines UI. You'll see:
```
2023-01-24T00:50:51.7443210Z Testing subcommand: renew
2023-01-24T00:57:59.8185016Z Testing subcommand: run
```
I think this 7+ minutes is due to the random sleep with `certbot renew` which this PR should fix.