### PR TITLE
remove old python macos cover tests

### DIFF
--- a/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
+++ b/.azure-pipelines/templates/jobs/standard-tests-jobs.yml
@@ -4,19 +4,11 @@ jobs:
       PYTHON_VERSION: 3.12
     strategy:
       matrix:
-        macos-py38-cover:
-          # mac unit+cover tests with the oldest python we support
+        macos-cover:
           IMAGE_NAME: macOS-15
-          PYTHON_VERSION: 3.8
           TOXENV: cover
           # As of pip 23.1.0, builds started failing on macOS unless this flag was set.
           # See https://github.com/certbot/certbot/pull/9717#issuecomment-1610861794.
-          PIP_USE_PEP517: "true"
-        macos-cover:
-          # mac unit+cover tests with the newest python we support
-          IMAGE_NAME: macOS-15
-          TOXENV: cover
-          # See explanation under macos-py38-cover.
           PIP_USE_PEP517: "true"
         linux-oldest:
           IMAGE_NAME: ubuntu-22.04


### PR DESCRIPTION
i don't know what's going on with our python 3.8 macOS coverage test, but [we continue to have problems with it](https://dev.azure.com/certbot/certbot/_build/results?buildId=8185&view=logs&j=999f41b6-3cf2-5383-a044-3c897dccbd27&t=6e8afa9d-4988-50c9-b8f9-05c880d84e94) during the incredibly simple step at https://github.com/certbot/certbot/blob/59f32c9d11507da19f9b7e2db9507d5af6a1c7f5/.azure-pipelines/templates/steps/tox-steps.yml#L29-L32

i don't think this is due to a bug in our setup as our code isn't doing much here. i think it is instead a bug on azure's end

to copy over my mattermost message from a couple weeks ago about removing this test that Will upvoted:

> also, i traced the origin of our [dual macOS tests](https://github.com/certbot/certbot/blob/38fc7fcc4804d8429fbdeb990fe1bc2ddf255629/.azure-pipelines/templates/jobs/standard-tests-jobs.yml#L7-L20) to https://github.com/certbot/certbot/pull/4697 and https://github.com/certbot/certbot/pull/8591. essentially we initially had python 2 and python3 macOS tests and then when we dropped python 2 support we made them oldest python 3 and newest python 3 tests without any discussion afaict. in other words, i'm not aware of any particularly good reason we did things that way
>
> with that in mind, i personally think it's probably fine to just drop our oldest macOS test altho i'm also kind of curious to see github's response to the questions in https://github.com/actions/runner-images/issues/10812#issuecomment-2463900486

it's been a week and a half and github still hasn't responded to that issue so i'm personally no longer really interested in waiting and would rather just have our CI fixed