### PR TITLE
Enable stale issue tracker

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          # REMOVEME: dry run to see if this works
-          debug-only: true
-
           # Idle number of days before marking issues stale
           days-before-issue-stale: 365
 


### PR DESCRIPTION
The debug output for the tracker looks good, so I think we're ready to enable it.

Fixes #9456 