### PR TITLE
docs: document reconfigure verb

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -763,7 +763,7 @@ A list of common options that may be updated with the ``reconfigure`` command ca
 ``certbot help reconfigure``.
 
 As a practical example, if you were using the ``webroot`` authenticator and had relocated your website to another directory,
-you would need to change the ``--webroot-path`` to the new directory:
+you can change the ``--webroot-path`` to the new directory using the following command:
 
 .. code-block:: shell
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -751,6 +751,23 @@ time, Certbot will remember these options and apply them once again.
 Sometimes, you may encounter the need to change some of these options for future certificate renewals. To achieve this,
 you will need to perform the following steps:
 
+Certbot v2.3.0 and newer
+~~~~~~~~~~~~~~~~~~~~~~~~
+The ``certbot reconfigure`` command can be used to change a certificate's renewal options.
+This command will use the new renewal options to perform a test renewal against the Let's Encrypt staging server.
+If this is successful, the new renewal options will be saved and will apply to future renewals.
+
+As a practical example, if you were using the ``webroot`` authenticator and had relocated your website to another directory,
+you would need to change the ``--webroot-path`` to the new directory:
+
+.. code-block:: shell
+
+  certbot reconfigure --cert-name example.com --webroot-path /path/to/new/location
+
+If this command succeeds, you are done!
+
+Certbot v2.2.0 and older
+~~~~~~~~~~~~~~~~~~~~~~~~
 1. Perform a *dry run renewal* with the amended options on the command line. This allows you to confirm that the change
    is valid and will result in successful future renewals.
 2. If the dry run is successful, perform a *live renewal* of the certificate. This will persist the change for future

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -757,14 +757,17 @@ The ``certbot reconfigure`` command can be used to change a certificate's renewa
 This command will use the new renewal options to perform a test renewal against the Let's Encrypt staging server.
 If this is successful, the new renewal options will be saved and will apply to future renewals.
 
+You will need to specify the ``--cert-name``, which can be found by running ``certbot certificates``.
+
+A list of common options that may be updated with the ``reconfigure`` command can be found by running
+``certbot help reconfigure``.
+
 As a practical example, if you were using the ``webroot`` authenticator and had relocated your website to another directory,
 you would need to change the ``--webroot-path`` to the new directory:
 
 .. code-block:: shell
 
   certbot reconfigure --cert-name example.com --webroot-path /path/to/new/location
-
-If this command succeeds, you are done!
 
 Certbot v2.2.0 and older
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #9531.

----

We should remove the branching/old instructions eventually, I think either during @zoracon's user guide rewrite or maybe once we have pushed Certbot 2.x to all snap users. 

<img width="567" alt="image" src="https://user-images.githubusercontent.com/311534/217636664-adb36a2a-b8e6-43e0-9d1e-cdada41c2d66.png">


