### PR TITLE
Add support for Alpine Linux

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -94,6 +94,7 @@ Authors
 * [Felix Yan](https://github.com/felixonmars)
 * [Filip Ochnik](https://github.com/filipochnik)
 * [Florian Klink](https://github.com/flokli)
+* [Francesco Colista](https://github.com/fcolista)
 * [Francois Marier](https://github.com/fmarier)
 * [Frank](https://github.com/Frankkkkk)
 * [Frederic BLANC](https://github.com/fblanc)

--- a/certbot-apache/certbot_apache/_internal/entrypoint.py
+++ b/certbot-apache/certbot_apache/_internal/entrypoint.py
@@ -4,6 +4,7 @@ from typing import Type
 
 from certbot import util
 from certbot_apache._internal import configurator
+from certbot_apache._internal import override_alpine
 from certbot_apache._internal import override_arch
 from certbot_apache._internal import override_centos
 from certbot_apache._internal import override_darwin
@@ -14,6 +15,7 @@ from certbot_apache._internal import override_suse
 from certbot_apache._internal import override_void
 
 OVERRIDE_CLASSES: Dict[str, Type[configurator.ApacheConfigurator]] = {
+    "alpine": override_alpine.AlpineConfigurator,
     "arch": override_arch.ArchConfigurator,
     "cloudlinux": override_centos.CentOSConfigurator,
     "darwin": override_darwin.DarwinConfigurator,

--- a/certbot-apache/certbot_apache/_internal/override_alpine.py
+++ b/certbot-apache/certbot_apache/_internal/override_alpine.py
@@ -1,0 +1,19 @@
+""" Distribution specific override class for Alpine Linux """
+from certbot_apache._internal import configurator
+from certbot_apache._internal.configurator import OsOptions
+
+
+class AlpineConfigurator(configurator.ApacheConfigurator):
+    """Alpine Linux specific ApacheConfigurator override class"""
+
+    OS_DEFAULTS = OsOptions(
+        server_root="/etc/apache2",
+        vhost_root="/etc/apache2/conf.d",
+        vhost_files="*.conf",
+        logs_root="/var/log/apache2",
+        ctl="apachectl",
+        version_cmd=['apachectl', '-v'],
+        restart_cmd=['apachectl', 'graceful'],
+        conftest_cmd=['apachectl', 'configtest'],
+        challenge_location="/etc/apache2/conf.d",
+    )

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* Added support for [Alpine Linux](https://www.alpinelinux.org) distribution when is used the apache plugin
 
 ### Changed
 


### PR DESCRIPTION
Hi, I'm the certbot maintainer for Alpine Linux (https://www.alpinelinux.org).

We are using this patch downstream: 
https://git.alpinelinux.org/aports/commit/?id=85f48c053ea3bd0d4c2cf4f34ad17ecef0b06849

Perhaps would be nice if you implement directly upstream :)
Thank you for considering.
