### PR TITLE
Increase stale frequency

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Update Stale Issues
 on:
   schedule:
-    # Run at midnight every night
-    - cron: '24 1 * * *'
+    # Run 24 minutes past the hour 4 times a day.
+    - cron: '24 */6 * * *'
 permissions:
   issues: write
 jobs:


### PR DESCRIPTION
I personally think this has been working well, however, as of writing this, [we still have 318 issues that can be marked as stale](https://github.com/certbot/certbot/issues?q=is%3Aissue+is%3Aopen+updated%3A%3C2022-03-23). Because the value of `operations-per-run` includes things like fetch operations, going through this backlog is going to take quite a while... See https://github.com/certbot/certbot/actions/runs/4496221273/jobs/7910677458#step:2:2289 and https://github.com/actions/stale#operations-per-run.

Increasing the frequency this runs should help us a bit. I chose this approach over bumping `operations-per-run` because it should result in updated issues getting the needs-update label removed more quickly which I think is nice.