### PR TITLE
Docs: Reset requirements.txt path

### DIFF
--- a/acme/.readthedocs.yaml
+++ b/acme/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/acme/.readthedocs.yaml
+++ b/acme/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/acme/.readthedocs.yaml
+++ b/acme/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: acme/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: acme/readthedocs.org.requirements.txt

--- a/certbot-dns-cloudflare/.readthedocs.yaml
+++ b/certbot-dns-cloudflare/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-cloudflare/.readthedocs.yaml
+++ b/certbot-dns-cloudflare/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-cloudflare/.readthedocs.yaml
+++ b/certbot-dns-cloudflare/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-cloudflare/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-cloudflare/readthedocs.org.requirements.txt

--- a/certbot-dns-digitalocean/.readthedocs.yaml
+++ b/certbot-dns-digitalocean/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-digitalocean/.readthedocs.yaml
+++ b/certbot-dns-digitalocean/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-digitalocean/.readthedocs.yaml
+++ b/certbot-dns-digitalocean/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-digitalocean/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-digitalocean/readthedocs.org.requirements.txt

--- a/certbot-dns-dnsimple/.readthedocs.yaml
+++ b/certbot-dns-dnsimple/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-dnsimple/.readthedocs.yaml
+++ b/certbot-dns-dnsimple/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-dnsimple/.readthedocs.yaml
+++ b/certbot-dns-dnsimple/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-dnsimple/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-dnsimple/readthedocs.org.requirements.txt

--- a/certbot-dns-dnsmadeeasy/.readthedocs.yaml
+++ b/certbot-dns-dnsmadeeasy/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-dnsmadeeasy/.readthedocs.yaml
+++ b/certbot-dns-dnsmadeeasy/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-dnsmadeeasy/.readthedocs.yaml
+++ b/certbot-dns-dnsmadeeasy/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-dnsmadeeasy/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-dnsmadeeasy/readthedocs.org.requirements.txt

--- a/certbot-dns-gehirn/.readthedocs.yaml
+++ b/certbot-dns-gehirn/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-gehirn/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-gehirn/readthedocs.org.requirements.txt

--- a/certbot-dns-gehirn/.readthedocs.yaml
+++ b/certbot-dns-gehirn/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-gehirn/.readthedocs.yaml
+++ b/certbot-dns-gehirn/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-google/.readthedocs.yaml
+++ b/certbot-dns-google/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-google/.readthedocs.yaml
+++ b/certbot-dns-google/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-google/.readthedocs.yaml
+++ b/certbot-dns-google/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-google/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-google/readthedocs.org.requirements.txt

--- a/certbot-dns-linode/.readthedocs.yaml
+++ b/certbot-dns-linode/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-linode/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-linode/readthedocs.org.requirements.txt

--- a/certbot-dns-linode/.readthedocs.yaml
+++ b/certbot-dns-linode/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-linode/.readthedocs.yaml
+++ b/certbot-dns-linode/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-luadns/.readthedocs.yaml
+++ b/certbot-dns-luadns/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-luadns/.readthedocs.yaml
+++ b/certbot-dns-luadns/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-luadns/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-luadns/readthedocs.org.requirements.txt

--- a/certbot-dns-luadns/.readthedocs.yaml
+++ b/certbot-dns-luadns/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-nsone/.readthedocs.yaml
+++ b/certbot-dns-nsone/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-nsone/.readthedocs.yaml
+++ b/certbot-dns-nsone/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-nsone/.readthedocs.yaml
+++ b/certbot-dns-nsone/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-nsone/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references

--- a/certbot-dns-nsone/.readthedocs.yaml
+++ b/certbot-dns-nsone/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-nsone/readthedocs.org.requirements.txt

--- a/certbot-dns-ovh/.readthedocs.yaml
+++ b/certbot-dns-ovh/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-ovh/.readthedocs.yaml
+++ b/certbot-dns-ovh/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-ovh/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-ovh/readthedocs.org.requirements.txt

--- a/certbot-dns-ovh/.readthedocs.yaml
+++ b/certbot-dns-ovh/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-rfc2136/.readthedocs.yaml
+++ b/certbot-dns-rfc2136/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-rfc2136/.readthedocs.yaml
+++ b/certbot-dns-rfc2136/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-rfc2136/.readthedocs.yaml
+++ b/certbot-dns-rfc2136/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-rfc2136/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-rfc2136/readthedocs.org.requirements.txt

--- a/certbot-dns-route53/.readthedocs.yaml
+++ b/certbot-dns-route53/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-route53/.readthedocs.yaml
+++ b/certbot-dns-route53/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-route53/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-route53/readthedocs.org.requirements.txt

--- a/certbot-dns-route53/.readthedocs.yaml
+++ b/certbot-dns-route53/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-sakuracloud/.readthedocs.yaml
+++ b/certbot-dns-sakuracloud/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot-dns-sakuracloud/.readthedocs.yaml
+++ b/certbot-dns-sakuracloud/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot-dns-sakuracloud/.readthedocs.yaml
+++ b/certbot-dns-sakuracloud/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot-dns-sakuracloud/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot-dns-sakuracloud/readthedocs.org.requirements.txt

--- a/certbot/.readthedocs.yaml
+++ b/certbot/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: tools/requirements.txt
+   - requirements: readthedocs.org.requirements.txt

--- a/certbot/.readthedocs.yaml
+++ b/certbot/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: certbot/docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: readthedocs.org.requirements.txt
+   - requirements: certbot/readthedocs.org.requirements.txt

--- a/certbot/.readthedocs.yaml
+++ b/certbot/.readthedocs.yaml
@@ -30,4 +30,4 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: ../tools/requirements.txt
+   - requirements: tools/requirements.txt

--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -69,7 +69,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'Certbot'
 # this is now overridden by the footer.html template
-#copyright = u'2014-2018 - The Certbot software and documentation are licensed under the Apache 2.0 license as described at https://eff.org/cb-license.'
+copyright = u'2014-2018 - The Certbot software and documentation are licensed under the Apache 2.0 license as described at https://eff.org/cb-license.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Readthedocs does not like relative paths. I believe it can just read down from the root of the repo (hopefully). There's no clear way to test this locally.