### PR TITLE
Update python version in snaps

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -76,7 +76,7 @@ jobs:
         displayName: Install dependencies
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: 3.8
+          versionSpec: 3.12
           addToPath: true
       - task: DownloadSecureFile@1
         name: credentials

--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: 3.8
+          versionSpec: 3.12
           addToPath: true
       - script: |
           set -e
@@ -141,7 +141,7 @@ jobs:
         displayName: Install dependencies
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: 3.8
+          versionSpec: 3.12
           addToPath: true
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -71,7 +71,7 @@ def prepare_env(cli_args: List[str]) -> List[str]:
             raise e
 
     data = response.json()
-    connections = ['/snap/{0}/current/lib/python3.8/site-packages/'.format(item['slot']['snap'])
+    connections = ['/snap/{0}/current/lib/python3.12/site-packages/'.format(item['slot']['snap'])
                    for item in data.get('result', {}).get('established', [])
                    if item.get('plug', {}).get('plug') == 'plugin'
                    and item.get('plug-attrs', {}).get('content') == 'certbot-1']

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -71,7 +71,7 @@ def prepare_env(cli_args: List[str]) -> List[str]:
             raise e
 
     data = response.json()
-    connections = ['/snap/{0}/current/lib/python3.12/site-packages/'.format(item['slot']['snap'])
+    connections = ['/snap/{0}/current/lib/python3.10/site-packages/'.format(item['slot']['snap'])
                    for item in data.get('result', {}).get('established', [])
                    if item.get('plug', {}).get('plug') == 'plugin'
                    and item.get('plug-attrs', {}).get('content') == 'certbot-1']

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -71,7 +71,7 @@ def prepare_env(cli_args: List[str]) -> List[str]:
             raise e
 
     data = response.json()
-    connections = ['/snap/{0}/current/lib/python3.10/site-packages/'.format(item['slot']['snap'])
+    connections = ['/snap/{0}/current/lib/python3.12/site-packages/'.format(item['slot']['snap'])
                    for item in data.get('result', {}).get('established', [])
                    if item.get('plug', {}).get('plug') == 'plugin'
                    and item.get('plug-attrs', {}).get('content') == 'certbot-1']

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -375,8 +375,8 @@ Certbot plugin snaps expose their Python modules to the Certbot snap via a
 `snap content interface`_ where ``certbot-1`` is the value for the ``content``
 attribute. The Certbot snap only uses this to find the names of connected
 plugin snaps and it expects to find the Python modules to be loaded under
-``lib/python3.8/site-packages/`` in the plugin snap. This location is the
-default when using the ``core20`` `base snap`_ and the `python snapcraft
+``lib/python3.12/site-packages/`` in the plugin snap. This location is the
+default when using the ``core24`` `base snap`_ and the `python snapcraft
 plugin`_.
 
 The Certbot snap also provides a separate content interface which

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,20 +19,18 @@ grade: stable
 adopt-info: certbot
 
 environment:
-  PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH"
-  PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
-  #PYTHONHOME: "$SNAP"
+  #PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH"
+  PYTHONHOME: "$SNAP"
+  PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:$SNAP/usr/lib/python3.12/lib-dynload:${PYTHONPATH}"
+
 
 apps:
   certbot:
     command: bin/python3 -s $SNAP/bin/certbot
     environment:
-      PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:$PATH"
+      PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
-      #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
-      #PYTHONHOME: "$SNAP"
-      #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ adopt-info: certbot
 environment:
   PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH"
   PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
-  PYTHONHOME: "$SNAP"
+  #PYTHONHOME: "$SNAP"
 
 apps:
   certbot:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,6 +67,8 @@ parts:
       - libpython3-stdlib
       - libpython3.12-stdlib
       - libpython3.12-minimal
+      - python3-pip
+      - python3-wheel
       - python3-venv
       - python3-minimal
       - python3-pkg-resources

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,8 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
+      PYTHONHOME: "$SNAP"
+      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages/:$SNAP/usr/lib/python3.12"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,10 +14,6 @@ description: |
    - Keep track of when your certificate is going to expire, and renew it
    - Help you revoke the certificate if that ever becomes necessary.
 confinement: classic
-# this was removed for classic snaps in snapcraft 7
-environment:
-  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/lib:$SNAP/usr/lib
-  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
 base: core24
 grade: stable
 adopt-info: certbot
@@ -102,9 +98,7 @@ parts:
       # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
       - PIP_CONSTRAINT: $CRAFT_PART_SRC/snap-constraints.txt
     override-build: |
-      echo "which python3"
-      which python3
-      bin/python3 -m venv "${CRAFT_PART_INSTALL}"
+      "${CRAFT_PART_INSTALL}/bin/python3" -m venv "${CRAFT_PART_INSTALL}"
       "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
       craftctl default
     override-pull: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,12 +26,12 @@ apps:
   certbot:
     command: bin/python3 -s $SNAP/bin/certbot
     environment:
-      PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
+      PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:$PATH"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
-      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
+      #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
       #PYTHONHOME: "$SNAP"
-      #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
+      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ description: |
    - Keep track of when your certificate is going to expire, and renew it
    - Help you revoke the certificate if that ever becomes necessary.
 confinement: classic
-base: core24
+base: core22
 grade: stable
 adopt-info: certbot
 
@@ -25,8 +25,8 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
-      PYTHONHOME: "$SNAP"
-      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
+      #PYTHONHOME: "$SNAP"
+      #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,9 @@ base: core24
 grade: stable
 adopt-info: certbot
 
+environment:
+  PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
+
 apps:
   certbot:
     command: bin/python3 -s $SNAP/bin/certbot
@@ -98,8 +101,9 @@ parts:
       # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
       - PIP_CONSTRAINT: $CRAFT_PART_SRC/snap-constraints.txt
     override-build: |
-      craftctl default
+      python3 -m venv "${CRAFT_PART_INSTALL}"
       "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
+      craftctl default
     override-pull: |
       craftctl default
       grep -v python-augeas "${CRAFT_PART_SRC}/tools/requirements.txt" >> "${CRAFT_PART_SRC}/snap-constraints.txt"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,6 +53,7 @@ parts:
       - ./certbot-nginx
     stage:
       - -usr/lib/python3.12/sitecustomize.py # maybe unnecessary
+      - -pyvenv.cfg
       # Old versions of this file used to unstage
       # lib/python3.8/site-packages/augeas.py to avoid conflicts between
       # python-augeas 0.5.0 which was pinned in snap-constraints.txt and

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,6 +102,8 @@ parts:
       # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
       - PIP_CONSTRAINT: $CRAFT_PART_SRC/snap-constraints.txt
     override-build: |
+      echo "which python3"
+      which python3
       python3 -m venv "${CRAFT_PART_INSTALL}"
       "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
       craftctl default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,6 +68,7 @@ parts:
       - python3-minimal
       - python3-pkg-resources
       - python3.12-minimal
+      - python3.12-venv
     # To build cryptography and cffi if needed
     build-packages:
       - gcc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,7 @@ parts:
       - libssl-dev
       - libffi-dev
       - python3-dev
+      - python3-venv
       - cargo
       - pkg-config
     build-environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
-      PYTHONPATH: "$SNAP/bin/python3:$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
+      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
       #PYTHONHOME: "$SNAP"
       #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,10 @@ description: |
    - Keep track of when your certificate is going to expire, and renew it
    - Help you revoke the certificate if that ever becomes necessary.
 confinement: classic
+# this was removed for classic snaps in snapcraft 7
+environment:
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/lib:$SNAP/usr/lib
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
 base: core24
 grade: stable
 adopt-info: certbot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -106,6 +106,7 @@ parts:
       grep -v python-augeas "${CRAFT_PART_SRC}/tools/requirements.txt" >> "${CRAFT_PART_SRC}/snap-constraints.txt"
       craftctl set version=$(grep -oP "__version__ = '\K.*(?=')" "${CRAFT_PART_SRC}/certbot/certbot/__init__.py")
     build-attributes:
+      # https://snapcraft.io/docs/how-to-classic#fix-linter-warnings-by-patching-elf-binaries
       - enable-patchelf
   shared-metadata:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,8 +25,8 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
-      PYTHONHOME: "$SNAP"
-      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
+      #PYTHONHOME: "$SNAP"
+      #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,9 +19,7 @@ grade: stable
 adopt-info: certbot
 
 environment:
-  PYTHONHOME: "$SNAP"
-  PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:$SNAP/usr/lib/python3.12/lib-dynload:${PYTHONPATH}"
-
+  PYTHONPATH: "$SNAP/lib/python3.12/site-packages:${PYTHONPATH}"
 
 apps:
   certbot:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,6 @@ grade: stable
 adopt-info: certbot
 
 environment:
-  #PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH"
   PYTHONHOME: "$SNAP"
   PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:$SNAP/usr/lib/python3.12/lib-dynload:${PYTHONPATH}"
 
@@ -69,9 +68,9 @@ parts:
       - libpython3.12-stdlib
       - libpython3.12-minimal
       - python3-minimal
+      - python3-venv
       - python3-pkg-resources
       - python3.12-minimal
-      - python3-venv
     # To build cryptography and cffi if needed
     build-packages:
       - gcc
@@ -81,8 +80,6 @@ parts:
       - libssl-dev
       - libffi-dev
       - python3-dev
-      - python3
-      - python3-venv
       - cargo
       - pkg-config
     build-environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,15 +90,15 @@ parts:
       # used. This is done to let these constraints be applied not only on the certbot package
       # build, but also on any isolated build that pip could trigger when building wheels for
       # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
-      - PIP_CONSTRAINT: $SNAPCRAFT_PART_SRC/snap-constraints.txt
+      - PIP_CONSTRAINT: $CRAFT_PART_SRC/snap-constraints.txt
     override-build: |
-      python3 -m venv "${SNAPCRAFT_PART_INSTALL}"
-      "${SNAPCRAFT_PART_INSTALL}/bin/python3" "${SNAPCRAFT_PART_SRC}/tools/pipstrap.py"
+      python3 -m venv "${CRAFT_PART_INSTALL}"
+      "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
       craftctl default
     override-pull: |
       craftctl default
-      grep -v python-augeas "${SNAPCRAFT_PART_SRC}/tools/requirements.txt" >> "${SNAPCRAFT_PART_SRC}/snap-constraints.txt"
-      craftctl set version=$(grep -oP "__version__ = '\K.*(?=')" "${SNAPCRAFT_PART_SRC}/certbot/certbot/__init__.py")
+      grep -v python-augeas "${CRAFT_PART_SRC}/tools/requirements.txt" >> "${CRAFT_PART_SRC}/snap-constraints.txt"
+      craftctl set version=$(grep -oP "__version__ = '\K.*(?=')" "${CRAFT_PART_SRC}/certbot/certbot/__init__.py")
     build-attributes:
       - enable-patchelf
   shared-metadata:
@@ -107,7 +107,7 @@ parts:
     override-pull: |
       craftctl default
       mkdir -p certbot-metadata
-      grep -oP "__version__ = '\K.*(?=')" $SNAPCRAFT_PART_SRC/certbot/certbot/__init__.py > certbot-metadata/certbot-version.txt
+      grep -oP "__version__ = '\K.*(?=')" $CRAFT_PART_SRC/certbot/certbot/__init__.py > certbot-metadata/certbot-version.txt
     stage: [certbot-metadata/certbot-version.txt]
 
 plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ apps:
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
       #PYTHONHOME: "$SNAP"
-      #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
+      #PYTHONPATH: "$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.10:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot
@@ -49,7 +49,7 @@ parts:
       - ./certbot-apache
       - ./certbot-nginx
     stage:
-      - -usr/lib/python3.12/sitecustomize.py # maybe unnecessary
+      - -usr/lib/python3.10/sitecustomize.py # maybe unnecessary
       # Old versions of this file used to unstage
       # lib/python3.8/site-packages/augeas.py to avoid conflicts between
       # python-augeas 0.5.0 which was pinned in snap-constraints.txt and
@@ -59,18 +59,18 @@ parts:
       # effect so we now stage the file to keep the auto-generated cffi file.
     stage-packages:
       - libaugeas0
-      - libpython3.12-dev
+      - libpython3.10-dev
       # added to stage python:
       - libpython3-stdlib
-      - libpython3.12-stdlib
-      - libpython3.12-minimal
+      - libpython3.10-stdlib
+      - libpython3.10-minimal
       - python3-pip
       - python3-wheel
       - python3-venv
       - python3-minimal
       - python3-pkg-resources
-      - python3.12-minimal
-      - python3.12-venv
+      - python3.10-minimal
+      - python3.10-venv
     # To build cryptography and cffi if needed
     build-packages:
       - gcc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,18 +58,6 @@ parts:
       # the same path. Since we've combined things in one part and removed the
       # python-augeas pinning, unstaging this file had a different, unintended
       # effect so we now stage the file to keep the auto-generated cffi file.
-      # WORKAROUND: Skip venv from python plugin
-      - -bin/activate
-      - -bin/activate.csh
-      - -bin/activate.fish
-      - -bin/Activate.ps1
-      - -bin/python
-      - -bin/python3
-      - -bin/python3.10
-      - -bin/pip
-      - -bin/pip3
-      - -bin/pip3.10
-      - -pyvenv.cfg
     stage-packages:
       - libaugeas0
       - libpython3.12-dev
@@ -93,6 +81,7 @@ parts:
       - libssl-dev
       - libffi-dev
       - python3-dev
+      - python3
       - python3-venv
       - cargo
       - pkg-config
@@ -108,10 +97,6 @@ parts:
       # build, but also on any isolated build that pip could trigger when building wheels for
       # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
       - PIP_CONSTRAINT: $CRAFT_PART_SRC/snap-constraints.txt
-      # WORKAROUND: The python plugin is broken with gnome extension
-      # from https://github.com/Unrud/video-downloader/blob/master/snap/snapcraft.yaml
-      - PATH: ${CRAFT_PART_INSTALL}/bin:${PATH}
-      - PYTHONPATH: ""
     override-build: |
       python3 -m venv "${CRAFT_PART_INSTALL}"
       "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
-      PYTHONPATH: "$SNAP/bin/python3:$PYTHONPATH"
+      PYTHONPATH: "$SNAP/bin/python3:$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
       #PYTHONHOME: "$SNAP"
       #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,7 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
+      PYTHONHOME: "$SNAP"
       PYTHONPATH: "${SNAP}/lib/python3.12/site-packages:${SNAP}/usr/lib/python3/dist-packages:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,7 @@ grade: stable
 adopt-info: certbot
 
 environment:
+  PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH"
   PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ confinement: classic
 # this was removed for classic snaps in snapcraft 7
 environment:
   LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/lib:$SNAP/usr/lib
-  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
 base: core24
 grade: stable
 adopt-info: certbot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ description: |
    - Keep track of when your certificate is going to expire, and renew it
    - Help you revoke the certificate if that ever becomes necessary.
 confinement: classic
-base: core20
+base: core24
 grade: stable
 adopt-info: certbot
 
@@ -47,7 +47,7 @@ parts:
       - ./certbot-apache
       - ./certbot-nginx
     stage:
-      - -usr/lib/python3.8/sitecustomize.py # maybe unnecessary
+      - -usr/lib/python3.12/sitecustomize.py # maybe unnecessary
       # Old versions of this file used to unstage
       # lib/python3.8/site-packages/augeas.py to avoid conflicts between
       # python-augeas 0.5.0 which was pinned in snap-constraints.txt and
@@ -57,18 +57,17 @@ parts:
       # effect so we now stage the file to keep the auto-generated cffi file.
     stage-packages:
       - libaugeas0
-      - libpython3.8-dev
+      - libpython3.12-dev
       # added to stage python:
       - libpython3-stdlib
-      - libpython3.8-stdlib
-      - libpython3.8-minimal
+      - libpython3.12-stdlib
+      - libpython3.12-minimal
       - python3-pip
       - python3-wheel
       - python3-venv
       - python3-minimal
-      - python3-distutils
       - python3-pkg-resources
-      - python3.8-minimal
+      - python3.12-minimal
     # To build cryptography and cffi if needed
     build-packages:
       - gcc
@@ -85,7 +84,7 @@ parts:
       # stability of fetching the rust crates needed to build the cryptography
       # library.
       - CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      - SNAPCRAFT_PYTHON_VENV_ARGS: --upgrade
+      - PARTS_PYTHON_VENV_ARGS: --upgrade
       # Constraints are passed through the environment variable PIP_CONSTRAINTS instead of using the
       # parts.[part_name].constraints option available in snapcraft.yaml when the Python plugin is
       # used. This is done to let these constraints be applied not only on the certbot package
@@ -95,16 +94,18 @@ parts:
     override-build: |
       python3 -m venv "${SNAPCRAFT_PART_INSTALL}"
       "${SNAPCRAFT_PART_INSTALL}/bin/python3" "${SNAPCRAFT_PART_SRC}/tools/pipstrap.py"
-      snapcraftctl build
+      craftctl default
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       grep -v python-augeas "${SNAPCRAFT_PART_SRC}/tools/requirements.txt" >> "${SNAPCRAFT_PART_SRC}/snap-constraints.txt"
-      snapcraftctl set-version `grep -oP "__version__ = '\K.*(?=')" "${SNAPCRAFT_PART_SRC}/certbot/certbot/__init__.py"`
+      craftctl set version=$(grep -oP "__version__ = '\K.*(?=')" "${SNAPCRAFT_PART_SRC}/certbot/certbot/__init__.py")
+    build-attributes:
+      - enable-patchelf
   shared-metadata:
     plugin: dump
     source: .
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       mkdir -p certbot-metadata
       grep -oP "__version__ = '\K.*(?=')" $SNAPCRAFT_PART_SRC/certbot/certbot/__init__.py > certbot-metadata/certbot-version.txt
     stage: [certbot-metadata/certbot-version.txt]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -98,9 +98,8 @@ parts:
       # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
       - PIP_CONSTRAINT: $CRAFT_PART_SRC/snap-constraints.txt
     override-build: |
-      "${CRAFT_PART_INSTALL}/bin/python3" -m venv "${CRAFT_PART_INSTALL}"
-      "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
       craftctl default
+      "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
     override-pull: |
       craftctl default
       grep -v python-augeas "${CRAFT_PART_SRC}/tools/requirements.txt" >> "${CRAFT_PART_SRC}/snap-constraints.txt"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,7 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
+      PYTHONPATH: "$SNAP/bin/python3:$PYTHONPATH"
       #PYTHONHOME: "$SNAP"
       #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:
@@ -57,6 +58,18 @@ parts:
       # the same path. Since we've combined things in one part and removed the
       # python-augeas pinning, unstaging this file had a different, unintended
       # effect so we now stage the file to keep the auto-generated cffi file.
+      # WORKAROUND: Skip venv from python plugin
+      - -bin/activate
+      - -bin/activate.csh
+      - -bin/activate.fish
+      - -bin/Activate.ps1
+      - -bin/python
+      - -bin/python3
+      - -bin/python3.10
+      - -bin/pip
+      - -bin/pip3
+      - -bin/pip3.10
+      - -pyvenv.cfg
     stage-packages:
       - libaugeas0
       - libpython3.12-dev
@@ -95,6 +108,10 @@ parts:
       # build, but also on any isolated build that pip could trigger when building wheels for
       # dependencies. See https://github.com/certbot/certbot/pull/8443 for more info.
       - PIP_CONSTRAINT: $CRAFT_PART_SRC/snap-constraints.txt
+      # WORKAROUND: The python plugin is broken with gnome extension
+      # from https://github.com/Unrud/video-downloader/blob/master/snap/snapcraft.yaml
+      - PATH: ${CRAFT_PART_INSTALL}/bin:${PATH}
+      - PYTHONPATH: ""
     override-build: |
       python3 -m venv "${CRAFT_PART_INSTALL}"
       "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -104,7 +104,7 @@ parts:
     override-build: |
       echo "which python3"
       which python3
-      python3 -m venv "${CRAFT_PART_INSTALL}"
+      bin/python3 -m venv "${CRAFT_PART_INSTALL}"
       "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
       craftctl default
     override-pull: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,8 +67,8 @@ parts:
       - libpython3-stdlib
       - libpython3.12-stdlib
       - libpython3.12-minimal
-      - python3-minimal
       - python3-venv
+      - python3-minimal
       - python3-pkg-resources
       - python3.12-minimal
     # To build cryptography and cffi if needed

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ description: |
    - Keep track of when your certificate is going to expire, and renew it
    - Help you revoke the certificate if that ever becomes necessary.
 confinement: classic
-base: core22
+base: core24
 grade: stable
 adopt-info: certbot
 
@@ -25,8 +25,8 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
-      #PYTHONHOME: "$SNAP"
-      #PYTHONPATH: "$SNAP/lib/python3.10/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.10:${PYTHONPATH}"
+      PYTHONHOME: "$SNAP"
+      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot
@@ -49,7 +49,7 @@ parts:
       - ./certbot-apache
       - ./certbot-nginx
     stage:
-      - -usr/lib/python3.10/sitecustomize.py # maybe unnecessary
+      - -usr/lib/python3.12/sitecustomize.py # maybe unnecessary
       # Old versions of this file used to unstage
       # lib/python3.8/site-packages/augeas.py to avoid conflicts between
       # python-augeas 0.5.0 which was pinned in snap-constraints.txt and
@@ -59,18 +59,18 @@ parts:
       # effect so we now stage the file to keep the auto-generated cffi file.
     stage-packages:
       - libaugeas0
-      - libpython3.10-dev
+      - libpython3.12-dev
       # added to stage python:
       - libpython3-stdlib
-      - libpython3.10-stdlib
-      - libpython3.10-minimal
+      - libpython3.12-stdlib
+      - libpython3.12-minimal
       - python3-pip
       - python3-wheel
       - python3-venv
       - python3-minimal
       - python3-pkg-resources
-      - python3.10-minimal
-      - python3.10-venv
+      - python3.12-minimal
+      - python3.12-venv
     # To build cryptography and cffi if needed
     build-packages:
       - gcc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,8 +25,7 @@ apps:
       PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
-      PYTHONHOME: "$SNAP"
-      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages/:$SNAP/usr/lib/python3.12"
+      PYTHONPATH: "${SNAP}/lib/python3.12/site-packages:${SNAP}/usr/lib/python3/dist-packages:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,8 @@ base: core24
 grade: stable
 adopt-info: certbot
 
+# Workaround for misconfigured pyvenv.cfg; see discussion on snapcraft forum for more info
+# https://forum.snapcraft.io/t/upgrading-classic-snap-to-core24-using-snapcraft-8-3-causes-python-3-12-errors-at-runtime/
 environment:
   PYTHONPATH: "$SNAP/lib/python3.12/site-packages:${PYTHONPATH}"
 
@@ -51,7 +53,7 @@ parts:
       - ./certbot-nginx
     stage:
       - -usr/lib/python3.12/sitecustomize.py # maybe unnecessary
-      - -pyvenv.cfg
+      - -pyvenv.cfg # Workaround for misconfiguration, as noted above
       # Old versions of this file used to unstage
       # lib/python3.8/site-packages/augeas.py to avoid conflicts between
       # python-augeas 0.5.0 which was pinned in snap-constraints.txt and

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,6 +73,7 @@ parts:
       - python3-minimal
       - python3-pkg-resources
       - python3.12-minimal
+      - python3-venv
     # To build cryptography and cffi if needed
     build-packages:
       - gcc
@@ -86,7 +87,6 @@ parts:
       - python3-venv
       - cargo
       - pkg-config
-      - python3.12-venv
     build-environment:
       # We set this environment variable while building to try and increase the
       # stability of fetching the rust crates needed to build the cryptography

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,6 +86,7 @@ parts:
       - python3-venv
       - cargo
       - pkg-config
+      - python3.12-venv
     build-environment:
       # We set this environment variable while building to try and increase the
       # stability of fetching the rust crates needed to build the cryptography

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,7 @@ adopt-info: certbot
 environment:
   PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH"
   PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
+  PYTHONHOME: "$SNAP"
 
 apps:
   certbot:
@@ -31,7 +32,7 @@ apps:
       CERTBOT_SNAPPED: "True"
       #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
       #PYTHONHOME: "$SNAP"
-      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
+      #PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot
@@ -69,13 +70,9 @@ parts:
       - libpython3-stdlib
       - libpython3.12-stdlib
       - libpython3.12-minimal
-      - python3-pip
-      - python3-wheel
-      - python3-venv
       - python3-minimal
       - python3-pkg-resources
       - python3.12-minimal
-      - python3.12-venv
     # To build cryptography and cffi if needed
     build-packages:
       - gcc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ apps:
       AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
       CERTBOT_SNAPPED: "True"
       PYTHONHOME: "$SNAP"
-      PYTHONPATH: "${SNAP}/lib/python3.12/site-packages:${SNAP}/usr/lib/python3/dist-packages:${PYTHONPATH}"
+      PYTHONPATH: "$SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12:${PYTHONPATH}"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot

--- a/tools/snap/README.md
+++ b/tools/snap/README.md
@@ -12,7 +12,7 @@ These steps need to be done once to set up your VM and do not need to be run aga
  1. Start with a Focal VM. You need a full virtual machine using something like DigitalOcean, EC2, or VirtualBox. Docker won't work. Another version of Ubuntu can probably be used, but Focal was used when writing these instructions.
  2. Set up a user other than root with sudo privileges for use with snapcraft and run all of the following commands with it. A command to do this for a user named certbot looks like `adduser certbot && usermod -aG sudo certbot && su - certbot`.
  3. Install git and python with `sudo apt update && sudo apt install -y git python`.
- 4. Set up lxd for use with snapcraft by running `sudo snap install lxd && sudo /snap/bin/lxd.migrate -yes; sudo /snap/bin/lxd waitready && sudo /snap/bin/lxd init --auto` (errors here are ok; it may already
+ 4. Set up lxd for use with snapcraft by running `sudo snap install lxd; sudo /snap/bin/lxd waitready && sudo /snap/bin/lxd init --auto` (errors here are ok; it may already
  have been installed on your system).
  5. Add your current user to the lxd group and update your shell to have the new assignment by running `sudo usermod -a -G lxd ${USER} && newgrp lxd`.
  6. Install snapcraft with `sudo snap install --classic snapcraft`.

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -42,10 +42,6 @@ PLUGINS = [basename(path) for path in glob.glob(join(CERTBOT_DIR, 'certbot-dns-*
 print = functools.partial(print, flush=True)
 
 
-def _snap_log_name(target: str, arch: str):
-    return f'{target}_{arch}.txt'
-
-
 def _execute_build(
         target: str, archs: Set[str], status: Dict[str, Dict[str, str]],
         workspace: str, output_lock: Lock) -> Tuple[int, List[str]]:
@@ -109,7 +105,9 @@ def _build_snap(
         workspace = CERTBOT_DIR
     else:
         workspace = join(CERTBOT_DIR, target)
-        # init and commit git repo in workspace
+        # Init and commit git repo in workspace. This is necessary starting in core24
+        # as "Projects must be at the top level of a git repository"
+        # https://snapcraft.io/docs/migrate-core24#remote-build
         subprocess.run(['git', 'init'], capture_output=True, check=True, cwd=workspace)
         subprocess.run(['git', 'add', '-A'], capture_output=True, check=True, cwd=workspace)
         subprocess.run(['git', 'commit', '-m', 'init'], capture_output=True, check=True, cwd=workspace)
@@ -125,6 +123,8 @@ def _build_snap(
             print(f'Build {target} for {",".join(archs)} (attempt {4-retry}/3) ended with '
                   f'exit code {exit_code}.')
 
+            # This output may change, and is set by
+            # https://github.com/canonical/snapcraft/blob/8ab7fd0c8a1d3f13045bec41a6e0158c063faa9b/snapcraft/commands/remote.py#L278
             failed_archs = [arch for arch in archs if status[target][arch] != 'Succeeded']
             # If the command failed or any architecture wasn't built
             # successfully, let's try to print all the output about the problem
@@ -157,6 +157,8 @@ def _build_snap(
 def _extract_state(project: str, output: str, status: Dict[str, Dict[str, str]]) -> None:
     state = status[project]
 
+    # This output may change, and is set by
+    # https://github.com/canonical/snapcraft/blob/8ab7fd0c8a1d3f13045bec41a6e0158c063faa9b/snapcraft/commands/remote.py#L218
     if "Starting new build" in output:
         for arch in state.keys():
             state[arch] = "Starting new build"
@@ -204,6 +206,9 @@ def _dump_failed_build_logs(
         if result != 'Succeeded':
             failures = True
 
+            # log name is no longer set deterministically as target_arch.txt
+            # this will still result in a single output though, as we're filtering
+            # by target above and arch here
             build_output_path = [log_name for log_name in logs_list if arch in log_name]
             if not build_output_path:
                 build_output = f'No output has been dumped by snapcraft remote-build.'

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -103,6 +103,10 @@ def _build_snap(
         workspace = CERTBOT_DIR
     else:
         workspace = join(CERTBOT_DIR, target)
+        # init and commit git repo in workspace
+        subprocess.run(['git', 'init'], capture_output=True, check=True, cwd=workspace)
+        subprocess.run(['git', 'add', '-A'], capture_output=True, check=True, cwd=workspace)
+        subprocess.run(['git', 'commit', '-m', 'init'], capture_output=True, check=True, cwd=workspace)
 
     build_success = False
     retry = 3

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -61,7 +61,6 @@ def _execute_build(
     # length but from a larger character set just because we can.
     random_string = ''.join(random.choice(string.ascii_lowercase + string.digits)
                             for _ in range(32))
-    unused_build_id = f'snapcraft-{target}-{random_string}'
 
     with tempfile.TemporaryDirectory() as tempdir:
         environ = os.environ.copy()

--- a/tools/snap/generate_dnsplugins_snapcraft.sh
+++ b/tools/snap/generate_dnsplugins_snapcraft.sh
@@ -16,7 +16,7 @@ summary: ${DESCRIPTION}
 description: ${DESCRIPTION}
 confinement: strict
 grade: stable
-base: core20
+base: core24
 adopt-info: ${PLUGIN}
 
 parts:
@@ -24,8 +24,8 @@ parts:
     plugin: python
     source: .
     override-pull: |
-        snapcraftctl pull
-        snapcraftctl set-version \`grep ^version \$SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"\`
+        craftctl default
+        craftctl set version=\$(grep ^version \$SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]")
     build-environment:
       # We set this environment variable while building to try and increase the
       # stability of fetching the rust crates needed to build the cryptography
@@ -53,7 +53,7 @@ parts:
     source: .
     stage: [setup.py, certbot-shared]
     override-pull: |
-        snapcraftctl pull
+        craftctl default
         mkdir -p \$SNAPCRAFT_PART_SRC/certbot-shared
 
 slots:
@@ -61,7 +61,7 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - \$SNAP/lib/python3.8/site-packages
+      - \$SNAP/lib/python3.12/site-packages
 
 plugs:
   certbot-metadata:


### PR DESCRIPTION
Fixes #9872

To upgrade to python3.12 as 3.8 is reaching EOL, we need to upgrade the core snap that certbot is based on. The latest version is core24, so we're going with that for longevity. We will want to notify third party snaps to make changes as well. They can release their snaps to a version higher than certbot's, and their users will not be upgraded until the matching (or greater) version of certbot is released. They should do this as otherwise including these changes will break their plugins. A longer explanation of this is included at the bottom of this entry.

Key documents are https://snapcraft.io/docs/migrate-core22 and https://snapcraft.io/docs/migrate-core24. The discussion at https://forum.snapcraft.io/t/upgrading-classic-snap-to-core24-using-snapcraft-8-3-causes-python-3-12-errors-at-runtime/ is also relevant to understanding some changes, which may become unnecessary in future versions of snapcraft. Any other necessary changes are noted inline.

- [x] new certbot snap builds and runs
- [x] new plugin snap builds and runs
- [x] does new certbot run with old plugin (this would be weird)
  - good news: doesn't immediately crash core certbot. expected news: also does not see new plugin.
- [x] does old certbot run with new plugin (this would be weird)
  - same news as above
- [x] launch remote tests for other archs
  - [x] get builds working again
  - [x] find a new fix for build reuse issue or determine it's no longer an issue
    - if it finds an existing build with the current id and you haven't passed `--recover`, it errors, cancels both attempts, and removes the (pending) remote build. so options for addressing:
     - a) lol just double the number of attempts, because the third one you do will be the same as starting a new one. this is obviously the wrong answer but it would be hilarious.
     - [x] b) change the contents of the directory between attempts
- [ ] investigate existing third party snaps
  - There are 20 found by searching "certbot" on snapcraft.io, listed on pages [two](https://snapcraft.io/store?q=certbot&page=2) to [three](https://snapcraft.io/store?q=certbot&page=3)
  - [ ] check to see if all 20 literally use our scripts
- [ ] contact and roll out updates for third party snaps
- [x] manually test builds on non-amd64 architectures
  - tested on arm64/ubuntu22 using ec2, this worked! including packaging and loading augeas! 

As it turns out, we've kind of already solved the problem of third-party updates!
The entire point of the [post-refresh hook](https://github.com/certbot/certbot/blob/master/tools/snap/generate_dnsplugins_postrefreshhook.sh) is so that if the plugin version number is greater than certbot's version number, it won't be installed. The first two I checked both already use this framework, so they just need to switch themselves to core24/python3.12, bump their version number (to 3.0 probably), and publish the snap. It will be out there and ready but not installed, until we publish the certbot 3.0 snap, at which point on the next refresh it will just update itself and Just Work.

In fact, if they are all straight up using our scripts to generate their snap and snap hook files, we can publish the updates (to master or a branch) to make it even less work for them. So 1) grab our new scripts 2) change version number 3) build and publish new snap and that's it.

In case we missed one, it might be worth figuring a way to detect that situation and notify. Like, can we check for a connected snap that doesn't show up in the plugins list?