### PR TITLE
2.7.3 prep

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'cryptography>=3.2.1',

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     # We specify the minimum acme and certbot version as the current plugin

--- a/certbot-compatibility-test/setup.py
+++ b/certbot-compatibility-test/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'certbot',

--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'cloudflare>=1.5.1',

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'python-digitalocean>=1.11', # 1.15.0 or newer is recommended for TTL support

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     # This version of lexicon is required to address the problem described in

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'google-api-python-client>=1.6.5',

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'dns-lexicon>=3.15.1',

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'dnspython>=1.15.0',

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'boto3>=1.15.15',

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.7.1'
+version = '2.7.2'
 
 install_requires = [
     # We specify the minimum acme and certbot version as the current plugin

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -7,6 +7,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Fixed a bug where arguments with contained spaces weren't being handled correctly
+* Fixed a bug that caused the ACME account to not be properly restored on
+  renewal causing problems in setups where the user had multiple accounts with
+  the same ACME server.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
-## 2.7.2 - master
+## 2.7.2 - 2023-10-19
 
 ### Fixed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
+## 2.7.3 - master
+
+### Fixed
+
+* Fixed a bug where arguments with contained spaces weren't being handled correctly
+
+More details about these changes can be found on our GitHub repo.
+
 ## 2.7.2 - 2023-10-19
 
 ### Fixed

--- a/certbot/certbot/__init__.py
+++ b/certbot/certbot/__init__.py
@@ -3,7 +3,7 @@ import sys
 import warnings
 
 # version number like 1.2.3a0, must have at least 2 parts, like 1.2
-__version__ = '2.7.1'
+__version__ = '2.7.2'
 
 if sys.version_info[:2] == (3, 7):
     warnings.warn(

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -219,6 +219,8 @@ class HelpfulArgumentParser:
 
                 if '=' in arg:
                     arg = arg.split('=')[0]
+                elif ' ' in arg:
+                    arg = arg.split(' ')[0]
 
                 if arg.startswith('--'):
                     args.append(arg)

--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -194,6 +194,7 @@ def restore_required_config_elements(config: configuration.NamespaceConfig,
 
     """
 
+    updated_values = {}
     required_items = itertools.chain(
         (("pref_challs", _restore_pref_challs),),
         zip(BOOL_CONFIG_ITEMS, itertools.repeat(_restore_bool)),
@@ -202,7 +203,9 @@ def restore_required_config_elements(config: configuration.NamespaceConfig,
     for item_name, restore_func in required_items:
         if item_name in renewalparams and not config.set_by_user(item_name):
             value = restore_func(item_name, renewalparams[item_name])
-            setattr(config, item_name, value)
+            updated_values[item_name] = value
+    for key, value in updated_values.items():
+        setattr(config, key, value)
 
 
 def _remove_deprecated_config_elements(renewalparams: Mapping[str, Any]) -> Dict[str, Any]:

--- a/certbot/certbot/_internal/tests/cli_test.py
+++ b/certbot/certbot/_internal/tests/cli_test.py
@@ -594,6 +594,13 @@ class ParseTest(unittest.TestCase):
         assert_set_by_user_with_value(namespace, 'text_mode', True)
         assert_set_by_user_with_value(namespace, 'verbose_count', 1)
         assert_set_by_user_with_value(namespace, 'email', 'foo@example.com')
+    
+    def test_arg_with_contained_spaces(self):
+        # This can happen if a user specifies an arg like "-d foo.com" enclosed
+        # in double quotes, or as its own line in a docker-compose.yml file (as
+        # in #9811)
+        namespace = self.parse(['certonly', '-d foo.com'])
+        assert_set_by_user_with_value(namespace, 'domains', ['foo.com'])
 
 if __name__ == '__main__':
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/certbot/_internal/tests/renewal_test.py
+++ b/certbot/certbot/_internal/tests/renewal_test.py
@@ -253,6 +253,18 @@ class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):
         self._call(self.config, {'server': constants.V1_URI})
         assert self.config.server == constants.CLI_DEFAULTS['server']
 
+    def test_related_values(self):
+        # certbot.configuration.NamespaceConfig.set_by_user considers some values as related to each
+        # other and considers both set by the user if either is. This test ensures all renewal
+        # parameters are restored regardless of their restoration order or relation between values.
+        # See https://github.com/certbot/certbot/issues/9805 for more info.
+        renewalparams = {
+            'server': 'https://example.org',
+            'account': 'somehash',
+        }
+        self._call(self.config, renewalparams)
+        self.assertEqual(self.config.account, renewalparams['account'])
+
 
 class DescribeResultsTest(unittest.TestCase):
     """Tests for certbot._internal.renewal._renew_describe_results."""

--- a/certbot/docs/cli-help.txt
+++ b/certbot/docs/cli-help.txt
@@ -36,7 +36,7 @@ manage your account:
   --agree-tos       Agree to the ACME server's Subscriber Agreement
    -m EMAIL         Email address for important account notifications
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -c CONFIG_FILE, --config CONFIG_FILE
                         path to config file (default: /etc/letsencrypt/cli.ini
@@ -122,7 +122,7 @@ optional arguments:
                         case, and to know when to deprecate support for past
                         Python versions and flags. If you wish to hide this
                         information from the Let's Encrypt server, set this to
-                        "". (default: CertbotACMEClient/2.7.1 (certbot;
+                        "". (default: CertbotACMEClient/2.7.2 (certbot;
                         OS_NAME OS_VERSION) Authenticator/XXX Installer/YYY
                         (SUBCOMMAND; flags: FLAGS) Py/major.minor.patchlevel).
                         The flags encoded in the user agent are: --duplicate,


### PR DESCRIPTION
This PR should not be squashed to preserve the signed and tagged release commit.

This PR is the changes from https://github.com/certbot/certbot/pull/9815 plus the cherry picking for the 2.7.3 release.