### PR TITLE
Switch from gpg2 to gpg

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -39,7 +39,7 @@ if [ "$RELEASE_GPG_KEY" = "" ]; then
         F2871B4152AE13C49519111F447BF683AA3B26C3
     "
     for key in $TRUSTED_KEYS; do
-        if gpg2 --with-colons --card-status | grep -q "$key"; then
+        if gpg --with-colons --card-status | grep -q "$key"; then
             RELEASE_GPG_KEY="$key"
             break
         fi
@@ -157,7 +157,7 @@ done
 cd "$built_package_dir"
 echo "Generating checksum file and signing it"
 sha256sum *.tar.gz > SHA256SUMS
-gpg2 -u "$RELEASE_GPG_KEY" --detach-sign --armor --sign --digest-algo sha256 SHA256SUMS
+gpg -u "$RELEASE_GPG_KEY" --detach-sign --armor --sign --digest-algo sha256 SHA256SUMS
 git add *.tar.gz SHA256SUMS*
 
 echo "Installing packages to generate documentation"
@@ -196,8 +196,8 @@ deactivate
 git add certbot/docs/cli-help.txt
 while ! git commit --gpg-sign="$RELEASE_GPG_KEY" -m "Release $version"; do
     echo "Unable to sign the release commit using git."
-    echo "You may have to configure git to use gpg2 by running:"
-    echo 'git config --global gpg.program $(command -v gpg2)'
+    echo "You may have to configure git to use gpg by running:"
+    echo 'git config --global gpg.program $(command -v gpg)'
     read -p "Press enter to try signing again."
 done
 git tag --local-user "$RELEASE_GPG_KEY" --sign --message "Release $version" "$tag"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -19,7 +19,7 @@ CheckVersion() {
 CheckVersion "$1"
 CheckVersion "$2"
 
-if [ "$RELEASE_GPG_KEY" = "" ] && ! gpg2 --card-status >/dev/null 2>&1; then
+if [ "$RELEASE_GPG_KEY" = "" ] && ! gpg --card-status >/dev/null 2>&1; then
     echo OpenPGP card not found!
     echo Please insert your PGP card and run this script again.
     exit 1


### PR DESCRIPTION
The `gnupg` package from Homebrew only installs a `gpg` binary, not a `gpg2` binary. I had previously worked around this by manually creating an alias, but I think we can do better.

GPG version 1 is ancient and [hasn't seen a release since 2006](https://gnupg.org/download/release_notes.html). Additionally, `gpg` has referred to GPG 2 in Ubuntu since at least 20.04 which is the oldest non-EOL'd version as of writing this so I think this change is safe to make.