### PR TITLE
Update syntax for mattermost webhooks

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -28,5 +28,5 @@ jobs:
                 --arg title "$TITLE" \
         '{ "text": "[\($repo)] | [\($title) #\($number)](\($pr_url)) was merged into master by \($user)" }' > mattermost.json
     - uses: mattermost/action-mattermost-notify@master
-      env:
+      with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_MERGE_WEBHOOK }}


### PR DESCRIPTION
According to the [action-mattermost-notify README](https://github.com/mattermost/action-mattermost-notify?tab=readme-ov-file#usage), we should be using `with` instead of `env`. Merging this PR will be a test for the fix!