### PR TITLE
Fix excessive master to main switch

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged == true && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
-    - uses: mattermost/action-mattermost-notify@main
+    - uses: mattermost/action-mattermost-notify@master
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_MERGE_WEBHOOK }}
         TEXT: >

--- a/.github/workflows/notify_weekly.yaml
+++ b/.github/workflows/notify_weekly.yaml
@@ -15,7 +15,7 @@ jobs:
         DATE=$(date --date="7 days ago" +"%Y-%m-%d")
         echo "MERGED_URL=https://github.com/pulls?q=merged%3A%3E${DATE}+org%3Acertbot" >> $GITHUB_ENV
         echo "UPDATED_URL=https://github.com/pulls?q=updated%3A%3E${DATE}+org%3Acertbot" >> $GITHUB_ENV
-    - uses: mattermost/action-mattermost-notify@main
+    - uses: mattermost/action-mattermost-notify@master
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
         MATTERMOST_CHANNEL: private-certbot


### PR DESCRIPTION
I noticed our GitHub CI failed last night at https://github.com/certbot/certbot/actions/runs/11162616005. It looks like mattermost/action-mattermost-notify still uses master and this was changed in the big find/replace at https://github.com/certbot/certbot/commit/84c8dbc52a14f9dbbe6de53779eaed3058109b9e. This PR just switches it back.