### PR TITLE
Switch to using docker compose v2

### DIFF
--- a/certbot-ci/certbot_integration_tests/conftest.py
+++ b/certbot-ci/certbot_integration_tests/conftest.py
@@ -89,7 +89,7 @@ def _setup_primary_node(config):
                              'boulder, but is not installed or not available for current user.')
 
         try:
-            subprocess.check_output(['docker', 'compose', 'ps'], stderr=subprocess.STDOUT)
+            subprocess.check_output(['docker', 'compose', 'ls'], stderr=subprocess.STDOUT)
         except (subprocess.CalledProcessError, OSError):
             raise ValueError(
                 'Error: A version of Docker with the "compose" subcommand '

--- a/certbot-ci/certbot_integration_tests/conftest.py
+++ b/certbot-ci/certbot_integration_tests/conftest.py
@@ -69,7 +69,7 @@ def _setup_primary_node(config):
     Setup the environment for integration tests.
 
     This function will:
-        - check runtime compatibility (Docker, docker-compose, Nginx)
+        - check runtime compatibility (Docker, docker compose, Nginx)
         - create a temporary workspace and the persistent GIT repositories space
         - configure and start a DNS server using Docker, if configured
         - configure and start paralleled ACME CA servers using Docker
@@ -89,10 +89,11 @@ def _setup_primary_node(config):
                              'boulder, but is not installed or not available for current user.')
 
         try:
-            subprocess.check_output(['docker-compose', '-v'], stderr=subprocess.STDOUT)
+            subprocess.check_output(['docker', 'compose', 'ps'], stderr=subprocess.STDOUT)
         except (subprocess.CalledProcessError, OSError):
             raise ValueError(
-                'Error: docker-compose is required in PATH to launch the integration tests, '
+                'Error: A version of Docker with the "compose" subcommand '
+                'is required in PATH to launch the integration tests, '
                 'but is not installed or not available for current user.'
             )
 

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -205,9 +205,9 @@ class ACMEServer:
                     f.write(json.dumps(config, indent=2, separators=(',', ': ')))
 
         # This command needs to be run before we try and terminate running processes because
-        # docker-compose up doesn't always respond to SIGTERM. See
+        # docker compose up doesn't always respond to SIGTERM. See
         # https://github.com/certbot/certbot/pull/9435.
-        self._register_preterminate_cmd(['docker-compose', 'down'], cwd=instance_path)
+        self._register_preterminate_cmd(['docker', 'compose', 'down'], cwd=instance_path)
         # Boulder docker generates build artifacts owned by root with 0o744 permissions.
         # If we started the acme server from a normal user that has access to the Docker
         # daemon, this user will not be able to delete these artifacts from the host.
@@ -217,7 +217,7 @@ class ACMEServer:
                                          '-rf', '/workspace/boulder'])
         try:
             # Launch the Boulder server
-            self._launch_process(['docker-compose', 'up', '--force-recreate'], cwd=instance_path)
+            self._launch_process(['docker', 'compose', 'up', '--force-recreate'], cwd=instance_path)
 
             # Wait for the ACME CA server to be up.
             print('=> Waiting for boulder instance to respond...')
@@ -236,7 +236,7 @@ class ACMEServer:
             # If we failed to set up boulder, print its logs.
             print('=> Boulder setup failed. Boulder logs are:')
             process = self._launch_process([
-                'docker-compose', 'logs'], cwd=instance_path, force_stderr=True
+                'docker', 'compose', 'logs'], cwd=instance_path, force_stderr=True
             )
             process.wait(MAX_SUBPROCESS_WAIT)
             raise

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * We no longer publish our beta Windows installer as was originally announced
   [here](https://community.letsencrypt.org/t/certbot-discontinuing-windows-beta-support-in-2024/208101).
+* Switch to using docker compose v2, as Azure's images dropped v1.
 
 ### Fixed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,7 +16,6 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * We no longer publish our beta Windows installer as was originally announced
   [here](https://community.letsencrypt.org/t/certbot-discontinuing-windows-beta-support-in-2024/208101).
-* Switch to using docker compose v2, as Azure's images dropped v1.
 
 ### Fixed
 

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -154,7 +154,7 @@ Running automated integration tests
 
 Generally it is sufficient to open a pull request and let Github and Azure Pipelines run
 integration tests for you. However, you may want to run them locally before submitting
-your pull request. You need Docker and docker-compose (v1 or v2) installed and working.
+your pull request. You need Docker installed and working.
 
 The tox environment `integration` will setup `Pebble`_, the Let's Encrypt ACME CA server
 for integration testing, then launch the Certbot integration tests.

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -154,7 +154,7 @@ Running automated integration tests
 
 Generally it is sufficient to open a pull request and let Github and Azure Pipelines run
 integration tests for you. However, you may want to run them locally before submitting
-your pull request. You need Docker and docker-compose installed and working.
+your pull request. You need Docker and docker-compose (v1 or v2) installed and working.
 
 The tox environment `integration` will setup `Pebble`_, the Let's Encrypt ACME CA server
 for integration testing, then launch the Certbot integration tests.


### PR DESCRIPTION
Azure recently dropped the `docker-compose` standalone executable (aka docker-compose v1), and since it's not receiving updates anymore, let's get with the times and update to v2 as well.