### PR TITLE
fix: pem subject common name is not first domain provided

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -270,6 +270,7 @@ Authors
 * [Timothy Guan-tin Chien](https://github.com/timdream)
 * [Torsten Bögershausen](https://github.com/tboegi)
 * [Travis Raines](https://github.com/rainest)
+* [Trim21](https://github.com/trim21)
 * [Trung Ngo](https://github.com/Ngo-The-Trung)
 * [Valentin](https://github.com/e00E)
 * [venyii](https://github.com/venyii)

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -257,7 +257,7 @@ def make_csr(private_key_pem: bytes, domains: Optional[Union[Set[str], List[str]
             value=san_string
         ),
     ]
-    if domains and len(domains) > 0:
+    if domains:
         csr.get_subject().CN = list(domains)[0]
     if must_staple:
         extensions.append(crypto.X509Extension(

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -257,6 +257,8 @@ def make_csr(private_key_pem: bytes, domains: Optional[Union[Set[str], List[str]
             value=san_string
         ),
     ]
+    if len(domains) > 0:
+        csr.get_subject().CN = domains[0]
     if must_staple:
         extensions.append(crypto.X509Extension(
             b"1.3.6.1.5.5.7.1.24",

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -258,7 +258,7 @@ def make_csr(private_key_pem: bytes, domains: Optional[Union[Set[str], List[str]
         ),
     ]
     if len(domains) > 0:
-        csr.get_subject().CN = domains[0]
+        csr.get_subject().CN = list(domains)[0]
     if must_staple:
         extensions.append(crypto.X509Extension(
             b"1.3.6.1.5.5.7.1.24",

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -257,7 +257,7 @@ def make_csr(private_key_pem: bytes, domains: Optional[Union[Set[str], List[str]
             value=san_string
         ),
     ]
-    if len(domains) > 0:
+    if domains and len(domains) > 0:
         csr.get_subject().CN = list(domains)[0]
     if must_staple:
         extensions.append(crypto.X509Extension(

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fix certification subject common name is not first domain provided.
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [X] (bug fix, not needed) Add or update any documentation as needed to support the changes in this PR.
- [X] Include your name in `AUTHORS.md` if you like.

close https://github.com/certbot/certbot/issues/9661

follow what ss csr do:

https://github.com/certbot/certbot/blob/9aca4039b31b13b78c64cb1477bf7598976c0710/acme/acme/crypto_util.py#L403-L404

I'm not formaillier with certbot, don't know if it's the best way to fix this, I test it locally and it generated expected CN.

 I find previous issue https://github.com/certbot/certbot/issues/2904#issuecomment-215733228 and find this in v0.5.0

https://github.com/certbot/certbot/blob/7aa5edb2121da9280ee3a6f979c7802459fea2b7/letsencrypt/crypto_util.py#L111

but it got removed in this PR https://github.com/certbot/certbot/pull/4165