### PR TITLE
Granular permissions

### DIFF
--- a/certbot-dns-route53/examples/sample-aws-policy.json
+++ b/certbot-dns-route53/examples/sample-aws-policy.json
@@ -19,7 +19,19 @@
             ],
             "Resource" : [
                 "arn:aws:route53:::hostedzone/YOURHOSTEDZONEID"
-            ]
+            ],
+			"Condition": {
+				"ForAllValues:StringLike": {
+					"route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+						"_acme-challenge.*"
+					]
+				},
+				"ForAllValues:StringEquals": {
+					"route53:ChangeResourceRecordSetsRecordTypes": [
+						"TXT"
+					]
+				}
+			}
         }
     ]
 }


### PR DESCRIPTION
Set granular permissions to TXT DNS records with names starting with `_acme-challenge.` only
This replaces original policy that is too permissive

The `Condition` clause uses [Route 53 resource record set permission](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-permissions.html)

Policy tested with Certbot 2.9.0
