### PR TITLE
Bump stale limit

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -44,4 +44,4 @@ jobs:
           # Limit the number of actions per run. As of writing this, GitHub's
           # rate limit is 1000 requests per hour so we're still a ways off. See
           # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions.
-          operations-per-run: 120
+          operations-per-run: 180


### PR DESCRIPTION
Our stale bot has been running out of operations again. See https://github.com/certbot/certbot/actions/runs/4910536559/jobs/8767791030#step:2:4452.

I increased this by 60 instead of [the 90 I did last time](https://github.com/certbot/certbot/pull/9668) because I felt like that flooded my inbox with stale e-mails for awhile.