### PR TITLE
Remove Hardcoded RSA Default from API

### DIFF
--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -702,7 +702,7 @@ class NginxConfigurator(common.Configurator):
         tmp_dir = os.path.join(self.config.work_dir, "snakeoil")
         le_key = crypto_util.generate_key(
             key_size=2048, key_dir=tmp_dir, keyname="key.pem",
-            strict_permissions=self.config.strict_permissions)S
+            strict_permissions=self.config.strict_permissions)
         assert le_key.file is not None
         key = OpenSSL.crypto.load_privatekey(
             OpenSSL.crypto.FILETYPE_PEM, le_key.pem)

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -701,8 +701,8 @@ class NginxConfigurator(common.Configurator):
         # TODO: generate only once
         tmp_dir = os.path.join(self.config.work_dir, "snakeoil")
         le_key = crypto_util.generate_key(
-            key_size=1024, key_dir=tmp_dir, keyname="key.pem",
-            strict_permissions=self.config.strict_permissions)
+            key_size=2048, key_dir=tmp_dir, keyname="key.pem",
+            strict_permissions=self.config.strict_permissions)S
         assert le_key.file is not None
         key = OpenSSL.crypto.load_privatekey(
             OpenSSL.crypto.FILETYPE_PEM, le_key.pem)

--- a/certbot/certbot/_internal/tests/crypto_util_test.py
+++ b/certbot/certbot/_internal/tests/crypto_util_test.py
@@ -200,7 +200,7 @@ class MakeKeyTest(unittest.TestCase):
         with pytest.raises(errors.Error,
                            match=re.escape('Invalid key_type specified: unf.  Use [rsa|ecdsa]')):
             OpenSSL.crypto.load_privatekey(
-                OpenSSL.crypto.FILETYPE_PEM, make_key(key_type='unf'))
+                OpenSSL.crypto.FILETYPE_PEM, make_key(2048, key_type='unf'))
 
 
 class VerifyCertSetup(unittest.TestCase):

--- a/certbot/certbot/_internal/tests/crypto_util_test.py
+++ b/certbot/certbot/_internal/tests/crypto_util_test.py
@@ -185,7 +185,7 @@ class MakeKeyTest(unittest.TestCase):
         from certbot.crypto_util import make_key
 
         # Try a bad key size for RSA and ECDSA
-        with pytest.raises(errors.Error, match='Unsupported RSA key length: 512'):
+        with pytest.raises(errors.Error, match='Unsupported RSA key length: 1024'):
             make_key(bits=1024, key_type='rsa')
 
     def test_bad_elliptic_curve_name(self):

--- a/certbot/certbot/_internal/tests/crypto_util_test.py
+++ b/certbot/certbot/_internal/tests/crypto_util_test.py
@@ -168,7 +168,7 @@ class MakeKeyTest(unittest.TestCase):
         from certbot.crypto_util import make_key
 
         # Do not test larger keys as it takes too long.
-        OpenSSL.crypto.load_privatekey(OpenSSL.crypto.FILETYPE_PEM, make_key(1024))
+        OpenSSL.crypto.load_privatekey(OpenSSL.crypto.FILETYPE_PEM, make_key(2048))
 
     def test_ec(self):  # pylint: disable=no-self-use
         # ECDSA Key Type Tests

--- a/certbot/certbot/_internal/tests/crypto_util_test.py
+++ b/certbot/certbot/_internal/tests/crypto_util_test.py
@@ -186,7 +186,7 @@ class MakeKeyTest(unittest.TestCase):
 
         # Try a bad key size for RSA and ECDSA
         with pytest.raises(errors.Error, match='Unsupported RSA key length: 512'):
-            make_key(bits=512, key_type='rsa')
+            make_key(bits=1024, key_type='rsa')
 
     def test_bad_elliptic_curve_name(self):
         from certbot.crypto_util import make_key
@@ -200,7 +200,7 @@ class MakeKeyTest(unittest.TestCase):
         with pytest.raises(errors.Error,
                            match=re.escape('Invalid key_type specified: unf.  Use [rsa|ecdsa]')):
             OpenSSL.crypto.load_privatekey(
-                OpenSSL.crypto.FILETYPE_PEM, make_key(1024, key_type='unf'))
+                OpenSSL.crypto.FILETYPE_PEM, make_key(key_type='unf'))
 
 
 class VerifyCertSetup(unittest.TestCase):

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -208,7 +208,7 @@ def import_csr_file(csrfile: str, data: bytes) -> Tuple[int, util.CSR, List[str]
     return PEM, util.CSR(file=csrfile, data=data_pem, form="pem"), domains
 
 
-def make_key(bits: int = 1024, key_type: str = "rsa",
+def make_key(bits: int, key_type: str = "rsa",
              elliptic_curve: Optional[str] = None) -> bytes:
     """Generate PEM encoded RSA|EC key.
 
@@ -221,7 +221,7 @@ def make_key(bits: int = 1024, key_type: str = "rsa",
     :rtype: str
     """
     if key_type == 'rsa':
-        if bits < 1024:
+        if bits < 2048:
             raise errors.Error("Unsupported RSA key length: {}".format(bits))
 
         key = crypto.PKey()

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -208,11 +208,11 @@ def import_csr_file(csrfile: str, data: bytes) -> Tuple[int, util.CSR, List[str]
     return PEM, util.CSR(file=csrfile, data=data_pem, form="pem"), domains
 
 
-def make_key(bits: int, key_type: str = "rsa",
+def make_key(bits: int = 2048, key_type: str = "rsa",
              elliptic_curve: Optional[str] = None) -> bytes:
     """Generate PEM encoded RSA|EC key.
 
-    :param int bits: Number of bits if key_type=rsa. At least 1024 for RSA.
+    :param int bits: Number of bits if key_type=rsa. At least 2048 for RSA.
     :param str key_type: The type of key to generate, but be rsa or ecdsa
     :param str elliptic_curve: The elliptic curve to use.
 


### PR DESCRIPTION
Rectifies: https://github.com/certbot/certbot/security/advisories/GHSA-pcq2-mjvr-m4jj

Lowered to low risk since this parameter is not in active use. However we should not hardcode `1024` at all. Bumped the exception to `2048`.
