### PR TITLE
remove centos7 test

### DIFF
--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -33,11 +33,6 @@ targets:
   #-----------------------------------------------------------------------------
   # CentOS
   # These AMI were found on https://centos.org/download/aws-images/.
-  - ami: ami-0aedf6b1cb669b4c7
-    name: centos7
-    type: centos
-    virt: hvm
-    user: centos
   - ami: ami-08f2fe20b72b2ffa7
     name: centos9stream
     type: centos


### PR DESCRIPTION
centos 7 reached it's eol on sunday. see https://www.redhat.com/en/topics/linux/centos-linux-eol