### PR TITLE
Bypass Lexicon subdomain resolution in Lexicon-based DNS plugins

### DIFF
--- a/certbot/certbot/plugins/dns_common_lexicon.py
+++ b/certbot/certbot/plugins/dns_common_lexicon.py
@@ -198,6 +198,10 @@ class LexiconDNSAuthenticator(dns_common.DNSAuthenticator):
 
         dict_config = {
             'domain': domain,
+            # We bypass Lexicon subdomain resolution by setting the 'delegated' field in the config
+            # to the value of the 'domain' field itself. Here we consider that the domain passed to
+            # _build_lexicon_config() is already the exact subdomain of the actual DNS zone to use.
+            'delegated': domain,
             'provider_name': self._provider_name,
             'ttl': self._ttl,
             self._provider_name: {item[2]: self._credentials.conf(item[0])


### PR DESCRIPTION
As always, brittle code breaks first.

The Lexicon-based DNS plugins use a mechanism to determine which actual segment of the input domain is actually the DNS zone in which the DNS-01 challenge has to be initiated (eg. `subdomain.domain.com` or `domain.com` for input `subdomain.domain.com`): they tries recursively to configure Lexicon and initiate authentication from the most specific to most generic domain segment, and select the first segment where Lexicon stop erroring out.

This mechanism broke with #9746 because now the plugins call Lexicon client instead of the underlying providers, and the client makes guess on the actual domain requested. Typically for `subdomain.domain.com` it will actually try to authenticate against `domain.com`, and so the mechanism above does not work anymore.

This PR fixes the issue by using the `delegated` field in Lexicon config each time the plugin needs it. This field is designed for this kind of purpose: it will instruct Lexicon what is the actual DNS zone domain instead of guessing it.

I tested the change with one of my OVH account. The expected behavior is re-established and the plugin is able to test `subdomain.domain.com` then `domain.com` as before.

Fixes #9791
Fixes #9818