### PR TITLE
silence ocsp warning

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -15,7 +15,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Removed a CryptographyDeprecationWarning that was being displayed to users
+  when checking OCSP status.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/ocsp.py
+++ b/certbot/certbot/ocsp.py
@@ -7,6 +7,7 @@ import subprocess
 from subprocess import PIPE
 from typing import Optional
 from typing import Tuple
+import warnings
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
@@ -235,12 +236,17 @@ def _check_ocsp_response(response_ocsp: 'ocsp.OCSPResponse', request_ocsp: 'ocsp
     # https://github.com/openssl/openssl/blob/ef45aa14c5af024fcb8bef1c9007f3d1c115bd85/crypto/ocsp/ocsp_cl.c#L338-L391
     # thisUpdate/nextUpdate are expressed in UTC/GMT time zone
     now = datetime.now(pytz.UTC).replace(tzinfo=None)
-    if not response_ocsp.this_update:
-        raise AssertionError('param thisUpdate is not set.')
-    if response_ocsp.this_update > now + timedelta(minutes=5):
-        raise AssertionError('param thisUpdate is in the future.')
-    if response_ocsp.next_update and response_ocsp.next_update < now - timedelta(minutes=5):
-        raise AssertionError('param nextUpdate is in the past.')
+    # The this_update and next_update attributes were deprecated in cryptography's 43.0.0 release.
+    # Updating the code and tests to (also) work with the new API is being tracked in
+    # https://github.com/certbot/certbot/issues/10053.
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', message='Properties that return.*datetime object')
+        if not response_ocsp.this_update:
+            raise AssertionError('param thisUpdate is not set.')
+        if response_ocsp.this_update > now + timedelta(minutes=5):
+            raise AssertionError('param thisUpdate is in the future.')
+        if response_ocsp.next_update and response_ocsp.next_update < now - timedelta(minutes=5):
+            raise AssertionError('param nextUpdate is in the past.')
 
 
 def _check_ocsp_response_signature(response_ocsp: 'ocsp.OCSPResponse',


### PR DESCRIPTION
fixes https://github.com/certbot/certbot/issues/9967

actually fixing the underlying issue is being tracked by https://github.com/certbot/certbot/issues/10053

in addition to the unit test, i tested this manually. if you obtain any cert and run `certbot renew` in an up-to-date dev environment, there's 3 warnings when on `main` and none on this branch