### PR TITLE
google: ignore declare_namespace deprecation warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,7 @@
 #    updated.
 # 4) Ignore our own PendingDeprecationWarning about update_symlinks soon to be dropped.
 #    See https://github.com/certbot/certbot/issues/6284.
-# 5) Ignore pkg_resources.declare_namespace used a large number of Google's Python
+# 5) Ignore pkg_resources.declare_namespace used in a large number of Google's Python
 #    libs. e.g. https://github.com/googleapis/google-auth-library-python/issues/1229.
 filterwarnings =
     error

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,9 +21,12 @@
 #    updated.
 # 4) Ignore our own PendingDeprecationWarning about update_symlinks soon to be dropped.
 #    See https://github.com/certbot/certbot/issues/6284.
+# 5) Ignore pkg_resources.declare_namespace used a large number of Google's Python
+#    libs. e.g. https://github.com/googleapis/google-auth-library-python/issues/1229.
 filterwarnings =
     error
     ignore:decodestring\(\) is a deprecated alias:DeprecationWarning:dns
     ignore:.*rsyncdir:DeprecationWarning
     ignore:'urllib3.contrib.pyopenssl:DeprecationWarning:requests_toolbelt
     ignore:update_symlinks is deprecated:PendingDeprecationWarning
+    ignore:.*declare_namespace\('google:DeprecationWarning


### PR DESCRIPTION
Fixes the nopin build on master. Failing build at https://dev.azure.com/certbot/certbot/_build/results?buildId=6471&view=results.