### PR TITLE
update centos9stream ami

### DIFF
--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -38,7 +38,7 @@ targets:
     type: centos
     virt: hvm
     user: centos
-  - ami: ami-0d5144f02e4eb6f05
+  - ami: ami-08f2fe20b72b2ffa7
     name: centos9stream
     type: centos
     virt: hvm


### PR DESCRIPTION
our "test farm tests" started failing with [this error](https://dev.azure.com/certbot/certbot/_build/results?buildId=7548&view=logs&j=9ad64ec1-64fe-5c1a-aa80-014a21728434&t=01dc0a99-87f2-5e74-d7b8-4950697fba7c&l=393). googling around i saw https://github.com/boto/boto3/issues/560#issuecomment-572666373 and checking the aws ami catalog, it appears this is the case here -- the ami we were using was deleted. to fix this, i updated to the ami to the current one. you can see tests passing with this change [here](https://dev.azure.com/certbot/certbot/_build/results?buildId=7550&view=results)