### PR TITLE
Bump up the number of stale operations to 30

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -39,4 +39,4 @@ jobs:
             take a look.
 
           # Limit the number of actions per hour, from 1-30. Default is 30
-          operations-per-run: 1
+          operations-per-run: 30


### PR DESCRIPTION
This is the default value, which is sensible since an "operation" basically corresponds to a GH API call, and 1 won't really let us do anything.