### PR TITLE
Swap out with updated AMI image IDs

### DIFF
--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -5,38 +5,40 @@
 
 targets:
   #-----------------------------------------------------------------------------
-  #Ubuntu
-  - ami: ami-051dcca84f1edfff1
+  # Ubuntu
+  # These AMI were found onhttps://cloud-images.ubuntu.com/locator/ec2/.
+  - ami: ami-0fc5d935ebf8bc3bc
     name: ubuntu22.04
     type: ubuntu
     virt: hvm
     user: ubuntu
-  - ami: ami-0758470213bdd23b1
+  - ami: ami-0fe0238291c8e3f07
     name: ubuntu20.04
     type: ubuntu
     virt: hvm
     user: ubuntu
   #-----------------------------------------------------------------------------
   # Debian
-  - ami: ami-0fec2c2e2017f4e7b
+  # These AMI were found on https://wiki.debian.org/Cloud/AmazonEC2Image.
+  - ami: ami-0c20d96b50ac700e3
     name: debian11
     type: ubuntu
     virt: hvm
     user: admin
-  - ami: ami-02ff60b9d37a0a0be
+  - ami: ami-0f238cd7c96d866ad
     name: debian12
     type: ubuntu
     virt: hvm
     user: admin
   #-----------------------------------------------------------------------------
   # CentOS
-  # These AMI were found on https://wiki.centos.org/Cloud/AWS.
-  - ami: ami-00e87074e52e6c9f9
+  # These AMI were found on https://centos.org/download/aws-images/.
+  - ami: ami-0aedf6b1cb669b4c7
     name: centos7
     type: centos
     virt: hvm
     user: centos
-  - ami: ami-0c0e36522a91d66e1
+  - ami: ami-0d5144f02e4eb6f05
     name: centos9stream
     type: centos
     virt: hvm


### PR DESCRIPTION
- Related to log failures: [Example](https://dev.azure.com/certbot/certbot/_build/results?buildId=7097&view=logs&j=9d9056dd-6d3a-5ab9-4437-796135c21b43&t=b7b5de09-bf79-583a-8b7d-ab998b2e2a8b)
- Added comments for other OS links as well
