### PR TITLE
Update azure standard tests to use macOS-15 and python3.12

### DIFF
--- a/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/extended-tests-jobs.yml
@@ -25,8 +25,9 @@ jobs:
         linux-integration-nginx-oldest:
           PYTHON_VERSION: 3.8
           TOXENV: integration-nginx-oldest
-        # python 3.8 integration tests are not run here because they're run as    
-        # part of the standard test suite 
+        linux-py38-integration:
+          PYTHON_VERSION: 3.8
+          TOXENV: integration
         linux-py39-integration:
           PYTHON_VERSION: 3.9
           TOXENV: integration
@@ -36,20 +37,19 @@ jobs:
         linux-py311-integration:
           PYTHON_VERSION: 3.11
           TOXENV: integration
-        linux-py312-integration:
-          PYTHON_VERSION: 3.12
-          TOXENV: integration
+        # python 3.12 integration tests are not run here because they're run as
+        # part of the standard test suite
         nginx-compat:
           TOXENV: nginx_compat
         linux-integration-rfc2136:
           IMAGE_NAME: ubuntu-22.04
-          PYTHON_VERSION: 3.8
+          PYTHON_VERSION: 3.12
           TOXENV: integration-dns-rfc2136
         le-modification:
           IMAGE_NAME: ubuntu-22.04
           TOXENV: modification
         farmtest-apache2:
-          PYTHON_VERSION: 3.8
+          PYTHON_VERSION: 3.12
           TOXENV: test-farm-apache2
     pool:
       vmImage: $(IMAGE_NAME)

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -4,9 +4,8 @@ jobs:
       PYTHON_VERSION: 3.12
     strategy:
       matrix:
-        macos-py38-cover:
+        macos-py312-cover:
           IMAGE_NAME: macOS-15
-          PYTHON_VERSION: 3.8
           TOXENV: cover
           # As of pip 23.1.0, builds started failing on macOS unless this flag was set.
           # See https://github.com/certbot/certbot/pull/9717#issuecomment-1610861794.
@@ -20,10 +19,9 @@ jobs:
           IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.8
           TOXENV: oldest
-        linux-py38:
+        linux-py312:
           IMAGE_NAME: ubuntu-22.04
-          PYTHON_VERSION: 3.8
-          TOXENV: py38
+          TOXENV: py312
         linux-cover:
           IMAGE_NAME: ubuntu-22.04
           TOXENV: cover
@@ -35,7 +33,6 @@ jobs:
           TOXENV: mypy
         linux-integration:
           IMAGE_NAME: ubuntu-22.04
-          PYTHON_VERSION: 3.8
           TOXENV: integration
         apache-compat:
           IMAGE_NAME: ubuntu-22.04

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -5,14 +5,14 @@ jobs:
     strategy:
       matrix:
         macos-py38-cover:
-          IMAGE_NAME: macOS-12
+          IMAGE_NAME: macOS-15
           PYTHON_VERSION: 3.8
           TOXENV: cover
           # As of pip 23.1.0, builds started failing on macOS unless this flag was set.
           # See https://github.com/certbot/certbot/pull/9717#issuecomment-1610861794.
           PIP_USE_PEP517: "true"
         macos-cover:
-          IMAGE_NAME: macOS-13
+          IMAGE_NAME: macOS-15
           TOXENV: cover
           # See explanation under macos-py38-cover.
           PIP_USE_PEP517: "true"

--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -4,13 +4,16 @@ jobs:
       PYTHON_VERSION: 3.12
     strategy:
       matrix:
-        macos-py312-cover:
+        macos-py38-cover:
+          # mac unit+cover tests with the oldest python we support
           IMAGE_NAME: macOS-15
+          PYTHON_VERSION: 3.8
           TOXENV: cover
           # As of pip 23.1.0, builds started failing on macOS unless this flag was set.
           # See https://github.com/certbot/certbot/pull/9717#issuecomment-1610861794.
           PIP_USE_PEP517: "true"
         macos-cover:
+          # mac unit+cover tests with the newest python we support
           IMAGE_NAME: macOS-15
           TOXENV: cover
           # See explanation under macos-py38-cover.
@@ -19,10 +22,13 @@ jobs:
           IMAGE_NAME: ubuntu-22.04
           PYTHON_VERSION: 3.8
           TOXENV: oldest
-        linux-py312:
+        linux-py38:
+          # linux unit tests with the oldest python we support
           IMAGE_NAME: ubuntu-22.04
-          TOXENV: py312
+          PYTHON_VERSION: 3.8
+          TOXENV: py38
         linux-cover:
+          # linux unit+cover tests with the newest python we support
           IMAGE_NAME: ubuntu-22.04
           TOXENV: cover
         linux-lint:


### PR DESCRIPTION
macOS-12 is [being deprecated](https://github.com/actions/runner-images/issues/10721) on Azure, so update to the latest available version.

We use python3.12 in our snap, so that should be the default version used for the standard tests (with 3.8 relegated to oldest and extended tests, at least for now).