### PR TITLE
Make `reconfigure` use staging server

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * Updates `joinpath` syntax to only use one addition per call, because the multiple inputs
   version was causing mypy errors on Python 3.10.
+* Makes the `reconfigure` verb actually use the staging server for the dry run to check the new
+  configuration.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -36,6 +36,7 @@ from certbot._internal.cli.cli_utils import HelpfulArgumentGroup
 from certbot._internal.cli.cli_utils import nonnegative_int
 from certbot._internal.cli.cli_utils import parse_preferred_challenges
 from certbot._internal.cli.cli_utils import read_file
+from certbot._internal.cli.cli_utils import set_test_server_options
 from certbot._internal.cli.group_adder import _add_all_groups
 from certbot._internal.cli.helpful import HelpfulArgumentParser
 from certbot._internal.cli.paths_parser import _paths_parser

--- a/certbot/certbot/_internal/cli/cli_utils.py
+++ b/certbot/certbot/_internal/cli/cli_utils.py
@@ -274,6 +274,9 @@ def set_test_server_options(verb: str, config: NamespaceConfig) -> None:
 
     if config.server == flag_default("server"):
         config.server = constants.STAGING_URI
+        # If the account has already been loaded (such as by calling reconstitute before this),
+        # clear it so that we don't try to use the prod account on the staging server.
+        config.account = None
 
     if config.dry_run:
         if verb not in ["certonly", "renew", "reconfigure"]:

--- a/certbot/certbot/_internal/cli/cli_utils.py
+++ b/certbot/certbot/_internal/cli/cli_utils.py
@@ -1,6 +1,7 @@
 """Certbot command line util function"""
 import argparse
 import copy
+import glob
 import inspect
 from typing import Any
 from typing import Iterable
@@ -17,6 +18,7 @@ from certbot import errors
 from certbot import util
 from certbot._internal import constants
 from certbot.compat import os
+from certbot.configuration import NamespaceConfig
 
 if TYPE_CHECKING:
     from certbot._internal.cli import helpful
@@ -256,8 +258,7 @@ def set_test_server_options(verb: str, config: NamespaceConfig) -> None:
     register_unsafely_without_email in config as necessary to prepare
     to use the test server.
 
-    """
-    """We have --staging/--dry-run; perform sanity check and set config.server"""
+    We have --staging/--dry-run; perform sanity check and set config.server"""
 
     # Flag combinations should produce these results:
     #                             | --staging      | --dry-run   |

--- a/certbot/certbot/_internal/cli/cli_utils.py
+++ b/certbot/certbot/_internal/cli/cli_utils.py
@@ -18,7 +18,6 @@ from certbot import errors
 from certbot import util
 from certbot._internal import constants
 from certbot.compat import os
-from certbot.configuration import NamespaceConfig
 
 if TYPE_CHECKING:
     from certbot._internal.cli import helpful
@@ -253,12 +252,21 @@ def nonnegative_int(value: str) -> int:
         raise argparse.ArgumentTypeError("value must be non-negative")
     return int_value
 
-def set_test_server_options(verb: str, config: NamespaceConfig) -> None:
+def set_test_server_options(verb: str, config: configuration.NamespaceConfig) -> None:
     """Updates server, break_my_certs, staging, tos, and
     register_unsafely_without_email in config as necessary to prepare
     to use the test server.
 
-    We have --staging/--dry-run; perform sanity check and set config.server"""
+    We have --staging/--dry-run; perform sanity check and set config.server
+
+    :param str verb: subcommand called
+
+    :param config: parsed command line arguments
+    :type config: configuration.NamespaceConfig
+
+    :raises errors.Error: if non-default server is used and --staging is set
+    :raises errors.Error: if inapplicable verb is used and --dry-run is set
+    """
 
     # Flag combinations should produce these results:
     #                             | --staging      | --dry-run   |

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -2,7 +2,6 @@
 
 import argparse
 import functools
-import glob
 import sys
 from typing import Any
 from typing import Dict
@@ -31,7 +30,6 @@ from certbot._internal.cli.verb_help import VERB_HELP
 from certbot._internal.cli.verb_help import VERB_HELP_MAP
 from certbot._internal.display import obj as display_obj
 from certbot._internal.plugins import disco
-from certbot.compat import os
 from certbot.configuration import ArgumentSource
 from certbot.configuration import NamespaceConfig
 
@@ -319,6 +317,9 @@ class HelpfulArgumentParser:
         return config
 
     def set_test_server(self, config: NamespaceConfig) -> None:
+        """Updates server, break_my_certs, staging, tos, and
+        register_unsafely_without_email in config as necessary to prepare
+        to use the test server."""
         return set_test_server_options(self.verb, config)
 
     def handle_csr(self, config: NamespaceConfig) -> None:

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1776,6 +1776,10 @@ def reconfigure(config: configuration.NamespaceConfig,
     # make a deep copy of lineage_config because we're about to modify it for a test dry run
     dry_run_lineage_config = copy.deepcopy(lineage_config)
 
+    # we also set noninteractive_mode to more accurately simulate renewal (since `certbot renew`
+    # implies noninteractive mode) and to avoid prompting the user as changes made to
+    # dry_run_lineage_config beyond this point will not be applied to the original lineage_config
+    dry_run_lineage_config.noninteractive_mode = True
     dry_run_lineage_config.dry_run = True
     cli.set_test_server_options("reconfigure", dry_run_lineage_config)
 

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1727,10 +1727,8 @@ def reconfigure(config: configuration.NamespaceConfig,
     # to say nothing of the difficulty in explaining what exactly this subcommand can modify
 
 
-    # To make sure that the requested changes work, do a dry run. While setting up the dry run,
-    # we will set all the needed fields in config, which will then be saved upon success.
-    config.dry_run = True
-
+    # To make sure that the requested changes work, we're going to do a dry run, and only save
+    # upon success. First, modify the config as the user requested.
     if not config.certname:
         certname_question = "Which certificate would you like to reconfigure?"
         config.certname = cert_manager.get_certnames(
@@ -1774,15 +1772,23 @@ def reconfigure(config: configuration.NamespaceConfig,
 
     # this is where lineage_config gets fully filled out (e.g. --apache will set auth and installer)
     installer, auth = plug_sel.choose_configurator_plugins(lineage_config, plugins, "certonly")
-    le_client = _init_le_client(lineage_config, auth, installer)
+
+    # make a deep copy of lineage_config because we're about to modify it for a test dry run
+    dry_run_lineage_config = copy.deepcopy(lineage_config)
+
+    dry_run_lineage_config.dry_run = True
+    cli.set_test_server_options("reconfigure", dry_run_lineage_config)
+
+    le_client = _init_le_client(dry_run_lineage_config, auth, installer)
 
     # renews cert as dry run to test that the new values are ok
     # at this point, renewal_candidate.configuration has the old values, but will use
     # the values from lineage_config when doing the dry run
-    _get_and_save_cert(le_client, lineage_config, certname=certname,
+    _get_and_save_cert(le_client, dry_run_lineage_config, certname=certname,
         lineage=renewal_candidate)
 
     # this function will update lineage.configuration with the new values, and save it to disk
+    # use the pre-dry-run version
     renewal_candidate.save_new_config_values(lineage_config)
 
     _report_reconfigure_results(renewal_file, orig_renewal_conf)

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1782,7 +1782,7 @@ def reconfigure(config: configuration.NamespaceConfig,
                    "If you would like to do so, use renew with the --force-renewal flag instead "
                    "of reconfigure. Note that doing so will count against any rate limits. For "
                    "more information on this method, see "
-                   "https://certbot.org/certonly-reconfiguration")
+                   "https://certbot.org/renew-reconfiguration")
             raise errors.ConfigurationError(msg)
 
     # this is where lineage_config gets fully filled out (e.g. --apache will set auth and installer)

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1779,7 +1779,7 @@ def reconfigure(config: configuration.NamespaceConfig,
     for param in ('account', 'server',):
         if getattr(lineage_config, param) != renewalparams.get(param):
             msg = ("Using reconfigure to change the ACME account or server is not supported. "
-                   "If you would like to do so, use certonly with the --force-renewal flag instead "
+                   "If you would like to do so, use renew with the --force-renewal flag instead "
                    "of reconfigure. Note that doing so will count against any rate limits. For "
                    "more information on this method, see "
                    "https://certbot.org/certonly-reconfiguration")

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1726,6 +1726,14 @@ def reconfigure(config: configuration.NamespaceConfig,
     # --cert-name, there's enough complexity with matching certs to domains that it's not worth it,
     # to say nothing of the difficulty in explaining what exactly this subcommand can modify
 
+    for param in ('account', 'server',):
+        if config.set_by_user(param):
+            msg = ("Using reconfigure to change the ACME account or server is not supported. "
+                   "If you would like to do so, use certonly with the --force-renewal flag instead "
+                   "of reconfigure. Note that doing so will count against any rate limits. For "
+                   "more information on this method, see "
+                   "https://certbot.org/certonly-reconfiguration")
+            raise errors.ConfigurationError(msg)
 
     # To make sure that the requested changes work, we're going to do a dry run, and only save
     # upon success. First, modify the config as the user requested.

--- a/certbot/certbot/_internal/tests/main_test.py
+++ b/certbot/certbot/_internal/tests/main_test.py
@@ -650,16 +650,35 @@ class ReconfigureTest(test_util.TempDirTestCase):
         assert 'staging' in self.mocks['_init_le_client'].call_args.args[0].server
         assert 'staging' in self.mocks['_get_and_save_cert'].call_args.args[1].server
 
-    def test_account_updates(self):
-        """ Even though we can't run the dry run with the new account id, it should still
-            update in the renewal conf file.
+    def test_account_or_server_errors(self):
+        """ Check that we error when the account id or server is specified
         """
-        assert self.original_config['renewalparams']['server'] == \
-            'https://acme-v02.api.letsencrypt.org/directory'
+        orig_account_id = self.original_config['renewalparams']['account']
+        orig_server = self.original_config['renewalparams']['server']
 
-        newaccountid = 'newaccountid'
-        new_config = self._call(f'--cert-name example.com --account {newaccountid}'.split())
-        assert new_config['renewalparams']['account'] == newaccountid
+        # new account
+        for account_id in orig_account_id, 'new_account_id':
+            try:
+                self._call(f'--cert-name example.com --account {account_id}'.split())
+            except errors.ConfigurationError as err:
+                assert "Using reconfigure to change the ACME account" in str(err)
+
+            # check that config isn't modified
+            with open(self.renewal_file, 'r') as f:
+                new_config = configobj.ConfigObj(f, encoding='utf-8', default_encoding='utf-8')
+            assert new_config['renewalparams']['account'] == orig_account_id
+
+        # new server
+        for server in orig_server, 'new_server.com':
+            try:
+                self._call(f'--cert-name example.com --server {server}'.split())
+            except errors.ConfigurationError as err:
+                assert "Using reconfigure to change the ACME account" in str(err)
+
+            # check that config isn't modified
+            with open(self.renewal_file, 'r') as f:
+                new_config = configobj.ConfigObj(f, encoding='utf-8', default_encoding='utf-8')
+            assert new_config['renewalparams']['server'] == orig_server
 
     @mock.patch('certbot._internal.hooks.validate_hooks')
     def test_update_hooks(self, unused_validate_hooks):

--- a/certbot/certbot/_internal/tests/main_test.py
+++ b/certbot/certbot/_internal/tests/main_test.py
@@ -622,7 +622,7 @@ class ReconfigureTest(test_util.TempDirTestCase):
         assert new_config['renewalparams']['authenticator'] == 'apache'
 
     def test_only_intended_changes(self):
-        # Check that we don't accidentally modify anything that we didn't mean to
+        """ Check that we don't accidentally modify anything that we didn't mean to """
         named_mock = mock.Mock()
         named_mock.name = 'apache'
 
@@ -641,14 +641,25 @@ class ReconfigureTest(test_util.TempDirTestCase):
 
     @mock.patch('certbot._internal.hooks.validate_hooks')
     def test_staging_used(self, unused_validate_hooks):
-        """ Check that we use the staging server for the dry run"""
+        """ Check that we use the staging server for the dry run """
         assert self.original_config['renewalparams']['server'] == \
             'https://acme-v02.api.letsencrypt.org/directory'
 
-        new_config = self._call('--cert-name example.com --pre-hook'.split() + ['echo pre'])
+        self._call('--cert-name example.com --pre-hook'.split() + ['echo pre'])
 
         assert 'staging' in self.mocks['_init_le_client'].call_args.args[0].server
         assert 'staging' in self.mocks['_get_and_save_cert'].call_args.args[1].server
+
+    def test_account_updates(self):
+        """ Even though we can't run the dry run with the new account id, it should still
+            update in the renewal conf file.
+        """
+        assert self.original_config['renewalparams']['server'] == \
+            'https://acme-v02.api.letsencrypt.org/directory'
+
+        newaccountid = 'newaccountid'
+        new_config = self._call(f'--cert-name example.com --account {newaccountid}'.split())
+        assert new_config['renewalparams']['account'] == newaccountid
 
     @mock.patch('certbot._internal.hooks.validate_hooks')
     def test_update_hooks(self, unused_validate_hooks):


### PR DESCRIPTION
Fixes #9847.

Creates `set_test_server_options` in `cli_utils` so that when `dry_run` is set after parse time, applicable options are additionally changed as well, and calls it from `main.reconfigure`.

Clears `config.account` in `set_test_server_options` when default `server` is switched to `staging`, so that the account id loaded during `reconstitute` isn't used with the staging server.

Note that this implies that if `account` was set on the cli and the default server is being used, the new account will not be tested during the dry run. Given that a dry run specifically implies using the staging server, there's not really a way to do that anyway. The new account will still be saved to the renewal conf file as the user requested.


Regression test failing on master:

```python
__________________________________________________________ ReconfigureTest.test_staging_used ___________________________________________________________

self = <certbot._internal.tests.main_test.ReconfigureTest testMethod=test_staging_used>

    def test_staging_used(self):
        """ Check that we use the staging server for the dry run"""
        assert self.original_config['renewalparams']['server'] == \
            'https://acme-v02.api.letsencrypt.org/directory'
    
        new_config = self._call('--cert-name example.com --pre-hook'.split() + ['echo pre'])
    
>       assert 'staging' in self.mocks['_init_le_client'].call_args.args[0].server
E       AssertionError: assert 'staging' in 'https://acme-v02.api.letsencrypt.org/directory'
E        +  where 'https://acme-v02.api.letsencrypt.org/directory' = <certbot.configuration.NamespaceConfig object at 0x7f49e303d780>.server

certbot/certbot/_internal/tests/main_test.py:649: AssertionError
```