### PR TITLE
Remove update symlinks

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* We deprecated support for the update_symlinks command. Support will be removed in a following
+  version of Certbot.
 
 ### Changed
 

--- a/certbot/certbot/_internal/cli/group_adder.py
+++ b/certbot/certbot/_internal/cli/group_adder.py
@@ -16,7 +16,7 @@ def _add_all_groups(helpful: "helpful.HelpfulArgumentParser") -> None:
     helpful.add_group("paths", description="Flags for changing execution paths & servers")
     helpful.add_group("manage",
         description="Various subcommands and flags are available for managing your certificates:",
-        verbs=["certificates", "delete", "renew", "revoke", "update_symlinks", "reconfigure"])
+        verbs=["certificates", "delete", "renew", "revoke", "reconfigure"])
 
     # VERBS
     for verb, docs in VERB_HELP:

--- a/certbot/certbot/_internal/cli/verb_help.py
+++ b/certbot/certbot/_internal/cli/verb_help.py
@@ -84,13 +84,6 @@ VERB_HELP = [
         "opts": 'Options for the "plugins" subcommand',
         "usage": "\n\n  certbot plugins [options]\n\n"
     }),
-    ("update_symlinks", {
-        "short": "Recreate symlinks in your /etc/letsencrypt/live/ directory",
-        "opts": ("Recreates certificate and key symlinks in {0}, if you changed them by hand "
-                 "or edited a renewal configuration file".format(
-                  os.path.join(flag_default("config_dir"), "live"))),
-        "usage": "\n\n  certbot update_symlinks [options]\n\n"
-    }),
     ("enhance", {
         "short": "Add security enhancements to your existing configuration",
         "opts": ("Helps to harden the TLS configuration by adding security enhancements "

--- a/certbot/certbot/_internal/cli/verb_help.py
+++ b/certbot/certbot/_internal/cli/verb_help.py
@@ -1,7 +1,5 @@
 """This module contain help information for verbs supported by certbot"""
 from certbot._internal.cli.cli_constants import SHORT_USAGE
-from certbot._internal.cli.cli_utils import flag_default
-from certbot.compat import os
 
 # The attributes here are:
 # short: a string that will be displayed by "certbot -h commands"

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -15,6 +15,7 @@ from typing import Optional
 from typing import Tuple
 from typing import TypeVar
 from typing import Union
+import warnings
 
 import configobj
 import josepy as jose
@@ -1279,6 +1280,7 @@ def update_symlinks(config: configuration.NamespaceConfig,
     :rtype: None
 
     """
+    warnings.warn("update_symlinks is deprecated and will be removed", PendingDeprecationWarning)
     cert_manager.update_live_symlinks(config)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,8 +19,11 @@
 #    unit tests. This warning should be ignored until our (transitive)
 #    dependency on requests-toolbelt is removed or our pinned version can be
 #    updated.
+# 4) Ignore our own PendingDeprecationWarning about update_symlinks soon to be dropped.
+#    See https://github.com/certbot/certbot/issues/6284.
 filterwarnings =
     error
     ignore:decodestring\(\) is a deprecated alias:DeprecationWarning:dns
     ignore:.*rsyncdir:DeprecationWarning
     ignore:'urllib3.contrib.pyopenssl:DeprecationWarning:requests_toolbelt
+    ignore:update_symlinks is deprecated:PendingDeprecationWarning


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/6284.

No one uses this. All the code is in `_internal`, but I went with adding a deprecation warning and removing info about the command from the help text as a first step just in case I'm wrong. It's also probably fine to just remove the code in one go, I could be convinced either way. Also happy to go with a `DeprecationWarning` instead of `PendingDeprecationWarning`.