### PR TITLE
Enable http2 in nginx configuration by default

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -7,6 +7,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 * Support for Python 3.12 was added.
+* Enable http/2 in nginx configuration files
 
 ### Changed
 


### PR DESCRIPTION
I added a few lines which check the nginx version and enable http2 in the configuration.
Fixes #3646 