### PR TITLE
use our own boulder rate limit file

### DIFF
--- a/certbot-ci/certbot_integration_tests/assets/boulder-rate-limit-policies.yml
+++ b/certbot-ci/certbot_integration_tests/assets/boulder-rate-limit-policies.yml
@@ -1,4 +1,5 @@
-# See cmd/shell.go for definitions of these rate limits.
+# See https://github.com/letsencrypt/boulder/blob/main/cmd/shell.go for
+# definitions of these rate limits.
 certificatesPerName:
   window: 2160h
   threshold: 99

--- a/certbot-ci/certbot_integration_tests/assets/boulder-rate-limit-policies.yml
+++ b/certbot-ci/certbot_integration_tests/assets/boulder-rate-limit-policies.yml
@@ -1,0 +1,54 @@
+# See cmd/shell.go for definitions of these rate limits.
+certificatesPerName:
+  window: 2160h
+  threshold: 99
+  overrides:
+    ratelimit.me: 1
+    lim.it: 0
+    # Hostnames used by the letsencrypt client integration test.
+    le.wtf: 9999
+    le1.wtf: 9999
+    le2.wtf: 9999
+    le3.wtf: 9999
+    le4.wtf: 9999
+    nginx.wtf: 9999
+    good-caa-reserved.com: 9999
+    bad-caa-reserved.com: 9999
+    ecdsa.le.wtf: 9999
+    must-staple.le.wtf: 9999
+  registrationOverrides:
+    101: 1000
+registrationsPerIP:
+  window: 168h # 1 week
+  threshold: 9999
+  overrides:
+    127.0.0.1: 999990
+registrationsPerIPRange:
+  window: 168h # 1 week
+  threshold: 99999
+  overrides:
+    127.0.0.1: 1000000
+pendingAuthorizationsPerAccount:
+  window: 168h # 1 week, should match pending authorization lifetime.
+  threshold: 999
+newOrdersPerAccount:
+  window: 3h
+  threshold: 9999
+certificatesPerFQDNSet:
+  window: 168h
+  threshold: 99999
+  overrides:
+    le.wtf: 9999
+    le1.wtf: 9999
+    le2.wtf: 9999
+    le3.wtf: 9999
+    le.wtf,le1.wtf: 9999
+    good-caa-reserved.com: 9999
+    nginx.wtf: 9999
+    ecdsa.le.wtf: 9999
+    must-staple.le.wtf: 9999
+certificatesPerFQDNSetFast:
+  window: 2h
+  threshold: 20
+  overrides:
+    le.wtf: 9


### PR DESCRIPTION
[Our boulder tests started failing](https://dev.azure.com/certbot/certbot/_build/results?buildId=7450&view=logs&j=6ad68b67-de4d-505d-ce4c-252f2315a668&t=3c5d8e74-2b1b-5f7c-3030-cb8c4f27ac96&l=256) because https://github.com/letsencrypt/boulder/pull/7201 deleted the alternate rate limit policy file. I expect us using our own copy of the file is pretty safe as [the files rarely change](https://github.com/letsencrypt/boulder/commits/main/test/rate-limit-policies.yml).

I also tried just using their remaining default test rate limits file, but [hit rate limits](https://dev.azure.com/certbot/certbot/_build/results?buildId=7455&view=logs&j=ba5bfc87-3e39-5d26-7266-6e160829f72c&t=e8c445a6-4476-5bfd-f3d9-3bd130c55c27&l=7942).

Finally, regardless of what file I used and even if I tried pinning back boulder, the overall docker config seems a bit slower now and requires a higher retry value before we time out waiting for boulder to start.

You can see tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=7460&view=results.