### PR TITLE
dns-rfc2136: add test coverage for PR #9672

### DIFF
--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py
@@ -43,7 +43,7 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         self.orig_get_client = self.auth._get_rfc2136_client
         self.auth._get_rfc2136_client = mock.MagicMock(return_value=self.mock_client)
 
-    def test_get_client(self):
+    def test_get_client_default_conf_values(self):
         # algorithm and sign_query are intentionally absent to test that the default (None)
         # value does not crash Certbot.
         creds = { "server": SERVER, "port": PORT, "name": NAME, "secret": SECRET }

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py
@@ -49,7 +49,9 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         creds = { "server": SERVER, "port": PORT, "name": NAME, "secret": SECRET }
         self.auth.credentials = mock.MagicMock()
         self.auth.credentials.conf = lambda key: creds.get(key, None)
-        self.orig_get_client()
+        client = self.orig_get_client()
+        assert client.algorithm == self.auth.ALGORITHMS["HMAC-MD5"]
+        assert client.sign_query == False
 
     @test_util.patch_display_util()
     def test_perform(self, unused_mock_get_utility):
@@ -186,16 +188,17 @@ class RFC2136ClientTest(unittest.TestCase):
             self.rfc2136_client._find_domain('foo.bar.'+DOMAIN)
 
     @mock.patch("dns.query.tcp")
-    @mock.patch("dns.message.QueryMessage.use_tsig")
-    def test_query_soa_found(self, mock_use_tsig, query_mock):
+    @mock.patch("dns.message.make_query")
+    def test_query_soa_found(self, mock_make_query, query_mock):
         query_mock.return_value = mock.MagicMock(answer=[mock.MagicMock()], flags=dns.flags.AA)
         query_mock.return_value.rcode.return_value = dns.rcode.NOERROR
+        mock_make_query.return_value = mock.MagicMock()
 
         # _query_soa | pylint: disable=protected-access
         result = self.rfc2136_client._query_soa(DOMAIN)
 
         query_mock.assert_called_with(mock.ANY, SERVER, TIMEOUT, PORT)
-        mock_use_tsig.assert_not_called()
+        mock_make_query.return_value.use_tsig.assert_not_called()
         assert result
 
     @mock.patch("dns.query.tcp")
@@ -230,14 +233,15 @@ class RFC2136ClientTest(unittest.TestCase):
         assert result
 
     @mock.patch("dns.query.tcp")
-    @mock.patch("dns.message.QueryMessage.use_tsig")
-    def test_query_soa_signed(self, mock_use_tsig, unused_mock_query):
+    @mock.patch("dns.message.make_query")
+    def test_query_soa_signed(self, mock_make_query, unused_mock_query):
+        mock_make_query.return_value = mock.MagicMock()
         self.rfc2136_client.sign_query = True
         self.rfc2136_client.algorithm = "alg0"
 
         self.rfc2136_client._query_soa(DOMAIN)
 
-        mock_use_tsig.assert_called_with(mock.ANY, algorithm="alg0")
+        mock_make_query.return_value.use_tsig.assert_called_with(mock.ANY, algorithm="alg0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I noticed slightly too late that the unit tests were not updated during #9672. Here is some test coverage for the changes.