### PR TITLE
Fix mypy joinpath errors

### DIFF
--- a/certbot-apache/certbot_apache/_internal/apache_util.py
+++ b/certbot-apache/certbot_apache/_internal/apache_util.py
@@ -257,6 +257,6 @@ def find_ssl_apache_conf(prefix: str) -> str:
     """
     file_manager = ExitStack()
     atexit.register(file_manager.close)
-    ref = importlib_resources.files("certbot_apache").joinpath(
-        "_internal", "tls_configs", "{0}-options-ssl-apache.conf".format(prefix))
+    ref = (importlib_resources.files("certbot_apache").joinpath("_internal")
+           .joinpath("tls_configs").joinpath("{0}-options-ssl-apache.conf".format(prefix)))
     return str(file_manager.enter_context(importlib_resources.as_file(ref)))

--- a/certbot-ci/certbot_integration_tests/nginx_tests/nginx_config.py
+++ b/certbot-ci/certbot_integration_tests/nginx_tests/nginx_config.py
@@ -32,13 +32,15 @@ def construct_nginx_config(nginx_root: str, nginx_webroot: str, http_port: int, 
     if not key_path:
         file_manager = ExitStack()
         atexit.register(file_manager.close)
-        ref = importlib_resources.files('certbot_integration_tests').joinpath('assets', 'key.pem')
+        ref = (importlib_resources.files('certbot_integration_tests').joinpath('assets')
+               .joinpath('key.pem'))
         key_path = str(file_manager.enter_context(importlib_resources.as_file(ref)))
 
     if not cert_path:
         file_manager = ExitStack()
         atexit.register(file_manager.close)
-        ref = importlib_resources.files('certbot_integration_tests').joinpath('assets', 'cert.pem')
+        ref = (importlib_resources.files('certbot_integration_tests').joinpath('assets')
+               .joinpath('cert.pem'))
         cert_path = str(file_manager.enter_context(importlib_resources.as_file(ref)))
 
     return '''\

--- a/certbot-ci/certbot_integration_tests/rfc2136_tests/context.py
+++ b/certbot-ci/certbot_integration_tests/rfc2136_tests/context.py
@@ -48,9 +48,8 @@ class IntegrationTestsContext(certbot_context.IntegrationTestsContext):
         :yields: Path to credentials file
         :rtype: str
         """
-        src_ref_file = importlib_resources.files('certbot_integration_tests').joinpath(
-            'assets', 'bind-config', f'rfc2136-credentials-{label}.ini.tpl'
-        )
+        src_ref_file = (importlib_resources.files('certbot_integration_tests').joinpath('assets')
+                        .joinpath('bind-config').joinpath(f'rfc2136-credentials-{label}.ini.tpl'))
         with importlib_resources.as_file(src_ref_file) as src_file:
             with open(src_file, 'r') as f:
                 contents = f.read().format(

--- a/certbot-ci/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/certbot_integration_tests/utils/misc.py
@@ -125,8 +125,8 @@ def generate_test_file_hooks(config_dir: str, hook_probe: str) -> None:
     """
     file_manager = contextlib.ExitStack()
     atexit.register(file_manager.close)
-    hook_path_ref = importlib_resources.files('certbot_integration_tests').joinpath(
-        'assets', 'hook.py')
+    hook_path_ref = (importlib_resources.files('certbot_integration_tests').joinpath('assets')
+                     .joinpath('hook.py'))
     hook_path = str(file_manager.enter_context(importlib_resources.as_file(hook_path_ref)))
 
     for hook_dir in list_renewal_hooks_dirs(config_dir):
@@ -262,9 +262,8 @@ def load_sample_data_path(workspace: str) -> str:
     :returns: the path to the loaded sample data directory
     :rtype: str
     """
-    original_ref = importlib_resources.files('certbot_integration_tests').joinpath(
-        'assets', 'sample-config'
-    )
+    original_ref = (importlib_resources.files('certbot_integration_tests').joinpath('assets')
+                    .joinpath('sample-config'))
     with importlib_resources.as_file(original_ref) as original:
         copied = os.path.join(workspace, 'sample-config')
         shutil.copytree(original, copied, symlinks=True)

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -171,8 +171,8 @@ class NginxConfigurator(common.Configurator):
 
         file_manager = ExitStack()
         atexit.register(file_manager.close)
-        ref = importlib_resources.files("certbot_nginx").joinpath(
-            "_internal", "tls_configs", config_filename)
+        ref = (importlib_resources.files("certbot_nginx").joinpath("_internal")
+               .joinpath("tls_configs").joinpath(config_filename))
 
         return str(file_manager.enter_context(importlib_resources.as_file(ref)))
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Updates `joinpath` syntax to only use one addition per call, because the multiple inputs
+  version was causing mypy errors on Python 3.10.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/plugins/common.py
+++ b/certbot/certbot/plugins/common.py
@@ -465,7 +465,7 @@ def dir_setup(test_dir: str, pkg: str) -> Tuple[str, str, str]:  # pragma: no co
     filesystem.chmod(config_dir, constants.CONFIG_DIRS_MODE)
     filesystem.chmod(work_dir, constants.CONFIG_DIRS_MODE)
 
-    test_dir_ref = importlib_resources.files(pkg).joinpath("testdata", test_dir)
+    test_dir_ref = importlib_resources.files(pkg).joinpath("testdata").joinpath(test_dir)
     with importlib_resources.as_file(test_dir_ref) as path:
         shutil.copytree(
             path, os.path.join(temp_dir, test_dir), symlinks=True)


### PR DESCRIPTION
Changes based on https://github.com/certbot/certbot/pull/9837/

This was causing mypy error `Too many arguments for "joinpath" of "Traversable"  [call-arg]` using python 3.10.12.

After these changes, `tox -e mypy` passes on the same system.