### PR TITLE
letstest: replace buster with bookworm

### DIFF
--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -18,13 +18,13 @@ targets:
     user: ubuntu
   #-----------------------------------------------------------------------------
   # Debian
-  - ami: ami-01db78123b2b99496
-    name: debian10
+  - ami: ami-0fec2c2e2017f4e7b
+    name: debian11
     type: ubuntu
     virt: hvm
     user: admin
-  - ami: ami-0fec2c2e2017f4e7b
-    name: debian11
+  - ami: ami-02ff60b9d37a0a0be
+    name: debian12
     type: ubuntu
     virt: hvm
     user: admin


### PR DESCRIPTION
CI is failing because of *reasons* and let's do away with Debian 10 (LTS) in the farm tests and replace it with Debian 12 (stable).

https://dev.azure.com/certbot/certbot/_build/results?buildId=6857&view=logs&j=9d9056dd-6d3a-5ab9-4437-796135c21b43 shows the farm tests passing.