### PR TITLE
helpful: fix handling of abbreviated ConfigArgparse arguments

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -27,7 +27,7 @@ More details about these changes can be found on our GitHub repo.
 * Correctly specified the new minimum version of the ConfigArgParse package
   that Certbot requires which is 1.5.3.
 * Fixed a bug where argument sources weren't correctly detected in abbreviated
-  arguments
+  arguments, short arguments, and some other circumstances
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fixed a bug where argument sources weren't correctly detected in abbreviated
+  arguments, short arguments, and some other circumstances
 
 More details about these changes can be found on our GitHub repo.
 
@@ -26,8 +27,6 @@ More details about these changes can be found on our GitHub repo.
   version 2.7.0 of the plugin.
 * Correctly specified the new minimum version of the ConfigArgParse package
   that Certbot requires which is 1.5.3.
-* Fixed a bug where argument sources weren't correctly detected in abbreviated
-  arguments, short arguments, and some other circumstances
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -26,6 +26,8 @@ More details about these changes can be found on our GitHub repo.
   version 2.7.0 of the plugin.
 * Correctly specified the new minimum version of the ConfigArgParse package
   that Certbot requires which is 1.5.3.
+* Fixed a bug where argument sources weren't correctly detected in abbreviated
+  arguments
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -3,7 +3,6 @@
 import argparse
 import functools
 import glob
-import logging
 import sys
 from typing import Any
 from typing import Dict
@@ -34,9 +33,6 @@ from certbot._internal.plugins import disco
 from certbot.compat import os
 from certbot.configuration import ArgumentSource
 from certbot.configuration import NamespaceConfig
-
-
-logger = logging.getLogger(__name__)
 
 
 class HelpfulArgumentParser:

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -252,7 +252,6 @@ class HelpfulArgumentParser:
                 if normalize_arg(option_string).startswith(normalize_arg(arg)):
                     return action
 
-        logger.debug("Failed to find an associated action for argument %s", arg)
         return None
 
     def parse_args(self) -> NamespaceConfig:

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -205,10 +205,9 @@ class HelpfulArgumentParser:
                 if action is not None:
                     actions.append(action)
                 else:
-                    logger.debug(
-                        "Failed to find an action corresponding with %s argument %s",
-                        source.name, arg)
-            result.update({ action.dest: source for action in actions})
+                    raise AssertionError(
+                        f"Action corresponding with {source.name} argument {arg} is None")
+            result.update({ action.dest: source for action in actions })
 
         # config file sources look like "config_file|<name of file>"
         for source_key in source_to_settings_dict:
@@ -229,7 +228,7 @@ class HelpfulArgumentParser:
                 if action is not None:
                     result[action.dest] = ArgumentSource.COMMAND_LINE
                 else:
-                    logger.debug("Failed to find an action corresponding with CLI argument %s", arg)
+                    raise AssertionError(f"Action corresponding with CLI argument {arg} is None")
 
         return result
 

--- a/certbot/certbot/_internal/tests/cli_test.py
+++ b/certbot/certbot/_internal/tests/cli_test.py
@@ -552,6 +552,25 @@ class ParseTest(unittest.TestCase):
             ])
             assert_value_and_source(namespace, 'server', COMMAND_LINE_VALUE, ArgumentSource.COMMAND_LINE)
 
+    def test_abbreviated_command_line_argument(self):
+        # Argparse's "allow_abbrev" option (which is True by default) allows
+        # for unambiguous partial arguments (e.g. "--preferred-chal dns" will be
+        # interepreted the same as "--preferred-challenges dns")
+        namespace = self.parse('--preferred-chal dns --no-dir')
+        assert_set_by_user_with_value(namespace, 'pref_challs', ['dns-01'])
+        assert_set_by_user_with_value(namespace, 'directory_hooks', False)
+
+        with tempfile.NamedTemporaryFile() as tmp_config:
+            tmp_config.close()  # close now because of compatibility issues on Windows
+            with open(tmp_config.name, 'w') as file_h:
+                file_h.write('preferred-chal = dns')
+
+            namespace = self.parse([
+                'certonly',
+                '--config', tmp_config.name,
+            ])
+            assert_set_by_user_with_value(namespace, 'pref_challs', ['dns-01'])
+
 
 if __name__ == '__main__':
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/certbot/_internal/tests/cli_test.py
+++ b/certbot/certbot/_internal/tests/cli_test.py
@@ -552,7 +552,7 @@ class ParseTest(unittest.TestCase):
             ])
             assert_value_and_source(namespace, 'server', COMMAND_LINE_VALUE, ArgumentSource.COMMAND_LINE)
 
-    def test_abbreviated_command_line_argument(self):
+    def test_abbreviated_arguments(self):
         # Argparse's "allow_abbrev" option (which is True by default) allows
         # for unambiguous partial arguments (e.g. "--preferred-chal dns" will be
         # interepreted the same as "--preferred-challenges dns")
@@ -571,6 +571,29 @@ class ParseTest(unittest.TestCase):
             ])
             assert_set_by_user_with_value(namespace, 'pref_challs', ['dns-01'])
 
+    @mock.patch('certbot._internal.hooks.validate_hooks')
+    def test_argument_with_equals(self, unsused_mock_validate_hooks):
+        namespace = self.parse('-d=example.com')
+        assert_set_by_user_with_value(namespace, 'domains', ['example.com'])
+
+        # make sure it doesn't choke on equals signs being present in the argument value
+        plugins = disco.PluginsRegistry.find_all()
+        namespace = cli.prepare_and_parse_args(plugins, ['run', '--pre-hook="foo=bar"'])
+        assert_set_by_user_with_value(namespace, 'pre_hook', '"foo=bar"')
+
+    def test_adjacent_short_args(self):
+        namespace = self.parse('-tv')
+        assert_set_by_user_with_value(namespace, 'text_mode', True)
+        assert_set_by_user_with_value(namespace, 'verbose_count', 1)
+
+        namespace = self.parse('-tvvv')
+        assert_set_by_user_with_value(namespace, 'text_mode', True)
+        assert_set_by_user_with_value(namespace, 'verbose_count', 3)
+
+        namespace = self.parse('-tvm foo@example.com')
+        assert_set_by_user_with_value(namespace, 'text_mode', True)
+        assert_set_by_user_with_value(namespace, 'verbose_count', 1)
+        assert_set_by_user_with_value(namespace, 'email', 'foo@example.com')
 
 if __name__ == '__main__':
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover


### PR DESCRIPTION
ConfigArgparse allows for "abbreviated" arguments, i.e. just the prefix of an argument, but it doesn't set the argument sources in these cases. This commit checks for those cases and sets the sources appropriately.

Fixes #9793 