### PR TITLE
Add pytz as a dependency for integration tests

### DIFF
--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     # installation on Linux.
     'pywin32>=300 ; sys_platform == "win32"',
     'pyyaml',
+    'pytz>=2019.3',
     'requests',
     'setuptools',
     'types-python-dateutil'


### PR DESCRIPTION
Fixes build failures here: https://dev.azure.com/certbot/certbot/_build/results?buildId=6957&view=results