### PR TITLE
Make Docker builds more verbose

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,5 +1,5 @@
 #base image
-FROM python:3.12-alpine3.18 as certbot
+FROM python:3.12-alpine3.18 AS certbot
 
 ENTRYPOINT [ "certbot" ]
 EXPOSE 80 443
@@ -44,6 +44,6 @@ RUN apk add --no-cache --virtual .build-deps \
 #static definition for making a plugin, but beware that
 #using this layer definition will cause collisions if you make
 #extensive use of the cache.
-FROM certbot as certbot-plugin
+FROM certbot AS certbot-plugin
 COPY --from=plugin-src . /opt/certbot/src/plugin
 RUN python tools/pip_install.py --no-cache-dir --editable /opt/certbot/src/plugin

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -25,6 +25,12 @@ RUN apk add --no-cache --virtual .certbot-deps \
 # cryptography library
 ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 # Install certbot from sources
+#
+# For some reason, setting the CARGO_LOG and CARGO_TERM_VERBOSE environment
+# variables and -v/--verbose flags on pip seems to help cryptography builds not
+# hang when building Docker images for other architectures using QEMU. See
+# https://github.com/certbot/certbot/issues/10020. This may hopefully also help
+# us to get more information about the problem to aid further debugging.
 RUN apk add --no-cache --virtual .build-deps \
         gcc \
         linux-headers \
@@ -35,7 +41,8 @@ RUN apk add --no-cache --virtual .build-deps \
         cargo \
         git \
         pkgconfig \
-    && python tools/pip_install.py --no-cache-dir \
+    && CARGO_LOG=trace CARGO_TERM_VERBOSE=true python tools/pip_install.py \
+            --no-cache-dir -vvv \
             --editable src/acme \
             --editable src/certbot \
     && apk del .build-deps \

--- a/tools/docker/lib/common
+++ b/tools/docker/lib/common
@@ -70,7 +70,7 @@ ParseArgs() {
     local IFS=","
     # Handle the special value "all"
     if [[ "${ARCH_LIST}" == "all" ]]; then
-        # Replace with comma separated 
+        # Replace with comma separated
         ARCH_LIST="${ALL_TARGET_ARCH[*]}"
     fi
 
@@ -88,7 +88,7 @@ ParseArgs() {
 }
 
 
-# Function for use with trap in the primary scripts to remove the 
+# Function for use with trap in the primary scripts to remove the
 # docker builder and restore the original directory
 Cleanup() {
     docker buildx rm certbot_builder || true
@@ -106,5 +106,11 @@ CreateBuilder() {
     # just incase the env is not perfectly clean, remove any old instance of the builder
     docker buildx rm certbot_builder || true
     # create the builder instance
-    docker buildx create --name certbot_builder --driver docker-container --driver-opt=network=host --bootstrap
+    #
+    # BUILDKIT_STEP_LOG_MAX_* environment variables are set to prevent docker
+    # from truncating build logs that can be useful during debugging. See
+    # https://github.com/docker/buildx/issues/484#issuecomment-749352728
+    docker buildx create --name certbot_builder --driver docker-container \
+        --driver-opt=network=host --driver-opt env.BUILDKIT_STEP_LOG_MAX_SIZE=-1 \
+        --driver-opt env.BUILDKIT_STEP_LOG_MAX_SPEED=-1 --bootstrap
 }


### PR DESCRIPTION
See https://github.com/certbot/certbot/issues/10020 for more info about my digging here. As surprising as it may be, I'm now up to only 1 out of 10 builds failing when this level of verbosity is set so while this isn't perfect, it should help and like I said in the Dockerfile comment, it may help us to get more information about where the build is hanging.

To see the warnings my commit message about using consistent casing in the Dockerfile is talking about, see https://dev.azure.com/certbot/certbot/_build/results?buildId=8076&view=logs&j=db9d590d-ed27-5cbb-1855-2594371ebd55&t=9950ec7a-c9d6-5c77-fe7e-8b5a3934be17&l=122.