### PR TITLE
docs: generate a man page with a structure

### DIFF
--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -286,7 +286,7 @@ latex_documents = [
 man_pages = [
     ('index', 'certbot', u'Certbot Documentation',
      [project], 7),
-    ('man/certbot', 'certbot', u'certbot script documentation',
+    ('man/certbot', 'certbot', u"Automatically configure HTTPS using Let's Encrypt",
      [project], 1),
 ]
 

--- a/certbot/docs/man/certbot.rst
+++ b/certbot/docs/man/certbot.rst
@@ -1,3 +1,23 @@
 :orphan:
 
+=======
+certbot
+=======
+
+Synopsis
+========
+The objective of Certbot, Let's Encrypt, and the ACME (Automated Certificate Management
+Environment) protocol is to make it possible to set up an HTTPS server and have it automatically
+obtain a browser-trusted certificate, without any human intervention. This is accomplished by
+running a certificate management agent on the web server.
+
+This agent is used to:
+
+- Automatically prove to the Let's Encrypt CA that you control the website
+- Obtain a browser-trusted certificate and set it up on your web server
+- Keep track of when your certificate is going to expire, and renew it
+- Help you revoke the certificate if that ever becomes necessary.
+
+Options
+=======
 .. literalinclude:: ../cli-help.txt


### PR DESCRIPTION
If you looked at [the Debian man page for Certbot](https://manpages.debian.org/bullseye/certbot/certbot.1.en.html) or [the FreeBSD one](https://man.freebsd.org/cgi/man.cgi?query=certbot&sektion=1&apropos=0&manpath=FreeBSD+13.1-RELEASE+and+Ports), you will notice that the entire document is in the "NAME" section. It looks weird in particular on the [FreeBSD man page listing](https://man.freebsd.org/cgi/man.cgi?query=certbot&apropos=1&sektion=0&manpath=FreeBSD+13.1-RELEASE+and+Ports&arch=default&format=html).

This PR adds some structure to the man page by adding a new "Synopsis" section (lifted from the Certbot snap's synopsis) and shoving the `certbot --help all` output into a new "Options" section. I think this should be sustainable for us, without having to worry about the man page in particular.

Fixes #9560.

----

Before:

<img width="1453" alt="image" src="https://user-images.githubusercontent.com/311534/216464534-49926e38-b0a7-4b44-807f-882a731ae87d.png">

After:

<img width="1455" alt="image" src="https://user-images.githubusercontent.com/311534/216464460-d3a2dfd9-b606-4ded-a2c7-80a46ba96089.png">
