### PR TITLE
Reset set_by_cli between each test

### DIFF
--- a/certbot/tests/conftest.py
+++ b/certbot/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+from certbot._internal import cli
+
+@pytest.fixture(autouse=True)
+def reset_cli_global():
+    cli.set_by_cli.detector = None

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -422,7 +422,6 @@ class RevokeTest(test_util.TempDirTestCase):
         if not args:
             args = 'revoke --cert-path={0} '
             args = args.format(self.tmp_cert_path).split()
-        cli.set_by_cli.detector = None # required to reset set_by_cli state
         plugins = disco.PluginsRegistry.find_all()
         config = configuration.NamespaceConfig(
             cli.prepare_and_parse_args(plugins, args))
@@ -588,7 +587,6 @@ class ReconfigureTest(test_util.TempDirTestCase):
 
     def _call(self, passed_args):
         full_args = passed_args + ['--config-dir', self.config_dir]
-        cli.set_by_cli.detector = None # required to reset set_by_cli state
         plugins = disco.PluginsRegistry.find_all()
         config = configuration.NamespaceConfig(
             cli.prepare_and_parse_args(plugins, full_args))


### PR DESCRIPTION
I now believe tests started failing after https://github.com/certbot/certbot/pull/9355 was merged because the annoying and sneaky global/static variable `certbot._internal.cli.set_by_cli.detector` was being [reset as part of _call at the beginning of each test](https://github.com/certbot/certbot/pull/9355/files#diff-289e430aa6a8e8c631ec77be0da1d77b676f5578c8c4fe03146bce322da18640R591) and was not (also) being reset after each test. The tests introduced in that PR was not the only or first use of this pattern in `main_test.py`. I think this pattern meant that depending on the exact test order (which I believe will vary by machine/run a bit due to [our use of `--numprocesses auto`](https://github.com/certbot/certbot/blob/23090198bf132704f1c860d5b6b623a2fcb593f8/tox.ini#L40) to spread tests across processes), the value of `certbot._internal.cli.set_by_cli.detector` may still have been set to something when other tests ran affecting their result.

In particular, building off my explanation at the beginning of https://github.com/certbot/certbot/pull/9564, `set_by_cli('authenticator')` was returning `True` claiming the value was set to Apache, however, Apache wasn't actually requested on the command line in the failing test. I believe this caused [this code](https://github.com/certbot/certbot/blob/23090198bf132704f1c860d5b6b623a2fcb593f8/certbot/certbot/_internal/renewal.py#L194-L196) to leave `config.authenticator` unset which then caused us to blow up later because we didn't know what plugin to use.

This PR fixes this by making use of a global pytest fixture that resets `cli.set_by_cli.detector` to `None` between every test. I initially just put this in `main_test.py` as its the only place we currently do this in our tests, but I personally think it's useful to do it more globally to avoid hitting this in the future in places like the unit tests for the `cli` module or other modules that use it such as `client` or `renewal`.

This PR introduces the first import of `pytest` in our shipped code although I think/hope there will be many to come and I don't think it's a problem because [the Certbot test extras depend on pytest](https://github.com/certbot/certbot/blob/23090198bf132704f1c860d5b6b623a2fcb593f8/certbot/setup.py#L93), [we claimed this dependency years ago](https://github.com/certbot/certbot/blob/23090198bf132704f1c860d5b6b623a2fcb593f8/certbot/CHANGELOG.md#changed-46), and [instruct packagers to run our tests using pytest](https://eff-certbot.readthedocs.io/en/stable/packaging.html#notes-for-package-maintainers).

The last thing I want to say in my wall of text is I think us hitting this problem is another good reason we should prioritize cleaning up our testing and/or [CLI parsing](https://github.com/certbot/certbot/issues/4493).