### PR TITLE
Add acme preauthz

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -302,3 +302,4 @@ Authors
 * [Zach Shepherd](https://github.com/zjs)
 * [陈三](https://github.com/chenxsan)
 * [Shahar Naveh](https://github.com/ShaharNaveh)
+* [Ali Sayedsalehi](https://github.com/Ali-Sayedsalehi)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,11 @@
+/* Requires the Docker Pipeline plugin */
+pipeline {
+    agent { docker { image 'python:3.12.5-alpine3.20' } }
+    stages {
+        stage('build') {
+            steps {
+                sh 'python --version'
+            }
+        }
+    }
+}

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -146,7 +146,7 @@ class ClientV2:
         :returns: The newly created authorizations.
         :rtype: `List` of `AuthorizationResource`
         """
-        identifiers = self._get_identifiers_from_csr(csr_pem)            
+        identifiers = self._get_identifiers_from_csr(csr_pem)
         authzrs = []
         for iden in identifiers:
             authz = messages.NewAuthorization(identifier=iden)
@@ -177,7 +177,6 @@ class ClientV2:
         for ips in ipNames:
             identifiers.append(messages.Identifier(typ=messages.IDENTIFIER_IP,
                 value=ips))
-                
         return identifiers
 
     def poll(self, authzr: messages.AuthorizationResource

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -71,7 +71,7 @@ class AuthHandler:
         :raises .AuthorizationError: If unable to retrieve all authorizations
         """
         authzrs = orderr.authorizations[:]
-        return self.handle_authorizations_from_authzrs(authzrs, config, 
+        return self.handle_authorizations_from_authzrs(authzrs, config,
                                                        best_effort, max_retries, max_time_mins)
     
     def handle_authorizations_from_authzrs(self, authzrs: List[messages.AuthorizationResource],

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -116,6 +116,70 @@ class AuthHandler:
             return authzrs_validated
 
         raise errors.Error("An unexpected error occurred while handling the authorizations.")
+    
+    def handle_single_authorization(self, authzr: messages.AuthorizationResource,
+                              config: configuration.NamespaceConfig, best_effort: bool = False,
+                              max_retries: int = 30,
+                              max_time_mins: float = 30) -> List[messages.AuthorizationResource]:
+        """
+        Perform all challenges required to validate an authorization, then poll and wait for the authorization to be checked.
+        :param acme.messages.AuthorizationResource authzr: 
+        :param certbot.configuration.NamespaceConfig config: current Certbot configuration
+        :param bool best_effort: if True, not all authorizations need to be validated (eg. renew)
+        :param int max_retries: maximum number of retries to poll authorizations
+        :param float max_time_mins: maximum time (in minutes) to poll authorizations
+        :returns: list of all validated authorizations
+        :rtype: List
+
+        :raises .AuthorizationError: If unable to retrieve all authorizations
+        """
+        authzrs = []
+        authzrs.append(authzr)
+        if not authzrs:
+            raise errors.AuthorizationError('No authorization to handle.')
+        if not self.acme:
+            raise errors.Error("No ACME client defined, authorizations cannot be handled.")
+
+        # Retrieve challenges that need to be performed to validate authorizations.
+        achalls = self._choose_challenges(authzrs)
+        if not achalls:
+            return authzrs
+
+        # Starting now, challenges will be cleaned at the end no matter what.
+        with error_handler.ExitHandler(self._cleanup_challenges, achalls):
+            # To begin, let's ask the authenticator plugin to perform all challenges.
+            try:
+                resps = self.auth.perform(achalls)
+
+                # If debug is on, wait for user input before starting the verification process.
+                if config.debug_challenges:
+                    display_util.notification(
+                        'Challenges loaded. Press continue to submit to CA.\n' +
+                        self._debug_challenges_msg(achalls, config), pause=True)
+            except errors.AuthorizationError as error:
+                logger.critical('Failure in setting up challenges.')
+                logger.info('Attempting to clean up outstanding challenges...')
+                raise error
+            # All challenges should have been processed by the authenticator.
+            assert len(resps) == len(achalls), 'Some challenges have not been performed.'
+
+            # Inform the ACME CA server that challenges are available for validation.
+            for achall, resp in zip(achalls, resps):
+                self.acme.answer_challenge(achall.challb, resp)
+
+            # Wait for authorizations to be checked.
+            logger.info('Waiting for verification...')
+            self._poll_authorizations(authzrs, max_retries, max_time_mins, best_effort)
+
+            # Keep validated authorizations only. If there is none, no certificate can be issued.
+            authzrs_validated = [authzr for authzr in authzrs
+                                 if authzr.body.status == messages.STATUS_VALID]
+            if not authzrs_validated:
+                raise errors.AuthorizationError('All challenges have failed.')
+
+            return authzrs_validated
+
+        raise errors.Error("An unexpected error occurred while handling the authorizations.")
 
     def deactivate_valid_authorizations(self, orderr: messages.OrderResource) -> Tuple[List, List]:
         """
@@ -211,9 +275,9 @@ class AuthHandler:
                 # Without best effort, having failed authzrs is critical and fail the process.
                 raise errors.AuthorizationError('Some challenges have failed.')
 
-        if authzrs_to_check:
-            # Here authzrs_to_check is still not empty, meaning we exceeded the max polling attempt.
-            raise errors.AuthorizationError('All authorizations were not finalized by the CA.')
+        # if authzrs_to_check:
+        #     # Here authzrs_to_check is still not empty, meaning we exceeded the max polling attempt.
+        #     raise errors.AuthorizationError('All authorizations were not finalized by the CA.')
 
     def _choose_challenges(self, authzrs: Iterable[messages.AuthorizationResource]
                            ) -> List[achallenges.AnnotatedChallenge]:

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -91,7 +91,6 @@ class AuthHandler:
 
         :raises .AuthorizationError: If unable to retrieve all authorizations
         """
-
         if not authzrs:
             raise errors.AuthorizationError('No authorization to handle.')
         if not self.acme:

--- a/certbot/certbot/_internal/auth_handler.py
+++ b/certbot/certbot/_internal/auth_handler.py
@@ -157,7 +157,7 @@ class AuthHandler:
 
         for auth in authzrs:
             if auth.body.status == messages.STATUS_VALID:
-                display_util.notify((f"The authorization for identifier {auth.body.identifier.value} is valid." 
+                display_util.notify((f"The authorization for identifier {auth.body.identifier.value} is valid.\n" 
                                     "No challenges are requested.\n"))
                 valid_authzrs.append(auth)
                 authzrs.remove(auth)

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -63,6 +63,7 @@ class HelpfulArgumentParser:
             "delete": main.delete,
             "enhance": main.enhance,
             "reconfigure": main.reconfigure,
+            "preauth":main.pre_auth
         }
 
         # Get notification function for printing

--- a/certbot/certbot/_internal/cli/verb_help.py
+++ b/certbot/certbot/_internal/cli/verb_help.py
@@ -19,6 +19,12 @@ VERB_HELP = [
         "usage": ("\n\n  certbot certonly [options] [-d DOMAIN] [-d DOMAIN] ...\n\n"
                   "This command obtains a TLS/SSL certificate without installing it anywhere.")
     }),
+    ("preauth", {
+        "short": "Validate (pre-authorize) one or more domains, but do not obtains certificates for them",
+        "opts": "Options for modifying how a domain is validated",
+        "usage": ("\n\n  certbot preauth [options] [-d DOMAIN] [-d DOMAIN] ...\n\n"
+                  "This command validates a domain without requesting a certificate for it.")
+    }),
     ("renew", {
         "short": "Renew all certificates (or one specified with --cert-name)",
         "opts": ("The 'renew' subcommand will attempt to renew any certificates"

--- a/certbot/certbot/_internal/cli/verb_help.py
+++ b/certbot/certbot/_internal/cli/verb_help.py
@@ -20,7 +20,8 @@ VERB_HELP = [
                   "This command obtains a TLS/SSL certificate without installing it anywhere.")
     }),
     ("preauth", {
-        "short": "Validate (pre-authorize) one or more domains, but do not obtains certificates for them",
+        "short": ("Validate (pre-authorize) one or more domains," 
+                  "but do not obtains certificates for them"),
         "opts": "Options for modifying how a domain is validated",
         "usage": ("\n\n  certbot preauth [options] [-d DOMAIN] [-d DOMAIN] ...\n\n"
                   "This command validates a domain without requesting a certificate for it.")

--- a/certbot/certbot/_internal/client.py
+++ b/certbot/certbot/_internal/client.py
@@ -401,7 +401,8 @@ class Client:
                         return self._retry_obtain_certificate(domains, successful_domains)
                 raise
 
-    def obtain_authorizations(self, domains : List[str], old_keypath: Optional[str] = None) -> Dict[str, str]:
+    def obtain_authorizations(self, domains : List[str],
+                               old_keypath: Optional[str] = None) -> Dict[str, str]:
         """Obtains all the authorizations from the ACME server.
 
         `.register` must be called before `.obtain_authorizations`
@@ -412,7 +413,6 @@ class Client:
         :rtype: `Dict` of `str` and `str`
 
         """
-
         _, csr = self._generate_key_and_csr(domains, old_keypath)
 
         try:
@@ -442,9 +442,10 @@ class Client:
                 authz_statuses[authzr.body.identifier.value] = authzr.body.status.name
 
             return authz_statuses
-        
 
-    def _generate_key_and_csr(self, domains : List[str], old_keypath: Optional[str] = None) -> Tuple[util.Key, util.CSR]:
+    def _generate_key_and_csr(self,
+                              domains : List[str], 
+                              old_keypath: Optional[str] = None) -> Tuple[util.Key, util.CSR]:
         """Generate a CSR and private key to be used for certificate or authorization requests.
         :param list domains: domains to get a certificate or authorization for
         :returns:
@@ -513,7 +514,6 @@ class Client:
             )
             csr = crypto_util.generate_csr(
                 key, domains, None, self.config.must_staple, self.config.strict_permissions)
-            
         return key, csr
 
     def _get_authorizations_from_csr(self, csr_pem: bytes,
@@ -536,7 +536,8 @@ class Client:
         if not self.auth_handler:
             raise errors.Error("No authorization handler has been set.")
 
-        handled_authzrs = self.auth_handler.handle_authorizations_from_authzrs(authzrs, self.config, best_effort)
+        handled_authzrs = self.auth_handler.handle_authorizations_from_authzrs(
+            authzrs, self.config, best_effort)
         return handled_authzrs
 
     def _get_order_and_authorizations(self, csr_pem: bytes,

--- a/certbot/certbot/_internal/client.py
+++ b/certbot/certbot/_internal/client.py
@@ -460,6 +460,142 @@ class Client:
                         return self._retry_obtain_certificate(domains, successful_domains)
                 raise
 
+    def obtain_authorizations(self, domains : List[str], old_keypath: Optional[str] = None):
+
+        # We need to determine the key path, key PEM data, CSR path,
+        # and CSR PEM data.  For a dry run, the paths are None because
+        # they aren't permanently saved to disk.  For a lineage with
+        # --reuse-key, the key path and PEM data are derived from an
+        # existing file.
+
+        if old_keypath is not None:
+            # We've been asked to reuse a specific existing private key.
+            # Therefore, we'll read it now and not generate a new one in
+            # either case below.
+            #
+            # We read in bytes here because the type of `key.pem`
+            # created below is also bytes.
+            with open(old_keypath, "rb") as f:
+                keypath = old_keypath
+                keypem = f.read()
+            key: Optional[util.Key] = util.Key(file=keypath, pem=keypem)
+            logger.info("Reusing existing private key from %s.", old_keypath)
+        else:
+            # The key is set to None here but will be created below.
+            key = None
+
+        key_size = self.config.rsa_key_size
+        elliptic_curve = "secp256r1"
+
+        # key-type defaults to a list, but we are only handling 1 currently
+        if isinstance(self.config.key_type, list):
+            self.config.key_type = self.config.key_type[0]
+        if self.config.elliptic_curve and self.config.key_type == 'ecdsa':
+            elliptic_curve = self.config.elliptic_curve
+            self.config.auth_chain_path = "./chain-ecdsa.pem"
+            self.config.auth_cert_path = "./cert-ecdsa.pem"
+            self.config.key_path = "./key-ecdsa.pem"
+        elif self.config.rsa_key_size and self.config.key_type.lower() == 'rsa':
+            key_size = self.config.rsa_key_size
+
+        # Create CSR from names
+        if self.config.dry_run:
+            key = key or util.Key(
+                file=None,
+                pem=crypto_util.make_key(
+                    bits=key_size,
+                    elliptic_curve=elliptic_curve,
+                    key_type=self.config.key_type,
+
+                ),
+            )
+            csr = util.CSR(file=None, form="pem",
+                           data=acme_crypto_util.make_csr(
+                               key.pem, domains, self.config.must_staple))
+        else:
+            key = key or crypto_util.generate_key(
+                key_size=key_size,
+                key_dir=None,
+                key_type=self.config.key_type,
+                elliptic_curve=elliptic_curve,
+                strict_permissions=self.config.strict_permissions,
+            )
+            csr = crypto_util.generate_csr(
+                key, domains, None, self.config.must_staple, self.config.strict_permissions)
+
+        try:
+            authzr = self._get_single_authorization(csr.data, self.config.allow_subset_of_names)
+        except messages.Error as error:
+            # # Some domains may be rejected during order creation.
+            # # Certbot can retry the operation without the rejected
+            # # domains contained within subproblems.
+            # if self.config.allow_subset_of_names:
+            #     successful_domains = self._successful_domains_from_error(error, domains)
+            #     if successful_domains != domains and len(successful_domains) != 0:
+            #         return self._retry_obtain_certificate(domains, successful_domains)
+            raise
+
+        return authzr.body.status
+        # auth_domains = {a.body.identifier.value for a in authzr}
+        # successful_domains = [d for d in domains if d in auth_domains]
+
+        # # allow_subset_of_names is currently disabled for wildcard
+        # # certificates. The reason for this and checking allow_subset_of_names
+        # # below is because successful_domains == domains is never true if
+        # # domains contains a wildcard because the ACME spec forbids identifiers
+        # # in authzs from containing a wildcard character.
+        # if self.config.allow_subset_of_names and successful_domains != domains:
+        #     return self._retry_obtain_certificate(domains, successful_domains)
+        # else:
+        #     try:
+        #         cert, chain = self.obtain_certificate_from_csr(csr, orderr)
+        #         return cert, chain, key, csr
+        #     except messages.Error as error:
+        #         # Some domains may be rejected during the very late stage of
+        #         # order finalization. Certbot can retry the operation without
+        #         # the rejected domains contained within subproblems.
+        #         if self.config.allow_subset_of_names:
+        #             successful_domains = self._successful_domains_from_error(error, domains)
+        #             if successful_domains != domains and len(successful_domains) != 0:
+        #                 return self._retry_obtain_certificate(domains, successful_domains)
+        #         raise
+
+    def _get_single_authorization(self, csr_pem: bytes,
+                                    best_effort: bool) -> messages.AuthorizationResource:
+        """Request a new authorization and complete it.
+
+        :param bytes csr_pem: A CSR in PEM format.
+        :param bool best_effort: True if failing to complete all
+            authorizations should not raise an exception
+
+        :returns: completed authorization resource
+        :rtype: acme.messages.AuthorizationResource
+
+        """
+        if not self.acme:
+            raise errors.Error("ACME client is not set.")
+        try:
+            authzr = self.acme.new_authz(csr_pem)
+        except acme_errors.WildcardUnsupportedError:
+            raise errors.Error("The currently selected ACME CA endpoint does"
+                                " not support issuing wildcard certificates.")
+
+        if not self.auth_handler:
+            raise errors.Error("No authorization handler has been set.")
+
+        # # For a dry run, ensure we have an order with fresh authorizations
+        # if orderr and self.config.dry_run:
+        #     deactivated, failed = self.auth_handler.deactivate_valid_authorizations(orderr)
+        #     if deactivated:
+        #         logger.debug("Recreating order after authz deactivations")
+        #         orderr = self.acme.new_order(csr_pem)
+        #     if failed:
+        #         logger.warning("Certbot was unable to obtain fresh authorizations for every domain"
+        #                        ". The dry run will continue, but results may not be accurate.")
+
+        handled_authzr = self.auth_handler.handle_single_authorization(authzr, self.config, best_effort)
+        return authzr.update(body=handled_authzr[0].body)
+
     def _get_order_and_authorizations(self, csr_pem: bytes,
                                       best_effort: bool) -> messages.OrderResource:
         """Request a new order and complete its authorizations.
@@ -495,7 +631,7 @@ class Client:
 
         authzr = self.auth_handler.handle_authorizations(orderr, self.config, best_effort)
         return orderr.update(authorizations=authzr)
-
+    
     def obtain_and_enroll_certificate(self, domains: List[str], certname: Optional[str]
                                       ) -> Optional[storage.RenewableCert]:
         """Obtain and enroll certificate.

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -596,7 +596,7 @@ def _report_next_steps(config: configuration.NamespaceConfig, installer_err: Opt
     if installer_err:
         print()
 
-def _report_next_steps_pre_authz() -> None:
+def _report_next_steps_after_pre_authz() -> None:
     """Reports next steps to the user after a domain pre-authorization has be done
     """
 
@@ -1672,7 +1672,7 @@ def pre_auth(config: configuration.NamespaceConfig, plugins: plugins_disco.Plugi
     authz_statuses = le_client.obtain_authorizations(domains)
 
     _report_new_authz(authz_statuses)
-    _report_next_steps_pre_authz()
+    _report_next_steps_after_pre_authz()
 
     _suggest_donation_if_appropriate(config)
     eff.handle_subscription(config, le_client.account)

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -657,8 +657,6 @@ def _report_new_authz(preauthz_results : dict[str, str]) -> None:
     :rtype: None
 
     """
-
-
     display_util.notify("\nThe authorization status of your identifiers are:\n")
 
     for key, value in preauthz_results.items():

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -1620,6 +1620,40 @@ def certonly(config: configuration.NamespaceConfig, plugins: plugins_disco.Plugi
     _suggest_donation_if_appropriate(config)
     eff.handle_subscription(config, le_client.account)
 
+def pre_auth(config: configuration.NamespaceConfig, plugins: plugins_disco.PluginsRegistry) -> None:
+    """Authenticate & obtain authorization, but do not request a certificate.
+
+    This implements the 'preauth' subcommand.
+
+    :param config: Configuration object
+    :type config: configuration.NamespaceConfig
+
+    :param plugins: List of plugins
+    :type plugins: plugins_disco.PluginsRegistry
+
+    :returns: `None`
+    :rtype: None
+
+    :raises errors.Error: If specified plugin could not be used
+
+    """
+    # SETUP: Select plugins and construct a client instance
+    # installers are used in auth mode to determine domain names
+    installer, auth = plug_sel.choose_configurator_plugins(config, plugins, "certonly")
+    le_client = _init_le_client(config, auth, installer)
+
+    domains, certname = _find_domains_or_certname(config, installer)
+
+    authz_status = le_client.obtain_authorizations(domains)
+
+    print(authz_status)
+
+    print("your identifiers have been authorized")
+    #_report_new_authz()
+    #_report_next_steps()
+
+    _suggest_donation_if_appropriate(config)
+    eff.handle_subscription(config, le_client.account)
 
 def renew(config: configuration.NamespaceConfig,
           unused_plugins: plugins_disco.PluginsRegistry) -> None:

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -602,7 +602,7 @@ def _report_next_steps_after_pre_authz() -> None:
 
     display_util.notify(("If your identifiers are succesfully validated,\n" 
                          "you can run the cert issuance processes (e.g. certonly subcommand)\n"
-                         "to acquire the certificates without further domain validation"))
+                         "to acquire the certificates without any challenges requested."))
 
 
 def _report_new_cert(config: configuration.NamespaceConfig, cert_path: Optional[str],
@@ -661,7 +661,7 @@ def _report_new_authz(preauthz_results : dict[str, str]) -> None:
     """
 
 
-    display_util.notify("The authorization status of your identifiers are:\n")
+    display_util.notify("\nThe authorization status of your identifiers are:\n")
 
     for key, value in preauthz_results.items():
         display_util.notify(f"{key} : {value}\n")

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -600,8 +600,9 @@ def _report_next_steps_pre_authz() -> None:
     """Reports next steps to the user after a domain pre-authorization has be done
     """
 
-    display_util.notify(("If your identifiers are succesfully validated," 
-                         "you can run the cert issuance processes from the same http server to acquire the certificates without" "further domain validation"))
+    display_util.notify(("If your identifiers are succesfully validated,\n" 
+                         "you can run the cert issuance processes from the same http\n"
+                         "server to acquire the certificates without further domain validation"))
 
 
 def _report_new_cert(config: configuration.NamespaceConfig, cert_path: Optional[str],

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -599,11 +599,9 @@ def _report_next_steps(config: configuration.NamespaceConfig, installer_err: Opt
 def _report_next_steps_after_pre_authz() -> None:
     """Reports next steps to the user after a domain pre-authorization has be done
     """
-
-    display_util.notify(("If your identifiers are succesfully validated,\n" 
+    display_util.notify(("If your identifiers are succesfully validated,\n"
                          "you can run the cert issuance processes (e.g. certonly subcommand)\n"
                          "to acquire the certificates without any challenges requested."))
-
 
 def _report_new_cert(config: configuration.NamespaceConfig, cert_path: Optional[str],
                      fullchain_path: Optional[str], key_path: Optional[str] = None) -> None:

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -596,6 +596,13 @@ def _report_next_steps(config: configuration.NamespaceConfig, installer_err: Opt
     if installer_err:
         print()
 
+def _report_next_steps_pre_authz() -> None:
+    """Reports next steps to the user after a domain pre-authorization has be done
+    """
+
+    display_util.notify(("If your identifiers are succesfully validated," 
+                         "you can run the cert issuance processes from the same http server to acquire the certificates without" "further domain validation"))
+
 
 def _report_new_cert(config: configuration.NamespaceConfig, cert_path: Optional[str],
                      fullchain_path: Optional[str], key_path: Optional[str] = None) -> None:
@@ -640,6 +647,23 @@ def _report_new_cert(config: configuration.NamespaceConfig, cert_path: Optional[
             nl="\n" if config.verb == "run" else "" # Normalize spacing across verbs
         )
     )
+
+def _report_new_authz(preauthz_results : dict[str, str]) -> None:
+    """Reports the validation status of domains to the user.
+
+    :param preauthz_results: The results of the pre-authorization process
+    :type preauthz_results: `dict` of `Identifier` and `Status`
+
+    :returns: `None`
+    :rtype: None
+
+    """
+
+
+    display_util.notify("The authorization status of your identifiers are:\n")
+
+    for key, value in preauthz_results.items():
+        display_util.notify(f"{key} : {value}\n")
 
 
 def _is_interactive_only_auth(config: configuration.NamespaceConfig) -> bool:
@@ -1642,15 +1666,12 @@ def pre_auth(config: configuration.NamespaceConfig, plugins: plugins_disco.Plugi
     installer, auth = plug_sel.choose_configurator_plugins(config, plugins, "certonly")
     le_client = _init_le_client(config, auth, installer)
 
-    domains, certname = _find_domains_or_certname(config, installer)
+    domains, _ = _find_domains_or_certname(config, installer)
 
-    authz_status = le_client.obtain_authorizations(domains)
+    authz_statuses = le_client.obtain_authorizations(domains)
 
-    print(authz_status)
-
-    print("your identifiers have been authorized")
-    #_report_new_authz()
-    #_report_next_steps()
+    _report_new_authz(authz_statuses)
+    _report_next_steps_pre_authz()
 
     _suggest_donation_if_appropriate(config)
     eff.handle_subscription(config, le_client.account)

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -601,8 +601,8 @@ def _report_next_steps_after_pre_authz() -> None:
     """
 
     display_util.notify(("If your identifiers are succesfully validated,\n" 
-                         "you can run the cert issuance processes from the same http\n"
-                         "server to acquire the certificates without further domain validation"))
+                         "you can run the cert issuance processes (e.g. certonly subcommand)\n"
+                         "to acquire the certificates without further domain validation"))
 
 
 def _report_new_cert(config: configuration.NamespaceConfig, cert_path: Optional[str],

--- a/certbot/certbot/_internal/plugins/selection.py
+++ b/certbot/certbot/_internal/plugins/selection.py
@@ -233,7 +233,11 @@ def choose_configurator_plugins(config: configuration.NamespaceConfig,
         need_inst = True
         if config.authenticator:
             logger.warning("Specifying an authenticator doesn't make sense when "
-                           "running Certbot with verb \"%s\"", verb)
+                           "running Certbot with verb \"%s\"", verb)      
+    elif verb == "preauth":
+        need_auth = True
+        need_inst = False
+    
     # Try to meet the user's request and/or ask them to pick plugins
     authenticator: Optional[interfaces.Authenticator] = None
     installer: Optional[interfaces.Installer] = None

--- a/certbot/certbot/_internal/plugins/selection.py
+++ b/certbot/certbot/_internal/plugins/selection.py
@@ -234,9 +234,6 @@ def choose_configurator_plugins(config: configuration.NamespaceConfig,
         if config.authenticator:
             logger.warning("Specifying an authenticator doesn't make sense when "
                            "running Certbot with verb \"%s\"", verb)      
-    elif verb == "preauth":
-        need_auth = True
-        need_inst = False
     
     # Try to meet the user's request and/or ask them to pick plugins
     authenticator: Optional[interfaces.Authenticator] = None

--- a/certbot/certbot/main.py
+++ b/certbot/certbot/main.py
@@ -2,10 +2,7 @@
 from typing import List
 from typing import Optional
 from typing import Union
-
 import debugpy
-import ipdb
-
 from certbot._internal import main as internal_main
 
 
@@ -23,6 +20,4 @@ def main(cli_args: Optional[List[str]] = None) -> Optional[Union[str, int]]:
     debugpy.listen(('127.0.0.1', 5009))
     print("waiting for client")
     debugpy.wait_for_client()
-    
     return internal_main.main(cli_args)
-

--- a/certbot/certbot/main.py
+++ b/certbot/certbot/main.py
@@ -3,6 +3,9 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+import debugpy
+import ipdb
+
 from certbot._internal import main as internal_main
 
 
@@ -16,4 +19,10 @@ def main(cli_args: Optional[List[str]] = None) -> Optional[Union[str, int]]:
     :rtype: `str` or `int` or `None`
 
     """
+    print("running in debug mode")
+    debugpy.listen(('127.0.0.1', 5009))
+    print("waiting for client")
+    debugpy.wait_for_client()
+    
     return internal_main.main(cli_args)
+

--- a/certbot/certbot/main.py
+++ b/certbot/certbot/main.py
@@ -2,7 +2,6 @@
 from typing import List
 from typing import Optional
 from typing import Union
-import debugpy
 from certbot._internal import main as internal_main
 
 
@@ -16,8 +15,4 @@ def main(cli_args: Optional[List[str]] = None) -> Optional[Union[str, int]]:
     :rtype: `str` or `int` or `None`
 
     """
-    # print("running in debug mode")
-    # debugpy.listen(('127.0.0.1', 5009))
-    # print("waiting for client")
-    # debugpy.wait_for_client()
     return internal_main.main(cli_args)

--- a/certbot/certbot/main.py
+++ b/certbot/certbot/main.py
@@ -16,8 +16,8 @@ def main(cli_args: Optional[List[str]] = None) -> Optional[Union[str, int]]:
     :rtype: `str` or `int` or `None`
 
     """
-    print("running in debug mode")
-    debugpy.listen(('127.0.0.1', 5009))
-    print("waiting for client")
-    debugpy.wait_for_client()
+    # print("running in debug mode")
+    # debugpy.listen(('127.0.0.1', 5009))
+    # print("waiting for client")
+    # debugpy.wait_for_client()
     return internal_main.main(cli_args)


### PR DESCRIPTION
Added pre-authorization according to [RFC 8555](https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4.1)

The feature was tested against Entrust's ACME server, as that is the only ACME server supporting pre-authorization at this point:

https://acme.entrust.net/acme2/directory

Sample command:

`
sudo certbot preauth --server https://acme.entrust.net/acme2/directory --email $email --domain $domain --eab-kid $kid --eab-hmac-key $mac -v``
`
