### PR TITLE
switch `cert_and_chain_from_fullchain` to cryptography APIs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -139,6 +139,7 @@ Authors
 * [John Reed](https://github.com/leerspace)
 * [Jonas Berlin](https://github.com/xkr47)
 * [Jonathan Herlin](https://github.com/Jonher937)
+* [Jonathan Vanasco](https://github.com/jvanasco)
 * [Jon Walsh](https://github.com/code-tree)
 * [Joona Hoikkala](https://github.com/joohoi)
 * [Josh McCullough](https://github.com/JoshMcCullough)

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -598,7 +598,7 @@ def cert_and_chain_from_fullchain(fullchain_pem: str) -> Tuple[str, str]:
     certs_normalized: List[str] = []
     for cert_pem in certs:
         cert = x509.load_pem_x509_certificate(cert_pem)
-        cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+        cert_pem = cert.public_bytes(Encoding.PEM)
         certs_normalized.append(cert_pem.decode())
 
     # Since each normalized cert has a newline suffix, no extra newlines are required.


### PR DESCRIPTION
## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.

I am in the process of migrating our libraries from openssl to cryptography

I know from several discussions with certbot and cryptography devs in PRs and LetsEncrypt that certbot is moving int he same direction, and i've seen @alexzorin working on some similar stuff.  this just has one function ported, but i can probably tackle most of this file (in terms of string/bytes in and string/bytes out) if you'd like.