### PR TITLE
Fix F541 and E711

### DIFF
--- a/certbot-apache/certbot_apache/_internal/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/configurator_test.py
@@ -1518,16 +1518,11 @@ class MultiVhostsTest(util.ApacheTest):
         with_index_1 = ["/path[1]/section[1]"]
         without_index = ["/path/section"]
         with_index_2 = ["/path[2]/section[2]"]
-        assert self.config._get_new_vh_path(without_index,
-                                                      with_index_1) == \
-                         None
-        assert self.config._get_new_vh_path(without_index,
-                                                      with_index_2) == \
-                         with_index_2[0]
+        assert self.config._get_new_vh_path(without_index, with_index_1) is None
+        assert self.config._get_new_vh_path(without_index, with_index_2) == with_index_2[0]
 
         both = with_index_1 + with_index_2
-        assert self.config._get_new_vh_path(without_index, both) == \
-                         with_index_2[0]
+        assert self.config._get_new_vh_path(without_index, both) == with_index_2[0]
 
     @mock.patch("certbot_apache._internal.configurator.display_util.notify")
     def test_make_vhost_ssl_with_existing_rewrite_rule(self, mock_notify):

--- a/certbot-apache/certbot_apache/_internal/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/configurator_test.py
@@ -1417,7 +1417,7 @@ class AugeasVhostsTest(util.ApacheTest):
         self.config.parser.aug.match.side_effect = RuntimeError
         path = "debian_apache_2_4/augeas_vhosts/apache2/sites-available/old-and-default.conf"
         chosen_vhost = self.config._create_vhost(path)
-        assert None == chosen_vhost
+        assert chosen_vhost is None
 
     def test_choosevhost_works(self):
         path = "debian_apache_2_4/augeas_vhosts/apache2/sites-available/old-and-default.conf"

--- a/certbot-apache/certbot_apache/_internal/tests/configurator_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/configurator_test.py
@@ -174,9 +174,9 @@ class MultipleVhostsTest(util.ApacheTest):
         assert "certbot.demo" in names
 
     def test_get_bad_path(self):
-        assert apache_util.get_file_path(None) == None
-        assert apache_util.get_file_path("nonexistent") == None
-        assert self.config._create_vhost("nonexistent") == None # pylint: disable=protected-access
+        assert apache_util.get_file_path(None) is None
+        assert apache_util.get_file_path("nonexistent") is None
+        assert self.config._create_vhost("nonexistent") is None # pylint: disable=protected-access
 
     def test_get_aug_internal_path(self):
         from certbot_apache._internal.apache_util import get_internal_aug_path
@@ -303,7 +303,7 @@ class MultipleVhostsTest(util.ApacheTest):
         # pylint: disable=protected-access
         assert self.vh_truth[3] == self.config._find_best_vhost("certbot.demo")
         assert self.vh_truth[0] == self.config._find_best_vhost("encryption-example.demo")
-        assert self.config._find_best_vhost("does-not-exist.com") == None
+        assert self.config._find_best_vhost("does-not-exist.com") is None
 
     def test_find_best_vhost_variety(self):
         # pylint: disable=protected-access
@@ -1723,14 +1723,14 @@ class InstallSslOptionsConfTest(util.ApacheTest):
 
         self.config._openssl_version = None
         with mock.patch("certbot_apache._internal.configurator.logger.warning") as mock_log:
-            assert self.config.openssl_version() == None
+            assert self.config.openssl_version() is None
             assert "Could not find ssl_module" in mock_log.call_args[0][0]
 
         # When no ssl_module is present at all
         self.config._openssl_version = None
         assert "ssl_module" not in self.config.parser.modules
         with mock.patch("certbot_apache._internal.configurator.logger.warning") as mock_log:
-            assert self.config.openssl_version() == None
+            assert self.config.openssl_version() is None
             assert "Could not find ssl_module" in mock_log.call_args[0][0]
 
         # When ssl_module is statically linked but --apache-bin not provided
@@ -1738,13 +1738,13 @@ class InstallSslOptionsConfTest(util.ApacheTest):
         self.config.options.bin = None
         self.config.parser.modules['ssl_module'] = None
         with mock.patch("certbot_apache._internal.configurator.logger.warning") as mock_log:
-            assert self.config.openssl_version() == None
+            assert self.config.openssl_version() is None
             assert "ssl_module is statically linked but" in mock_log.call_args[0][0]
 
         self.config.parser.modules['ssl_module'] = "/fake/path"
         with mock.patch("certbot_apache._internal.configurator.logger.warning") as mock_log:
             # Check that correct logger.warning was printed
-            assert self.config.openssl_version() == None
+            assert self.config.openssl_version() is None
             assert "Unable to read" in mock_log.call_args[0][0]
 
         contents_missing_openssl = b"these contents won't match the regex"
@@ -1753,7 +1753,7 @@ class InstallSslOptionsConfTest(util.ApacheTest):
             mock_omf.return_value = contents_missing_openssl
             with mock.patch("certbot_apache._internal.configurator.logger.warning") as mock_log:
                 # Check that correct logger.warning was printed
-                assert self.config.openssl_version() == None
+                assert self.config.openssl_version() is None
                 assert "Could not find OpenSSL" in mock_log.call_args[0][0]
 
     def test_open_module_file(self):

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py
@@ -51,7 +51,7 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         self.auth.credentials.conf = lambda key: creds.get(key, None)
         client = self.orig_get_client()
         assert client.algorithm == self.auth.ALGORITHMS["HMAC-MD5"]
-        assert client.sign_query == False
+        assert client.sign_query is False
 
     @test_util.patch_display_util()
     def test_perform(self, unused_mock_get_utility):

--- a/certbot/certbot/_internal/tests/account_test.py
+++ b/certbot/certbot/_internal/tests/account_test.py
@@ -1,6 +1,5 @@
 """Tests for certbot._internal.account."""
 import datetime
-import json
 import sys
 import unittest
 from unittest import mock

--- a/certbot/certbot/_internal/tests/configuration_test.py
+++ b/certbot/certbot/_internal/tests/configuration_test.py
@@ -1,15 +1,11 @@
 """Tests for certbot.configuration."""
 import sys
-import unittest
 from unittest import mock
-import warnings
 
 import pytest
 
 from certbot import errors
-from certbot._internal import cli
 from certbot._internal import constants
-from certbot._internal.plugins import disco
 from certbot.compat import misc
 from certbot.compat import os
 from certbot.tests import util as test_util

--- a/certbot/certbot/_internal/tests/display/util_test.py
+++ b/certbot/certbot/_internal/tests/display/util_test.py
@@ -1,13 +1,8 @@
 """Test :mod:`certbot.display.util`."""
-import io
-import socket
 import sys
-import tempfile
-from unittest import mock
 
 import pytest
 
-from certbot import errors
 import certbot.tests.util as test_util
 
 

--- a/certbot/certbot/_internal/tests/main_test.py
+++ b/certbot/certbot/_internal/tests/main_test.py
@@ -659,7 +659,7 @@ class ReconfigureTest(test_util.TempDirTestCase):
 
         # new account
         try:
-            self._call(f'--cert-name example.com --account newaccountid'.split())
+            self._call('--cert-name example.com --account newaccountid'.split())
         except errors.ConfigurationError as err:
             assert "Using reconfigure to change the ACME account" in str(err)
 
@@ -674,7 +674,7 @@ class ReconfigureTest(test_util.TempDirTestCase):
 
         # new server
         try:
-            self._call(f'--cert-name example.com --server x.com'.split())
+            self._call('--cert-name example.com --server x.com'.split())
         except errors.ConfigurationError as err:
             assert "Using reconfigure to change the ACME account" in str(err)
 

--- a/certbot/certbot/_internal/tests/plugins/enhancements_test.py
+++ b/certbot/certbot/_internal/tests/plugins/enhancements_test.py
@@ -1,6 +1,5 @@
 """Tests for new style enhancements"""
 import sys
-import unittest
 from unittest import mock
 
 import pytest
@@ -16,7 +15,6 @@ class EnhancementTest(test_util.ConfigTestCase):
     def setUp(self):
         super().setUp()
         self.mockinstaller = mock.MagicMock(spec=enhancements.AutoHSTSEnhancement)
-
 
     @test_util.patch_display_util()
     def test_enhancement_enabled_enhancements(self, _):
@@ -57,8 +55,7 @@ class EnhancementTest(test_util.ConfigTestCase):
         lineage = "lineage"
         enhancements.enable(lineage, domains, self.mockinstaller, self.config)
         assert self.mockinstaller.enable_autohsts.called
-        assert self.mockinstaller.enable_autohsts.call_args[0] == \
-                          (lineage, domains)
+        assert self.mockinstaller.enable_autohsts.call_args[0] == (lineage, domains)
 
 
 if __name__ == '__main__':

--- a/certbot/certbot/_internal/tests/plugins/selection_test.py
+++ b/certbot/certbot/_internal/tests/plugins/selection_test.py
@@ -245,7 +245,7 @@ class TestChooseConfiguratorPlugins(unittest.TestCase):
         inst, auth = self._runWithArgs("certonly --apache")
         assert inst.name == "apache"
         assert auth.name == "apache"
-    
+
     def test_noninteractive_inst_arg(self):
         # For certonly, if an installer arg is set, it should be returned as expected
         inst, auth = self._runWithArgs("certonly -a nginx -i nginx")
@@ -258,18 +258,19 @@ class TestChooseConfiguratorPlugins(unittest.TestCase):
 
         # if no installer arg is set (or it's set to none), one shouldn't be returned
         inst, auth = self._runWithArgs("certonly -a nginx")
-        assert inst == None
+        assert inst is None
         assert auth.name == "nginx"
         inst, auth = self._runWithArgs("certonly -a nginx -i none")
-        assert inst == None
+        assert inst is None
         assert auth.name == "nginx"
 
         inst, auth = self._runWithArgs("certonly -a apache")
-        assert inst == None
+        assert inst is None
         assert auth.name == "apache"
         inst, auth = self._runWithArgs("certonly -a apache -i none")
-        assert inst == None
+        assert inst is None
         assert auth.name == "apache"
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/certbot/_internal/tests/plugins/storage_test.py
+++ b/certbot/certbot/_internal/tests/plugins/storage_test.py
@@ -1,10 +1,6 @@
 """Tests for certbot.plugins.storage.PluginStorage"""
 import json
 import sys
-from typing import Iterable
-from typing import List
-from typing import Optional
-import unittest
 from unittest import mock
 
 import pytest

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -206,7 +206,7 @@ def _dump_failed_build_logs(
 
             build_output_path = [log_name for log_name in logs_list if arch in log_name]
             if not build_output_path:
-                build_output = f'No output has been dumped by snapcraft remote-build.'
+                build_output = 'No output has been dumped by snapcraft remote-build.'
             else:
                 with open(build_output_path[0]) as file_h:
                     build_output = file_h.read()


### PR DESCRIPTION
There are a quite a lot of imports that are unused.

F541 is Unnecessary f-interpolation without placeholders
E711 is incorrect use of == for boolean and None comparisons

## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `main` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
