### PR TITLE
Allow manually triggering GH actions

### DIFF
--- a/.github/workflows/notify_weekly.yaml
+++ b/.github/workflows/notify_weekly.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Every week on Thursday @ 13:00
     - cron: "0 13 * * 4"
+  workflow_dispatch:
 jobs:
   send-mattermost-message:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Run 1:24AM every night
     - cron: '24 1 * * *'
+  workflow_dispatch:
 permissions:
   issues: write
 jobs:


### PR DESCRIPTION
for PRs like https://github.com/certbot/certbot/pull/10013, i think it'd be kind of nice if we could manually trigger our actions test them. https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow makes it sound like we can!

i put this on the master branch of my fork at https://github.com/bmw/letsencrypt and [was able to manually trigger a run](https://github.com/bmw/letsencrypt/actions/workflows/stale.yml) (notice the "manually run by bmw text"). when doing this, as described at the github docs link, you get to choose the branch to run the workflow on so i believe we'd be able to do things like run a workflow on another branch in this repo to test changes before they're made to the main branch

finally, i didn't do this for the `merged.yaml` github action because it expects to be triggered on a pull request and have PR information available. i think in theory we could make the PR info a [workflow input](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs) and largely rewrite that action, but i didn't try doing that here