### PR TITLE
docs: clarify --dry-run documentation

### DIFF
--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -149,16 +149,12 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
         [None, "testing", "renew", "certonly"],
         "--dry-run", action="store_true", dest="dry_run",
         default=flag_default("dry_run"),
-        help="Perform a test run of the client, obtaining test (invalid) certificates"
-             " but not saving them to disk. This can currently only be used"
-             " with the 'certonly' and 'renew' subcommands. \nNote: Although --dry-run"
-             " tries to avoid making any persistent changes on a system, it "
-             " is not completely side-effect free: if used with webserver authenticator plugins"
-             " like apache and nginx, it makes and then reverts temporary config changes"
-             " in order to obtain test certificates, and reloads webservers to deploy and then"
-             " roll back those changes.  It also calls --pre-hook and --post-hook commands"
-             " if they are defined because they may be necessary to accurately simulate"
-             " renewal. --deploy-hook commands are not called.")
+        help="Perform a test run against the Let's Encrypt staging server, obtaining test"
+             " (invalid) certificates but not saving them to disk. This can only be used with the"
+             " 'certonly' and 'renew' subcommands."
+             " --pre-hook and --post-hook commands run by default."
+             " --deploy-hook commands do not run, unless enabled by --run-deploy-hooks."
+             " The test server may be overridden with --server.")
     helpful.add(
         ["testing", "renew", "certonly", "reconfigure"],
         "--run-deploy-hooks", action="store_true", dest="run_deploy_hooks",
@@ -270,8 +266,8 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
     # overwrites server, handled in HelpfulArgumentParser.parse_args()
     helpful.add(["testing", "revoke", "run"], "--test-cert", "--staging",
         dest="staging", action="store_true", default=flag_default("staging"),
-        help="Use the staging server to obtain or revoke test (invalid) certificates; equivalent"
-             " to --server " + constants.STAGING_URI)
+        help="Use the Let's Encrypt staging server to obtain or revoke test (invalid) "
+             "certificates; equivalent to --server " + constants.STAGING_URI)
     helpful.add(
         "testing", "--debug", action="store_true", default=flag_default("debug"),
         help="Show tracebacks in case of errors")

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -151,7 +151,8 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
         default=flag_default("dry_run"),
         help="Perform a test run against the Let's Encrypt staging server, obtaining test"
              " (invalid) certificates but not saving them to disk. This can only be used with the"
-             " 'certonly' and 'renew' subcommands."
+             " 'certonly' and 'renew' subcommands. It may trigger webserver reloads to "
+             " temporarily modify & roll back configuration files."
              " --pre-hook and --post-hook commands run by default."
              " --deploy-hook commands do not run, unless enabled by --run-deploy-hooks."
              " The test server may be overridden with --server.")

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -1097,14 +1097,6 @@ can use the `REQUESTS_CA_BUNDLE
 environment variable to override the root certificates trusted by Certbot. Certbot
 uses the ``requests`` library, which does not use the operating system trusted root store.
 
-If you use ``--server`` to specify an ACME CA that implements the standardized
-version of the spec, you may be able to obtain a certificate for a
-wildcard domain. Some CAs (such as Let's Encrypt) require that domain
-validation for wildcard domains must be done through modifications to
-DNS records which means that the dns-01_ challenge type must be used. To
-see a list of Certbot plugins that support this challenge type and how
-to use them, see plugins_.
-
 Lock Files
 ==========
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -1091,11 +1091,19 @@ ACME directory. For example, if you would like to use Let's Encrypt's
 staging server, you would add ``--server
 https://acme-staging-v02.api.letsencrypt.org/directory`` to the command line.
 
+.. note:: ``--dry-run`` uses the Let's Encrypt staging server, unless ``--server``
+   is specified on the CLI or in the :ref:`cli.ini configuration file <config-file>`.
+   Take caution when using ``--dry-run`` with a custom server, as it may cause real
+   certificates to be issued and discarded.
+
 If Certbot does not trust the SSL certificate used by the ACME server, you
 can use the `REQUESTS_CA_BUNDLE
 <https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification>`_
 environment variable to override the root certificates trusted by Certbot. Certbot
 uses the ``requests`` library, which does not use the operating system trusted root store.
+Make sure that ``REQUESTS_CA_BUNDLE`` is set globally in the environment and not only on
+the CLI, or scheduled renewal will not succeed.
+
 
 Lock Files
 ==========


### PR DESCRIPTION
Fixes #9679.

----

1\. `--dry-run` help text has changed from:

    --dry-run             Perform a test run of the client, obtaining test
                          (invalid) certificates but not saving them to disk.
                          This can currently only be used with the 'certonly'
                          and 'renew' subcommands. Note: Although --dry-run
                          tries to avoid making any persistent changes on a
                          system, it is not completely side-effect free: if used
                          with webserver authenticator plugins like apache and
                          nginx, it makes and then reverts temporary config
                          changes in order to obtain test certificates, and
                          reloads webservers to deploy and then roll back those
                          changes. It also calls --pre-hook and --post-hook
                          commands if they are defined because they may be
                          necessary to accurately simulate renewal. --deploy-
                          hook commands are not called. (default: False)

to:

    --dry-run             Perform a test run against the Let's Encrypt staging
                          server, obtaining test (invalid) certificates but not
                          saving them to disk. This can only be used with the
                          'certonly' and 'renew' subcommands. --pre-hook and
                          --post-hook commands run by default. --deploy-hook
                          commands do not run, unless enabled by --run-deploy-
                          hooks. The test server may be overridden with
                          --server. (default: False)

It would have been good to have kept the bits about side-effects, but it did feel too long and written from a defensive developer perspective rather than a user one. I'm not sure. This is where I landed, but happy to have my mind changed.

2\. User Guide added the note about `--dry-run`,  mentioned a footgun around `REQUESTS_CA_BUNDLE` and removed a strange paragraph about wildcards:

<img width="726" alt="image" src="https://user-images.githubusercontent.com/311534/233812342-bda304c6-0e6a-422f-bb90-3076f09b7291.png">

