### PR TITLE
Added support for fifth PEM file that contains everything

### DIFF
--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -403,6 +403,10 @@ def renew_cert(config: configuration.NamespaceConfig, domains: Optional[List[str
         prior_version = lineage.latest_common_version()
         # TODO: Check return value of save_successor
         lineage.save_successor(prior_version, new_cert, new_key.pem, new_chain, config)
+        # NOTE: Saving the successor first and then updating the symlinks in that order
+        # is important to keep the update "atomic".
+        # Only when the new files have been completely written, the symlink may be
+        # reassigned.
         lineage.update_all_links_to(lineage.latest_common_version())
         lineage.truncate()
 

--- a/certbot/certbot/_internal/tests/cert_manager_test.py
+++ b/certbot/certbot/_internal/tests/cert_manager_test.py
@@ -13,7 +13,7 @@ import pytest
 
 from certbot import configuration
 from certbot import errors
-from certbot._internal.storage import ALL_FOUR
+from certbot._internal.storage import ALL_FIVE
 from certbot._internal.tests import storage_test
 from certbot.compat import filesystem
 from certbot.compat import os
@@ -55,7 +55,7 @@ class BaseCertManagerTest(test_util.ConfigTestCase):
         else:
             filesystem.makedirs(os.path.join(self.config.default_archive_dir, domain))
 
-        for kind in ALL_FOUR:
+        for kind in ALL_FIVE:
             config_file[kind] = os.path.join(self.config.live_dir, domain,
                                         kind + ".pem")
 
@@ -80,8 +80,8 @@ class UpdateLiveSymlinksTest(BaseCertManagerTest):
             else:
                 archive_dir_path = os.path.join(self.config.default_archive_dir, domain)
             archive_paths[domain] = {kind:
-                os.path.join(archive_dir_path, kind + "1.pem") for kind in ALL_FOUR}
-            for kind in ALL_FOUR:
+                os.path.join(archive_dir_path, kind + "1.pem") for kind in ALL_FIVE}
+            for kind in ALL_FIVE:
                 live_path = self.config_files[domain][kind]
                 archive_path = archive_paths[domain][kind]
                 open(archive_path, 'a').close()
@@ -95,7 +95,7 @@ class UpdateLiveSymlinksTest(BaseCertManagerTest):
         prev_dir = os.getcwd()
         try:
             for domain in self.domains:
-                for kind in ALL_FOUR:
+                for kind in ALL_FIVE:
                     os.chdir(os.path.dirname(self.config_files[domain][kind]))
                     assert filesystem.realpath(filesystem.readlink(self.config_files[domain][kind])) == \
                         filesystem.realpath(archive_paths[domain][kind])

--- a/certbot/certbot/tests/util.py
+++ b/certbot/certbot/tests/util.py
@@ -182,7 +182,7 @@ def make_lineage(config_dir: str, testfile: str, ec: bool = True) -> str:
         shutil.copyfile(os.path.join(sample_archive, kind),
                         os.path.join(archive_dir, kind))
 
-    for kind in storage.ALL_FOUR:
+    for kind in storage.ALL_FIVE:
         os.symlink(os.path.join(archive_dir, '{0}1.pem'.format(kind)),
                    os.path.join(live_dir, '{0}.pem'.format(kind)))
 


### PR DESCRIPTION
Fixes #5087.

Currently, Certbot creates four PEM files (`privkey.pem`, `cert.pem`, `chain.pem` and `fullchain.pem`). This PR adds a a fifth PEM file (`everything.pem`) which includes the private key, the leaf certificate and the chain in that order.

This does not only expand support to some server daemons which require a single, combined PEM file, but also enables some server daemons to obtain a renewed certificate without the need for reloading and/or service interruption. Some server daemons (e.g. Postfix) pick up a new private key and/or certificate as soon as the corresponding file has changed on disk. Hence, it is crucial that the update is "atomic". First, the file (in the archive folder) has to be written and then the symlink (in the live folder) must be updated.