### PR TITLE
Use the legacy snapcraft build until #9890 is fixed

### DIFF
--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -240,6 +240,10 @@ def main():
         subprocess.run(['tools/snap/generate_dnsplugins_all.sh'],
                        check=True, cwd=CERTBOT_DIR)
 
+    # Use the legacy remote launchpad build until
+    # https://github.com/certbot/certbot/issues/9890 is fixed
+    os.environ['SNAPCRAFT_REMOTE_BUILD_STRATEGY'] = 'force-fallback'
+
     print('Start remote snap builds...')
     print(f' - archs: {", ".join(archs)}')
     print(f' - projects: {", ".join(sorted(targets))}')


### PR DESCRIPTION
Sets the environment variable to use the legacy launchpad remote build strategy as described in https://snapcraft.io/docs/remote-build#heading--legacy-remote-build.

You can see the snap test recognizing the certbot build here: https://dev.azure.com/certbot/certbot/_build/results?buildId=7462&view=logs&j=f44d40a4-7318-5ffe-762c-ae4557889284&t=07786725-57f8-5198-4d13-ea77f640bd5c

And all snap build and tests here: https://dev.azure.com/certbot/certbot/_build/results?buildId=7466&view=results