### PR TITLE
Fix tox environments

### DIFF
--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -7,10 +7,10 @@ jobs:
         macos-py37-cover:
           IMAGE_NAME: macOS-12
           PYTHON_VERSION: 3.7
-          TOXENV: py37-cover
+          TOXENV: cover
         macos-cover:
           IMAGE_NAME: macOS-12
-          TOXENV: py3-cover
+          TOXENV: cover
         windows-py37:
           IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.7
@@ -18,7 +18,7 @@ jobs:
         windows-py39-cover:
           IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.9
-          TOXENV: py39-cover-win
+          TOXENV: cover-win
         windows-integration-certbot:
           IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.9
@@ -37,7 +37,7 @@ jobs:
           TOXENV: py37
         linux-cover:
           IMAGE_NAME: ubuntu-22.04
-          TOXENV: py3-cover
+          TOXENV: cover
         linux-lint:
           IMAGE_NAME: ubuntu-22.04
           TOXENV: lint-posix

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -94,18 +94,17 @@ class ErrorTest(unittest.TestCase):
 
     # this test is based on a minimal reproduction of a contextmanager/immutable
     # exception related error: https://github.com/python/cpython/issues/99856
-    def test_with_context_manager(self):
+    def test_setting_traceback(self):
         from acme.messages import Error
 
-        @contextlib.contextmanager
-        def context():
-            yield
+        self.assertIsNone(self.error_custom.__traceback__)
 
         try:
-            with context():
-                raise self.error_custom
-        except Error as e:
-            self.assertIsNotNone(self.error_custom.__traceback__)
+            1/0
+        except ZeroDivisionError as e:
+            self.error_custom.__traceback__ = e.__traceback__
+
+        self.assertIsNotNone(self.error_custom.__traceback__)
 
 
 class ConstantTest(unittest.TestCase):

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -95,8 +95,6 @@ class ErrorTest(unittest.TestCase):
     # this test is based on a minimal reproduction of a contextmanager/immutable
     # exception related error: https://github.com/python/cpython/issues/99856
     def test_setting_traceback(self):
-        from acme.messages import Error
-
         self.assertIsNone(self.error_custom.__traceback__)
 
         try:

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -130,7 +130,7 @@ For debugging, we recommend putting
 
 Once you are done with your code changes, and the tests in ``foo_test.py``
 pass, run all of the unit tests for Certbot and check for coverage with ``tox
--e py3-cover``. You should then check for code style with ``tox -e lint`` (all
+-e cover``. You should then check for code style with ``tox -e lint`` (all
 files) or ``pylint --rcfile=.pylintrc path/to/file.py`` (single file at a
 time).
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 skipsdist = true
-envlist = {py3-cover,lint,mypy}-{win,posix}
+envlist = {cover,lint,mypy}-{win,posix}
 
 [base]
 # pip installs the requested packages in editable mode


### PR DESCRIPTION
As discussed in Mattermost, you can't just add something like `py37-` to a tox environment name to have it use that version of Python and run the specified test. For instance, `tox -e lint` will run `pylint` for us, but `py37-lint` doesn't match the [name of the lint environment in `tox.ini`](https://github.com/certbot/certbot/blob/81ff6fcc0d1460d669d516dc4df6d90c39507cfa/tox.ini#L117) so `tox` falls back to the default environment which is our unit tests and runs that with Python 3.7.

I personally think this behavior is very unintuitive and want to talk to `tox` devs about it, but this should fix all our current problems here for now. The upstream issue for this is https://github.com/tox-dev/tox/issues/2858.