### PR TITLE
add IONOS Cloud DNS plugin to the documentation

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -326,6 +326,7 @@ dns-dnsmanager_    Y    N    DNS Authentication for dnsmanager.io
 standalone-nfq_    Y    N    HTTP Authentication that works with any webserver (Linux only)
 dns-solidserver_   Y    N    DNS Authentication using SOLIDserver (EfficientIP)
 dns-stackit_       Y    N    DNS Authentication using STACKIT DNS
+dns-ionos_         Y    N    DNS Authentication using IONOS Cloud DNS
 ================== ==== ==== ===============================================================
 
 .. _haproxy: https://github.com/greenhost/certbot-haproxy
@@ -353,6 +354,7 @@ dns-stackit_       Y    N    DNS Authentication using STACKIT DNS
 .. _standalone-nfq: https://github.com/alexzorin/certbot-standalone-nfq
 .. _dns-solidserver: https://gitlab.com/charlyhong/certbot-dns-solidserver
 .. _dns-stackit: https://github.com/stackitcloud/certbot-dns-stackit
+.. _dns-ionos: https://github.com/ionos-cloud/certbot-dns-ionos-cloud
 
 If you're interested, you can also :ref:`write your own plugin <dev-plugin>`.
 


### PR DESCRIPTION
Hi Certbot team, 

We have created recently a certbot plugin that integrates with the [IONOS DNS Cloud](https://github.com/ionos-cloud/certbot-dns-ionos-cloud) API. This change adds the plugin to the Third party plugins list in the docs. 

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
