### PR TITLE
Drop setuptools as a runtime dependency

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -15,7 +15,6 @@ install_requires = [
     'pyrfc3339',
     'pytz>=2019.3',
     'requests>=2.20.0',
-    'setuptools>=41.6.0',
 ]
 
 docs_extras = [

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -11,7 +11,6 @@ install_requires = [
     f'certbot>={version}',
     'importlib_resources>=1.3.1; python_version < "3.9"',
     'python-augeas',
-    'setuptools>=41.6.0',
 ]
 
 dev_extras = [

--- a/certbot-ci/setup.py
+++ b/certbot-ci/setup.py
@@ -22,7 +22,6 @@ install_requires = [
     # requests unvendored its dependencies in version 2.16.0 and this code relies on that for
     # calling `urllib3.disable_warnings`.
     'requests>=2.16.0',
-    'setuptools',
     'types-python-dateutil',
 ]
 

--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -10,7 +10,6 @@ install_requires = [
     # for now, do not upgrade to cloudflare>=2.20 to avoid deprecation warnings and the breaking
     # changes in version 3.0. see https://github.com/certbot/certbot/issues/9938
     'cloudflare>=1.5.1, <2.20',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'python-digitalocean>=1.11', # 1.15.0 or newer is recommended for TTL support
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -10,7 +10,6 @@ install_requires = [
     # This version of lexicon is required to address the problem described in
     # https://github.com/AnalogJ/lexicon/issues/387.
     'dns-lexicon>=3.14.1',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -9,7 +9,6 @@ version = '2.12.0.dev0'
 install_requires = [
     'google-api-python-client>=1.6.5',
     'google-auth>=2.16.0',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.15.1',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'dnspython>=1.15.0',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'boto3>=1.15.15',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -8,7 +8,6 @@ version = '2.12.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',
-    'setuptools>=41.6.0',
 ]
 
 if os.environ.get('SNAP_BUILD'):

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -13,7 +13,6 @@ install_requires = [
     # pyOpenSSL 23.1.0 is a bad release: https://github.com/pyca/pyopenssl/issues/1199
     'PyOpenSSL>=17.5.0,!=23.1.0',
     'pyparsing>=2.2.1',
-    'setuptools>=41.6.0',
 ]
 
 test_extras = [

--- a/certbot/setup.py
+++ b/certbot/setup.py
@@ -43,7 +43,6 @@ install_requires = [
     # This dependency needs to be added using environment markers to avoid its
     # installation on Linux.
     'pywin32>=300 ; sys_platform == "win32"',
-    'setuptools>=41.6.0',
 ]
 
 dev_extras = [


### PR DESCRIPTION
Because of the change from using setuptools.pkg_resources to using importlib, we no longer need a runtime dependency on setuptools. It is still required, however, for running setup.py.

This closes #10023.
