### PR TITLE
Automatically run test files with pytest

### DIFF
--- a/acme/tests/challenges_test.py
+++ b/acme/tests/challenges_test.py
@@ -507,4 +507,4 @@ class JWSPayloadRFC8555Compliant(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/challenges_test.py
+++ b/acme/tests/challenges_test.py
@@ -1,4 +1,5 @@
 """Tests for acme.challenges."""
+import sys
 import unittest
 from unittest import mock
 import urllib.parse as urllib_parse
@@ -6,6 +7,7 @@ import urllib.parse as urllib_parse
 import josepy as jose
 from josepy.jwk import JWKEC
 import OpenSSL
+import pytest
 import requests
 
 from acme import errors
@@ -505,4 +507,4 @@ class JWSPayloadRFC8555Compliant(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -4,11 +4,13 @@ import copy
 import datetime
 import http.client as http_client
 import json
+import sys
 from typing import Dict
 import unittest
 from unittest import mock
 
 import josepy as jose
+import pytest
 import requests
 
 from acme import challenges
@@ -792,4 +794,4 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/client_test.py
+++ b/acme/tests/client_test.py
@@ -794,4 +794,4 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/crypto_util_test.py
+++ b/acme/tests/crypto_util_test.py
@@ -3,6 +3,7 @@ import ipaddress
 import itertools
 import socket
 import socketserver
+import sys
 import threading
 import time
 from typing import List
@@ -10,6 +11,7 @@ import unittest
 
 import josepy as jose
 import OpenSSL
+import pytest
 
 from acme import errors
 import test_util
@@ -351,4 +353,4 @@ class DumpPyopensslChainTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/crypto_util_test.py
+++ b/acme/tests/crypto_util_test.py
@@ -353,4 +353,4 @@ class DumpPyopensslChainTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/errors_test.py
+++ b/acme/tests/errors_test.py
@@ -1,6 +1,9 @@
 """Tests for acme.errors."""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 
 class BadNonceTest(unittest.TestCase):
@@ -49,4 +52,4 @@ class PollErrorTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/errors_test.py
+++ b/acme/tests/errors_test.py
@@ -52,4 +52,4 @@ class PollErrorTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/fields_test.py
+++ b/acme/tests/fields_test.py
@@ -58,4 +58,4 @@ class RFC3339FieldTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/fields_test.py
+++ b/acme/tests/fields_test.py
@@ -1,9 +1,11 @@
 """Tests for acme.fields."""
 import datetime
+import sys
 import unittest
 import warnings
 
 import josepy as jose
+import pytest
 import pytz
 
 
@@ -56,4 +58,4 @@ class RFC3339FieldTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/jose_test.py
+++ b/acme/tests/jose_test.py
@@ -1,6 +1,9 @@
 """Tests for acme.jose shim."""
 import importlib
+import sys
 import unittest
+
+import pytest
 
 
 class JoseTest(unittest.TestCase):
@@ -51,4 +54,4 @@ class JoseTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/jose_test.py
+++ b/acme/tests/jose_test.py
@@ -54,4 +54,4 @@ class JoseTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/jws_test.py
+++ b/acme/tests/jws_test.py
@@ -65,4 +65,4 @@ class JWSTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/jws_test.py
+++ b/acme/tests/jws_test.py
@@ -1,7 +1,9 @@
 """Tests for acme.jws."""
+import sys
 import unittest
 
 import josepy as jose
+import pytest
 
 import test_util
 
@@ -63,4 +65,4 @@ class JWSTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -1,11 +1,13 @@
 """Tests for acme.messages."""
 import contextlib
+import sys
 from typing import Dict
 import unittest
 from unittest import mock
 import warnings
 
 import josepy as jose
+import pytest
 
 from acme import challenges
 import test_util
@@ -520,4 +522,4 @@ class JWSPayloadRFC8555Compliant(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -522,4 +522,4 @@ class JWSPayloadRFC8555Compliant(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/standalone_test.py
+++ b/acme/tests/standalone_test.py
@@ -2,12 +2,14 @@
 import http.client as http_client
 import socket
 import socketserver
+import sys
 import threading
 from typing import Set
 import unittest
 from unittest import mock
 
 import josepy as jose
+import pytest
 import requests
 
 from acme import challenges
@@ -267,4 +269,4 @@ class HTTP01DualNetworkedServersTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/acme/tests/standalone_test.py
+++ b/acme/tests/standalone_test.py
@@ -269,4 +269,4 @@ class HTTP01DualNetworkedServersTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/util_test.py
+++ b/acme/tests/util_test.py
@@ -16,4 +16,4 @@ class MapKeysTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/acme/tests/util_test.py
+++ b/acme/tests/util_test.py
@@ -1,5 +1,8 @@
 """Tests for acme.util."""
+import sys
 import unittest
+
+import pytest
 
 
 class MapKeysTest(unittest.TestCase):
@@ -13,4 +16,4 @@ class MapKeysTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -17,6 +17,10 @@ dev_extras = [
     'apacheconfig>=0.3.2',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-apache',
     version=version,
@@ -52,6 +56,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'dev': dev_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-apache/tests/autohsts_test.py
+++ b/certbot-apache/tests/autohsts_test.py
@@ -183,4 +183,4 @@ class AutoHSTSTest(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/autohsts_test.py
+++ b/certbot-apache/tests/autohsts_test.py
@@ -1,8 +1,11 @@
 # pylint: disable=too-many-lines
 """Test for certbot_apache._internal.configurator AutoHSTS functionality"""
 import re
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot_apache._internal import constants
@@ -180,4 +183,4 @@ class AutoHSTSTest(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/centos_test.py
+++ b/certbot-apache/tests/centos_test.py
@@ -1,6 +1,9 @@
 """Test for certbot_apache._internal.configurator for Centos overrides"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import filesystem
@@ -238,4 +241,4 @@ class MultipleVhostsTestCentOS(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/centos_test.py
+++ b/certbot-apache/tests/centos_test.py
@@ -241,4 +241,4 @@ class MultipleVhostsTestCentOS(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/complex_parsing_test.py
+++ b/certbot-apache/tests/complex_parsing_test.py
@@ -1,6 +1,9 @@
 """Tests for certbot_apache._internal.parser."""
 import shutil
+import sys
 import unittest
+
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -124,4 +127,4 @@ class ComplexParserTest(util.ParserTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/complex_parsing_test.py
+++ b/certbot-apache/tests/complex_parsing_test.py
@@ -127,4 +127,4 @@ class ComplexParserTest(util.ParserTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/configurator_reverter_test.py
+++ b/certbot-apache/tests/configurator_reverter_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.configurator implementations of reverter"""
 import shutil
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 import util
@@ -73,4 +76,4 @@ class ConfiguratorReverterTest(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/configurator_reverter_test.py
+++ b/certbot-apache/tests/configurator_reverter_test.py
@@ -76,4 +76,4 @@ class ConfiguratorReverterTest(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/configurator_test.py
+++ b/certbot-apache/tests/configurator_test.py
@@ -1776,4 +1776,4 @@ class InstallSslOptionsConfTest(util.ApacheTest):
             self.assertEqual(self.config._open_module_file("/nonsense/"), "testing 12 3")
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/configurator_test.py
+++ b/certbot-apache/tests/configurator_test.py
@@ -3,9 +3,12 @@
 import copy
 import shutil
 import socket
+import sys
 import tempfile
 import unittest
 from unittest import mock
+
+import pytest
 
 from acme import challenges
 from certbot import achallenges
@@ -1773,4 +1776,4 @@ class InstallSslOptionsConfTest(util.ApacheTest):
             self.assertEqual(self.config._open_module_file("/nonsense/"), "testing 12 3")
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/debian_test.py
+++ b/certbot-apache/tests/debian_test.py
@@ -1,7 +1,10 @@
 """Test for certbot_apache._internal.configurator for Debian overrides"""
 import shutil
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -211,4 +214,4 @@ class MultipleVhostsTestDebian(util.ApacheTest):
             errors.MisconfigurationError, self.config.enable_mod, "ssl")
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/debian_test.py
+++ b/certbot-apache/tests/debian_test.py
@@ -214,4 +214,4 @@ class MultipleVhostsTestDebian(util.ApacheTest):
             errors.MisconfigurationError, self.config.enable_mod, "ssl")
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/display_ops_test.py
+++ b/certbot-apache/tests/display_ops_test.py
@@ -103,4 +103,4 @@ class SelectVhostTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/display_ops_test.py
+++ b/certbot-apache/tests/display_ops_test.py
@@ -1,6 +1,9 @@
 """Test certbot_apache._internal.display_ops."""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.display import util as display_util
@@ -100,4 +103,4 @@ class SelectVhostTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/entrypoint_test.py
+++ b/certbot-apache/tests/entrypoint_test.py
@@ -46,4 +46,4 @@ class EntryPointTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/entrypoint_test.py
+++ b/certbot-apache/tests/entrypoint_test.py
@@ -1,6 +1,9 @@
 """Test for certbot_apache._internal.entrypoint for override class resolution"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot_apache._internal import configurator
 from certbot_apache._internal import entrypoint
@@ -43,4 +46,4 @@ class EntryPointTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/fedora_test.py
+++ b/certbot-apache/tests/fedora_test.py
@@ -193,4 +193,4 @@ class MultipleVhostsTestFedora(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/fedora_test.py
+++ b/certbot-apache/tests/fedora_test.py
@@ -1,6 +1,9 @@
 """Test for certbot_apache._internal.configurator for Fedora 29+ overrides"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import filesystem
@@ -190,4 +193,4 @@ class MultipleVhostsTestFedora(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/gentoo_test.py
+++ b/certbot-apache/tests/gentoo_test.py
@@ -136,4 +136,4 @@ class MultipleVhostsTestGentoo(util.ApacheTest):
         self.assertEqual(mock_run_script.call_count, 3)
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/gentoo_test.py
+++ b/certbot-apache/tests/gentoo_test.py
@@ -1,6 +1,9 @@
 """Test for certbot_apache._internal.configurator for Gentoo overrides"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import filesystem
@@ -133,4 +136,4 @@ class MultipleVhostsTestGentoo(util.ApacheTest):
         self.assertEqual(mock_run_script.call_count, 3)
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -1,8 +1,11 @@
 """Test for certbot_apache._internal.http_01."""
 import errno
+import sys
 from typing import List
 import unittest
 from unittest import mock
+
+import pytest
 
 from acme import challenges
 from certbot import achallenges
@@ -220,4 +223,4 @@ class ApacheHttp01Test(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/http_01_test.py
+++ b/certbot-apache/tests/http_01_test.py
@@ -223,4 +223,4 @@ class ApacheHttp01Test(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/obj_test.py
+++ b/certbot-apache/tests/obj_test.py
@@ -1,5 +1,8 @@
 """Tests for certbot_apache._internal.obj."""
+import sys
 import unittest
+
+import pytest
 
 
 class VirtualHostTest(unittest.TestCase):
@@ -137,4 +140,4 @@ class AddrTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/obj_test.py
+++ b/certbot-apache/tests/obj_test.py
@@ -140,4 +140,4 @@ class AddrTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/parser_test.py
+++ b/certbot-apache/tests/parser_test.py
@@ -403,4 +403,4 @@ class ParserInitTest(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/parser_test.py
+++ b/certbot-apache/tests/parser_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot_apache._internal.parser."""
 import shutil
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -400,4 +403,4 @@ class ParserInitTest(util.ApacheTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/parsernode_configurator_test.py
+++ b/certbot-apache/tests/parsernode_configurator_test.py
@@ -1,6 +1,9 @@
 """Tests for ApacheConfigurator for AugeasParserNode classes"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 import util
 
@@ -40,4 +43,4 @@ class ConfiguratorParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-p
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/parsernode_configurator_test.py
+++ b/certbot-apache/tests/parsernode_configurator_test.py
@@ -43,4 +43,4 @@ class ConfiguratorParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-p
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/parsernode_test.py
+++ b/certbot-apache/tests/parsernode_test.py
@@ -1,6 +1,9 @@
 """ Tests for ParserNode interface """
 
+import sys
 import unittest
+
+import pytest
 
 from certbot_apache._internal import interfaces
 from certbot_apache._internal import parsernode_util as util
@@ -125,4 +128,4 @@ class ParserNodeTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/parsernode_test.py
+++ b/certbot-apache/tests/parsernode_test.py
@@ -128,4 +128,4 @@ class ParserNodeTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-apache/tests/parsernode_util_test.py
+++ b/certbot-apache/tests/parsernode_util_test.py
@@ -1,5 +1,8 @@
 """ Tests for ParserNode utils """
+import sys
 import unittest
+
+import pytest
 
 from certbot_apache._internal import parsernode_util as util
 
@@ -112,4 +115,4 @@ class ParserNodeUtilTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-apache/tests/parsernode_util_test.py
+++ b/certbot-apache/tests/parsernode_util_test.py
@@ -115,4 +115,4 @@ class ParserNodeUtilTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-cloudflare',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-cloudflare/tests/dns_cloudflare_test.py
+++ b/certbot-dns-cloudflare/tests/dns_cloudflare_test.py
@@ -247,4 +247,4 @@ class CloudflareClientTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-cloudflare/tests/dns_cloudflare_test.py
+++ b/certbot-dns-cloudflare/tests/dns_cloudflare_test.py
@@ -1,9 +1,11 @@
 """Tests for certbot_dns_cloudflare._internal.dns_cloudflare."""
 
+import sys
 import unittest
 from unittest import mock
 
 import CloudFlare
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -245,4 +247,4 @@ class CloudflareClientTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-digitalocean',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-digitalocean/tests/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/tests/dns_digitalocean_test.py
@@ -174,4 +174,4 @@ class DigitalOceanClientTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-digitalocean/tests/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/tests/dns_digitalocean_test.py
@@ -1,9 +1,11 @@
 """Tests for certbot_dns_digitalocean._internal.dns_digitalocean."""
 
+import sys
 import unittest
 from unittest import mock
 
 import digitalocean
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -172,4 +174,4 @@ class DigitalOceanClientTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -32,6 +32,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-dnsimple',
     version=version,
@@ -67,6 +71,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-dnsimple/tests/dns_dnsimple_test.py
+++ b/certbot-dns-dnsimple/tests/dns_dnsimple_test.py
@@ -1,8 +1,10 @@
 """Tests for certbot_dns_dnsimple._internal.dns_dnsimple."""
 
+import sys
 import unittest
 from unittest import mock
 
+import pytest
 from requests.exceptions import HTTPError
 
 from certbot.compat import os
@@ -48,4 +50,4 @@ class DNSimpleLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseL
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-dnsimple/tests/dns_dnsimple_test.py
+++ b/certbot-dns-dnsimple/tests/dns_dnsimple_test.py
@@ -50,4 +50,4 @@ class DNSimpleLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseL
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-dnsmadeeasy',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-dnsmadeeasy/tests/dns_dnsmadeeasy_test.py
+++ b/certbot-dns-dnsmadeeasy/tests/dns_dnsmadeeasy_test.py
@@ -1,8 +1,10 @@
 """Tests for certbot_dns_dnsmadeeasy._internal.dns_dnsmadeeasy."""
 
+import sys
 import unittest
 from unittest import mock
 
+import pytest
 from requests.exceptions import HTTPError
 
 from certbot.compat import os
@@ -53,4 +55,4 @@ class DNSMadeEasyLexiconClientTest(unittest.TestCase,
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-dnsmadeeasy/tests/dns_dnsmadeeasy_test.py
+++ b/certbot-dns-dnsmadeeasy/tests/dns_dnsmadeeasy_test.py
@@ -55,4 +55,4 @@ class DNSMadeEasyLexiconClientTest(unittest.TestCase,
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-gehirn',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-gehirn/tests/dns_gehirn_test.py
+++ b/certbot-dns-gehirn/tests/dns_gehirn_test.py
@@ -1,8 +1,10 @@
 """Tests for certbot_dns_gehirn._internal.dns_gehirn."""
 
+import sys
 import unittest
 from unittest import mock
 
+import pytest
 from requests.exceptions import HTTPError
 
 from certbot.compat import os
@@ -52,4 +54,4 @@ class GehirnLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLex
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-gehirn/tests/dns_gehirn_test.py
+++ b/certbot-dns-gehirn/tests/dns_gehirn_test.py
@@ -54,4 +54,4 @@ class GehirnLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLex
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -33,6 +33,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-google',
     version=version,
@@ -68,6 +72,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-google/tests/dns_google_test.py
+++ b/certbot-dns-google/tests/dns_google_test.py
@@ -1,5 +1,6 @@
 """Tests for certbot_dns_google._internal.dns_google."""
 
+import sys
 import unittest
 from unittest import mock
 
@@ -7,6 +8,7 @@ from googleapiclient import discovery
 from googleapiclient.errors import Error
 from googleapiclient.http import HttpMock
 from httplib2 import ServerNotFoundError
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -410,4 +412,4 @@ class DummyResponse:
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-google/tests/dns_google_test.py
+++ b/certbot-dns-google/tests/dns_google_test.py
@@ -412,4 +412,4 @@ class DummyResponse:
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-linode',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-linode/tests/dns_linode_test.py
+++ b/certbot-dns-linode/tests/dns_linode_test.py
@@ -147,4 +147,4 @@ class Linode4LexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLe
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-linode/tests/dns_linode_test.py
+++ b/certbot-dns-linode/tests/dns_linode_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot_dns_linode._internal.dns_linode."""
 
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -144,4 +147,4 @@ class Linode4LexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLe
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-luadns',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-luadns/tests/dns_luadns_test.py
+++ b/certbot-dns-luadns/tests/dns_luadns_test.py
@@ -1,8 +1,10 @@
 """Tests for certbot_dns_luadns._internal.dns_luadns."""
 
+import sys
 import unittest
 from unittest import mock
 
+import pytest
 from requests.exceptions import HTTPError
 
 from certbot.compat import os
@@ -49,4 +51,4 @@ class LuaDNSLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLex
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-luadns/tests/dns_luadns_test.py
+++ b/certbot-dns-luadns/tests/dns_luadns_test.py
@@ -51,4 +51,4 @@ class LuaDNSLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLex
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-nsone',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-nsone/tests/dns_nsone_test.py
+++ b/certbot-dns-nsone/tests/dns_nsone_test.py
@@ -51,4 +51,4 @@ class NS1LexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexico
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-nsone/tests/dns_nsone_test.py
+++ b/certbot-dns-nsone/tests/dns_nsone_test.py
@@ -1,8 +1,10 @@
 """Tests for certbot_dns_nsone._internal.dns_nsone."""
 
+import sys
 import unittest
 from unittest import mock
 
+import pytest
 from requests.exceptions import HTTPError
 
 from certbot.compat import os
@@ -49,4 +51,4 @@ class NS1LexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexico
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-ovh',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-ovh/tests/dns_ovh_test.py
+++ b/certbot-dns-ovh/tests/dns_ovh_test.py
@@ -61,4 +61,4 @@ class OVHLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexico
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-ovh/tests/dns_ovh_test.py
+++ b/certbot-dns-ovh/tests/dns_ovh_test.py
@@ -1,8 +1,10 @@
 """Tests for certbot_dns_ovh._internal.dns_ovh."""
 
+import sys
 import unittest
 from unittest import mock
 
+import pytest
 from requests.exceptions import HTTPError
 
 from certbot.compat import os
@@ -59,4 +61,4 @@ class OVHLexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexico
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-rfc2136',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-rfc2136/tests/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/tests/dns_rfc2136_test.py
@@ -1,11 +1,13 @@
 """Tests for certbot_dns_rfc2136._internal.dns_rfc2136."""
 
+import sys
 import unittest
 from unittest import mock
 
 import dns.flags
 import dns.rcode
 import dns.tsig
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -234,4 +236,4 @@ class RFC2136ClientTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-rfc2136/tests/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/tests/dns_rfc2136_test.py
@@ -236,4 +236,4 @@ class RFC2136ClientTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-route53',
     version=version,
@@ -65,6 +69,7 @@ setup(
     keywords=['certbot', 'route53', 'aws'],
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-route53/tests/dns_route53_test.py
+++ b/certbot-dns-route53/tests/dns_route53_test.py
@@ -1,10 +1,12 @@
 """Tests for certbot_dns_route53._internal.dns_route53.Authenticator"""
 
+import sys
 import unittest
 from unittest import mock
 
 from botocore.exceptions import ClientError
 from botocore.exceptions import NoCredentialsError
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -257,4 +259,4 @@ class ClientTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-route53/tests/dns_route53_test.py
+++ b/certbot-dns-route53/tests/dns_route53_test.py
@@ -259,4 +259,4 @@ class ClientTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -30,6 +30,10 @@ docs_extras = [
     'sphinx_rtd_theme',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-dns-sakuracloud',
     version=version,
@@ -65,6 +69,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'docs': docs_extras,
+        'test': test_extras,
     },
     entry_points={
         'certbot.plugins': [

--- a/certbot-dns-sakuracloud/tests/dns_sakuracloud_test.py
+++ b/certbot-dns-sakuracloud/tests/dns_sakuracloud_test.py
@@ -1,8 +1,10 @@
 """Tests for certbot_dns_sakuracloud._internal.dns_sakuracloud."""
 
+import sys
 import unittest
 from unittest import mock
 
+import pytest
 from requests.exceptions import HTTPError
 
 from certbot.compat import os
@@ -53,4 +55,4 @@ class SakuraCloudLexiconClientTest(unittest.TestCase,
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-dns-sakuracloud/tests/dns_sakuracloud_test.py
+++ b/certbot-dns-sakuracloud/tests/dns_sakuracloud_test.py
@@ -55,4 +55,4 @@ class SakuraCloudLexiconClientTest(unittest.TestCase,
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -14,6 +14,10 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
+test_extras = [
+    'pytest',
+]
+
 setup(
     name='certbot-nginx',
     version=version,
@@ -47,6 +51,9 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,
+    extras_require={
+        'test': test_extras,
+    },
     entry_points={
         'certbot.plugins': [
             'nginx = certbot_nginx._internal.configurator:NginxConfigurator',

--- a/certbot-nginx/tests/configurator_test.py
+++ b/certbot-nginx/tests/configurator_test.py
@@ -1,8 +1,10 @@
 """Test for certbot_nginx._internal.configurator."""
+import sys
 import unittest
 from unittest import mock
 
 import OpenSSL
+import pytest
 
 from acme import challenges
 from acme import messages
@@ -1133,4 +1135,4 @@ class DetermineDefaultServerRootTest(certbot_test_util.ConfigTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/configurator_test.py
+++ b/certbot-nginx/tests/configurator_test.py
@@ -1135,4 +1135,4 @@ class DetermineDefaultServerRootTest(certbot_test_util.ConfigTestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/display_ops_test.py
+++ b/certbot-nginx/tests/display_ops_test.py
@@ -1,5 +1,8 @@
 """Test certbot_nginx._internal.display_ops."""
+import sys
 import unittest
+
+import pytest
 
 from certbot.display import util as display_util
 from certbot.tests import util as certbot_util
@@ -40,4 +43,4 @@ class SelectVhostMultiTest(util.NginxTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/display_ops_test.py
+++ b/certbot-nginx/tests/display_ops_test.py
@@ -43,4 +43,4 @@ class SelectVhostMultiTest(util.NginxTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/http_01_test.py
+++ b/certbot-nginx/tests/http_01_test.py
@@ -230,4 +230,4 @@ class HttpPerformTest(util.NginxTest):
         self.assertEqual(addrs, [http_addr])
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/http_01_test.py
+++ b/certbot-nginx/tests/http_01_test.py
@@ -1,8 +1,10 @@
 """Tests for certbot_nginx._internal.http_01"""
+import sys
 import unittest
 from unittest import mock
 
 import josepy as jose
+import pytest
 
 from acme import challenges
 from certbot import achallenges
@@ -228,4 +230,4 @@ class HttpPerformTest(util.NginxTest):
         self.assertEqual(addrs, [http_addr])
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/nginxparser_test.py
+++ b/certbot-nginx/tests/nginxparser_test.py
@@ -1,10 +1,12 @@
 """Test for certbot_nginx._internal.nginxparser."""
 import copy
 import operator
+import sys
 import tempfile
 import unittest
 
 from pyparsing import ParseException
+import pytest
 
 from certbot_nginx._internal.nginxparser import dump
 from certbot_nginx._internal.nginxparser import dumps
@@ -508,4 +510,4 @@ class TestUnspacedList(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/nginxparser_test.py
+++ b/certbot-nginx/tests/nginxparser_test.py
@@ -510,4 +510,4 @@ class TestUnspacedList(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/obj_test.py
+++ b/certbot-nginx/tests/obj_test.py
@@ -229,4 +229,4 @@ class VirtualHostTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/obj_test.py
+++ b/certbot-nginx/tests/obj_test.py
@@ -1,6 +1,9 @@
 """Test the helper objects in certbot_nginx._internal.obj."""
 import itertools
+import sys
 import unittest
+
+import pytest
 
 
 class AddrTest(unittest.TestCase):
@@ -226,4 +229,4 @@ class VirtualHostTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/parser_obj_test.py
+++ b/certbot-nginx/tests/parser_obj_test.py
@@ -1,7 +1,10 @@
 """ Tests for functions and classes in parser_obj.py """
 
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot_nginx._internal.parser_obj import COMMENT_BLOCK
 from certbot_nginx._internal.parser_obj import parse_raw
@@ -256,4 +259,4 @@ class StatementsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/parser_obj_test.py
+++ b/certbot-nginx/tests/parser_obj_test.py
@@ -259,4 +259,4 @@ class StatementsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/parser_test.py
+++ b/certbot-nginx/tests/parser_test.py
@@ -2,9 +2,12 @@
 import glob
 import re
 import shutil
+import sys
 from typing import List
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -544,4 +547,4 @@ class NginxParserTest(util.NginxTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot-nginx/tests/parser_test.py
+++ b/certbot-nginx/tests/parser_test.py
@@ -547,4 +547,4 @@ class NginxParserTest(util.NginxTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -15,6 +15,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Certbot will now only keep the current and 5 previous certificates in the `/etc/letsencrypt/archive` directory for each certificate lineage. Any prior certificates will be automatically deleted upon renewal. This number may be further lowered in future releases.
   * As always, users should only reference the certificate files within `/etc/letsencrypt/live` and never use `/etc/letsencrypt/archive` directly. See [Where are my certificates?](https://eff-certbot.readthedocs.io/en/stable/using.html#where-are-my-certificates) in the Certbot User Guide.
 * `certbot.configuration.NamespaceConfig.key_dir` and `.csr_dir` are now deprecated.
+* All Certbot components now require `pytest` to run tests.
 
 ### Fixed
 

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -332,4 +332,4 @@ class AccountFileStorageTest(test_util.ConfigTestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/account_test.py
+++ b/certbot/tests/account_test.py
@@ -1,10 +1,12 @@
 """Tests for certbot._internal.account."""
 import datetime
 import json
+import sys
 import unittest
 from unittest import mock
 
 import josepy as jose
+import pytest
 import pytz
 
 from acme import messages
@@ -330,4 +332,4 @@ class AccountFileStorageTest(test_util.ConfigTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -594,4 +594,4 @@ def gen_dom_authzr(domain, challs):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/auth_handler_test.py
+++ b/certbot/tests/auth_handler_test.py
@@ -1,10 +1,12 @@
 """Tests for certbot._internal.auth_handler."""
 import datetime
 import logging
+import sys
 import unittest
 from unittest import mock
 
 from josepy import b64encode
+import pytest
 
 from acme import challenges
 from acme import client as acme_client
@@ -592,4 +594,4 @@ def gen_dom_authzr(domain, challs):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -712,4 +712,4 @@ class GetCertnameTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/cert_manager_test.py
+++ b/certbot/tests/cert_manager_test.py
@@ -3,11 +3,13 @@
 # pylint: disable=protected-access
 import re
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest import mock
 
 import configobj
+import pytest
 
 from certbot import configuration
 from certbot import errors
@@ -710,4 +712,4 @@ class GetCertnameTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -3,9 +3,12 @@ import argparse
 import copy
 from importlib import reload as reload_module
 import io
+import sys
 import tempfile
 import unittest
 from unittest import mock
+
+import pytest
 
 from acme import challenges
 from certbot import errors
@@ -521,4 +524,4 @@ def _call_set_by_cli(var, args, verb):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/cli_test.py
+++ b/certbot/tests/cli_test.py
@@ -524,4 +524,4 @@ def _call_set_by_cli(var, args, verb):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -3,12 +3,14 @@ import contextlib
 import datetime
 import platform
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
 from josepy import interfaces
+import pytest
 
 from certbot import errors
 from certbot import util
@@ -979,4 +981,4 @@ class RollbackTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/client_test.py
+++ b/certbot/tests/client_test.py
@@ -981,4 +981,4 @@ class RollbackTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/compat/filesystem_test.py
+++ b/certbot/tests/compat/filesystem_test.py
@@ -682,4 +682,4 @@ def _create_probe(tempdir, name='probe'):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/compat/filesystem_test.py
+++ b/certbot/tests/compat/filesystem_test.py
@@ -1,8 +1,11 @@
 """Tests for certbot.compat.filesystem"""
 import contextlib
 import errno
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import util
 from certbot._internal import lock
@@ -679,4 +682,4 @@ def _create_probe(tempdir, name='probe'):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/compat/misc_test.py
+++ b/certbot/tests/compat/misc_test.py
@@ -46,4 +46,4 @@ class ExecuteStatusTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/compat/misc_test.py
+++ b/certbot/tests/compat/misc_test.py
@@ -1,6 +1,9 @@
 """Tests for certbot.compat.misc"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot.compat import os
 
@@ -43,4 +46,4 @@ class ExecuteStatusTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/compat/os_test.py
+++ b/certbot/tests/compat/os_test.py
@@ -20,4 +20,4 @@ class OsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/compat/os_test.py
+++ b/certbot/tests/compat/os_test.py
@@ -1,5 +1,8 @@
 """Unit test for os module."""
+import sys
 import unittest
+
+import pytest
 
 from certbot.compat import os
 
@@ -17,4 +20,4 @@ class OsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/configuration_test.py
+++ b/certbot/tests/configuration_test.py
@@ -166,4 +166,4 @@ class NamespaceConfigTest(test_util.ConfigTestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/configuration_test.py
+++ b/certbot/tests/configuration_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot.configuration."""
+import sys
 import unittest
 from unittest import mock
 import warnings
+
+import pytest
 
 from certbot import errors
 from certbot._internal import constants
@@ -163,4 +166,4 @@ class NamespaceConfigTest(test_util.ConfigTestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -527,4 +527,4 @@ class FindChainWithIssuerTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/crypto_util_test.py
+++ b/certbot/tests/crypto_util_test.py
@@ -1,9 +1,11 @@
 """Tests for certbot.crypto_util."""
 import logging
+import sys
 import unittest
 from unittest import mock
 
 import OpenSSL
+import pytest
 
 from certbot import errors
 from certbot import util
@@ -525,4 +527,4 @@ class FindChainWithIssuerTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/display/completer_test.py
+++ b/certbot/tests/display/completer_test.py
@@ -107,4 +107,4 @@ def enable_tab_completion(unused_command):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/display/completer_test.py
+++ b/certbot/tests/display/completer_test.py
@@ -1,19 +1,22 @@
 """Test certbot._internal.display.completer."""
+from importlib import reload as reload_module
+import string
+import sys
 from typing import List
+import unittest
+from unittest import mock
+
+import pytest
+
+from certbot.compat import filesystem
+from certbot.compat import os
+import certbot.tests.util as test_util
 
 try:
     import readline  # pylint: disable=import-error
 except ImportError:
     import certbot._internal.display.dummy_readline as readline  # type: ignore
-from importlib import reload as reload_module
-import string
-import sys
-import unittest
-from unittest import mock
 
-from certbot.compat import filesystem
-from certbot.compat import os
-import certbot.tests.util as test_util
 
 
 class CompleterTest(test_util.TempDirTestCase):
@@ -104,4 +107,4 @@ def enable_tab_completion(unused_command):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/display/internal_util_test.py
+++ b/certbot/tests/display/internal_util_test.py
@@ -149,4 +149,4 @@ class DescribeACMEErrorTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/display/internal_util_test.py
+++ b/certbot/tests/display/internal_util_test.py
@@ -1,9 +1,12 @@
 """Test :mod:`certbot._internal.display.util`."""
 import io
 import socket
+import sys
 import tempfile
 import unittest
 from unittest import mock
+
+import pytest
 
 from acme import messages as acme_messages
 from certbot import errors
@@ -146,4 +149,4 @@ class DescribeACMEErrorTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/display/obj_test.py
+++ b/certbot/tests/display/obj_test.py
@@ -1,6 +1,9 @@
 """Test :mod:`certbot._internal.display.obj`."""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot._internal.display import obj as display_obj
@@ -330,4 +333,4 @@ class NoninteractiveDisplayTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/display/obj_test.py
+++ b/certbot/tests/display/obj_test.py
@@ -333,4 +333,4 @@ class NoninteractiveDisplayTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import mock
 
 import josepy as jose
+import pytest
 
 from acme import messages
 from certbot import errors
@@ -517,4 +518,4 @@ class ReportExecutedCommand(unittest.TestCase):
         self.assertEqual(mock_notify.call_count, 0)
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/display/ops_test.py
+++ b/certbot/tests/display/ops_test.py
@@ -518,4 +518,4 @@ class ReportExecutedCommand(unittest.TestCase):
         self.assertEqual(mock_notify.call_count, 0)
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -1,9 +1,12 @@
 """Test :mod:`certbot.display.util`."""
 import io
 import socket
+import sys
 import tempfile
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 import certbot.tests.util as test_util
@@ -95,4 +98,4 @@ class DirectorySelectTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/display/util_test.py
+++ b/certbot/tests/display/util_test.py
@@ -98,4 +98,4 @@ class DirectorySelectTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/eff_test.py
+++ b/certbot/tests/eff_test.py
@@ -181,4 +181,4 @@ class SubscribeTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/eff_test.py
+++ b/certbot/tests/eff_test.py
@@ -1,9 +1,11 @@
 """Tests for certbot._internal.eff."""
 import datetime
+import sys
 import unittest
 from unittest import mock
 
 import josepy
+import pytest
 import pytz
 import requests
 
@@ -179,4 +181,4 @@ class SubscribeTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -152,4 +152,4 @@ class ExitHandlerTest(ErrorHandlerTest):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/error_handler_test.py
+++ b/certbot/tests/error_handler_test.py
@@ -8,6 +8,8 @@ from typing import Union
 import unittest
 from unittest import mock
 
+import pytest
+
 from certbot.compat import os
 
 
@@ -150,4 +152,4 @@ class ExitHandlerTest(ErrorHandlerTest):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/errors_test.py
+++ b/certbot/tests/errors_test.py
@@ -1,6 +1,9 @@
 """Tests for certbot.errors."""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from acme import messages
 from certbot import achallenges
@@ -52,4 +55,4 @@ class StandaloneBindErrorTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/errors_test.py
+++ b/certbot/tests/errors_test.py
@@ -55,4 +55,4 @@ class StandaloneBindErrorTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/helpful_test.py
+++ b/certbot/tests/helpful_test.py
@@ -1,6 +1,9 @@
 """Tests for certbot.helpful_parser"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot._internal import constants
@@ -202,4 +205,4 @@ class TestAddDeprecatedArgument(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/helpful_test.py
+++ b/certbot/tests/helpful_test.py
@@ -205,4 +205,4 @@ class TestAddDeprecatedArgument(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -1,6 +1,9 @@
 """Tests for certbot._internal.hooks."""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot import util
@@ -459,4 +462,4 @@ def create_hook(file_path):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/hook_test.py
+++ b/certbot/tests/hook_test.py
@@ -462,4 +462,4 @@ def create_hook(file_path):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/lock_test.py
+++ b/certbot/tests/lock_test.py
@@ -1,8 +1,11 @@
 """Tests for certbot._internal.lock."""
 import functools
 import multiprocessing
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -138,4 +141,4 @@ class LockFileTest(test_util.TempDirTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/lock_test.py
+++ b/certbot/tests/lock_test.py
@@ -141,4 +141,4 @@ class LockFileTest(test_util.TempDirTestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -8,6 +8,8 @@ from typing import Optional
 import unittest
 from unittest import mock
 
+import pytest
+
 from acme import messages
 from certbot import errors
 from certbot import util
@@ -433,4 +435,4 @@ class ExitWithAdviceTest(test_util.TempDirTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/log_test.py
+++ b/certbot/tests/log_test.py
@@ -435,4 +435,4 @@ class ExitWithAdviceTest(test_util.TempDirTestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -2470,4 +2470,4 @@ class ShowAccountTest(test_util.ConfigTestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/main_test.py
+++ b/certbot/tests/main_test.py
@@ -16,6 +16,7 @@ from unittest import mock
 
 import configobj
 import josepy as jose
+import pytest
 import pytz
 
 from acme.messages import Error as acme_error
@@ -2469,4 +2470,4 @@ class ShowAccountTest(test_util.ConfigTestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -3,6 +3,7 @@
 import contextlib
 from datetime import datetime
 from datetime import timedelta
+import sys
 import unittest
 from unittest import mock
 
@@ -12,6 +13,7 @@ from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.x509 import ocsp as ocsp_lib
+import pytest
 import pytz
 
 from certbot import errors
@@ -386,4 +388,4 @@ revoked
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/ocsp_test.py
+++ b/certbot/tests/ocsp_test.py
@@ -388,4 +388,4 @@ revoked
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/common_test.py
+++ b/certbot/tests/plugins/common_test.py
@@ -368,4 +368,4 @@ class InstallVersionControlledFileTest(test_util.TempDirTestCase):
             self.assertIs(mock_logger.warning.called, False)
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/common_test.py
+++ b/certbot/tests/plugins/common_test.py
@@ -1,10 +1,12 @@
 """Tests for certbot.plugins.common."""
 import functools
 import shutil
+import sys
 import unittest
 from unittest import mock
 
 import josepy as jose
+import pytest
 
 from acme import challenges
 from certbot import achallenges
@@ -366,4 +368,4 @@ class InstallVersionControlledFileTest(test_util.TempDirTestCase):
             self.assertIs(mock_logger.warning.called, False)
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -1,11 +1,13 @@
 """Tests for certbot._internal.plugins.disco."""
 import functools
 import string
+import sys
 from typing import List
 import unittest
 from unittest import mock
 
 import pkg_resources
+import pytest
 
 from certbot import errors
 from certbot import interfaces
@@ -271,4 +273,4 @@ class PluginsRegistryTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/disco_test.py
+++ b/certbot/tests/plugins/disco_test.py
@@ -273,4 +273,4 @@ class PluginsRegistryTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/dns_common_lexicon_test.py
+++ b/certbot/tests/plugins/dns_common_lexicon_test.py
@@ -26,4 +26,4 @@ class LexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexiconCl
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/dns_common_lexicon_test.py
+++ b/certbot/tests/plugins/dns_common_lexicon_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot.plugins.dns_common_lexicon."""
 
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot.plugins import dns_common_lexicon
 from certbot.plugins import dns_test_common_lexicon
@@ -23,4 +26,4 @@ class LexiconClientTest(unittest.TestCase, dns_test_common_lexicon.BaseLexiconCl
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/dns_common_test.py
+++ b/certbot/tests/plugins/dns_common_test.py
@@ -2,8 +2,11 @@
 
 import collections
 import logging
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot import util
@@ -233,4 +236,4 @@ class DomainNameGuessTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/dns_common_test.py
+++ b/certbot/tests/plugins/dns_common_test.py
@@ -236,4 +236,4 @@ class DomainNameGuessTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/enhancements_test.py
+++ b/certbot/tests/plugins/enhancements_test.py
@@ -1,6 +1,9 @@
 """Tests for new style enhancements"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot._internal.plugins import null
 from certbot.plugins import enhancements
@@ -59,4 +62,4 @@ class EnhancementTest(test_util.ConfigTestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/enhancements_test.py
+++ b/certbot/tests/plugins/enhancements_test.py
@@ -62,4 +62,4 @@ class EnhancementTest(test_util.ConfigTestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/manual_test.py
+++ b/certbot/tests/plugins/manual_test.py
@@ -161,4 +161,4 @@ class AuthenticatorTest(test_util.TempDirTestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/manual_test.py
+++ b/certbot/tests/plugins/manual_test.py
@@ -4,6 +4,8 @@ import textwrap
 import unittest
 from unittest import mock
 
+import pytest
+
 from acme import challenges
 from certbot import errors
 from certbot.compat import filesystem
@@ -159,4 +161,4 @@ class AuthenticatorTest(test_util.TempDirTestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/null_test.py
+++ b/certbot/tests/plugins/null_test.py
@@ -1,6 +1,9 @@
 """Tests for certbot._internal.plugins.null."""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 
 class InstallerTest(unittest.TestCase):
@@ -17,4 +20,4 @@ class InstallerTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/null_test.py
+++ b/certbot/tests/plugins/null_test.py
@@ -20,4 +20,4 @@ class InstallerTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/selection_test.py
+++ b/certbot/tests/plugins/selection_test.py
@@ -4,6 +4,8 @@ from typing import List
 import unittest
 from unittest import mock
 
+import pytest
+
 from certbot import errors
 from certbot import interfaces
 from certbot._internal.display import obj as display_obj
@@ -261,4 +263,4 @@ class TestChooseConfiguratorPlugins(unittest.TestCase):
         self.assertEqual(auth.name, "apache")
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/selection_test.py
+++ b/certbot/tests/plugins/selection_test.py
@@ -263,4 +263,4 @@ class TestChooseConfiguratorPlugins(unittest.TestCase):
         self.assertEqual(auth.name, "apache")
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/standalone_test.py
+++ b/certbot/tests/plugins/standalone_test.py
@@ -187,4 +187,4 @@ class AuthenticatorTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/standalone_test.py
+++ b/certbot/tests/plugins/standalone_test.py
@@ -1,6 +1,7 @@
 """Tests for certbot._internal.plugins.standalone."""
 import errno
 import socket
+import sys
 from typing import Dict
 from typing import Set
 from typing import Tuple
@@ -9,6 +10,7 @@ from unittest import mock
 
 import josepy as jose
 import OpenSSL.crypto
+import pytest
 
 from acme import challenges
 from acme import standalone as acme_standalone
@@ -185,4 +187,4 @@ class AuthenticatorTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/storage_test.py
+++ b/certbot/tests/plugins/storage_test.py
@@ -1,10 +1,13 @@
 """Tests for certbot.plugins.storage.PluginStorage"""
 import json
+import sys
 from typing import Iterable
 from typing import List
 from typing import Optional
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import filesystem
@@ -117,4 +120,4 @@ class PluginStorageTest(test_util.ConfigTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/storage_test.py
+++ b/certbot/tests/plugins/storage_test.py
@@ -120,4 +120,4 @@ class PluginStorageTest(test_util.ConfigTestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/util_test.py
+++ b/certbot/tests/plugins/util_test.py
@@ -44,4 +44,4 @@ class PathSurgeryTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/util_test.py
+++ b/certbot/tests/plugins/util_test.py
@@ -1,6 +1,9 @@
 """Tests for certbot.plugins.util."""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot.compat import os
 
@@ -41,4 +44,4 @@ class PathSurgeryTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/webroot_test.py
+++ b/certbot/tests/plugins/webroot_test.py
@@ -6,11 +6,13 @@ import argparse
 import errno
 import json
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest import mock
 
 import josepy as jose
+import pytest
 
 from acme import challenges
 from certbot import achallenges
@@ -360,4 +362,4 @@ class WebrootActionTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/plugins/webroot_test.py
+++ b/certbot/tests/plugins/webroot_test.py
@@ -362,4 +362,4 @@ class WebrootActionTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot._internal.renewal"""
 import copy
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from acme import challenges
 from certbot import configuration
@@ -305,4 +308,4 @@ class DescribeResultsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/renewal_test.py
+++ b/certbot/tests/renewal_test.py
@@ -308,4 +308,4 @@ class DescribeResultsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/renewupdater_test.py
+++ b/certbot/tests/renewupdater_test.py
@@ -1,6 +1,9 @@
 """Tests for renewal updater interfaces"""
+import sys
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import interfaces
 from certbot._internal import main
@@ -120,4 +123,4 @@ class RenewUpdaterTest(test_util.ConfigTestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/renewupdater_test.py
+++ b/certbot/tests/renewupdater_test.py
@@ -123,4 +123,4 @@ class RenewUpdaterTest(test_util.ConfigTestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/reverter_test.py
+++ b/certbot/tests/reverter_test.py
@@ -457,4 +457,4 @@ def update_file(filename, string):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/reverter_test.py
+++ b/certbot/tests/reverter_test.py
@@ -2,9 +2,12 @@
 import csv
 import logging
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest import mock
+
+import pytest
 
 from certbot import errors
 from certbot.compat import os
@@ -454,4 +457,4 @@ def update_file(filename, string):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -969,4 +969,4 @@ class CertPathForCertNameTest(BaseRenewableCertTest):
         self.assertRaises(errors.CertStorageError, self._call, self.config, 'fake-example.org')
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/storage_test.py
+++ b/certbot/tests/storage_test.py
@@ -3,10 +3,12 @@
 import datetime
 import shutil
 import stat
+import sys
 import unittest
 from unittest import mock
 
 import configobj
+import pytest
 import pytz
 
 import certbot
@@ -967,4 +969,4 @@ class CertPathForCertNameTest(BaseRenewableCertTest):
         self.assertRaises(errors.CertStorageError, self._call, self.config, 'fake-example.org')
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -656,4 +656,4 @@ class ParseLooseVersionTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))  # pragma: no cover
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -7,6 +7,8 @@ import sys
 import unittest
 from unittest import mock
 
+import pytest
+
 from certbot import errors
 from certbot.compat import filesystem
 from certbot.compat import os
@@ -654,4 +656,4 @@ class ParseLooseVersionTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()  # pragma: no cover
+    sys.exit(pytest.main([__file__]))  # pragma: no cover


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/9572.

I still agree with what I said in the conversation at https://github.com/certbot/certbot/pull/9567#issuecomment-1423128771, that doing this seems slightly unconventional to me. This approach is very common with `unittest` (see for example https://docs.python.org/3/library/unittest.html#basic-example) and it's somewhat hard to find recommendations/snippets doing this with `pytest`.

With that said, I think making `python test_file.py` Just Work™ is pretty nice and I feel confident it's stable. As described at https://docs.pytest.org/en/7.1.x/how-to/usage.html, `pytest test_file.py` is the recommended way to run tests on a module and `sys.exit(pytest.main([PYTEST_CLI_ARGS]))` is the recommended way to run make a file run `pytest` and exit with the correct status. Putting those two things together makes calling `sys.exit(pytest.main([__file__]))` seem pretty sane to me.