### PR TITLE
Support read-only root

### DIFF
--- a/certbot/certbot/_internal/lock.py
+++ b/certbot/certbot/_internal/lock.py
@@ -169,7 +169,10 @@ class _UnixLockMechanism(_BaseLockMechanism):
         # process B: delete file
         # process C: open and lock a different file at the same path
         try:
-            os.remove(self._path)
+            path = self._path
+            if os.path.islink(path):
+                path = os.readlink(path)
+            os.remove(path)
         finally:
             # Following check is done to make mypy happy: it ensure that self._fd, marked
             # as Optional[int] is effectively int to make it compatible with os.close signature.

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -114,7 +114,6 @@ def _get_and_save_cert(le_client: client.Client, config: configuration.Namespace
     :raises errors.Error: if certificate could not be obtained
 
     """
-    hooks.pre_hook(config)
     renewed_domains: List[str] = []
 
     try:
@@ -827,6 +826,7 @@ def _init_le_client(config: configuration.NamespaceConfig,
     :rtype: client.Client
 
     """
+    hooks.pre_hook(config)
     acc: Optional[account.Account]
     if authenticator is not None:
         # if authenticator was given, then we will need account...


### PR DESCRIPTION
When using a root filesystem that's mounted read-only, certbot fails handle the lock for its configuration in */etc/letsencrypt*. The easiest solution is to place a symlink at */etc/letsencrypt/.certbot.lock* that points to a writeable location like */var/lib/letsencrypt/etc-letsencrypt-lock*.

But even this requires some tweaking of the code: At release time, we have to check for a symlink and don't remove it but the target.

To get a writeable filesystem during operation the filesystem must be remounted rw. This could be done with a pre-hook, but they are run to late. Hence, the run of the pre-hook is scheduled earlier to allow mounting the filesystem read-write before any access takes place.

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
