### PR TITLE
Fix requests-toolbelt warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,7 +15,12 @@
 #    certbot-dns-rfc2136.
 # 2) pytest-cov uses deprecated functionality in pytest-xdist, to be resolved by
 #    https://github.com/pytest-dev/pytest-cov/issues/557.
+# 3) requests-toolbelt<0.10.1 can cause this warning to be raised during our
+#    unit tests. This warning should be ignored until our (transitive)
+#    dependency on requests-toolbelt is removed or our pinned version can be
+#    updated.
 filterwarnings =
     error
     ignore:decodestring\(\) is a deprecated alias:DeprecationWarning:dns
     ignore:.*rsyncdir:DeprecationWarning
+    ignore:'urllib3.contrib.pyopenssl:DeprecationWarning:requests_toolbelt


### PR DESCRIPTION
Before this PR, if you activate the developer environment and run `pytest certbot/tests/main_test.py` tests will fail due to this warning.

We haven't been hitting this with `tox` because `requests-toolbelt` isn't installed in those environments. It's in our developer environment because `poetry` and `twine` depends on it. `requests-toolbelt` is an optional dependency of `dnspython` though and if it's installed, we hit this warning during our unit tests.