### PR TITLE
Fix docs

### DIFF
--- a/acme/docs/conf.py
+++ b/acme/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinx_rtd_theme',
 ]
 
 autodoc_member_order = 'bysource'

--- a/acme/docs/conf.py
+++ b/acme/docs/conf.py
@@ -122,14 +122,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-cloudflare/docs/conf.py
+++ b/certbot-dns-cloudflare/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-cloudflare/docs/conf.py
+++ b/certbot-dns-cloudflare/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-cloudflare/docs/conf.py
+++ b/certbot-dns-cloudflare/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-digitalocean/docs/conf.py
+++ b/certbot-dns-digitalocean/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-digitalocean/docs/conf.py
+++ b/certbot-dns-digitalocean/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-digitalocean/docs/conf.py
+++ b/certbot-dns-digitalocean/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-dnsimple/docs/conf.py
+++ b/certbot-dns-dnsimple/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-dnsimple/docs/conf.py
+++ b/certbot-dns-dnsimple/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-dnsimple/docs/conf.py
+++ b/certbot-dns-dnsimple/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-dnsmadeeasy/docs/conf.py
+++ b/certbot-dns-dnsmadeeasy/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-dnsmadeeasy/docs/conf.py
+++ b/certbot-dns-dnsmadeeasy/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-dnsmadeeasy/docs/conf.py
+++ b/certbot-dns-dnsmadeeasy/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-gehirn/docs/conf.py
+++ b/certbot-dns-gehirn/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-gehirn/docs/conf.py
+++ b/certbot-dns-gehirn/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-gehirn/docs/conf.py
+++ b/certbot-dns-gehirn/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-google/docs/conf.py
+++ b/certbot-dns-google/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 import sys
 
 sys.path.insert(0, os.path.abspath('_ext'))
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-google/docs/conf.py
+++ b/certbot-dns-google/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 import sys
 
 sys.path.insert(0, os.path.abspath('_ext'))

--- a/certbot-dns-google/docs/conf.py
+++ b/certbot-dns-google/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-linode/docs/conf.py
+++ b/certbot-dns-linode/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-linode/docs/conf.py
+++ b/certbot-dns-linode/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-linode/docs/conf.py
+++ b/certbot-dns-linode/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-luadns/docs/conf.py
+++ b/certbot-dns-luadns/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-luadns/docs/conf.py
+++ b/certbot-dns-luadns/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-luadns/docs/conf.py
+++ b/certbot-dns-luadns/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-nsone/docs/conf.py
+++ b/certbot-dns-nsone/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-nsone/docs/conf.py
+++ b/certbot-dns-nsone/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-nsone/docs/conf.py
+++ b/certbot-dns-nsone/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-ovh/docs/conf.py
+++ b/certbot-dns-ovh/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-ovh/docs/conf.py
+++ b/certbot-dns-ovh/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-ovh/docs/conf.py
+++ b/certbot-dns-ovh/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-rfc2136/docs/conf.py
+++ b/certbot-dns-rfc2136/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-rfc2136/docs/conf.py
+++ b/certbot-dns-rfc2136/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-rfc2136/docs/conf.py
+++ b/certbot-dns-rfc2136/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-route53/docs/conf.py
+++ b/certbot-dns-route53/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-route53/docs/conf.py
+++ b/certbot-dns-route53/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-route53/docs/conf.py
+++ b/certbot-dns-route53/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot-dns-sakuracloud/docs/conf.py
+++ b/certbot-dns-sakuracloud/docs/conf.py
@@ -93,14 +93,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/certbot-dns-sakuracloud/docs/conf.py
+++ b/certbot-dns-sakuracloud/docs/conf.py
@@ -16,7 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+# import os
 
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))

--- a/certbot-dns-sakuracloud/docs/conf.py
+++ b/certbot-dns-sakuracloud/docs/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.viewcode']
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme']
 
 autodoc_member_order = 'bysource'
 autodoc_default_flags = ['show-inheritance']

--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinx_rtd_theme',
 ]
 
 if sphinx.version_info >= (1, 6):

--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -133,14 +133,7 @@ suppress_warnings = ['image.nonlocal_uri']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/tools/sphinx-quickstart.sh
+++ b/tools/sphinx-quickstart.sh
@@ -7,13 +7,12 @@ fi
 
 PROJECT=$1
 
-yes "n" | sphinx-quickstart --dot _ --project $PROJECT --author "Certbot Project" -v 0 --release 0 --language en --suffix .rst --master index --ext-autodoc --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode --makefile --batchfile $PROJECT/docs
+yes "n" | sphinx-quickstart --dot _ --project $PROJECT --author "Certbot Project" -v 0 --release 0 --language en --suffix .rst --master index --ext-autodoc --ext-intersphinx --ext-todo --ext-coverage --ext-viewcode --extensions sphinx_rtd_theme --makefile --batchfile $PROJECT/docs
 
 cd $PROJECT/docs
-sed -i -e "s|\# import os|import os|" conf.py
 sed -i -e "s|\# needs_sphinx = '1.0'|needs_sphinx = '1.0'|" conf.py
 sed -i -e "s|intersphinx_mapping = {'https://docs.python.org/': None}|intersphinx_mapping = {\n    'python': ('https://docs.python.org/', None),\n    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),\n    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),\n}|" conf.py
-sed -i -e "s|html_theme = 'alabaster'|\n# https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally\n# on_rtd is whether we are on readthedocs.org\non_rtd = os.environ.get('READTHEDOCS', None) == 'True'\nif not on_rtd:  # only import and set the theme if we're building docs locally\n    import sphinx_rtd_theme\n    html_theme = 'sphinx_rtd_theme'\n    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]\n# otherwise, readthedocs.org uses their theme by default, so no need to specify it|" conf.py
+sed -i -e "s|html_theme = 'alabaster'|html_theme = 'sphinx_rtd_theme'|" conf.py
 sed -i -e "s|# Add any paths that contain templates here, relative to this directory.|autodoc_member_order = 'bysource'\nautodoc_default_flags = ['show-inheritance']\n\n# Add any paths that contain templates here, relative to this directory.|" conf.py
 sed -i -e "s|# The name of the Pygments (syntax highlighting) style to use.|default_role = 'py:obj'\n\n# The name of the Pygments (syntax highlighting) style to use.|" conf.py
 # If the --ext-todo flag is removed from sphinx-quickstart, the line below can be removed.


### PR DESCRIPTION
Our [docs builds failed last night](https://readthedocs.org/projects/certbot-dns-cloudflare/builds/21714606/), presumably because #9754 updated `sphinx_rtd_theme` which changed some unknown thing.

Looking into it, our usage of this project was very unconventional. Following the code comment I deleted in this PR to https://docs.readthedocs.io/en/stable/faq.html#i-want-to-use-the-read-the-docs-theme-locally, simple instructions are given to put the following in your `conf.py` file:
```
extensions = [
    ...
    'sphinx_rtd_theme',
]

html_theme = "sphinx_rtd_theme"
```
I did this instead of the more complicated logic we were using and all builds passed locally. I also triggered a build on readthedocs with these changes which also passed. See https://readthedocs.org/projects/certbot-dns-cloudflare/builds/21722746/.