### PR TITLE
Double progressive release percentage

### DIFF
--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -49,7 +49,7 @@ ALL_SNAPS = ['certbot'] + PLUGIN_SNAPS
 # for sanity checking.
 SNAP_ARCH_COUNT = 3
 # The percentage of users the 2.0 Certbot snap should be deployed to.
-PROGRESSIVE_RELEASE_PERCENTAGE = 5
+PROGRESSIVE_RELEASE_PERCENTAGE = 10
 
 
 def parse_args(args):


### PR DESCRIPTION
Based on https://opensource.eff.org/eff-open-source/pl/dh745713q3ry5ncrgrb5xu6fua.

Once this lands, I plan to run the script with `--progressive-only` to bump the percentage. I figure doing outside of a release has a little benefit as it changes fewer things at once.