### PR TITLE
avoid pyOpenSSL 23.1.0

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -8,7 +8,8 @@ version = '2.5.0.dev0'
 install_requires = [
     'cryptography>=2.5.0',
     'josepy>=1.13.0',
-    'PyOpenSSL>=17.5.0',
+    # pyOpenSSL 23.1.0 is a bad release: https://github.com/pyca/pyopenssl/issues/1199
+    'PyOpenSSL>=17.5.0,!=23.1.0',
     'pyrfc3339',
     'pytz>=2019.3',
     'requests>=2.20.0',

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -9,7 +9,8 @@ install_requires = [
     # https://github.com/certbot/certbot/issues/8761 for more info.
     f'acme>={version}',
     f'certbot>={version}',
-    'PyOpenSSL>=17.5.0',
+    # pyOpenSSL 23.1.0 is a bad release: https://github.com/pyca/pyopenssl/issues/1199
+    'PyOpenSSL>=17.5.0,!=23.1.0',
     'pyparsing>=2.2.1',
     'setuptools>=41.6.0',
 ]


### PR DESCRIPTION
Our `NO_PIN` test [fails](https://dev.azure.com/certbot/certbot/_build/results?buildId=6542&view=logs&j=ce03f7c1-1e3f-5d55-28be-f084e7c62a50&t=597fea95-d44e-53a2-5b71-76ed20bd4dde) due to https://github.com/pyca/pyopenssl/issues/1199.

This PR might strictly not be necessary once a new release of `PyOpenSSL` is available? I suppose it depends whether they yank the release.