### PR TITLE
acme.messages.OrderResource: Make roundtrippable through JSON

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,6 +23,7 @@ Authors
 * [amplifi](https://github.com/amplifi)
 * [Andrew Murray](https://github.com/radarhere)
 * [Andrzej Górski](https://github.com/andrzej3393)
+* [Anna Glasgall](https://github.com/aglasgall)
 * [Anselm Levskaya](https://github.com/levskaya)
 * [Antoine Jacoutot](https://github.com/ajacoutot)
 * [April King](https://github.com/april)

--- a/acme/tests/messages_test.py
+++ b/acme/tests/messages_test.py
@@ -492,6 +492,36 @@ class OrderResourceTest(unittest.TestCase):
             'authorizations': None,
         }
 
+    def test_json_de_serializable(self):
+        from acme.messages import ChallengeBody
+        from acme.messages import STATUS_PENDING
+        challbs = (
+            ChallengeBody(
+                uri='http://challb1', status=STATUS_PENDING,
+                chall=challenges.HTTP01(token=b'IlirfxKKXAsHtmzK29Pj8A')),
+            ChallengeBody(uri='http://challb2', status=STATUS_PENDING,
+                          chall=challenges.DNS(
+                              token=b'DGyRejmCefe7v4NfDGDKfA')),
+        )
+
+        from acme.messages import Authorization
+        from acme.messages import AuthorizationResource
+        from acme.messages import Identifier
+        from acme.messages import IDENTIFIER_FQDN
+        identifier = Identifier(typ=IDENTIFIER_FQDN, value='example.com')
+        authz = AuthorizationResource(uri="http://authz1",
+                                      body=Authorization(
+                                          identifier=identifier,
+                                          challenges=challbs))
+        from acme.messages import Order
+        body = Order(identifiers=(identifier,), status=STATUS_PENDING,
+                     authorizations=tuple(challb.uri for challb in challbs))
+        from acme.messages import OrderResource
+        orderr = OrderResource(uri="http://order1", body=body,
+                               csr_pem=b'test blob',
+                               authorizations=(authz,))
+        self.assertEqual(orderr,
+                         OrderResource.from_json(orderr.to_json()))
 
 class NewOrderTest(unittest.TestCase):
     """Tests for acme.messages.NewOrder."""

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* `acme.messages.OrderResource` now supports being round-tripped
+  through JSON
 
 ### Changed
 


### PR DESCRIPTION
Right now if you to_json() an `OrderResource` and later deserialize it, the `AuthorizationResource` objects don't come back through the round-trip (they just get de-jsonified as frozendicts and worse, they can't even be passed to `AuthorizationResource.from_json` because frozendicts aren't dicts). In addition, the `csr_pem` field gets encoded as an array of integers, which definitely does not get de-jsonified into what we want.

Fix these by adding an encoder to `authorizations` and encoder and decoder to `csr_pem`.

Fixes https://github.com/certbot/certbot/issues/9615

## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
