### PR TITLE
docker: Add proper entrypoint

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Docker container now adheres to consistency guidelines without forcing
+  `--entrypoint` overrides.
 
 ### Fixed
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,7 +1,8 @@
-#base image 
+#base image
 FROM python:3.10-alpine3.16 as certbot
 
-ENTRYPOINT [ "certbot" ]
+COPY "./container-entrypoint.sh" "/init"
+ENTRYPOINT [ "/init" ]
 EXPOSE 80 443
 VOLUME /etc/letsencrypt /var/lib/letsencrypt
 WORKDIR /opt/certbot

--- a/tools/docker/container-entrypoint.sh
+++ b/tools/docker/container-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2023 Olliver Schinagl <oliver@schinagl.nl>
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -le 0 ] || \
+   [ "${1#-}" != "${1}" ] || \
+   [ -d "${1}" ] || \
+   ! command -v "${1}" > '/dev/null' 2>&1; then
+	bin='certbot'
+fi
+
+exec ${bin:+${bin}} "${@}"
+
+exit 0


### PR DESCRIPTION
As per docker guidelines [0] a container should always really have a consistent entrypoint, without having to override it or do special tricks.

The behavior should be _identical_ as before, but will no longer trigger errors because certbot doesn't understand certain parameters (/bin/sh for example being common). Further more, allows a proper entrypoint for a CI to work easily with the container as well. Allowing for scenario's such as `apk add git && certbot renew` in your certbot image for example.

E.g. `docker run certbot --help` works, as does `docker run certbot /bin/sh` or `docker run certbot ls`.

[0]: https://github.com/docker-library/official-images#consistency