### PR TITLE
route53: add support to override default AWS_ENDPOINT_URL

### DIFF
--- a/certbot-dns-route53/README.rst
+++ b/certbot-dns-route53/README.rst
@@ -1,1 +1,7 @@
 Amazon Web Services Route 53 DNS Authenticator plugin for Certbot
+
+To override API endpoint URL, set environment variable `AWS_ENDPOINT_URL` to a desired value.
+
+.. code-block::
+
+   export AWS_ENDPOINT_URL=https://route53.example.com/

--- a/certbot-dns-route53/certbot_dns_route53/_internal/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/_internal/dns_route53.py
@@ -16,6 +16,7 @@ from acme.challenges import ChallengeResponse
 from certbot import achallenges
 from certbot import errors
 from certbot.achallenges import AnnotatedChallenge
+from certbot.compat import os
 from certbot.plugins import dns_common
 from certbot.util import add_deprecated_argument
 
@@ -40,7 +41,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.r53 = boto3.client("route53")
+        self.r53 = boto3.client("route53", endpoint_url=os.getenv("AWS_ENDPOINT_URL"))
         self._resource_records: DefaultDict[str, List[Dict[str, str]]] = \
             collections.defaultdict(list)
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* `certbot-dns-route53` now supports API endpoint URL overriding.  This can be used for cloud platforms,
+  which provide AWS Route53-compatible API.  See `certbot-dns-route53` README for more details.
 
 ### Changed
 


### PR DESCRIPTION
This could be useful if certbot is used against non-Amazon cloud, which supports Route53 API.