### PR TITLE
Ensure _scrub_checklist_input honors indices order (#9943)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -166,6 +166,7 @@ Authors
 * [Luca Ebach](https://github.com/lucebac)
 * [Luca Olivetti](https://github.com/olivluca)
 * [Luke Rogers](https://github.com/lukeroge)
+* [Lukhnos Liu](https://github.com/lukhnos)
 * [Maarten](https://github.com/mrtndwrd)
 * [Mads Jensen](https://github.com/atombrella)
 * [Maikel Martens](https://github.com/krukas)

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -15,7 +15,10 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fixed a bug in Certbot where a CSR's SANs did not always follow the order of
+  the domain names that the user requested interactively. In some cases, the
+  resulting cert's common name might seem picked up randomly from the SANs
+  when it should be the first item the user had in mind.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/_internal/display/obj.py
+++ b/certbot/certbot/_internal/display/obj.py
@@ -328,8 +328,9 @@ class FileDisplay:
         except ValueError:
             return []
 
-        # Remove duplicates
-        indices_int = list(set(indices_int))
+        # Remove duplicates. dict is used instead of set, since dict perserves
+        # insertion order as of Python 3.7
+        indices_int = list(dict.fromkeys(indices_int).keys())
 
         # Check all input is within range
         for index in indices_int:

--- a/certbot/certbot/_internal/tests/display/obj_test.py
+++ b/certbot/certbot/_internal/tests/display/obj_test.py
@@ -194,6 +194,25 @@ class FileOutputDisplayTest(unittest.TestCase):
                 self.displayer._scrub_checklist_input(list_, TAGS))
             assert set_tags == exp[i]
 
+    def test_scrub_checklist_maintain_indices_order(self):
+        # pylint: disable=protected-access
+        source_tags = ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9"]
+        indices = [
+            ["4", "9"],
+            ["9", "4"],
+            ["4", "9", "4"],
+            ["9", "4", "9"],
+        ]
+        exp = [
+            ["T4", "T9"],
+            ["T9", "T4"],
+            ["T4", "T9"],
+            ["T9", "T4"],
+        ]
+        for i, list_ in enumerate(indices):
+            tags = self.displayer._scrub_checklist_input(list_, source_tags)
+            assert tags == exp[i]
+
     @mock.patch("certbot._internal.display.util.input_with_timeout")
     def test_directory_select(self, mock_input):
         args = ["msg", "/var/www/html", "--flag", True]


### PR DESCRIPTION
This fixes a bug where, when a user requests a cert interactively, the CSR's SANs are not listed in the order that the user has in mind. This is because, during the input validation, the _scrub_checklist_input method does not produce a list of tags (which represents the domain names the user has requested a cert for) in the order of in the given indices. As a result, the CN of the resulting cert, as well as the directory name used to store the certs, may not always be what the user has expected, which should be the first item chosen from the interactive prompt.

Fixes #9943.

## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `master` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
