### PR TITLE
Add dns-account-01 challenge support

### DIFF
--- a/acme/acme/_internal/tests/challenges_test.py
+++ b/acme/acme/_internal/tests/challenges_test.py
@@ -198,14 +198,16 @@ class DNSACCOUNT01Test(unittest.TestCase):
 
         from acme.challenges import DNSACCOUNT01
         self.accountURI = "https://example.com/acme/acct/1234"
-        # "_" || base32(SHA-256(Account Resource URL)[0:9])
+        self.scope = "wildcard"
+        # "_" || base32(SHA-256(<ACCOUNT_RESOURCE_URL>)[0:10]) || "._acme-" || <SCOPE> || "-challenge"
         self.accountLabel = '_' + b32encode(
             sha256(self.accountURI.encode()).digest()[:10]
-        ).decode().lower()
+        ).decode().lower() + '._acme-' + self.scope + '-challenge'
 
     def test_validation_domain_name(self):
-        assert self.accountLabel + '._acme-challenge.www.example.com' == \
-            self.msg.validation_domain_name(self.accountURI, 'www.example.com')
+        assert self.accountLabel + '.www.example.com' == \
+            self.msg.validation_domain_name(
+                self.accountURI, self.scope, 'www.example.com')
 
     def test_validation(self):
         assert "rAa7iIg4K2y63fvUhCfy8dP1Xl7wEhmQq0oChTcE3Zk" == \

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -324,9 +324,6 @@ class DNSACCOUNT01(KeyAuthorizationChallenge):
     response_cls = DNSACCOUNT01Response
     typ = response_cls.typ
 
-    LABEL = "_acme-challenge"
-    """Label clients prepend to the domain name being validated."""
-
     def validation(self, account_key: jose.JWK, **unused_kwargs: Any) -> str:
         """Generate validation.
 
@@ -337,17 +334,18 @@ class DNSACCOUNT01(KeyAuthorizationChallenge):
         return jose.b64encode(hashlib.sha256(self.key_authorization(
             account_key).encode("utf-8")).digest()).decode()
 
-    def validation_domain_name(self, acctURI: str, name: str) -> str:
+    def validation_domain_name(self, acctURI: str, scope: str, name: str) -> str:
         """Domain name for TXT validation record.
 
         :param str acctURI: Account Resource URI.
+        :param str scope: Scope of the challenge.
         :param str name: Domain name being validated.
         :rtype: str
 
         """
         acctLabel = b32encode(hashlib.sha256(
             acctURI.encode()).digest()[:10]).decode().lower()
-        return f"_{acctLabel}.{self.LABEL}.{name}"
+        return f"_{acctLabel}._acme-{scope}-challenge.{name}"
 
 
 @ChallengeResponse.register


### PR DESCRIPTION
This change adds support for the draft [dns-account-01 challenge](https://github.com/aaomidi/draft-ietf-acme-dns-account-challenge) in the Python acme library.