### PR TITLE
Replace assert False with pytest.fail

### DIFF
--- a/acme/acme/_internal/tests/jws_test.py
+++ b/acme/acme/_internal/tests/jws_test.py
@@ -21,7 +21,7 @@ class HeaderTest(unittest.TestCase):
     except (ValueError, TypeError):
         assert True
     else:
-        assert False  # pragma: no cover
+        pytest.fail("Exception from jose.b64decode wasn't raised")  # pragma: no cover
 
     def test_nonce_decoder(self):
         from acme.jws import Header

--- a/certbot/certbot/_internal/tests/main_test.py
+++ b/certbot/certbot/_internal/tests/main_test.py
@@ -1327,7 +1327,7 @@ class MainTest(test_util.ConfigTestCase):
     def test_certonly_bad_args(self):
         try:
             self._call(['-a', 'bad_auth', 'certonly'])
-            assert False, "Exception should have been raised"
+            pytest.fail("Exception should have been raised")
         except errors.PluginSelectionError as e:
             assert 'The requested bad_auth plugin does not appear' in str(e)
 
@@ -1356,7 +1356,7 @@ class MainTest(test_util.ConfigTestCase):
         except errors.Error as e:
             assert "Please try the certonly" in repr(e)
             return
-        assert False, "Expected supplying --csr to fail with default verb"
+        pytest.fail("Expected supplying --csr to fail with default verb")
 
     def test_csr_with_no_domains(self):
         with pytest.raises(errors.Error):


### PR DESCRIPTION
This seems to be better style. The assert False statements are automatically removed by Python when running in the optimized mode, which could hide test failures.

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `main` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
