### PR TITLE
document the github-releases credential

### DIFF
--- a/.azure-pipelines/templates/stages/release-deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/release-deploy-stage.yml
@@ -14,6 +14,23 @@ stages:
             path: '$(Pipeline.Workspace)'
         - task: GitHubRelease@1
           inputs:
+            # this "github-releases" credential is what azure pipelines calls a
+            # "service connection". it was created using the instructions at
+            # https://learn.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#github-service-connection
+            # with a fine-grained personal access token from github to limit
+            # the permissions given to azure pipelines. the connection on azure
+            # needs permissions for the "release" pipeline (and maybe the
+            # "full-test-suite" pipeline to simplify testing it). information
+            # on how to set up these permissions can be found at
+            # https://learn.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#secure-a-service-connection.
+            # the github token that is used needs "contents:write" and
+            # "workflows:write" permissions for the certbot repo
+            #
+            # as of writing this, the current token will expire on 3/15/2025.
+            # when recreating it, you may also want to create it using the
+            # shared "certbotbot" github account so the credentials aren't tied
+            # to any one dev's github account and their access to the certbot
+            # repo
             gitHubConnection: github-releases
             title: ${{ format('Certbot {0}', replace(variables['Build.SourceBranchName'], 'v', '')) }}
             releaseNotesFilePath: '$(Pipeline.Workspace)/release_notes.md'


### PR DESCRIPTION
this is a follow up from https://github.com/certbot/certbot/pull/9913. i personally like documenting the credential with its usage to avoid needing to find external documentation, but i can also/instead put this somewhere like our internal wiki if other people have a preference for that

i also created a calendar event with a reminder for the certbot team referencing this file and credential in feburary 2025, a month before it expires