### PR TITLE
Support unknown ACME challenge types

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -220,6 +220,7 @@ Authors
 * [Piotr Kasprzyk](https://github.com/kwadrat)
 * [Prayag Verma](https://github.com/pra85)
 * [Preston Locke](https://github.com/Preston12321)
+* [Q Misell][https://magicalcodewit.ch]
 * [Rasesh Patel](https://github.com/raspat1)
 * [Reinaldo de Souza Jr](https://github.com/juniorz)
 * [Remi Rampin](https://github.com/remram44)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* There is now a new `Other` annotated challenge object to allow plugins to support entirely novel challenges.
 
 ### Changed
 

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -384,7 +384,8 @@ def challb_to_achall(challb: messages.ChallengeBody, account_key: josepy.JWK,
             challb=challb, domain=domain, account_key=account_key)
     elif isinstance(chall, challenges.DNS):
         return achallenges.DNS(challb=challb, domain=domain)
-    raise errors.Error(f"Received unsupported challenge of type: {chall.typ}")
+    else:
+        return achallenges.Other(challb=challb, domain=domain)
 
 
 def gen_challenge_path(challbs: List[messages.ChallengeBody],

--- a/certbot/certbot/achallenges.py
+++ b/certbot/certbot/achallenges.py
@@ -59,3 +59,9 @@ class DNS(AnnotatedChallenge):
     """Client annotated "dns" ACME challenge."""
     __slots__ = ('challb', 'domain') # pylint: disable=redefined-slots-in-subclass
     acme_type = challenges.DNS
+
+
+class Other(AnnotatedChallenge):
+    """Client annotated ACME challenge of an unknown type."""
+    __slots__ = ('challb', 'domain') # pylint: disable=redefined-slots-in-subclass
+    acme_type = challenges.Challenge


### PR DESCRIPTION
This is, to my knowledge, an entirely inconsequential PR to add support for entirely novel challenge types.

Presently in the [`challb_to_achall` function](https://github.com/certbot/certbot/blob/399b932a869403b142fb0271aec510614085d6ed/certbot/certbot/_internal/auth_handler.py#L367) if the challenge type is not of a type known to certbot an error is thrown. This check is mostly pointless as an authenticator would not request a challenge unknown to it. This check does however forbid any plugins from supporting entirely novel challenges not of the key authorisation form.

My motivation for this is work on [draft-misell-acme-onion](https://datatracker.ietf.org/doc/draft-misell-acme-onion/), to support ACME for onion hidden services. This draft standard includes support for a challenge based on signing a CSR with the service's onion key. This was the only incompatibly in certbot I came across in implementing this draft as a plugin.

I think merging this would make sense, not just for this draft standard,  but any future extension to ACME (standardised, or custom for a specific purpose) that certbot plugin developers may wish to support.

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
