### PR TITLE
types: CredentialsConfiguration.conf can return None

### DIFF
--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/dns_digitalocean.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 import digitalocean
@@ -56,7 +57,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_digitalocean_client(self) -> "_DigitalOceanClient":
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        return _DigitalOceanClient(self.credentials.conf('token'))
+        return _DigitalOceanClient(cast(str, self.credentials.conf('token')))
 
 
 class _DigitalOceanClient:

--- a/certbot-dns-dnsimple/certbot_dns_dnsimple/_internal/dns_dnsimple.py
+++ b/certbot-dns-dnsimple/certbot_dns_dnsimple/_internal/dns_dnsimple.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 from lexicon.providers import dnsimple
@@ -58,7 +59,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_dnsimple_client(self) -> "_DNSimpleLexiconClient":
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        return _DNSimpleLexiconClient(self.credentials.conf('token'), self.ttl)
+        return _DNSimpleLexiconClient(cast(str, self.credentials.conf('token')), self.ttl)
 
 
 class _DNSimpleLexiconClient(dns_common_lexicon.LexiconClient):

--- a/certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy/_internal/dns_dnsmadeeasy.py
+++ b/certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy/_internal/dns_dnsmadeeasy.py
@@ -63,8 +63,8 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_dnsmadeeasy_client(self) -> "_DNSMadeEasyLexiconClient":
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        return _DNSMadeEasyLexiconClient(cast(str,self.credentials.conf('api-key')),
-                                         cast(str,self.credentials.conf('secret-key')),
+        return _DNSMadeEasyLexiconClient(cast(str, self.credentials.conf('api-key')),
+                                         cast(str, self.credentials.conf('secret-key')),
                                          self.ttl)
 
 

--- a/certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy/_internal/dns_dnsmadeeasy.py
+++ b/certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy/_internal/dns_dnsmadeeasy.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 from lexicon.providers import dnsmadeeasy
@@ -62,8 +63,8 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_dnsmadeeasy_client(self) -> "_DNSMadeEasyLexiconClient":
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        return _DNSMadeEasyLexiconClient(self.credentials.conf('api-key'),
-                                         self.credentials.conf('secret-key'),
+        return _DNSMadeEasyLexiconClient(cast(str,self.credentials.conf('api-key')),
+                                         cast(str,self.credentials.conf('secret-key')),
                                          self.ttl)
 
 

--- a/certbot-dns-gehirn/certbot_dns_gehirn/_internal/dns_gehirn.py
+++ b/certbot-dns-gehirn/certbot_dns_gehirn/_internal/dns_gehirn.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 from lexicon.providers import gehirn
@@ -64,8 +65,8 @@ class Authenticator(dns_common.DNSAuthenticator):
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
         return _GehirnLexiconClient(
-            self.credentials.conf('api-token'),
-            self.credentials.conf('api-secret'),
+            cast(str,self.credentials.conf('api-token')),
+            cast(str,self.credentials.conf('api-secret')),
             self.ttl
         )
 

--- a/certbot-dns-gehirn/certbot_dns_gehirn/_internal/dns_gehirn.py
+++ b/certbot-dns-gehirn/certbot_dns_gehirn/_internal/dns_gehirn.py
@@ -65,8 +65,8 @@ class Authenticator(dns_common.DNSAuthenticator):
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
         return _GehirnLexiconClient(
-            cast(str,self.credentials.conf('api-token')),
-            cast(str,self.credentials.conf('api-secret')),
+            cast(str, self.credentials.conf('api-token')),
+            cast(str, self.credentials.conf('api-secret')),
             self.ttl
         )
 

--- a/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
@@ -62,7 +62,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_linode_client(self) -> '_LinodeLexiconClient':
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        api_key = cast(str,self.credentials.conf('key'))
+        api_key = cast(str, self.credentials.conf('key'))
         api_version: Optional[Union[str, int]] = self.credentials.conf('version')
         if api_version == '':
             api_version = None

--- a/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
@@ -3,6 +3,7 @@ import logging
 import re
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 from typing import Union
 
@@ -61,7 +62,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_linode_client(self) -> '_LinodeLexiconClient':
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        api_key = self.credentials.conf('key')
+        api_key = cast(str,self.credentials.conf('key'))
         api_version: Optional[Union[str, int]] = self.credentials.conf('version')
         if api_version == '':
             api_version = None

--- a/certbot-dns-luadns/certbot_dns_luadns/_internal/dns_luadns.py
+++ b/certbot-dns-luadns/certbot_dns_luadns/_internal/dns_luadns.py
@@ -60,8 +60,8 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_luadns_client(self) -> "_LuaDNSLexiconClient":
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        return _LuaDNSLexiconClient(cast(str,self.credentials.conf('email')),
-                                    cast(str,self.credentials.conf('token')),
+        return _LuaDNSLexiconClient(cast(str, self.credentials.conf('email')),
+                                    cast(str, self.credentials.conf('token')),
                                     self.ttl)
 
 

--- a/certbot-dns-luadns/certbot_dns_luadns/_internal/dns_luadns.py
+++ b/certbot-dns-luadns/certbot_dns_luadns/_internal/dns_luadns.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 from lexicon.providers import luadns
@@ -59,8 +60,8 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_luadns_client(self) -> "_LuaDNSLexiconClient":
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        return _LuaDNSLexiconClient(self.credentials.conf('email'),
-                                    self.credentials.conf('token'),
+        return _LuaDNSLexiconClient(cast(str,self.credentials.conf('email')),
+                                    cast(str,self.credentials.conf('token')),
                                     self.ttl)
 
 

--- a/certbot-dns-nsone/certbot_dns_nsone/_internal/dns_nsone.py
+++ b/certbot-dns-nsone/certbot_dns_nsone/_internal/dns_nsone.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 from lexicon.providers import nsone
@@ -58,7 +59,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_nsone_client(self) -> "_NS1LexiconClient":
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        return _NS1LexiconClient(self.credentials.conf('api-key'), self.ttl)
+        return _NS1LexiconClient(cast(str, self.credentials.conf('api-key')), self.ttl)
 
 
 class _NS1LexiconClient(dns_common_lexicon.LexiconClient):

--- a/certbot-dns-ovh/certbot_dns_ovh/_internal/dns_ovh.py
+++ b/certbot-dns-ovh/certbot_dns_ovh/_internal/dns_ovh.py
@@ -67,9 +67,9 @@ class Authenticator(dns_common.DNSAuthenticator):
             raise errors.Error("Plugin has not been prepared.")
         return _OVHLexiconClient(
             cast(str, self.credentials.conf('endpoint')),
-            cast(str,self.credentials.conf('application-key')),
-            cast(str,self.credentials.conf('application-secret')),
-            cast(str,self.credentials.conf('consumer-key')),
+            cast(str, self.credentials.conf('application-key')),
+            cast(str, self.credentials.conf('application-secret')),
+            cast(str, self.credentials.conf('consumer-key')),
             self.ttl
         )
 

--- a/certbot-dns-ovh/certbot_dns_ovh/_internal/dns_ovh.py
+++ b/certbot-dns-ovh/certbot_dns_ovh/_internal/dns_ovh.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 from lexicon.providers import ovh
@@ -65,10 +66,10 @@ class Authenticator(dns_common.DNSAuthenticator):
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
         return _OVHLexiconClient(
-            self.credentials.conf('endpoint'),
-            self.credentials.conf('application-key'),
-            self.credentials.conf('application-secret'),
-            self.credentials.conf('consumer-key'),
+            cast(str, self.credentials.conf('endpoint')),
+            cast(str,self.credentials.conf('application-key')),
+            cast(str,self.credentials.conf('application-secret')),
+            cast(str,self.credentials.conf('consumer-key')),
             self.ttl
         )
 

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/dns_rfc2136.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/dns_rfc2136.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 import dns.flags
@@ -59,7 +60,7 @@ class Authenticator(dns_common.DNSAuthenticator):
                'RFC 2136 Dynamic Updates.'
 
     def _validate_credentials(self, credentials: CredentialsConfiguration) -> None:
-        server = credentials.conf('server')
+        server = cast(str, credentials.conf('server'))
         if not is_ipaddress(server):
             raise errors.PluginError("The configured target DNS server ({0}) is not a valid IPv4 "
                                      "or IPv6 address. A hostname is not allowed.".format(server))
@@ -89,11 +90,11 @@ class Authenticator(dns_common.DNSAuthenticator):
     def _get_rfc2136_client(self) -> "_RFC2136Client":
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
-        return _RFC2136Client(self.credentials.conf('server'),
-                              int(self.credentials.conf('port') or self.PORT),
-                              self.credentials.conf('name'),
-                              self.credentials.conf('secret'),
-                              self.ALGORITHMS.get(self.credentials.conf('algorithm'),
+        return _RFC2136Client(cast(str, self.credentials.conf('server')),
+                              int(cast(str, self.credentials.conf('port')) or self.PORT),
+                              cast(str, self.credentials.conf('name')),
+                              cast(str, self.credentials.conf('secret')),
+                              self.ALGORITHMS.get(self.credentials.conf('algorithm') or '',
                                                   dns.tsig.HMAC_MD5))
 
 

--- a/certbot-dns-sakuracloud/certbot_dns_sakuracloud/_internal/dns_sakuracloud.py
+++ b/certbot-dns-sakuracloud/certbot_dns_sakuracloud/_internal/dns_sakuracloud.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Optional
 
 from lexicon.providers import sakuracloud
@@ -64,8 +65,8 @@ class Authenticator(dns_common.DNSAuthenticator):
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
         return _SakuraCloudLexiconClient(
-            self.credentials.conf('api-token'),
-            self.credentials.conf('api-secret'),
+            cast(str, self.credentials.conf('api-token')),
+            cast(str, self.credentials.conf('api-secret')),
             self.ttl
         )
 

--- a/certbot/certbot/plugins/dns_common.py
+++ b/certbot/certbot/plugins/dns_common.py
@@ -316,8 +316,8 @@ class CredentialsConfiguration:
         """Find a configuration value for variable `var`, as transformed by `mapper`.
 
         :param str var: The variable to get.
-        :returns: The value of the variable.
-        :rtype: str
+        :returns: The value of the variable, if it exists.
+        :rtype: str or None
         """
 
         return self._get(var)

--- a/certbot/certbot/plugins/dns_common.py
+++ b/certbot/certbot/plugins/dns_common.py
@@ -312,7 +312,7 @@ class CredentialsConfiguration:
                     )
             )
 
-    def conf(self, var: str) -> str:
+    def conf(self, var: str) -> Optional[str]:
         """Find a configuration value for variable `var`, as transformed by `mapper`.
 
         :param str var: The variable to get.
@@ -325,7 +325,7 @@ class CredentialsConfiguration:
     def _has(self, var: str) -> bool:
         return self.mapper(var) in self.confobj
 
-    def _get(self, var: str) -> str:
+    def _get(self, var: str) -> Optional[str]:
         return self.confobj.get(self.mapper(var))
 
 


### PR DESCRIPTION
While reviewing a PR, I noticed a potential crash that should have been caught by mypy, but wasn't.

I think the use of `cast` in this change is unfortunate in that there isn't a way, with the types we have, to represent a required/validated option, versus one which is optional. I don't think we can do much about that without changing the DNS plugin public API.

Even so, I think it's better to have the code smell of `cast` around, rather than a false sense of security. At least it should trigger a more careful look for reviewers of such code.