### PR TITLE
Example explanation for standalone authenticator in `cli.ini` mentions incorrect port

### DIFF
--- a/certbot/examples/cli.ini
+++ b/certbot/examples/cli.ini
@@ -17,7 +17,7 @@ rsa-key-size = 4096
 # Uncomment and update to register with the specified e-mail address
 # email = foo@example.com
 
-# Uncomment to use the standalone authenticator on port 443
+# Uncomment to use the standalone authenticator on port 80
 # authenticator = standalone
 
 # Uncomment to use the webroot authenticator. Replace webroot-path with the


### PR DESCRIPTION
The standalone authenticator doesn't use port 443, so the comment in the `cli.ini` example also shouldn't say so.