### PR TITLE
stage SSL lib and set OPENSSL_MODULES

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -14,7 +14,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Included an OpenSSL library that was missing in our Certbot snap fixing
+  crashes affecting 32-bit ARM users.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,22 +19,21 @@ grade: stable
 adopt-info: certbot
 
 environment:
+  AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
+  CERTBOT_SNAPPED: "True"
+  # This is needed to help openssl find its legacy provider on architectures
+  # where we cannot use cryptography's pre-built wheels. See
+  # https://github.com/certbot/certbot/issues/10055.
+  OPENSSL_MODULES: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules"
+  PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
   PYTHONPATH: "$SNAP/lib/python3.12/site-packages:${PYTHONPATH}"
 
 apps:
   certbot:
     command: bin/python3 -s $SNAP/bin/certbot
-    environment:
-      PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
-      AUGEAS_LENS_LIB: "$SNAP/usr/share/augeas/lenses/dist"
-      CERTBOT_SNAPPED: "True"
   renew:
     command: bin/python3 -s $SNAP/bin/certbot -q renew
     daemon: oneshot
-    environment:
-      PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
-      AUGEAS_LENS_LIB: $SNAP/usr/share/augeas/lenses/dist
-      CERTBOT_SNAPPED: "True"
     # Run approximately twice a day with randomization
     timer: 00:00~24:00/2
 
@@ -62,6 +61,10 @@ parts:
     stage-packages:
       - libaugeas0
       - libpython3.12-dev
+      # This library included so openssl has a legacy provider available at
+      # runtime when we are unable to use cryptography's pre-built wheels. See
+      # https://github.com/certbot/certbot/issues/10055.
+      - libssl3t64
       # added to stage python:
       - libpython3-stdlib
       - libpython3.12-stdlib


### PR DESCRIPTION
fixes https://github.com/certbot/certbot/issues/10055 by staging the missing openssl library that cryptography is looking for and failing to find

i've manually confirmed that on a 32-bit ARM system this fixes the error and run our integration tests against the new snap on an amd64 system to confirm everything still works there

rather than duplicating `OPENSSL_MODULES` in each app's environment, i just set the variable globally and updated the other environment variables to use the same approach. i can reduplicate things if the reviewer prefers, but the snap still seems to build just fine and i've confirmed that environment variables are still properly set in both the `certbot` command and the `certbot renew` timer. this approach of duplicating environment variables comes all the way from initial experiments with a certbot snap and i'm not aware of any particularly good reason to have this duplication. see 0f6486ec7f

after this lands and a build is pushed to our snap's edge channel, i plan to update https://github.com/certbot/certbot/issues/10055 suggesting updating to that as a workaround for 32-bit ARM users until we do our next release