### PR TITLE
Remove support for Linode API v3

### DIFF
--- a/certbot-dns-linode/certbot_dns_linode/__init__.py
+++ b/certbot-dns-linode/certbot_dns_linode/__init__.py
@@ -40,7 +40,6 @@ Tokens page (legacy) <https://manager.linode.com/profile/api>`_ or `Applications
 
    # Linode API credentials used by Certbot
    dns_linode_key = 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ64
-   dns_linode_version = 4
 
 The path to this file can be provided interactively or using the
 ``--dns-linode-credentials`` command-line argument. Certbot records the path

--- a/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
@@ -1,11 +1,8 @@
 """DNS Authenticator for Linode."""
 import logging
-import re
 from typing import Any
 from typing import Callable
-from typing import cast
 from typing import Optional
-from typing import Union
 
 from certbot import errors
 from certbot.plugins import dns_common_lexicon

--- a/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/dns_linode.py
@@ -12,7 +12,6 @@ from certbot.plugins import dns_common_lexicon
 
 logger = logging.getLogger(__name__)
 
-API_KEY_URL = 'https://manager.linode.com/profile/api'
 API_KEY_URL_V4 = 'https://cloud.linode.com/profile/tokens'
 
 
@@ -28,7 +27,7 @@ class Authenticator(dns_common_lexicon.LexiconDNSAuthenticator):
         super().__init__(*args, **kwargs)
         self._add_provider_option('key',
                                   'API key for Linode account, '
-                                  f'obtained from {API_KEY_URL} or {API_KEY_URL_V4}',
+                                  f'obtained from {API_KEY_URL_V4}',
                                   'auth_token')
 
     @classmethod
@@ -46,26 +45,7 @@ class Authenticator(dns_common_lexicon.LexiconDNSAuthenticator):
         if not hasattr(self, '_credentials'):  # pragma: no cover
             self._setup_credentials()
 
-        api_key = cast(str, self._credentials.conf('key'))
-        api_version: Optional[Union[str, int]] = self._credentials.conf('version')
-
-        if not api_version:
-            api_version = 3
-
-            # Match for v4 api key
-            regex_v4 = re.compile('^[0-9a-f]{64}$')
-            regex_match = regex_v4.match(api_key)
-            if regex_match:
-                api_version = 4
-        else:
-            api_version = int(api_version)
-
-        if api_version == 3:
-            return 'linode'
-        elif api_version == 4:
-            return 'linode4'
-
-        raise errors.PluginError(f'Invalid api version specified: {api_version}. (Supported: 3, 4)')
+        return 'linode4'
 
     def _setup_credentials(self) -> None:
         self._credentials = self._configure_credentials(

--- a/certbot-dns-linode/certbot_dns_linode/_internal/tests/dns_linode_test.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/tests/dns_linode_test.py
@@ -14,7 +14,6 @@ from certbot.tests import util as test_util
 from certbot_dns_linode._internal.dns_linode import Authenticator
 
 TOKEN = 'a-token'
-TOKEN_V3 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ64'
 TOKEN_V4 = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
 
 
@@ -35,17 +34,6 @@ class AuthenticatorTest(test_util.TempDirTestCase,
         self.auth = Authenticator(self.config, "linode")
 
     # pylint: disable=protected-access
-    def test_api_version_3_detection(self):
-        path = os.path.join(self.tempdir, 'file_3_auto.ini')
-        dns_test_common.write({"linode_key": TOKEN_V3}, path)
-
-        config = mock.MagicMock(linode_credentials=path,
-                                linode_propagation_seconds=0)
-        auth = Authenticator(config, "linode")
-
-        assert auth._provider_name == "linode"
-
-    # pylint: disable=protected-access
     def test_api_version_4_detection(self):
         path = os.path.join(self.tempdir, 'file_4_auto.ini')
         dns_test_common.write({"linode_key": TOKEN_V4}, path)
@@ -55,62 +43,6 @@ class AuthenticatorTest(test_util.TempDirTestCase,
         auth = Authenticator(config, "linode")
 
         assert auth._provider_name == "linode4"
-
-    # pylint: disable=protected-access
-    def test_api_version_3_detection_empty_version(self):
-        path = os.path.join(self.tempdir, 'file_3_auto_empty.ini')
-        dns_test_common.write({"linode_key": TOKEN_V3, "linode_version": ""}, path)
-
-        config = mock.MagicMock(linode_credentials=path,
-                                linode_propagation_seconds=0)
-        auth = Authenticator(config, "linode")
-
-        assert auth._provider_name == "linode"
-
-    # pylint: disable=protected-access
-    def test_api_version_4_detection_empty_version(self):
-        path = os.path.join(self.tempdir, 'file_4_auto_empty.ini')
-        dns_test_common.write({"linode_key": TOKEN_V4, "linode_version": ""}, path)
-
-        config = mock.MagicMock(linode_credentials=path,
-                                linode_propagation_seconds=0)
-        auth = Authenticator(config, "linode")
-
-        assert auth._provider_name == "linode4"
-
-    # pylint: disable=protected-access
-    def test_api_version_3_manual(self):
-        path = os.path.join(self.tempdir, 'file_3_manual.ini')
-        dns_test_common.write({"linode_key": TOKEN_V4, "linode_version": 3}, path)
-
-        config = mock.MagicMock(linode_credentials=path,
-                                linode_propagation_seconds=0)
-        auth = Authenticator(config, "linode")
-
-        assert auth._provider_name == "linode"
-
-    # pylint: disable=protected-access
-    def test_api_version_4_manual(self):
-        path = os.path.join(self.tempdir, 'file_4_manual.ini')
-        dns_test_common.write({"linode_key": TOKEN_V3, "linode_version": 4}, path)
-
-        config = mock.MagicMock(linode_credentials=path,
-                                linode_propagation_seconds=0)
-        auth = Authenticator(config, "linode")
-
-        assert auth._provider_name == "linode4"
-
-    # pylint: disable=protected-access
-    def test_api_version_error(self):
-        path = os.path.join(self.tempdir, 'file_version_error.ini')
-        dns_test_common.write({"linode_key": TOKEN_V3, "linode_version": 5}, path)
-
-        config = mock.MagicMock(linode_credentials=path,
-                                linode_propagation_seconds=0)
-        auth = Authenticator(config, "linode")
-
-        with pytest.raises(errors.PluginError):
-            assert auth._provider_name == "linode4"
 
 
 if __name__ == "__main__":

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -20,6 +20,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Help output now shows `False` as default when it can be set via `cli.ini` instead of `None`
 * Changed terms of service agreement text to have a newline after the TOS link
 * certbot-cloudflare-dns is now pinned to version 2.19 of Cloudflare's python library
+* Removed support for Linode API v3 which was sunset at the end of July 203.
 
 ### Fixed
 


### PR DESCRIPTION
The v3 api was sunset at the end of July 2023. This PR cleans up code related to api v3.

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `main` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
