### PR TITLE
update intersphinx mapping

### DIFF
--- a/certbot-dns-cloudflare/docs/conf.py
+++ b/certbot-dns-cloudflare/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-digitalocean/docs/conf.py
+++ b/certbot-dns-digitalocean/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-dnsimple/docs/conf.py
+++ b/certbot-dns-dnsimple/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-dnsmadeeasy/docs/conf.py
+++ b/certbot-dns-dnsmadeeasy/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-gehirn/docs/conf.py
+++ b/certbot-dns-gehirn/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-google/docs/conf.py
+++ b/certbot-dns-google/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-linode/docs/conf.py
+++ b/certbot-dns-linode/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-luadns/docs/conf.py
+++ b/certbot-dns-luadns/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-nsone/docs/conf.py
+++ b/certbot-dns-nsone/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-ovh/docs/conf.py
+++ b/certbot-dns-ovh/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-rfc2136/docs/conf.py
+++ b/certbot-dns-rfc2136/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-route53/docs/conf.py
+++ b/certbot-dns-route53/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot-dns-sakuracloud/docs/conf.py
+++ b/certbot-dns-sakuracloud/docs/conf.py
@@ -170,6 +170,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
     'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),
 }

--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -314,5 +314,5 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),
+    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),
 }

--- a/tools/sphinx-quickstart.sh
+++ b/tools/sphinx-quickstart.sh
@@ -11,7 +11,7 @@ yes "n" | sphinx-quickstart --dot _ --project $PROJECT --author "Certbot Project
 
 cd $PROJECT/docs
 sed -i -e "s|\# needs_sphinx = '1.0'|needs_sphinx = '1.0'|" conf.py
-sed -i -e "s|intersphinx_mapping = {'https://docs.python.org/': None}|intersphinx_mapping = {\n    'python': ('https://docs.python.org/', None),\n    'acme': ('https://acme-python.readthedocs.org/en/latest/', None),\n    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),\n}|" conf.py
+sed -i -e "s|intersphinx_mapping = {'https://docs.python.org/': None}|intersphinx_mapping = {\n    'python': ('https://docs.python.org/', None),\n    'acme': ('https://acme-python.readthedocs.io/en/latest/', None),\n    'certbot': ('https://eff-certbot.readthedocs.io/en/stable/', None),\n}|" conf.py
 sed -i -e "s|html_theme = 'alabaster'|html_theme = 'sphinx_rtd_theme'|" conf.py
 sed -i -e "s|# Add any paths that contain templates here, relative to this directory.|autodoc_member_order = 'bysource'\nautodoc_default_flags = ['show-inheritance']\n\n# Add any paths that contain templates here, relative to this directory.|" conf.py
 sed -i -e "s|# The name of the Pygments (syntax highlighting) style to use.|default_role = 'py:obj'\n\n# The name of the Pygments (syntax highlighting) style to use.|" conf.py


### PR DESCRIPTION
this hopefully fixes our nightly failures

readthedocs seems to redirect users to its .io site so https://acme-python.readthedocs.org/en/latest/objects.inv is supposed to redirect people to https://acme-python.readthedocs.io/en/latest/objects.inv, but that doesn't always seem to work and instead [sometimes serves a 403](https://dev.azure.com/certbot/certbot/_build/results?buildId=8237&view=logs&j=d74e04fe-9740-597d-e9fa-1d0400037dfd&t=dde413a4-f24c-59a0-9684-e33d79f9aa02&l=800)

removing the need for this redirect seems to fix things based on some quick testing and certainly shouldn't hurt