### PR TITLE
Simplify problems with vendored requests dependencies

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -47,15 +47,8 @@ ECDSA_KEY_TYPE = 'ecdsa'
 
 
 def _suppress_x509_verification_warnings() -> None:
-    try:
-        import urllib3
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    except ImportError:
-        # Handle old versions of request with vendorized urllib3
-        # pylint: disable=no-member,line-too-long
-        from requests.packages.urllib3.exceptions import InsecureRequestWarning  # type: ignore[import-untyped]
-        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)  # type: ignore[attr-defined]
-        # pylint: enable=no-member,line-too-long
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 def check_until_timeout(url: str, attempts: int = 30) -> None:

--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -19,7 +19,9 @@ install_requires = [
     'pywin32>=300 ; sys_platform == "win32"',
     'pyyaml',
     'pytz>=2019.3',
-    'requests',
+    # requests unvendored its dependencies in version 2.16.0 and this code relies on that for
+    # calling `urllib3.disable_warnings`.
+    'requests>=2.16.0',
     'setuptools',
     'types-python-dateutil',
 ]


### PR DESCRIPTION
A number of PRs hit problems trying to update dependencies recently. I believe this was due to https://github.com/python/typeshed/issues/6893.

Essentially, ancient versions of requests used to vendor its dependencies and newer versions of typing packages removed annotations for those ancient versions, so our code that conditionally tries to work with the vendored packages has problems in the eyes of mypy.

Luckily, we don't need to support the ancient versions of requests anymore either. [We already require `>=2.20` in acme](https://github.com/certbot/certbot/blob/8a95c030e63b126a5eae137806957428d579505b/acme/setup.py#L15) and as described in the code comments in this PR, requests stopped vendoring packages in version 2.16.