### PR TITLE
Update min cryptography to 3.2.1

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 version = '2.6.0.dev0'
 
 install_requires = [
-    'cryptography>=2.5.0',
+    'cryptography>=3.2.1',
     'josepy>=1.13.0',
     # pyOpenSSL 23.1.0 is a bad release: https://github.com/pyca/pyopenssl/issues/1199
     'PyOpenSSL>=17.5.0,!=23.1.0',

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     # in which we added 2.6 support (see #2243), so we relax the requirement.
     'ConfigArgParse>=0.9.3',
     'configobj>=5.0.6',
-    'cryptography>=2.5.0',
+    'cryptography>=3.2.1',
     'distro>=1.0.1',
     'josepy>=1.13.0',
     'parsedatetime>=2.4',


### PR DESCRIPTION
It looks like in https://github.com/certbot/certbot/pull/9110 we initially started to bump this to 2.5.0, changed our mind used 3.2.1, however, some code still references 2.5.0. This fixes that.