### PR TITLE
ACME: Allow subproblems to be `null`

### DIFF
--- a/acme/acme/_internal/tests/messages_test.py
+++ b/acme/acme/_internal/tests/messages_test.py
@@ -59,7 +59,7 @@ class ErrorTest(unittest.TestCase):
 
     def test_from_json_with_null_subproblems(self):
         from acme.messages import Error
-        parsed_error = Error.from_json(self.error.to_json() | {'subproblems': None})
+        parsed_error = Error.from_json({**self.error.to_json(), 'subproblems': None})
         assert parsed_error.subproblems is None
 
     def test_description(self):

--- a/acme/acme/_internal/tests/messages_test.py
+++ b/acme/acme/_internal/tests/messages_test.py
@@ -57,6 +57,11 @@ class ErrorTest(unittest.TestCase):
         assert 1 == len(parsed_error.subproblems)
         assert self.subproblem == parsed_error.subproblems[0]
 
+    def test_from_json_with_null_subproblems(self):
+        from acme.messages import Error
+        parsed_error = Error.from_json(self.error.to_json() | {'subproblems': None})
+        assert parsed_error.subproblems is None
+
     def test_description(self):
         assert 'The request message was malformed' == self.error.description
         assert self.error_custom.description is None

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -143,8 +143,12 @@ class Error(jose.JSONObjectWithFields, errors.Error):
     # Mypy does not understand the josepy magic happening here, and falsely claims
     # that subproblems is redefined. Let's ignore the type check here.
     @subproblems.decoder  # type: ignore
-    def subproblems(value: List[Dict[str, Any]]) -> Tuple['Error', ...]:  # pylint: disable=no-self-argument,missing-function-docstring
-        return tuple(Error.from_json(subproblem) for subproblem in value)
+    def subproblems(value: Optional[List[Dict[str, Any]]]) -> Optional[Tuple['Error', ...]]:  # pylint: disable=no-self-argument,missing-function-docstring
+        return (
+            tuple(Error.from_json(subproblem) for subproblem in value)
+            if value is not None
+            else None
+        )
 
     @classmethod
     def with_code(cls, code: str, **kwargs: Any) -> 'Error':


### PR DESCRIPTION
Hashicorp Vault seems to include `"subproblems": null` in acme error responses, instead of omitting it, which the acme lib doesn't allow/handle. But since `subproblems` are optional anyways, I think it makes sense to allow this.

Let me know if you agree, and I can add a CHANGELOG entry.