### PR TITLE
stop filtering private zones out in route53

### DIFF
--- a/certbot-dns-route53/certbot_dns_route53/_internal/dns_route53.py
+++ b/certbot-dns-route53/certbot_dns_route53/_internal/dns_route53.py
@@ -99,9 +99,6 @@ class Authenticator(dns_common.DNSAuthenticator):
         target_labels = domain.rstrip(".").split(".")
         for page in paginator.paginate():
             for zone in page["HostedZones"]:
-                if zone["Config"]["PrivateZone"]:
-                    continue
-
                 candidate_labels = zone["Name"].rstrip(".").split(".")
                 if candidate_labels == target_labels[-len(candidate_labels):]:
                     zones.append((zone["Name"], zone["Id"]))


### PR DESCRIPTION
As long as certbot can issue certificates from custom certificate authorities (such as hashicorp vault) it is possible to issue certs for endpoints inside the organisation (not public). Hence it must not filter out private zones in route53. 
Relates to https://github.com/certbot/certbot/issues/9831
