### PR TITLE
Fix reuse-key check to include check for `elliptic-curve` command line option

### DIFF
--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -364,8 +364,8 @@ def _avoid_reuse_key_conflicts(config: configuration.NamespaceConfig,
         ("--rsa-key-size",
          lambda: kt == "rsa" and config.rsa_key_size != lineage.rsa_key_size),
         ("--elliptic-curve",
-         lambda: kt == "ecdsa" and lineage.elliptic_curve and \
-                 config.elliptic_curve.lower() != lineage.elliptic_curve.lower())
+         lambda: kt == "ecdsa" and lineage.elliptic_curve and config.set_by_user('elliptic_curve') \
+                 and config.elliptic_curve.lower() != lineage.elliptic_curve.lower())
     ]
 
     for conflict in potential_conflicts:


### PR DESCRIPTION
Fixes #9731

Currently Certbot refuses to renew a certificate if the user uses `--reuse-key` and has a non-default ECDSA curve set previously. 

I think this is due to the fact the following code

https://github.com/certbot/certbot/blob/e6572e695b8c82c122a196b4ddbeb1dcfb24f8e4/certbot/certbot/_internal/renewal.py#L367-L368

checks the *default* ECDSA curve and the curve set in the lineage. This can be different of course and I think Certbot shouldn't refuse to renew a cert for just this, unless the user actually supplies a different ECDSA curve using `--elliptic-curve` on the command line.

This PR adds this latter check.

Now that I'm writing this text, I'm thinking *non* of the three checks actually check the *CLI* input? All the used `config.xxx` options are supplied with their default values, even if the option is not used on CLI or am I missing something? Maybe this PR needs to be expanded for the other two checks too?

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.

**Edit**:

Interestingly in `renewal_test.py` the `set_by_user` return value is hardcoded to `False`?

https://github.com/certbot/certbot/blob/e6572e695b8c82c122a196b4ddbeb1dcfb24f8e4/certbot/certbot/_internal/tests/renewal_test.py#L131-L161

Although I don't think it actually does something. If I set it to `True` the test succeeds too. But now I'm not so sure what the correct behaviour of `_avoid_reuse_key_conflicts` needs to be with regard to `set_by_user()`..