### PR TITLE
Change coverage upload condition

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -7,6 +7,11 @@ pr:
   - '*.x'
 
 variables:
+  # We set this here to avoid coverage data being uploaded from things like our
+  # nightly pipeline. This is done because codecov (helpfully) keeps track of
+  # the number of coverage uploads for a commit and displays a warning when
+  # comparing two commits with an unequal number of uploads. Only uploading
+  # coverage here should keep the number of uploads it sees consistent.
   uploadCoverage: true
 
 jobs:

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -6,5 +6,8 @@ pr:
   - master
   - '*.x'
 
+variables:
+  uploadCoverage: true
+
 jobs:
   - template: templates/jobs/standard-tests-jobs.yml

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -11,7 +11,6 @@ jobs:
         macos-cover:
           IMAGE_NAME: macOS-12
           TOXENV: cover
-          UPLOAD_COVERAGE: 1
         windows-py37:
           IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.7
@@ -20,12 +19,10 @@ jobs:
           IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.9
           TOXENV: cover-win
-          UPLOAD_COVERAGE: 1
         windows-integration-certbot:
           IMAGE_NAME: windows-2019
           PYTHON_VERSION: 3.9
           TOXENV: integration-certbot
-          UPLOAD_COVERAGE: 1
         linux-oldest-tests-1:
           IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.7
@@ -41,7 +38,6 @@ jobs:
         linux-cover:
           IMAGE_NAME: ubuntu-22.04
           TOXENV: cover
-          UPLOAD_COVERAGE: 1
         linux-lint:
           IMAGE_NAME: ubuntu-22.04
           TOXENV: lint-posix
@@ -53,7 +49,6 @@ jobs:
           PYTHON_VERSION: 3.8
           TOXENV: integration
           ACME_SERVER: pebble
-          UPLOAD_COVERAGE: 1
         apache-compat:
           IMAGE_NAME: ubuntu-22.04
           TOXENV: apache_compat

--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -78,5 +78,5 @@ steps:
       chmod +x codecov
       coverage xml
       ./codecov || echo "Uploading coverage data failed"
-    condition: and(eq(variables['uploadCoverage'], true), in(variables['TOXENV', 'cover', 'integration', 'integration-certbot'))
+    condition: and(eq(variables['uploadCoverage'], true), in(variables['TOXENV'], 'cover', 'integration', 'integration-certbot'))
     displayName: Upload coverage data

--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -78,5 +78,5 @@ steps:
       chmod +x codecov
       coverage xml
       ./codecov || echo "Uploading coverage data failed"
-    condition: ne(variables['UPLOAD_COVERAGE'], '')
+    condition: and(eq(variables['uploadCoverage'], true), in(variables['TOXENV', 'cover', 'integration', 'integration-certbot'))
     displayName: Upload coverage data

--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -78,5 +78,5 @@ steps:
       chmod +x codecov
       coverage xml
       ./codecov || echo "Uploading coverage data failed"
-    condition: and(eq(variables['uploadCoverage'], true), in(split(variables['TOXENV'], '-')[0], 'cover', 'integration'))
+    condition: and(eq(variables['uploadCoverage'], true), or(startsWith(variables['TOXENV'], 'cover'), startsWith(variables['TOXENV'], 'integration')))
     displayName: Upload coverage data

--- a/.azure-pipelines/templates/steps/tox-steps.yml
+++ b/.azure-pipelines/templates/steps/tox-steps.yml
@@ -78,5 +78,5 @@ steps:
       chmod +x codecov
       coverage xml
       ./codecov || echo "Uploading coverage data failed"
-    condition: and(eq(variables['uploadCoverage'], true), in(variables['TOXENV'], 'cover', 'integration', 'integration-certbot'))
+    condition: and(eq(variables['uploadCoverage'], true), in(split(variables['TOXENV'], '-')[0], 'cover', 'integration'))
     displayName: Upload coverage data


### PR DESCRIPTION
You can see an example of the warning I'm talking about in the YAML comment right now at https://app.codecov.io/gh/certbot/certbot/pull/9551. It looks like
![Screenshot 2023-01-26 at 11 28 30 AM](https://user-images.githubusercontent.com/6504915/214931419-d9b07085-4958-424a-af9a-23f22294182d.png)

You can also see coverage not being uploaded before I defined `uploadCoverage` by looking at https://dev.azure.com/certbot/certbot/_build/results?buildId=6293&view=logs&j=793d6b6d-211e-5cd0-3afc-ef20b2ea26fc&t=fac56f16-a5ee-5adb-8f49-50af4096855a&l=2.