### PR TITLE
Remove workaround that's not relevant since py2 isn't supported

### DIFF
--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -14,14 +14,6 @@ min_setuptools_version='41.6.0'
 if parse_version(setuptools_version) < parse_version(min_setuptools_version):
     raise RuntimeError(f'setuptools {min_setuptools_version}+ is required')
 
-# Workaround for https://bugs.python.org/issue8876, see
-# https://bugs.python.org/issue8876#msg208792
-# This can be removed when using Python 2.7.9 or later:
-# https://hg.python.org/cpython/raw-file/v2.7.9/Misc/NEWS
-if os.path.abspath(__file__).split(os.path.sep)[1] == 'vagrant':
-    del os.link
-
-
 def read_file(filename, encoding='utf8'):
     """Read unicode from given file."""
     with codecs.open(filename, encoding=encoding) as fd:


### PR DESCRIPTION
## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
