### PR TITLE
describe which permissions the dns-linode credentials need

### DIFF
--- a/certbot-dns-linode/certbot_dns_linode/__init__.py
+++ b/certbot-dns-linode/certbot_dns_linode/__init__.py
@@ -32,7 +32,7 @@ Credentials
 Use of this plugin requires a configuration file containing Linode API
 credentials, obtained from your Linode account's `Applications & API
 Tokens page (legacy) <https://manager.linode.com/profile/api>`_ or `Applications
-& API Tokens page (new) <https://cloud.linode.com/profile/tokens>`_.
+& API Tokens page (new) <https://cloud.linode.com/profile/tokens>`_. The credentials require the following permissions: _________.
 
 .. code-block:: ini
    :name: credentials.ini


### PR DESCRIPTION
It is not clear which permissions to choose for dns-linode credentials, and choosing all permissions is not the best idea for security if they are not all needed.

Which permissions are needed so we can describe that here?

Here are the available permissions (I'm guessing only "domains" is needed, but would like to double check):

<img width="164" alt="Screenshot 2023-12-02 at 7 38 50 PM" src="https://github.com/certbot/certbot/assets/297678/63a32709-2a96-47e1-bb87-615a0d45fb35">
