### PR TITLE
Update changelog for 3.0 and remove update_symlinks and {csr,key}_dir

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
-## 2.12.0 - master
+## 3.0.0 - master
 
 ### Added
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* The update_symlinks command was removed.
 
 ### Fixed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -11,6 +11,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 * The update_symlinks command was removed.
+* The `csr_dir` and `key_dir` attributes on
+  `certbot.configuration.NamespaceConfig` were removed.
 
 ### Fixed
 

--- a/certbot/certbot/_internal/cert_manager.py
+++ b/certbot/certbot/_internal/cert_manager.py
@@ -30,22 +30,6 @@ logger = logging.getLogger(__name__)
 ###################
 
 
-def update_live_symlinks(config: configuration.NamespaceConfig) -> None:
-    """Update the certificate file family symlinks to use archive_dir.
-
-    Use the information in the config file to make symlinks point to
-    the correct archive directory.
-
-    .. note:: This assumes that the installation is using a Reverter object.
-
-    :param config: Configuration.
-    :type config: :class:`certbot._internal.configuration.NamespaceConfig`
-
-    """
-    for renewal_file in storage.renewal_conf_files(config):
-        storage.RenewableCert(renewal_file, config, update_symlinks=True)
-
-
 def rename_lineage(config: configuration.NamespaceConfig) -> None:
     """Rename the specified lineage to the new name.
 

--- a/certbot/certbot/_internal/cli/helpful.py
+++ b/certbot/certbot/_internal/cli/helpful.py
@@ -58,7 +58,6 @@ class HelpfulArgumentParser:
             "revoke": main.revoke,
             "rollback": main.rollback,
             "everything": main.run,
-            "update_symlinks": main.update_symlinks,
             "certificates": main.certificates,
             "delete": main.delete,
             "enhance": main.enhance,

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -182,9 +182,6 @@ BACKUP_DIR = "backups"
 """Directory (relative to `certbot.configuration.NamespaceConfig.work_dir`)
 where backups are kept."""
 
-CSR_DIR = "csr"
-"""See `certbot.configuration.NamespaceConfig.csr_dir`."""
-
 IN_PROGRESS_DIR = "IN_PROGRESS"
 """Directory used before a permanent checkpoint is finalized (relative to
 `certbot.configuration.NamespaceConfig.work_dir`)."""

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -15,7 +15,6 @@ from typing import Optional
 from typing import Tuple
 from typing import TypeVar
 from typing import Union
-import warnings
 
 import configobj
 import josepy as jose
@@ -1264,27 +1263,6 @@ def rollback(config: configuration.NamespaceConfig, plugins: plugins_disco.Plugi
 
     """
     client.rollback(config.installer, config.checkpoints, config, plugins)
-
-
-def update_symlinks(config: configuration.NamespaceConfig,
-                    unused_plugins: plugins_disco.PluginsRegistry) -> None:
-    """Update the certificate file family symlinks
-
-    Use the information in the config file to make symlinks point to
-    the correct archive directory.
-
-    :param config: Configuration object
-    :type config: configuration.NamespaceConfig
-
-    :param unused_plugins: List of plugins (deprecated)
-    :type unused_plugins: plugins_disco.PluginsRegistry
-
-    :returns: `None`
-    :rtype: None
-
-    """
-    warnings.warn("update_symlinks is deprecated and will be removed", PendingDeprecationWarning)
-    cert_manager.update_live_symlinks(config)
 
 
 def rename(config: configuration.NamespaceConfig,

--- a/certbot/certbot/_internal/storage.py
+++ b/certbot/certbot/_internal/storage.py
@@ -455,8 +455,7 @@ class RenewableCert(interfaces.RenewableCert):
         renewal configuration file and/or systemwide defaults.
 
     """
-    def __init__(self, config_filename: str, cli_config: configuration.NamespaceConfig,
-                 update_symlinks: bool = False) -> None:
+    def __init__(self, config_filename: str, cli_config: configuration.NamespaceConfig) -> None:
         """Instantiate a RenewableCert object from an existing lineage.
 
         :param str config_filename: the path to the renewal config file
@@ -505,8 +504,6 @@ class RenewableCert(interfaces.RenewableCert):
         self.live_dir = os.path.dirname(self.cert)
 
         self._fix_symlinks()
-        if update_symlinks:
-            self._update_symlinks()
         self._check_symlinks()
 
     @property
@@ -593,17 +590,6 @@ class RenewableCert(interfaces.RenewableCert):
                 raise errors.CertStorageError("target {0} of symlink {1} does "
                                               "not exist".format(target, link))
 
-    def _update_symlinks(self) -> None:
-        """Updates symlinks to use archive_dir"""
-        for kind in ALL_FOUR:
-            link = getattr(self, kind)
-            previous_link = get_link_target(link)
-            new_link = os.path.join(self.relative_archive_dir(link),
-                os.path.basename(previous_link))
-
-            os.unlink(link)
-            os.symlink(new_link, link)
-
     def _consistent(self) -> bool:
         """Are the files associated with this lineage self-consistent?
 
@@ -636,10 +622,7 @@ class RenewableCert(interfaces.RenewableCert):
                              "cert lineage's directory within the "
                              "official archive directory. Link: %s, "
                              "target directory: %s, "
-                             "archive directory: %s. If you've specified "
-                             "the archive directory in the renewal configuration "
-                             "file, you may need to update links by running "
-                             "certbot update_symlinks.",
+                             "archive directory: %s.",
                              link, os.path.dirname(target), self.archive_dir)
                 return False
 

--- a/certbot/certbot/_internal/tests/cert_manager_test.py
+++ b/certbot/certbot/_internal/tests/cert_manager_test.py
@@ -65,44 +65,6 @@ class BaseCertManagerTest(test_util.ConfigTestCase):
         return config_file
 
 
-class UpdateLiveSymlinksTest(BaseCertManagerTest):
-    """Tests for certbot._internal.cert_manager.update_live_symlinks
-    """
-    def test_update_live_symlinks(self):
-        """Test update_live_symlinks"""
-        # create files with incorrect symlinks
-        from certbot._internal import cert_manager
-        archive_paths = {}
-        for domain in self.domains:
-            custom_archive = self.domains[domain]
-            if custom_archive is not None:
-                archive_dir_path = custom_archive
-            else:
-                archive_dir_path = os.path.join(self.config.default_archive_dir, domain)
-            archive_paths[domain] = {kind:
-                os.path.join(archive_dir_path, kind + "1.pem") for kind in ALL_FOUR}
-            for kind in ALL_FOUR:
-                live_path = self.config_files[domain][kind]
-                archive_path = archive_paths[domain][kind]
-                open(archive_path, 'a').close()
-                # path is incorrect but base must be correct
-                os.symlink(os.path.join(self.config.config_dir, kind + "1.pem"), live_path)
-
-        # run update symlinks
-        cert_manager.update_live_symlinks(self.config)
-
-        # check that symlinks go where they should
-        prev_dir = os.getcwd()
-        try:
-            for domain in self.domains:
-                for kind in ALL_FOUR:
-                    os.chdir(os.path.dirname(self.config_files[domain][kind]))
-                    assert filesystem.realpath(filesystem.readlink(self.config_files[domain][kind])) == \
-                        filesystem.realpath(archive_paths[domain][kind])
-        finally:
-            os.chdir(prev_dir)
-
-
 class DeleteTest(storage_test.BaseRenewableCertTest):
     """Tests for certbot._internal.cert_manager.delete
     """

--- a/certbot/certbot/_internal/tests/configuration_test.py
+++ b/certbot/certbot/_internal/tests/configuration_test.py
@@ -48,7 +48,6 @@ class NamespaceConfigTest(test_util.ConfigTestCase):
     def test_dynamic_dirs(self, mock_constants):
         mock_constants.ACCOUNTS_DIR = 'acc'
         mock_constants.BACKUP_DIR = 'backups'
-        mock_constants.CSR_DIR = 'csr'
 
         mock_constants.IN_PROGRESS_DIR = '../p'
         mock_constants.KEY_DIR = 'keys'
@@ -60,12 +59,6 @@ class NamespaceConfigTest(test_util.ConfigTestCase):
             os.path.normpath(os.path.join(self.config.config_dir, ref_path))
         assert os.path.normpath(self.config.backup_dir) == \
             os.path.normpath(os.path.join(self.config.work_dir, 'backups'))
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            assert os.path.normpath(self.config.csr_dir) == \
-                os.path.normpath(os.path.join(self.config.config_dir, 'csr'))
-            assert os.path.normpath(self.config.key_dir) == \
-                os.path.normpath(os.path.join(self.config.config_dir, 'keys'))
         assert os.path.normpath(self.config.in_progress_dir) == \
             os.path.normpath(os.path.join(self.config.work_dir, '../p'))
         assert os.path.normpath(self.config.temp_checkpoint_dir) == \
@@ -100,10 +93,6 @@ class NamespaceConfigTest(test_util.ConfigTestCase):
                          os.path.join(os.getcwd(), logs_base)
         assert os.path.isabs(config.accounts_dir)
         assert os.path.isabs(config.backup_dir)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            assert os.path.isabs(config.csr_dir)
-            assert os.path.isabs(config.key_dir)
         assert os.path.isabs(config.in_progress_dir)
         assert os.path.isabs(config.temp_checkpoint_dir)
 

--- a/certbot/certbot/_internal/tests/main_test.py
+++ b/certbot/certbot/_internal/tests/main_test.py
@@ -1215,11 +1215,6 @@ class MainTest(test_util.ConfigTestCase):
         client.rollback.assert_called_once_with(
             mock.ANY, 123, mock.ANY, mock.ANY)
 
-    @mock.patch('certbot._internal.cert_manager.update_live_symlinks')
-    def test_update_symlinks(self, mock_cert_manager):
-        self._call_no_clientmock(['update_symlinks'])
-        assert 1 == mock_cert_manager.call_count
-
     @mock.patch('certbot._internal.cert_manager.certificates')
     def test_certificates(self, mock_cert_manager):
         self._call_no_clientmock(['certificates'])

--- a/certbot/certbot/_internal/tests/storage_test.py
+++ b/certbot/certbot/_internal/tests/storage_test.py
@@ -838,21 +838,6 @@ class RenewableCertTests(BaseRenewableCertTest):
         assert stat.S_IMODE(os.lstat(temp).st_mode) == \
                          stat.S_IMODE(os.lstat(temp2).st_mode)
 
-    def test_update_symlinks(self):
-        from certbot._internal import storage
-        archive_dir_path = os.path.join(self.config.config_dir, "archive", "example.org")
-        for kind in ALL_FOUR:
-            live_path = self.config_file[kind]
-            basename = kind + "1.pem"
-            archive_path = os.path.join(archive_dir_path, basename)
-            open(archive_path, 'a').close()
-            os.symlink(os.path.join(self.config.config_dir, basename), live_path)
-        with pytest.raises(errors.CertStorageError):
-            storage.RenewableCert(self.config_file.filename,
-                          self.config)
-        storage.RenewableCert(self.config_file.filename, self.config,
-            update_symlinks=True)
-
     def test_truncate(self):
         # It should not do anything when there's less than 5 cert history
         for kind in ALL_FOUR:

--- a/certbot/certbot/configuration.py
+++ b/certbot/certbot/configuration.py
@@ -8,7 +8,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from urllib import parse
-import warnings
 
 from certbot import errors
 from certbot import util
@@ -43,9 +42,7 @@ class NamespaceConfig:
     paths defined in :py:mod:`certbot._internal.constants`:
 
       - `accounts_dir`
-      - `csr_dir`
       - `in_progress_dir`
-      - `key_dir`
       - `temp_checkpoint_dir`
 
     And the following paths are dynamically resolved using
@@ -286,23 +283,9 @@ class NamespaceConfig:
         return os.path.join(self.namespace.work_dir, constants.BACKUP_DIR)
 
     @property
-    def csr_dir(self) -> str:
-        """Directory where new Certificate Signing Requests (CSRs) are saved."""
-        warnings.warn("NamespaceConfig.csr_dir is deprecated and will be removed in an upcoming "
-                      "release of Certbot", DeprecationWarning)
-        return os.path.join(self.namespace.config_dir, constants.CSR_DIR)
-
-    @property
     def in_progress_dir(self) -> str:
         """Directory used before a permanent checkpoint is finalized."""
         return os.path.join(self.namespace.work_dir, constants.IN_PROGRESS_DIR)
-
-    @property
-    def key_dir(self) -> str:
-        """Keys storage."""
-        warnings.warn("NamespaceConfig.key_dir is deprecated and will be removed in an upcoming "
-                      "release of Certbot", DeprecationWarning)
-        return os.path.join(self.namespace.config_dir, constants.KEY_DIR)
 
     @property
     def temp_checkpoint_dir(self) -> str:

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,20 +19,17 @@
 #    unit tests. This warning should be ignored until our (transitive)
 #    dependency on requests-toolbelt is removed or our pinned version can be
 #    updated.
-# 4) Ignore our own PendingDeprecationWarning about update_symlinks soon to be dropped.
-#    See https://github.com/certbot/certbot/issues/6284.
-# 5) Ignore DeprecationWarning for datetime.utcfromtimestamp() triggered
+# 4) Ignore DeprecationWarning for datetime.utcfromtimestamp() triggered
 #    from dateutil. See https://github.com/dateutil/dateutil/issues/1314.
-# 6) Ignoring this allows us to continue to update pyOpenSSL (one of our crypto
+# 5) Ignoring this allows us to continue to update pyOpenSSL (one of our crypto
 #    dependencies) until https://github.com/certbot/certbot/issues/9828 is resolved.
-# 7) Similarly to 6), CSR support is deprecated in pyOpenSSL since 24.2, we silence
+# 6) Similarly to 6), CSR support is deprecated in pyOpenSSL since 24.2, we silence
 #    the warning until https://github.com/certbot/certbot/issues/9992 is resolved.
 filterwarnings =
     error
     ignore:decodestring\(\) is a deprecated alias:DeprecationWarning:dns
     ignore:.*rsyncdir:DeprecationWarning
     ignore:'urllib3.contrib.pyopenssl:DeprecationWarning:requests_toolbelt
-    ignore:update_symlinks is deprecated:PendingDeprecationWarning
     ignore:.*datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:dateutil
     ignore:X509Extension support in pyOpenSSL is deprecated:DeprecationWarning
     ignore:CSR support in pyOpenSSL is deprecated:DeprecationWarning


### PR DESCRIPTION
This is part of https://github.com/certbot/certbot/issues/9988.

I can split this into separate PRs if the reviewer wants. I just did it in a single PR since this PR isn't that large and to avoid merge conflicts, but each commit fully makes a single change so it may be easier to review it that way.

I changed the current version number in changelog to 3.0.0 because [our release script doesn't handle that](https://github.com/certbot/certbot/blob/ee2c4844b96a1635848d201c8f243ee5f6b2d9e9/tools/_release.sh#L99-L102). We did the same thing for 2.0 in https://github.com/certbot/certbot/pull/9461.