### PR TITLE
Disable stale for PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,8 +17,14 @@ jobs:
           # Idle number of days before marking issues stale
           days-before-issue-stale: 365
 
+          # Never mark PRs as stale
+          days-before-pr-stale: -1
+
           # Idle number of days before closing stale issues
           days-before-issue-close: 30
+
+          # Never close PRs as stale
+          days-before-pr-close: -1
 
           # Ignore issues with an assignee
           exempt-all-issue-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
           # Idle number of days before closing stale issues
           days-before-issue-close: 30
 
-          # Never close PRs as stale
+          # Never close PRs
           days-before-pr-close: -1
 
           # Ignore issues with an assignee


### PR DESCRIPTION
I noticed our stale action is processing PRs. See https://github.com/certbot/certbot/actions/runs/4169673316/jobs/7217894512#step:2:1225 for example. I don't think we want to do this as our old stale setup did not.

It's not very clear in the documentation, but I think setting these values to -1 should stop this. See https://github.com/actions/stale#days-before-stale and https://github.com/actions/stale#days-before-close.