### PR TITLE
Remove a confusing sentence point

### DIFF
--- a/certbot/certbot/_internal/plugins/manual.py
+++ b/certbot/certbot/_internal/plugins/manual.py
@@ -60,7 +60,7 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
     _DNS_INSTRUCTIONS = """\
 Please deploy a DNS TXT record under the name:
 
-{domain}.
+{domain}
 
 with the following value:
 


### PR DESCRIPTION
The origin sentence point after the domain is very confusing because there's many same punctuation in the domain. like:

```
xxx.yourdomain.com.
```

user may be not sure if this sentence point a part of the domain txt.

so in this PR we removed it.

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `main` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
