### PR TITLE
certbot-ci: fix crash in and simplify manual_http_hooks

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/test_main.py
@@ -118,7 +118,7 @@ def test_http_01(context: IntegrationTestsContext) -> None:
 def test_manual_http_auth(context: IntegrationTestsContext) -> None:
     """Test the HTTP-01 challenge using manual plugin."""
     with misc.create_http_server(context.http_01_port) as webroot,\
-            misc.manual_http_hooks(webroot, context.http_01_port) as scripts:
+            misc.manual_http_hooks(webroot) as scripts:
 
         certname = context.get_domain()
         context.certbot([

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -158,14 +158,12 @@ set -e
 
 
 @contextlib.contextmanager
-def manual_http_hooks(http_server_root: str,
-                      http_port: int) -> Generator[Tuple[str, str], None, None]:
+def manual_http_hooks(http_server_root: str) -> Generator[Tuple[str, str], None, None]:
     """
     Generate suitable http-01 hooks command for test purpose in the given HTTP
     server webroot directory. These hooks command use temporary python scripts
     that are deleted upon context exit.
     :param str http_server_root: path to the HTTP server configured to serve http-01 challenges
-    :param int http_port: HTTP port that the HTTP server listen on
     :return (str, str): a tuple containing the authentication hook and cleanup hook commands
     """
     tempdir = tempfile.mkdtemp()

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -180,7 +180,7 @@ os.makedirs(challenge_dir)
 challenge_file = os.path.join(challenge_dir, os.environ.get('CERTBOT_TOKEN'))
 with open(challenge_file, 'w') as file_h:
     file_h.write(os.environ.get('CERTBOT_VALIDATION'))
-'''.format(http_server_root.replace('\\', '\\\\'), http_port))
+'''.format(http_server_root.replace('\\', '\\\\')))
         os.chmod(auth_script_path, 0o755)
 
         cleanup_script_path = os.path.join(tempdir, 'cleanup.py')

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -175,23 +175,11 @@ def manual_http_hooks(http_server_root: str,
             file_h.write('''\
 #!/usr/bin/env python
 import os
-import requests
-import time
-import sys
 challenge_dir = os.path.join('{0}', '.well-known', 'acme-challenge')
 os.makedirs(challenge_dir)
 challenge_file = os.path.join(challenge_dir, os.environ.get('CERTBOT_TOKEN'))
 with open(challenge_file, 'w') as file_h:
     file_h.write(os.environ.get('CERTBOT_VALIDATION'))
-url = 'http://localhost:{1}/.well-known/acme-challenge/' + os.environ.get('CERTBOT_TOKEN')
-for _ in range(0, 10):
-    time.sleep(1)
-    try:
-        if request.get(url).status_code == 200:
-            sys.exit(0)
-    except requests.exceptions.ConnectionError:
-        pass
-raise ValueError('Error, url did not respond after 10 attempts: {{0}}'.format(url))
 '''.format(http_server_root.replace('\\', '\\\\'), http_port))
         os.chmod(auth_script_path, 0o755)
 


### PR DESCRIPTION
There is a typo (`request` instead of `requests`) in the `auth.py` generated by this function:

https://github.com/certbot/certbot/blob/d792d398134f4f8b67debaf82e6e75635409c627/certbot-ci/certbot_integration_tests/utils/misc.py#L184-L191

that has [never ever succeeded](https://gist.github.com/alexzorin/ff2686b7123cea49f1e4107d1e7d95f5#file-master-log-L203-L208).

Moreover, this polling code is not necessary because `create_http_server` already polls until the HTTP server to come up, and the file we wrote to disk is guaranteed is immediately visible by the web server anyway.

