### PR TITLE
post renewal hook: Add RENEWED_DOMAINS and FAILED_DOMAINS as environment variables

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -12,6 +12,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * `NamespaceConfig` now tracks how its arguments were set via a dictionary, allowing us to remove a bunch
   of global state previously needed to inspect whether a user set an argument or not.
+* Added `RENEWED_DOMAINS` and `FAILED_DOMAINS` environment variables for consumption by post renewal hooks.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/hooks.py
+++ b/certbot/certbot/_internal/hooks.py
@@ -103,7 +103,11 @@ def _run_pre_hook_if_necessary(command: str) -> None:
         executed_pre_hooks.add(command)
 
 
-def post_hook(config: configuration.NamespaceConfig) -> None:
+def post_hook(
+    config: configuration.NamespaceConfig,
+    renewed_domains: List[str]
+) -> None:
+
     """Run post-hooks if defined.
 
     This function also registers any executables found in
@@ -131,7 +135,16 @@ def post_hook(config: configuration.NamespaceConfig) -> None:
             _run_eventually(cmd)
     # certonly / run
     elif cmd:
-        _run_hook("post-hook", cmd)
+        _run_hook(
+            "post-hook",
+            cmd,
+            {
+                'RENEWED_DOMAINS': ' '.join(renewed_domains),
+                # Since other commands stop certbot execution on failure,
+                # it doesn't make sense to have a FAILED_DOMAINS variable
+                'FAILED_DOMAINS': ""
+            }
+        )
 
 
 post_hooks: List[str] = []

--- a/certbot/certbot/_internal/hooks.py
+++ b/certbot/certbot/_internal/hooks.py
@@ -1,6 +1,7 @@
 """Facilities for implementing hooks that call shell commands."""
 
 import logging
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Set
@@ -236,12 +237,14 @@ def _run_deploy_hook(command: str, domains: List[str], lineage_path: str, dry_ru
     _run_hook("deploy-hook", command)
 
 
-def _run_hook(cmd_name: str, shell_cmd: str, extra_env: Optional[dict[str, str]] = None) -> str:
+def _run_hook(cmd_name: str, shell_cmd: str, extra_env: Optional[Dict[str, str]] = None) -> str:
     """Run a hook command.
 
     :param str cmd_name: the user facing name of the hook being run
     :param shell_cmd: shell command to execute
     :type shell_cmd: `list` of `str` or `str`
+    :param dict extra_env: extra environment variables to set
+    :type extra_env: `dict` of `str` to `str`
 
     :returns: stderr if there was any"""
     env = util.env_no_snap_for_external_calls()

--- a/certbot/certbot/_internal/hooks.py
+++ b/certbot/certbot/_internal/hooks.py
@@ -145,7 +145,7 @@ def post_hook(
             "post-hook",
             cmd,
             {
-                'RENEWED_DOMAINS': ' '.join(renewed_domains_str),
+                'RENEWED_DOMAINS': renewed_domains_str,
                 # Since other commands stop certbot execution on failure,
                 # it doesn't make sense to have a FAILED_DOMAINS variable
                 'FAILED_DOMAINS': ""

--- a/certbot/certbot/_internal/hooks.py
+++ b/certbot/certbot/_internal/hooks.py
@@ -150,7 +150,7 @@ def _run_eventually(command: str) -> None:
         post_hooks.append(command)
 
 
-def run_saved_post_hooks(renewed_domains: List, failed_domains: List) -> None:
+def run_saved_post_hooks(renewed_domains: List[str], failed_domains: List[str]) -> None:
     """Run any post hooks that were saved up in the course of the 'renew' verb"""
     for cmd in post_hooks:
         _run_hook(

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -115,6 +115,8 @@ def _get_and_save_cert(le_client: client.Client, config: configuration.Namespace
 
     """
     hooks.pre_hook(config)
+    renewed_domains: List[str] = []
+
     try:
         if lineage is not None:
             # Renewal, where we already know the specific lineage we're
@@ -143,8 +145,9 @@ def _get_and_save_cert(le_client: client.Client, config: configuration.Namespace
                 raise errors.Error("Certificate could not be obtained")
             if lineage is not None:
                 hooks.deploy_hook(config, lineage.names(), lineage.live_dir)
+                renewed_domains.extend(domains)
     finally:
-        hooks.post_hook(config)
+        hooks.post_hook(config, renewed_domains)
 
     return lineage
 

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1632,10 +1632,12 @@ def renew(config: configuration.NamespaceConfig,
     :rtype: None
 
     """
+
+    renewed_domains, failed_domains = (list(), list())
     try:
-        renewal.handle_renewal_request(config)
+        renewed_domains, failed_domains = renewal.handle_renewal_request(config)
     finally:
-        hooks.run_saved_post_hooks()
+        hooks.run_saved_post_hooks(renewed_domains, failed_domains)
 
 
 def make_or_verify_needed_dirs(config: configuration.NamespaceConfig) -> None:

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1633,7 +1633,8 @@ def renew(config: configuration.NamespaceConfig,
 
     """
 
-    renewed_domains, failed_domains = (list(), list())
+    renewed_domains: List[str] = []
+    failed_domains: List[str] = []
     try:
         renewed_domains, failed_domains = renewal.handle_renewal_request(config)
     finally:

--- a/certbot/certbot/_internal/tests/hook_test.py
+++ b/certbot/certbot/_internal/tests/hook_test.py
@@ -10,6 +10,7 @@ from certbot import util
 from certbot.compat import filesystem
 from certbot.compat import os
 from certbot.tests import util as test_util
+from typing import List
 
 
 class ValidateHooksTest(unittest.TestCase):
@@ -252,7 +253,9 @@ class RunSavedPostHooksTest(HookTest):
     @classmethod
     def _call(cls, *args, **kwargs):
         from certbot._internal.hooks import run_saved_post_hooks
-        return run_saved_post_hooks()
+        # run_saved_post_hooks() requires a renewed_domains list and a failed_domains list
+        # but we're not using these for tests. Instead the lists are empty.
+        return run_saved_post_hooks(list(), list())
 
     def _call_with_mock_execute_and_eventually(self, *args, **kwargs):
         """Call run_saved_post_hooks but mock out execute and eventually

--- a/certbot/certbot/_internal/tests/hook_test.py
+++ b/certbot/certbot/_internal/tests/hook_test.py
@@ -195,7 +195,7 @@ class PostHookTest(HookTest):
     def test_certonly_and_run_with_hook(self):
         for verb in ("certonly", "run",):
             self.config.verb = verb
-            mock_execute = self._call_with_mock_execute(self.config)
+            mock_execute = self._call_with_mock_execute(self.config, [])
             mock_execute.assert_called_once_with("post-hook", self.config.post_hook, env=mock.ANY)
             assert not self._get_eventually()
 
@@ -203,8 +203,16 @@ class PostHookTest(HookTest):
         self.config.post_hook = None
         for verb in ("certonly", "run",):
             self.config.verb = verb
-            assert not self._call_with_mock_execute(self.config).called
+            assert not self._call_with_mock_execute(self.config, []).called
             assert not self._get_eventually()
+
+    def test_renew_env(self):
+        self.config.verb = "certonly"
+        args = self._call_with_mock_execute(self.config, ["success.org"]).call_args
+        assert args.kwargs['env']["RENEWED_DOMAINS"] == "success.org"
+
+        self.config.verb = "renew"
+        args = self._call_with_mock_execute(self.config, ["success.org"]).call_args
 
     def test_renew_disabled_dir_hooks(self):
         self.config.directory_hooks = False
@@ -239,7 +247,7 @@ class PostHookTest(HookTest):
         self.config.verb = "renew"
 
         for _ in range(2):
-            self._call(self.config)
+            self._call(self.config, [])
             assert self._get_eventually() == expected
 
     def _get_eventually(self):
@@ -253,9 +261,10 @@ class RunSavedPostHooksTest(HookTest):
     @classmethod
     def _call(cls, *args, **kwargs):
         from certbot._internal.hooks import run_saved_post_hooks
-        # run_saved_post_hooks() requires a renewed_domains list and a failed_domains list
-        # but we're not using these for tests. Instead the lists are empty.
-        return run_saved_post_hooks([], [])
+        renewed_domains = kwargs["renewed_domains"] if "renewed_domains" in kwargs else args[0]
+        failed_domains = kwargs["failed_domains"] if "failed_domains" in kwargs else args[1]
+
+        return run_saved_post_hooks(renewed_domains, failed_domains)
 
     def _call_with_mock_execute_and_eventually(self, *args, **kwargs):
         """Call run_saved_post_hooks but mock out execute and eventually
@@ -274,11 +283,11 @@ class RunSavedPostHooksTest(HookTest):
         self.eventually: List[str] = []
 
     def test_empty(self):
-        assert not self._call_with_mock_execute_and_eventually().called
+        assert not self._call_with_mock_execute_and_eventually([], []).called
 
     def test_multiple(self):
         self.eventually = ["foo", "bar", "baz", "qux"]
-        mock_execute = self._call_with_mock_execute_and_eventually()
+        mock_execute = self._call_with_mock_execute_and_eventually([], [])
 
         calls = mock_execute.call_args_list
         for actual_call, expected_arg in zip(calls, self.eventually):
@@ -286,8 +295,14 @@ class RunSavedPostHooksTest(HookTest):
 
     def test_single(self):
         self.eventually = ["foo"]
-        mock_execute = self._call_with_mock_execute_and_eventually()
+        mock_execute = self._call_with_mock_execute_and_eventually([], [])
         mock_execute.assert_called_once_with("post-hook", self.eventually[0], env=mock.ANY)
+
+    def test_env(self):
+        self.eventually = ["foo"]
+        mock_execute = self._call_with_mock_execute_and_eventually(["success.org"], ["failed.org"])
+        assert mock_execute.call_args.kwargs['env']["RENEWED_DOMAINS"] == "success.org"
+        assert mock_execute.call_args.kwargs['env']["FAILED_DOMAINS"] == "failed.org"
 
 
 class RenewalHookTest(HookTest):

--- a/certbot/certbot/_internal/tests/hook_test.py
+++ b/certbot/certbot/_internal/tests/hook_test.py
@@ -255,7 +255,7 @@ class RunSavedPostHooksTest(HookTest):
         from certbot._internal.hooks import run_saved_post_hooks
         # run_saved_post_hooks() requires a renewed_domains list and a failed_domains list
         # but we're not using these for tests. Instead the lists are empty.
-        return run_saved_post_hooks(list(), list())
+        return run_saved_post_hooks([], [])
 
     def _call_with_mock_execute_and_eventually(self, *args, **kwargs):
         """Call run_saved_post_hooks but mock out execute and eventually

--- a/certbot/certbot/_internal/tests/hook_test.py
+++ b/certbot/certbot/_internal/tests/hook_test.py
@@ -1,6 +1,7 @@
 """Tests for certbot._internal.hooks."""
 import sys
 import unittest
+from platform import python_version_tuple
 from unittest import mock
 
 import pytest
@@ -11,6 +12,17 @@ from certbot.compat import filesystem
 from certbot.compat import os
 from certbot.tests import util as test_util
 from typing import List
+
+
+def pyver_lt(major: int, minor: int):
+    pymajor = int(python_version_tuple()[0])
+    pyminor = int(python_version_tuple()[1])
+    if pymajor < major:
+        return True
+    elif pymajor > major:
+        return False
+    else:
+        return pyminor < minor
 
 
 class ValidateHooksTest(unittest.TestCase):
@@ -206,6 +218,7 @@ class PostHookTest(HookTest):
             assert not self._call_with_mock_execute(self.config, []).called
             assert not self._get_eventually()
 
+    @unittest.skipIf(pyver_lt(3, 8), "Python 3.8+ required for this test.")
     def test_renew_env(self):
         self.config.verb = "certonly"
         args = self._call_with_mock_execute(self.config, ["success.org"]).call_args
@@ -298,6 +311,7 @@ class RunSavedPostHooksTest(HookTest):
         mock_execute = self._call_with_mock_execute_and_eventually([], [])
         mock_execute.assert_called_once_with("post-hook", self.eventually[0], env=mock.ANY)
 
+    @unittest.skipIf(pyver_lt(3, 8), "Python 3.8+ required for this test.")
     def test_env(self):
         self.eventually = ["foo"]
         mock_execute = self._call_with_mock_execute_and_eventually(["success.org"], ["failed.org"])

--- a/certbot/certbot/_internal/tests/hook_test.py
+++ b/certbot/certbot/_internal/tests/hook_test.py
@@ -224,9 +224,6 @@ class PostHookTest(HookTest):
         args = self._call_with_mock_execute(self.config, ["success.org"]).call_args
         assert args.kwargs['env']["RENEWED_DOMAINS"] == "success.org"
 
-        self.config.verb = "renew"
-        args = self._call_with_mock_execute(self.config, ["success.org"]).call_args
-
     def test_renew_disabled_dir_hooks(self):
         self.config.directory_hooks = False
         self._test_renew_common([self.config.post_hook])

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -707,10 +707,11 @@ form is not appropriate to run daily because each certificate will be
 renewed every day, which will quickly run into the certificate authority
 rate limit.)
 
-Certbot provides the environment variables `RENEWED_DOMAINS` and `FAILED_DOMAINS`
-to all post renewal hooks. These variables contain a space separated list of
-domains. These variables can be used to determine if a renewal has succeeded or
-failed as part of your post renewal hook.
+Starting with Certbot 2.7.0, certbot provides the environment variables
+`RENEWED_DOMAINS` and `FAILED_DOMAINS` to all post renewal hooks. These
+variables contain a space separated list of domains. These variables can be used
+to determine if a renewal has succeeded or failed as part of your post renewal
+hook.
 
 Note that options provided to ``certbot renew`` will apply to
 *every* certificate for which renewal is attempted; for example,

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -707,6 +707,11 @@ form is not appropriate to run daily because each certificate will be
 renewed every day, which will quickly run into the certificate authority
 rate limit.)
 
+Certbot provides the environment variables `RENEWED_DOMAINS` and `FAILED_DOMAINS`
+to all post renewal hooks. These variables contain a space separated list of
+domains. These variables can be used to determine if a renewal has succeeded or
+failed as part of your post renewal hook.
+
 Note that options provided to ``certbot renew`` will apply to
 *every* certificate for which renewal is attempted; for example,
 ``certbot renew --rsa-key-size 4096`` would try to replace every


### PR DESCRIPTION
This change addresses #9723. Since it was relatively trivial to implement I went ahead and wrote a PR for review.

## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
