### PR TITLE
Specify channel in weekly mattermost message

### DIFF
--- a/.github/workflows/notify_weekly.yaml
+++ b/.github/workflows/notify_weekly.yaml
@@ -17,6 +17,7 @@ jobs:
     - uses: mattermost/action-mattermost-notify@master
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+        MATTERMOST_CHANNEL: private-certbot
         TEXT: |
           ## Updates Across Certbot Repos
           - Certbot team members SHOULD look at: [link](${{ env.MERGED_URL }})


### PR DESCRIPTION
As described in https://github.com/mattermost/action-mattermost-notify?tab=readme-ov-file#usage. If this doesn't work, we may need to re-generate the webhook URL and update it in the github actions secrets.