### PR TITLE
Correct 'seperate' typo

### DIFF
--- a/certbot/certbot/_internal/plugins/webroot.py
+++ b/certbot/certbot/_internal/plugins/webroot.py
@@ -58,7 +58,7 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
 
     description = """\
 Saves the necessary validation files to a .well-known/acme-challenge/ directory within the \
-nominated webroot path. A seperate HTTP server must be running and serving files from the \
+nominated webroot path. A separate HTTP server must be running and serving files from the \
 webroot path. HTTP challenge only (wildcards not supported)."""
 
     MORE_INFO = """\

--- a/certbot/docs/cli-help.txt
+++ b/certbot/docs/cli-help.txt
@@ -734,7 +734,7 @@ standalone:
 
 webroot:
   Saves the necessary validation files to a .well-known/acme-challenge/
-  directory within the nominated webroot path. A seperate HTTP server must
+  directory within the nominated webroot path. A separate HTTP server must
   be running and serving files from the webroot path. HTTP challenge only
   (wildcards not supported).
 


### PR DESCRIPTION
Separate is misspelled as seperate in two places.

This PR corrects that.
