### PR TITLE
Escape backslashes in format string in finish_release.py

### DIFF
--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -111,7 +111,7 @@ def get_snap_revisions(snap, channel, version):
     print('Getting revision numbers for', snap, version)
     cmd = ['snapcraft', 'status', snap]
     process = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True)
-    pattern = f'^\s+{channel}\s+{version}\s+(\d+)\s*'
+    pattern = f'^\\s+{channel}\\s+{version}\\s+(\\d+)\\s*'
     revisions = re.findall(pattern, process.stdout, re.MULTILINE)
     assert len(revisions) == SNAP_ARCH_COUNT, f'Unexpected number of snaps found for {channel} {snap} {version} (expected {SNAP_ARCH_COUNT}, found {len(revisions)})'
     return revisions


### PR DESCRIPTION
Fixes #10041.

I tested this manually and it worked.

```
$ python
Python 3.12.4 (main, Aug  5 2024, 15:30:13) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from finish_release import *
>>> assert_logged_into_snapcraft()
>>> snap = 'certbot'
>>> channel = 'beta'
>>> version = '3.0.0'
>>> print('Getting revision numbers for', snap, version)
Getting revision numbers for certbot 3.0.0
>>> cmd = ['snapcraft', 'status', snap]
>>> process = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True)
>>> pattern = f'^\\s+{channel}\\s+{version}\\s+(\\d+)\\s*'
>>> revisions = re.findall(pattern, process.stdout, re.MULTILINE)
>>> revisions
['4182', '4181', '4183']
>>> 
```