### PR TITLE
Certbot 3.0 outdated plugin warning

### DIFF
--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -94,7 +94,7 @@ def prepare_env(cli_args: List[str]) -> List[str]:
             ))
 
     if outdated_plugins:
-        LOGGER.warn('The following plugins are using an outdated python version and must be '
+        LOGGER.warning('The following plugins are using an outdated python version and must be '
                     'updated to be compatible with Certbot 3.0. Please see '
                     'https://community.letsencrypt.org/t/'
                     'certbot-3-0-could-have-potential-third-party-snap-breakages/226940 '

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -93,7 +93,7 @@ def prepare_env(cli_args: List[str]) -> List[str]:
                 CURRENT_PYTHON_VERSION_STRING
             ))
 
-    if len(outdated_plugins):
+    if outdated_plugins:
         LOGGER.error('The following plugins are using an outdated python version and must be '
                      'updated to be compatible with Certbot 3.0. Please see '
                      'https://community.letsencrypt.org/t/'

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -84,7 +84,7 @@ def prepare_env(cli_args: List[str]) -> List[str]:
             # "$SNAP/lib/python3.12/site-packages". If not, skip it and print an
             # error.
             slot_read: str = plugin.get('slot-attrs', {}).get('read', [])
-            if len(slot_read) != 0 and not CURRENT_PYTHON_VERSION_STRING in slot_read[0]:
+            if len(slot_read) != 0 and CURRENT_PYTHON_VERSION_STRING not in slot_read[0]:
                 outdated_plugins.append(plugin_name)
                 continue
 

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -100,7 +100,7 @@ def prepare_env(cli_args: List[str]) -> List[str]:
                     'certbot-3-0-could-have-potential-third-party-snap-breakages/226940 '
                     'for more information:')
         plugin_list = '\n'.join('  * {}'.format(plugin) for plugin in outdated_plugins)
-        LOGGER.warn(plugin_list)
+        LOGGER.warning(plugin_list)
 
     os.environ['CERTBOT_PLUGIN_PATH'] = ':'.join(connections)
 

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -75,10 +75,10 @@ def prepare_env(cli_args: List[str]) -> List[str]:
     connections = []
     outdated_plugins = []
     for plugin in data.get('result', {}).get('established', []):
-        plugin_name: str = plugin['slot']['snap']
         plug: str = plugin.get('plug', {}).get('plug')
         plug_content: str = plugin.get('plug-attrs', {}).get('content')
         if plug == 'plugin' and plug_content == 'certbot-1':
+            plugin_name: str = plugin['slot']['snap']
             # First, check that the plugin is using our expected python version,
             # i.e. its "read" slot is something like
             # "$SNAP/lib/python3.12/site-packages". If not, skip it and print an
@@ -93,7 +93,7 @@ def prepare_env(cli_args: List[str]) -> List[str]:
                 CURRENT_PYTHON_VERSION_STRING
             ))
 
-    if len(outdated_plugins) > 0:
+    if len(outdated_plugins):
         LOGGER.error('The following plugins are using an outdated python version and must be '
                      'updated to be compatible with Certbot 3.0. Please see '
                      'https://community.letsencrypt.org/t/'

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -94,13 +94,13 @@ def prepare_env(cli_args: List[str]) -> List[str]:
             ))
 
     if outdated_plugins:
-        LOGGER.error('The following plugins are using an outdated python version and must be '
-                     'updated to be compatible with Certbot 3.0. Please see '
-                     'https://community.letsencrypt.org/t/'
-                     'certbot-3-0-could-have-potential-third-party-snap-breakages/226940 '
-                     'for more information:')
+        LOGGER.warn('The following plugins are using an outdated python version and must be '
+                    'updated to be compatible with Certbot 3.0. Please see '
+                    'https://community.letsencrypt.org/t/'
+                    'certbot-3-0-could-have-potential-third-party-snap-breakages/226940 '
+                    'for more information:')
         plugin_list = '\n'.join('  * {}'.format(plugin) for plugin in outdated_plugins)
-        LOGGER.error(plugin_list)
+        LOGGER.warn(plugin_list)
 
     os.environ['CERTBOT_PLUGIN_PATH'] = ':'.join(connections)
 

--- a/certbot/certbot/_internal/snap_config.py
+++ b/certbot/certbot/_internal/snap_config.py
@@ -12,7 +12,6 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
 from requests.exceptions import RequestException
 
-import certbot
 from certbot.compat import os
 from certbot.errors import Error
 
@@ -97,7 +96,8 @@ def prepare_env(cli_args: List[str]) -> List[str]:
     if len(outdated_plugins) > 0:
         LOGGER.error('The following plugins are using an outdated python version and must be '
                      'updated to be compatible with Certbot 3.0. Please see '
-                     'https://community.letsencrypt.org/t/certbot-3-0-could-have-potential-third-party-snap-breakages/226940 '
+                     'https://community.letsencrypt.org/t/'
+                     'certbot-3-0-could-have-potential-third-party-snap-breakages/226940 '
                      'for more information:')
         plugin_list = '\n'.join('  * {}'.format(plugin) for plugin in outdated_plugins)
         LOGGER.error(plugin_list)


### PR DESCRIPTION
With Certbot 3.0 comes a bump to Python 3.12, so if any snap plugins
are still located in a python3.8 directory, print an error informing
the user.