### PR TITLE
Surface caaIdentities in meta to client

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -238,6 +238,7 @@ Authors
 * [Robert Xiao](https://github.com/nneonneo)
 * [Roland Shoemaker](https://github.com/rolandshoemaker)
 * [Roy Wellington Ⅳ](https://github.com/thanatos)
+* [Ryan De Villa](https://github.com/ryandv)
 * [rugk](https://github.com/rugk)
 * [Sachi King](https://github.com/nakato)
 * [Sagi Kedmi](https://github.com/sagi)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -7,6 +7,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 * Add `certbot.util.LooseVersion` class. See [GH #9489](https://github.com/certbot/certbot/issues/9489).
+* Display suggested CAA records based on the `meta.caaIdentities` property from the ACME server's
+  `/directory` response.
 
 ### Changed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -8,7 +8,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Add `certbot.util.LooseVersion` class. See [GH #9489](https://github.com/certbot/certbot/issues/9489).
 * Display suggested CAA records based on the `meta.caaIdentities` property from the ACME server's
-  `/directory` response.
+  `/directory` response. See [GH #4836](https://github.com/certbot/certbot/issues/4836).
 
 ### Changed
 


### PR DESCRIPTION
Just an idea for https://github.com/certbot/certbot/issues/4836. Will maybe follow up with other suggestions in the issue if this actually takes off.

Prints a message with suggested CAA record values upon successful challenge validation. Example terminal session below.

Thank you EFF, continue to hold fast to your principles.

## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.

<details>
  <summary>Example certbot_test session</summary>

  ```
Wed Aug 30 01:11:43 PM EDT 2023 → certbot_test certonly --preferred-challenges=dns
--> Using an existing workspace for certbot_test: /home/ryandv/src/github.com/certbot/certbot/.certbot_test_workspace
--> Invoke command:
=====
certbot --server https://acme-staging-v02.api.letsencrypt.org/directory --no-verify-ssl --http-01-port 5002 --https-port 5001 --config-dir /home/ryandv/src/github.com/certbot/certbot/.certbot_test_workspace/conf --work-dir /home/ryandv/src/github.com/certbot/certbot/.certbot_test_workspace/work --logs-dir /home/ryandv/src/github.com/certbot/certbot/.certbot_test_workspace/logs --manual --no-redirect --agree-tos --register-unsafely-without-email certonly --preferred-challenges=dns --no-random-sleep-on-renew --renew-by-default
=====
Saving debug log to /home/ryandv/src/github.com/certbot/certbot/.certbot_test_workspace/logs/letsencrypt.log
Please enter the domain name(s) you would like on your certificate (comma and/or
space separated) (Enter 'c' to cancel): test21.ryandv.me, test22.ryandv.me
Requesting a certificate for test21.ryandv.me and test22.ryandv.me

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Please deploy a DNS TXT record under the name:

_acme-challenge.test21.ryandv.me.

with the following value:

vh6g9fhgF-qo6VI0K2oxe2-SL_dUluqVp5OEXzCLkj4

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Press Enter to Continue

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Please deploy a DNS TXT record under the name:

_acme-challenge.test22.ryandv.me.

with the following value:

pm6KSPQKrUwejd4tq_pHIKTiQgJCJhIGtuq_FpRmQM4

(This must be set up in addition to the previous challenges; do not remove,
replace, or undo the previous challenge tasks yet. Note that you might be
asked to create multiple distinct TXT records with the same name. This is
permitted by DNS standards.)

Before continuing, verify the TXT record has been deployed. Depending on the DNS
provider, this may take some time, from a few seconds to multiple minutes. You can
check if it has finished deploying with aid of online tools, such as the Google
Admin Toolbox: https://toolbox.googleapps.com/apps/dig/#TXT/_acme-challenge.test22.ryandv.me.
Look for one or more bolded line(s) below the line ';ANSWER'. It should show the
value(s) you've just added.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Press Enter to Continue

If you would like to restrict certificate issuance to the current issuer,
please deploy DNS CAA records for the names:

test21.ryandv.me, test22.ryandv.me

with the following value:

0 issue "letsencrypt.org"

Successfully received certificate.
Certificate is saved at: /home/ryandv/src/github.com/certbot/certbot/.certbot_test_workspace/conf/live/test21.ryandv.me/fullchain.pem
Key is saved at:         /home/ryandv/src/github.com/certbot/certbot/.certbot_test_workspace/conf/live/test21.ryandv.me/privkey.pem
This certificate expires on 2023-11-28.
These files will be updated when the certificate renews.

NEXT STEPS:
- This certificate will not be renewed automatically. Autorenewal of --manual certificates requires the use of an authentication hook script (--manual-auth-hook) but one was not provided. To renew this certificate, repeat this same certbot command before the certificate's expiry date.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
If you like Certbot, please consider supporting our work by:
 * Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
 * Donating to EFF:                    https://eff.org/donate-le
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  ```

  Run with the following patch to point certbot_test at Let's Encrypt staging:

  ```
diff --git a/certbot-ci/certbot_integration_tests/utils/certbot_call.py b/certbot-ci/certbot_integration_tests/utils/certbot_call.py
index 3b92498d0..bcec38be2 100755
--- a/certbot-ci/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/certbot_integration_tests/utils/certbot_call.py
@@ -110,17 +110,20 @@ def _prepare_args_env(certbot_args: List[str], directory_url: str, http_01_port:
 
     command = [
         'certbot',
-        '--server', 'https://acme-staging-v02.api.letsencrypt.org/directory',
+        '--server', directory_url,
         '--no-verify-ssl',
         '--http-01-port', str(http_01_port),
         '--https-port', str(tls_alpn_01_port),
+        '--manual-public-ip-logging-ok',
         '--config-dir', config_dir,
         '--work-dir', os.path.join(workspace, 'work'),
         '--logs-dir', os.path.join(workspace, 'logs'),
-        '--manual',
+        '--non-interactive',
         '--no-redirect',
         '--agree-tos',
         '--register-unsafely-without-email',
+        '--debug',
+        '-vv'
     ]
 
     command.extend(certbot_args)
   ```
</details>
