### PR TITLE
disco: print the name of the plugin if it fails to load

### DIFF
--- a/certbot/certbot/_internal/plugins/disco.py
+++ b/certbot/certbot/_internal/plugins/disco.py
@@ -189,8 +189,14 @@ class PluginsRegistry(Mapping):
             pkg_resources.iter_entry_points(
                 constants.OLD_SETUPTOOLS_PLUGINS_ENTRY_POINT),)
         for entry_point in entry_points:
-            cls._load_entry_point(entry_point, plugins)
-
+            try:
+                cls._load_entry_point(entry_point, plugins)
+            except Exception as e:
+                raise errors.PluginError(
+                    f"The '{entry_point.module_name}' plugin errored while loading: {e}. "
+                     "You may need to remove or update this plugin. The Certbot log will "
+                     "contain the full error details and this should be reported to the "
+                     "plugin developer.") from e
         return cls(plugins)
 
     @classmethod

--- a/certbot/certbot/_internal/tests/plugins/disco_test.py
+++ b/certbot/certbot/_internal/tests/plugins/disco_test.py
@@ -194,6 +194,17 @@ class PluginsRegistryTest(unittest.TestCase):
         assert plugins["ep1"].entry_point is self.ep1
         assert "p1:ep1" not in plugins
 
+    def test_find_all_error_message(self):
+        from certbot._internal.plugins.disco import PluginsRegistry
+        with mock.patch("certbot._internal.plugins.disco.pkg_resources") as mock_pkg:
+            EP_SA.load = None # This triggers a TypeError when the entrypoint loads
+            mock_pkg.iter_entry_points.side_effect = [
+                iter([EP_SA]), iter([EP_WR, self.ep1])
+            ]
+            with self.assertRaises(errors.PluginError) as cm:
+                PluginsRegistry.find_all()
+            assert "standalone' plugin errored" in str(cm.exception)
+
     def test_getitem(self):
         assert self.plugin_ep == self.reg["mock"]
 


### PR DESCRIPTION
Whenever we get a post on the community forums where a plugin has blown up Certbot, it is hard to tell what is happening. This is because there is zero context printed in the Certbot log about which plugin triggered the error.

e.g.

    $ sudo -E certbot plugins
    An unexpected error occurred:
    TypeError: 'NoneType' object is not callable
    Ask for help or search for solutions at https://community.letsencrypt.org. See the logfile /var/folders/18/ppjd2l9x5_97j9xkms__nnjh0000gn/T/certbot-log-jcaecp09/log or re-run Certbot with -v for more details.

and the log:

    2023-06-12 19:22:44,305:DEBUG:certbot._internal.log:Exiting abnormally:
    Traceback (most recent call last):
      File "/Users/alex/devel/certbot/venv/bin/certbot", line 33, in <module>
        sys.exit(load_entry_point('certbot', 'console_scripts', 'certbot')())
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/alex/devel/certbot/certbot/certbot/main.py", line 19, in main
        return internal_main.main(cli_args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/main.py", line 1835, in main
        plugins = plugins_disco.PluginsRegistry.find_all()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/plugins/disco.py", line 193, in find_all
        cls._load_entry_point(entry_point, plugins)
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/plugins/disco.py", line 200, in _load_entry_point
        plugin_ep = PluginEntryPoint(entry_point)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/plugins/disco.py", line 40, in __init__
        self.plugin_cls: Type[interfaces.Plugin] = entry_point.load()
                                                  ^^^^^^^^^^^^^^^^^^
    TypeError: 'NoneType' object is not callable
    2023-06-12 19:22:44,305:ERROR:certbot._internal.log:An unexpected error occurred:
    2023-06-12 19:22:44,305:ERROR:certbot._internal.log:TypeError: 'NoneType' object is not callable

Nothing useful is there.

This PR adds context to the raised exception by re-raising it using the [`from` syntax](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement).

This is how it looks:

<img width="1097" alt="image" src="https://github.com/certbot/certbot/assets/311534/888b0b73-5eb1-4fb3-86e3-84691b585455">

and the original exception context is preserved:

    2023-06-12 19:12:09,446:DEBUG:certbot._internal.log:Exiting abnormally:
    Traceback (most recent call last):
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/plugins/disco.py", line 194, in find_all
        cls._load_entry_point(entry_point, plugins)
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/plugins/disco.py", line 206, in _load_entry_point
        plugin_ep = PluginEntryPoint(entry_point)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/plugins/disco.py", line 40, in __init__
        self.plugin_cls: Type[interfaces.Plugin] = entry_point.load()
                                                  ^^^^^^^^^^^^^^^^^^
    TypeError: 'NoneType' object is not callable

    The above exception was the direct cause of the following exception:

    Traceback (most recent call last):
      File "/Users/alex/devel/certbot/venv/bin/certbot", line 33, in <module>
        sys.exit(load_entry_point('certbot', 'console_scripts', 'certbot')())
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/alex/devel/certbot/certbot/certbot/main.py", line 19, in main
        return internal_main.main(cli_args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/main.py", line 1835, in main
        plugins = plugins_disco.PluginsRegistry.find_all()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/alex/devel/certbot/certbot/certbot/_internal/plugins/disco.py", line 196, in find_all
        raise errors.PluginError(
    certbot.errors.PluginError: The 'certbot._internal.plugins.manual' plugin errored while loading: 'NoneType' object is not callable. You may need to remove or update this plugin. The Certbot log will contain the full error details and this should be reported to the plugin developer.
    2023-06-12 19:12:09,446:ERROR:certbot._internal.log:The 'certbot._internal.plugins.manual' plugin errored while loading: 'NoneType' object is not callable. You may need to remove or update this plugin. The Certbot log will contain the full error details and this should be reported to the plugin developer.