### PR TITLE
Replace io.open with the built-in.

### DIFF
--- a/certbot-ci/certbot_integration_tests/certbot_tests/assertions.py
+++ b/certbot-ci/certbot_integration_tests/certbot_tests/assertions.py
@@ -1,5 +1,4 @@
 """This module contains advanced assertions for the certbot integration tests."""
-import io
 import os
 from typing import Optional
 from typing import Type
@@ -60,7 +59,7 @@ def assert_hook_execution(probe_path: str, probe_content: str) -> None:
     :param str probe_content: content expected when the hook is executed
     """
     encoding = 'utf-8' if POSIX_MODE else 'utf-16'
-    with io.open(probe_path, 'rt', encoding=encoding) as file:
+    with open(probe_path, 'rt', encoding=encoding) as file:
         data = file.read()
 
     lines = [line.strip() for line in data.splitlines()]
@@ -76,7 +75,7 @@ def assert_saved_lineage_option(config_dir: str, lineage: str,
     :param str option: the option key
     :param value: if desired, the expected option value
     """
-    with open(os.path.join(config_dir, 'renewal', '{0}.conf'.format(lineage))) as file_h:
+    with open(os.path.join(config_dir, 'renewal', f'{lineage}.conf')) as file_h:
         assert f"{option} = {value if value else ''}" in file_h.read()
 
 

--- a/certbot-nginx/certbot_nginx/_internal/http_01.py
+++ b/certbot-nginx/certbot_nginx/_internal/http_01.py
@@ -1,6 +1,5 @@
 """A class that performs HTTP-01 challenges for Nginx"""
 
-import io
 import logging
 from typing import Any
 from typing import List
@@ -139,7 +138,7 @@ class NginxHttp01(common.ChallengePerformer):
         self.configurator.reverter.register_file_creation(
             True, self.challenge_conf)
 
-        with io.open(self.challenge_conf, "w", encoding="utf-8") as new_conf:
+        with open(self.challenge_conf, "w", encoding="utf-8") as new_conf:
             nginxparser.dump(config, new_conf)
 
     def _default_listen_addresses(self) -> List[Addr]:

--- a/certbot-nginx/certbot_nginx/_internal/parser.py
+++ b/certbot-nginx/certbot_nginx/_internal/parser.py
@@ -2,7 +2,6 @@
 import copy
 import functools
 import glob
-import io
 import logging
 import re
 from typing import Any
@@ -211,7 +210,7 @@ class NginxParser:
             if item in self.parsed and not override:
                 continue
             try:
-                with io.open(item, "r", encoding="utf-8") as _file:
+                with open(item, "r", encoding="utf-8") as _file:
                     parsed = nginxparser.load(_file)
                     self.parsed[item] = parsed
                     trees.append(parsed)
@@ -255,7 +254,7 @@ class NginxParser:
                     continue
                 out = nginxparser.dumps(tree)
                 logger.debug('Writing nginx conf tree to %s:\n%s', filename, out)
-                with io.open(filename, 'w', encoding='utf-8') as _file:
+                with open(filename, 'w', encoding='utf-8') as _file:
                     _file.write(out)
 
             except IOError:
@@ -431,7 +430,7 @@ class NginxParser:
 def _parse_ssl_options(ssl_options: Optional[str]) -> List[UnspacedList]:
     if ssl_options is not None:
         try:
-            with io.open(ssl_options, "r", encoding="utf-8") as _file:
+            with open(ssl_options, "r", encoding="utf-8") as _file:
                 return nginxparser.load(_file)
         except IOError:
             logger.warning("Missing NGINX TLS options file: %s", ssl_options)

--- a/certbot/certbot/_internal/lock.py
+++ b/certbot/certbot/_internal/lock.py
@@ -187,13 +187,13 @@ class _WindowsLockMechanism(_BaseLockMechanism):
     By default on Windows, acquiring a file handler gives exclusive access to the process
     and results in an effective lock. However, it is possible to explicitly acquire the
     file handler in shared access in terms of read and write, and this is done by os.open
-    and io.open in Python. So an explicit lock needs to be done through the call of
+    in Python. So an explicit lock needs to be done through the call of
     msvcrt.locking, that will lock the first byte of the file. In theory, it is also
     possible to access a file in shared delete access, allowing other processes to delete an
     opened file. But this needs also to be done explicitly by all processes using the Windows
     low level APIs, and Python does not do it. As of Python 3.7 and below, Python developers
     state that deleting a file opened by a process from another process is not possible with
-    os.open and io.open.
+    os.open.
     Consequently, msvcrt.locking is sufficient to obtain an effective lock, and the race
     condition encountered on Linux is not possible on Windows, leading to a simpler workflow.
     """


### PR DESCRIPTION
As of Python 3, io.open is an alias for the built-in open function.

https://docs.python.org/3/library/io.html#io.open

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `main` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
