### PR TITLE
Skip Mattermost Job for Forked Repos

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   if_merged:
-    if: github.event.pull_request.merged == true
+    # Forked repos can not access Mattermost secret.
+    if: github.event.pull_request.merged == true && !github.event.pull_request.head.repo.fork 
     runs-on: ubuntu-latest
     steps:
     - name: Create Mattermost Message


### PR DESCRIPTION
Reason: Forked Repos can't access Mattermost Secret to properly send message to channel.
Open to suggestions, the push event is very limited in scope when I checked [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push).
