### PR TITLE
Update GitHub repo location letsencrypt -> certbot

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -31,7 +31,7 @@ setup(
     name='acme',
     version=version,
     description='ACME protocol implementation in Python',
-    url='https://github.com/letsencrypt/letsencrypt',
+    url='https://github.com/certbot/certbot',
     author="Certbot Project",
     author_email='certbot-dev@eff.org',
     license='Apache License 2.0',

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -25,7 +25,7 @@ setup(
     name='certbot-apache',
     version=version,
     description="Apache plugin for Certbot",
-    url='https://github.com/letsencrypt/letsencrypt',
+    url='https://github.com/certbot/certbot',
     author="Certbot Project",
     author_email='certbot-dev@eff.org',
     license='Apache License 2.0',

--- a/certbot-compatibility-test/setup.py
+++ b/certbot-compatibility-test/setup.py
@@ -14,7 +14,7 @@ setup(
     name='certbot-compatibility-test',
     version=version,
     description="Compatibility tests for Certbot",
-    url='https://github.com/letsencrypt/letsencrypt',
+    url='https://github.com/certbot/certbot',
     author="Certbot Project",
     author_email='certbot-dev@eff.org',
     license='Apache License 2.0',

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -23,7 +23,7 @@ setup(
     name='certbot-nginx',
     version=version,
     description="Nginx plugin for Certbot",
-    url='https://github.com/letsencrypt/letsencrypt',
+    url='https://github.com/certbot/certbot',
     author="Certbot Project",
     author_email='certbot-dev@eff.org',
     license='Apache License 2.0',

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -2794,7 +2794,7 @@ by default, these files can be used to control what parameters are
 used when renewing a specific certificate.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/letsencrypt/letsencrypt/issues?q=milestone%3A0.5.0+is%3Aissue
+https://github.com/certbot/certbot/issues?q=milestone%3A0.5.0+is%3Aissue
 
 ## 0.4.2 - 2016-03-03
 
@@ -2806,7 +2806,7 @@ against the new OpenSSL release.
 from the private beta.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.4.2
+https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.4.2
 
 ## 0.4.1 - 2016-02-29
 
@@ -2818,7 +2818,7 @@ https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.4.2
 * Fixed problems with parsing renewal config files from private beta.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/letsencrypt/letsencrypt/issues?q=is:issue+milestone:0.4.1
+https://github.com/certbot/certbot/issues?q=is:issue+milestone:0.4.1
 
 ## 0.4.0 - 2016-02-10
 
@@ -2843,7 +2843,7 @@ stability, security, and performance of the script.
 * Added support for Apache 2.2 to the Apache plugin.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.4.0
+https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.4.0
 
 ## 0.3.0 - 2016-01-27
 
@@ -2858,7 +2858,7 @@ security of letsencrypt-auto. A number of changes landed in this
 release to prepare for the new version of this script.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.3.0
+https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.3.0
 
 ## 0.2.0 - 2016-01-14
 
@@ -2878,7 +2878,7 @@ with PyOpenSSL versions 0.13 or 0.14.
 redirect on some systems.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.2.0
+https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.2.0
 
 ## 0.1.1 - 2015-12-15
 
@@ -2896,4 +2896,4 @@ issuance rate limits.
 * Fixed --webroot permission handling for non-root users
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/letsencrypt/letsencrypt/issues?q=milestone%3A0.1.1
+https://github.com/certbot/certbot/issues?q=milestone%3A0.1.1

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -2794,7 +2794,7 @@ by default, these files can be used to control what parameters are
 used when renewing a specific certificate.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/certbot/certbot/issues?q=milestone%3A0.5.0+is%3Aissue
+https://github.com/letsencrypt/letsencrypt/issues?q=milestone%3A0.5.0+is%3Aissue
 
 ## 0.4.2 - 2016-03-03
 
@@ -2806,7 +2806,7 @@ against the new OpenSSL release.
 from the private beta.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.4.2
+https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.4.2
 
 ## 0.4.1 - 2016-02-29
 
@@ -2818,7 +2818,7 @@ https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.4.2
 * Fixed problems with parsing renewal config files from private beta.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/certbot/certbot/issues?q=is:issue+milestone:0.4.1
+https://github.com/letsencrypt/letsencrypt/issues?q=is:issue+milestone:0.4.1
 
 ## 0.4.0 - 2016-02-10
 
@@ -2843,7 +2843,7 @@ stability, security, and performance of the script.
 * Added support for Apache 2.2 to the Apache plugin.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.4.0
+https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.4.0
 
 ## 0.3.0 - 2016-01-27
 
@@ -2858,7 +2858,7 @@ security of letsencrypt-auto. A number of changes landed in this
 release to prepare for the new version of this script.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.3.0
+https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.3.0
 
 ## 0.2.0 - 2016-01-14
 
@@ -2878,7 +2878,7 @@ with PyOpenSSL versions 0.13 or 0.14.
 redirect on some systems.
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/certbot/certbot/issues?q=is%3Aissue+milestone%3A0.2.0
+https://github.com/letsencrypt/letsencrypt/issues?q=is%3Aissue+milestone%3A0.2.0
 
 ## 0.1.1 - 2015-12-15
 
@@ -2896,4 +2896,4 @@ issuance rate limits.
 * Fixed --webroot permission handling for non-root users
 
 More details about these changes can be found on our GitHub repo:
-https://github.com/certbot/certbot/issues?q=milestone%3A0.1.1
+https://github.com/letsencrypt/letsencrypt/issues?q=milestone%3A0.1.1

--- a/certbot/certbot/_internal/tests/main_test.py
+++ b/certbot/certbot/_internal/tests/main_test.py
@@ -1110,7 +1110,7 @@ class MainTest(test_util.ConfigTestCase):
 
         # This needed two calls to find_all(), which we're avoiding for now
         # because of possible side effects:
-        # https://github.com/letsencrypt/letsencrypt/commit/51ed2b681f87b1eb29088dd48718a54f401e4855
+        # https://github.com/certbot/certbot/commit/51ed2b681f87b1eb29088dd48718a54f401e4855
         # with mock.patch('certbot._internal.cli.plugins_testable') as plugins:
         #    plugins.return_value = {"apache": True, "nginx": True}
         #    ret, _, _, _ = self._call(args)

--- a/certbot/certbot/configuration.py
+++ b/certbot/certbot/configuration.py
@@ -399,7 +399,6 @@ class NamespaceConfig:
 
     def __deepcopy__(self, _memo: Any) -> 'NamespaceConfig':
         # Work around https://bugs.python.org/issue1515 for py26 tests :( :(
-        # https://travis-ci.org/letsencrypt/letsencrypt/jobs/106900743#L3276
         new_ns = copy.deepcopy(self.namespace)
         new_sources = copy.deepcopy(self.argument_sources)
         return type(self)(new_ns, new_sources)

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -117,7 +117,7 @@ setup(
     version=version,
     description="ACME client",
     long_description=readme,
-    url='https://github.com/letsencrypt/letsencrypt',
+    url='https://github.com/certbot/certbot',
     author="Certbot Project",
     author_email='certbot-dev@eff.org',
     license='Apache License 2.0',

--- a/letstest/README.md
+++ b/letstest/README.md
@@ -50,4 +50,4 @@ See:
 - https://docs.aws.amazon.com/cli/latest/userguide/cli-ec2-keypairs.html
 
 Main repos:
-- https://github.com/letsencrypt/letsencrypt
+- https://github.com/certbot/certbot

--- a/letstest/letstest/multitester.py
+++ b/letstest/letstest/multitester.py
@@ -58,17 +58,17 @@ parser.add_argument('test_script',
                     default='test_apache2.sh',
                     help='path of bash script in to deploy and run')
 parser.add_argument('--repo',
-                    default='https://github.com/letsencrypt/letsencrypt.git',
+                    default='https://github.com/certbot/certbot.git',
                     help='certbot git repo to use')
 parser.add_argument('--branch',
                     default='~',
                     help='certbot git branch to trial')
 parser.add_argument('--pull_request',
                     default='~',
-                    help='letsencrypt/letsencrypt pull request to trial')
+                    help='certbot/certbot pull request to trial')
 parser.add_argument('--merge_master',
                     action='store_true',
-                    help="if set merges PR into master branch of letsencrypt/letsencrypt")
+                    help="if set merges PR into master branch of certbot/certbot")
 parser.add_argument('--saveinstances',
                     action='store_true',
                     help="don't kill EC2 instances after run, useful for debugging")

--- a/windows-installer/setup.py
+++ b/windows-installer/setup.py
@@ -7,7 +7,7 @@ setup(
     name='windows-installer',
     version=version,
     description='Environment to build the Certbot Windows installer',
-    url='https://github.com/letsencrypt/letsencrypt',
+    url='https://github.com/certbot/certbot',
     author="Certbot Project",
     author_email='certbot-dev@eff.org',
     license='Apache License 2.0',


### PR DESCRIPTION
Fixes #8082

The references to `letsencrypt/letsencrypt` that are left are the location of the logs (`/var/log/letsencrypt/letsencrypt.log`).

I don't think this requires a changelog entry, there is no change in behavior and the links ultimately point to the same place (they just read correct and don't rely on GitHub redirecting).

## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- ~~Include your name in `AUTHORS.md` if you like.~~