### PR TITLE
Increase stale operations per run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -41,5 +41,7 @@ jobs:
             should be reopened, please open a new issue with a link to this one and we'll
             take a look.
 
-          # Limit the number of actions per hour, from 1-30. Default is 30
+          # Limit the number of actions per run. As of writing this, GitHub's
+          # rate limit is 1000 requests per hour so we're still a ways off. See
+          # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions.
           operations-per-run: 120

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Update Stale Issues
 on:
   schedule:
-    # Run 24 minutes past the hour 4 times a day.
-    - cron: '24 */6 * * *'
+    # Run 1:24AM every night
+    - cron: '24 1 * * *'
 permissions:
   issues: write
 jobs:
@@ -42,4 +42,4 @@ jobs:
             take a look.
 
           # Limit the number of actions per hour, from 1-30. Default is 30
-          operations-per-run: 30
+          operations-per-run: 120


### PR DESCRIPTION
This undoes https://github.com/certbot/certbot/pull/9624 and instead of increasing how often it runs fourfold, it increases the number of operations per run fourfold. I opened this because some of our stale runs are running out of operations before they have a chance to do anything. See https://github.com/certbot/certbot/actions/runs/4657461177/jobs/8242079084#step:2:2363 for example. There's more information about changes like this at https://github.com/certbot/certbot/pull/9624.