### PR TITLE
logging: use logger.warning for DeprecatedArgumentAction

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -21,7 +21,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Deprecated flags were inadvertently not printing warnings since v1.16.0. This is now fixed.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -18,7 +18,6 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import Union
-import warnings
 
 import configargparse
 
@@ -455,7 +454,7 @@ class DeprecatedArgumentAction(argparse.Action):
     """Action to log a warning when an argument is used."""
     def __call__(self, unused1: Any, unused2: Any, unused3: Any,
                  option_string: Optional[str] = None) -> None:
-        warnings.warn("Use of %s is deprecated." % option_string, DeprecationWarning)
+        logger.warning("Use of %s is deprecated.", option_string)
 
 
 def add_deprecated_argument(add_argument: Callable[..., None], argument_name: str,

--- a/certbot/tests/util_test.py
+++ b/certbot/tests/util_test.py
@@ -351,19 +351,19 @@ class AddDeprecatedArgumentTest(unittest.TestCase):
 
     def test_warning_no_arg(self):
         self._call("--old-option", 0)
-        with mock.patch("warnings.warn") as mock_warn:
+        with mock.patch("certbot.util.logger.warning") as mock_warn:
             self.parser.parse_args(["--old-option"])
         assert mock_warn.call_count == 1
         assert "is deprecated" in mock_warn.call_args[0][0]
-        assert "--old-option" in mock_warn.call_args[0][0]
+        assert "--old-option" in mock_warn.call_args[0][1]
 
     def test_warning_with_arg(self):
         self._call("--old-option", 1)
-        with mock.patch("warnings.warn") as mock_warn:
+        with mock.patch("certbot.util.logger.warning") as mock_warn:
             self.parser.parse_args(["--old-option", "42"])
         assert mock_warn.call_count == 1
         assert "is deprecated" in mock_warn.call_args[0][0]
-        assert "--old-option" in mock_warn.call_args[0][0]
+        assert "--old-option" in mock_warn.call_args[0][1]
 
     def test_help(self):
         self._call("--old-option", 2)


### PR DESCRIPTION
This is part of fixing https://github.com/certbot/certbot/issues/9618. 

It does not have any effect until https://github.com/certbot/certbot/pull/9629 is merged.