### PR TITLE
Fix snap builds

### DIFF
--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -13,7 +13,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -21,11 +23,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -12,7 +12,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -20,11 +22,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -11,7 +11,9 @@ install_requires = [
     'setuptools>=41.6.0',
 ]
 
-if not os.environ.get('SNAP_BUILD'):
+if os.environ.get('SNAP_BUILD'):
+    install_requires.append('packaging')
+else:
     install_requires.extend([
         # We specify the minimum acme and certbot version as the current plugin
         # version for simplicity. See
@@ -19,11 +21,6 @@ if not os.environ.get('SNAP_BUILD'):
         f'acme>={version}',
         f'certbot>={version}',
     ])
-elif 'bdist_wheel' in sys.argv[1:]:
-    raise RuntimeError('Unset SNAP_BUILD when building wheels '
-                       'to include certbot dependencies.')
-if os.environ.get('SNAP_BUILD'):
-    install_requires.append('packaging')
 
 docs_extras = [
     'Sphinx>=1.0',  # autodoc_member_order = 'bysource', autodoc_default_flags

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -31,7 +31,7 @@ if ! command -v script >/dev/null 2>&1; then
     exit 1
 fi
 
-if [ -n "${SNAP_BUILD+x}" ]; then
+if [ -n "$SNAP_BUILD" ]; then
     echo "Running the release script with the environment variable SNAP_BUILD"
     echo "set will cause plugins' wheels to be built without dependencies"
     echo "on Certbot. See https://github.com/certbot/certbot/pull/8091 for more"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -31,6 +31,15 @@ if ! command -v script >/dev/null 2>&1; then
     exit 1
 fi
 
+if [ -n "${SNAP_BUILD+x}" ]; then
+    echo "Running the release script with the environment variable SNAP_BUILD"
+    echo "set will cause plugins' wheels to be built without dependencies"
+    echo "on Certbot. See https://github.com/certbot/certbot/pull/8091 for more"
+    echo "info. Please unset this environment variable and run this script"
+    echo "again."
+    exit 1
+fi
+
 export RELEASE_DIR="./releases"
 mv "$RELEASE_DIR" "$RELEASE_DIR.$(date +%s).bak" || true
 LOG_PATH="log"


### PR DESCRIPTION
This fixes our snap build failures which can be seen at https://dev.azure.com/certbot/certbot/_build/results?buildId=6922&view=logs&j=f44d40a4-7318-5ffe-762c-ae4557889284&t=07786725-57f8-5198-4d13-ea77f640bd5c&l=54354.

The cause was upgrading `pip` in https://github.com/certbot/certbot/pull/9717 and specifically the same `pip` change that caused trouble in that PR which from pip's changelog was:

> Remove `setup.py install` fallback when building a wheel failed for projects without `pyproject.toml`. ([#8368](https://github.com/pypa/pip/issues/8368))

This change allows `pip` to build our wheels without the Certbot dependencies and moves the (probably unnecessary) error checking for this to our release script.