### PR TITLE
fix centos 9 image

### DIFF
--- a/letstest/letstest/multitester.py
+++ b/letstest/letstest/multitester.py
@@ -286,15 +286,15 @@ def create_client_instance(ec2_client, target, security_group_id, subnet_id, sel
         # 32 bit systems
         machine_type = 'c1.medium'
     name = 'le-%s'%target['name']
-    print(name, end=" ")
-    return make_instance(ec2_client,
-                         name,
-                         target['ami'],
-                         KEYNAME,
-                         machine_type=machine_type,
-                         security_group_id=security_group_id,
-                         subnet_id=subnet_id,
-                         self_destruct=self_destruct)
+    try:
+        instance = make_instance(ec2_client, name, target['ami'], KEYNAME,
+                                 machine_type=machine_type, security_group_id=security_group_id,
+                                 subnet_id=subnet_id, self_destruct=self_destruct)
+    except Exception:
+        print(f'FAIL: Unable to create instance {name}')
+        raise
+    print(f'Created instance {name}')
+    return instance
 
 
 def test_client_process(fab_config, inqueue, outqueue, log_dir):
@@ -435,7 +435,6 @@ def main():
 
     instances = []
     try:
-        print("Creating instances: ", end="")
         # If we want to preserve instances, do not have them self-destruct.
         self_destruct = not cl_args.saveinstances
         for target in targetlist:
@@ -444,7 +443,6 @@ def main():
                                        security_group_id, subnet_id,
                                        self_destruct)
             )
-        print()
 
         # Install and launch client scripts in parallel
         #-------------------------------------------------------------------------------

--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -33,7 +33,7 @@ targets:
   #-----------------------------------------------------------------------------
   # CentOS
   # These AMI were found on https://centos.org/download/aws-images/.
-  - ami: ami-08f2fe20b72b2ffa7
+  - ami: ami-00d53d23711185071
     name: centos9stream
     type: centos
     virt: hvm


### PR DESCRIPTION
our "test farm tests" recently started failing every night. it was failing to even create the centos 9 image, but updating the AMI fixed it

i also included (a cleaned up version) of the modifications i made to the script to figure out it was the centos image causing problems. a successful run now looks like:
```
...
Making Security Group
  certbot-security-group already exists
Created instance le-ubuntu22.04
Created instance le-ubuntu20.04
Created instance le-debian11
Created instance le-debian12
Created instance le-centos9stream
Uploading and running test script in parallel: scripts/test_apache2.sh
...
```
while a failed run looks like:
```
Making Security Group
  certbot-security-group already exists
Created instance le-ubuntu22.04
Created instance le-ubuntu20.04
Created instance le-debian11
Created instance le-debian12
FAIL: Unable to create instance le-centos9stream
Logs in  /var/folders/tr/_jqrlt554c107b5lcxl3td_40000gn/T/tmp0puuqv0h
Terminating EC2 Instances
Traceback (most recent call last):
  File "/Users/bmw/Development/github.com/certbot/certbot/venv/bin/letstest", line 33, in <module>
    sys.exit(load_entry_point('letstest', 'console_scripts', 'letstest')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bmw/Development/github.com/certbot/certbot/letstest/letstest/multitester.py", line 442, in main
    create_client_instance(ec2_client, target,
  File "/Users/bmw/Development/github.com/certbot/certbot/letstest/letstest/multitester.py", line 290, in create_client_instance
    instance = make_instance(ec2_client, name, target['ami'], KEYNAME,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bmw/Development/github.com/certbot/certbot/letstest/letstest/multitester.py", line 141, in make_instance
    block_device_mappings = _get_block_device_mappings(ec2_client, ami_id)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bmw/Development/github.com/certbot/certbot/letstest/letstest/multitester.py", line 173, in _get_block_device_mappings
    for mapping in ec2_client.Image(ami_id).block_device_mappings
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bmw/Development/github.com/certbot/certbot/venv/lib/python3.12/site-packages/boto3/resources/factory.py", line 387, in property_loader
    return self.meta.data.get(name)
           ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```