### PR TITLE
Fix docs google permissions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -68,6 +68,7 @@ Authors
 * [Daniel Convissor](https://github.com/convissor)
 * [Daniel "Drex" Drexler](https://github.com/aeturnum)
 * [Daniel Huang](https://github.com/dhuang)
+* [Daniel McMahon] (https://github.com/igloodan)
 * [Dave Guarino](https://github.com/daguar)
 * [David cz](https://github.com/dave-cz)
 * [David Dworken](https://github.com/ddworken)

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -38,6 +38,19 @@ for an account with the following permissions:
 * ``dns.resourceRecordSets.list``
 * ``dns.resourceRecordSets.update``
 
+(The closest role is 'dns.admin <https://cloud.google.com/dns/docs/
+access-control#dns.admin)>')
+
+If the above permissions are assigned at the 'resource level <https://cloud
+.google.com/dns/docs/zones/iam-per-resource-zones>', the same user must
+have, at the PROJECT level, the following permissions:
+
+* ``dns.managedZones.get``
+* ``dns.managedZones.list``
+
+(The closest role is 'dns.reader <https://cloud.google.com/dns/docs/
+access-control#dns.reader)>')
+
 Google provides instructions for `creating a service account <https://developers
 .google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`_ and
 `information about the required permissions <https://cloud.google.com/dns/access

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -38,8 +38,8 @@ for an account with the following permissions:
 * ``dns.resourceRecordSets.list``
 * ``dns.resourceRecordSets.update``
 
-(The closest role is 'dns.admin <https://cloud.google.com/dns/docs/
-access-control#dns.admin)>')
+(The closest role is `dns.admin <https://cloud.google.com/dns/docs/
+access-control#dns.admin>`_).
 
 If the above permissions are assigned at the `resource level <https://cloud
 .google.com/dns/docs/zones/iam-per-resource-zones>`_, the same user must

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -41,8 +41,8 @@ for an account with the following permissions:
 (The closest role is 'dns.admin <https://cloud.google.com/dns/docs/
 access-control#dns.admin)>')
 
-If the above permissions are assigned at the 'resource level <https://cloud
-.google.com/dns/docs/zones/iam-per-resource-zones>', the same user must
+If the above permissions are assigned at the `resource level <https://cloud
+.google.com/dns/docs/zones/iam-per-resource-zones>`_, the same user must
 have, at the PROJECT level, the following permissions:
 
 * ``dns.managedZones.get``

--- a/certbot-dns-google/certbot_dns_google/__init__.py
+++ b/certbot-dns-google/certbot_dns_google/__init__.py
@@ -48,8 +48,8 @@ have, at the PROJECT level, the following permissions:
 * ``dns.managedZones.get``
 * ``dns.managedZones.list``
 
-(The closest role is 'dns.reader <https://cloud.google.com/dns/docs/
-access-control#dns.reader)>')
+(The closest role is `dns.reader <https://cloud.google.com/dns/docs/
+access-control#dns.reader>`_).
 
 Google provides instructions for `creating a service account <https://developers
 .google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount>`_ and


### PR DESCRIPTION
Google has recently allowed IAM permissions at the resource (rather than project) level on Google Cloud DNS which causes certbot-dns-google to fail if some permissions are not applied at the project level to find the DNS zone before making changes.

The resource (DNS Zone) requires (dns.admin) and the project requires (dns.reader) for the service account being used by certbot-dns-google.

This change request is a simple documentation change to reflect this.

Credit to [the-xentropy](https://github.com/the-xentropy) for pointing this out [here](https://github.com/kubernetes-sigs/external-dns/issues/1413#issuecomment-1400255596).
