### PR TITLE
fix(route53): explanation on credentials file

### DIFF
--- a/certbot-dns-route53/certbot_dns_route53/__init__.py
+++ b/certbot-dns-route53/certbot_dns_route53/__init__.py
@@ -63,7 +63,8 @@ credentials <https://boto3.readthedocs.io/en/latest/guide/configuration.html
 * Using the ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` environment
   variables.
 * Using a credentials configuration file at the default location,
-  ``~/.aws/config``.
+  ``~/.aws/credentials``. If you're running on sudo, the credentials
+  will be picked up from the root home.
 * Using a credentials configuration file at a path supplied using the
   ``AWS_CONFIG_FILE`` environment variable.
 


### PR DESCRIPTION
The credentials configuration file is at ~/.aws/credentials.

Also, when running on root it uses the root home (so /root/.aws). This was from my test at an ubuntu server.

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
