### PR TITLE
update docker image base

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -11,7 +11,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Updated our Docker images to be based on Alpine Linux 3.20.
 
 ### Fixed
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,5 +1,5 @@
 #base image
-FROM python:3.12-alpine3.18 AS certbot
+FROM python:3.12-alpine3.20 AS certbot
 
 ENTRYPOINT [ "certbot" ]
 EXPOSE 80 443
@@ -15,7 +15,7 @@ COPY certbot src/certbot
 # Install certbot runtime dependencies
 RUN apk add --no-cache --virtual .certbot-deps \
         libffi \
-        libssl1.1 \
+        libssl3 \
         openssl \
         ca-certificates \
         binutils


### PR DESCRIPTION
fixes https://github.com/certbot/certbot/issues/10047

the libssl package name on alpine linux for some reason includes the version number so i had to update that too. libssl1.1 is not available but libssl3 is