### PR TITLE
certbot-ci: boulder only supports port 80 for http-01

### DIFF
--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -21,6 +21,7 @@ steps:
         nginx-light \
         openssl
       sudo systemctl stop nginx
+      sudo sysctl net.ipv4.ip_unprivileged_port_start=0
     condition: startswith(variables['IMAGE_NAME'], 'ubuntu')
     displayName: Install Linux dependencies
   - task: UsePythonVersion@0

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -44,7 +44,7 @@ class ACMEServer:
     """
     def __init__(self, acme_server: str, nodes: List[str], http_proxy: bool = True,
                  stdout: bool = False, dns_server: Optional[str] = None,
-                 http_01_port: int = DEFAULT_HTTP_01_PORT) -> None:
+                 http_01_port: Optional[int] = None) -> None:
         """
         Create an ACMEServer instance.
         :param str acme_server: the type of acme server used (boulder-v2 or pebble)
@@ -63,12 +63,13 @@ class ACMEServer:
         self._processes: List[subprocess.Popen] = []
         self._stdout = sys.stdout if stdout else open(os.devnull, 'w') # pylint: disable=consider-using-with
         self._dns_server = dns_server
-        self._http_01_port = http_01_port
         self._preterminate_cmds_args: List[Tuple[Tuple[Any, ...], Dict[str, Any]]] = []
-        if http_01_port != DEFAULT_HTTP_01_PORT:
-            if self._acme_type != 'pebble' or self._proxy:
-                raise ValueError('setting http_01_port is not currently supported '
-                                  'with boulder or the HTTP proxy')
+        self._http_01_port = BOULDER_HTTP_01_PORT if self._acme_type == 'boulder' \
+                             else DEFAULT_HTTP_01_PORT
+        if http_01_port:
+            if (self._acme_type == 'pebble' and self._proxy) or self._acme_type == 'boulder':
+                raise ValueError('Setting http_01_port is not currently supported when '
+                                 'using Boulder or the HTTP proxy')
 
     def start(self) -> None:
         """Start the test stack"""
@@ -240,7 +241,7 @@ class ACMEServer:
         http_port_map = cast(Dict[str, int], self.acme_xdist['http_port'])
         mapping = {r'.+\.{0}\.wtf'.format(node): 'http://127.0.0.1:{0}'.format(port)
                    for node, port in http_port_map.items()}
-        command = [sys.executable, proxy.__file__, str(DEFAULT_HTTP_01_PORT), json.dumps(mapping)]
+        command = [sys.executable, proxy.__file__, str(self._http_01_port), json.dumps(mapping)]
         self._launch_process(command)
         print('=> Finished configuring the HTTP proxy.')
 

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -70,6 +70,7 @@ class ACMEServer:
             if (self._acme_type == 'pebble' and self._proxy) or self._acme_type == 'boulder':
                 raise ValueError('Setting http_01_port is not currently supported when '
                                  'using Boulder or the HTTP proxy')
+            self._http_01_port = http_01_port
 
     def start(self) -> None:
         """Start the test stack"""

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -238,7 +238,7 @@ class ACMEServer:
 
     def _prepare_http_proxy(self) -> None:
         """Configure and launch an HTTP proxy"""
-        print('=> Configuring the HTTP proxy...')
+        print(f'=> Configuring the HTTP proxy on port {self._http_01_port}...')
         http_port_map = cast(Dict[str, int], self.acme_xdist['http_port'])
         mapping = {r'.+\.{0}\.wtf'.format(node): 'http://127.0.0.1:{0}'.format(port)
                    for node, port in http_port_map.items()}

--- a/certbot-ci/certbot_integration_tests/utils/constants.py
+++ b/certbot-ci/certbot_integration_tests/utils/constants.py
@@ -1,5 +1,6 @@
 """Some useful constants to use throughout certbot-ci integration tests"""
 DEFAULT_HTTP_01_PORT = 5002
+BOULDER_HTTP_01_PORT = 80
 TLS_ALPN_01_PORT = 5001
 CHALLTESTSRV_PORT = 8055
 BOULDER_V2_CHALLTESTSRV_URL = f'http://10.77.77.77:{CHALLTESTSRV_PORT}'


### PR DESCRIPTION
Our nightly Boulder integration tests [started failing](https://dev.azure.com/certbot/certbot/_build/results?buildId=6280&view=results) because Boulder is in the process of removing the ability to set the VA challenge validation ports to anything but 80/443: https://github.com/letsencrypt/boulder/pull/6609

I considered aligning Pebble to 80/443 and having everything be the same in the code, but I really really really do not want to be forced to run our integration tests as root or whatever I'd be required to do to get Pebble to listen on 80 on macOS. This seems like the more convenient thing in the end.