### PR TITLE
suggest snap_config nits

### DIFF
--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -4,6 +4,8 @@ import socket
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import Tuple
+from typing import Union
 
 from requests import PreparedRequest, Session
 from requests.adapters import HTTPAdapter
@@ -100,10 +102,20 @@ class _SnapdConnectionPool(HTTPConnectionPool):
 
 
 class _SnapdAdapter(HTTPAdapter):
+    # get_connection is used with versions of requests before 2.32.2 and
+    # get_connection_with_tls_context is used instead in versions after that. as of
+    # writing this, Certbot in EPEL 9 is still seeing updates and they have requests 2.25.1 so to
+    # help out those packagers while ensuring this code works reliably, we offer custom versions of
+    # both functions for now. when certbot does declare a dependency on requests>=2.32.2 in its
+    # setup.py files, get_connection can be deleted
+    def get_connection(self, url: str,
+                       proxies: Optional[Iterable[str]] = None) -> _SnapdConnectionPool:
+        return _SnapdConnectionPool()
+
     def get_connection_with_tls_context(self, request: PreparedRequest,
                                         verify: bool,
                                         proxies: Optional[Iterable[str]] = None,
-                                        cert: Optional[bytes] = None
+                                        cert: Optional[Union[str, Tuple[str,str]]] = None
                                         ) -> _SnapdConnectionPool:
         """Required method for creating a new connection pool. Simply return our
         shim that forces a UNIX socket connection to snapd."""


### PR DESCRIPTION
i based the type for `certs` on https://github.com/psf/requests/blob/v2.32.2/src/requests/adapters.py#L394, https://github.com/psf/requests/blob/v2.32.2/src/requests/adapters.py#L85, and [that being the type for `cert` in `requests` more common (and better documented) APIs](https://requests.readthedocs.io/en/latest/api/#requests.request)