### PR TITLE
Remove a big chunk of F401. Remove pylint-args from apache-tests.

### DIFF
--- a/acme/acme/_internal/tests/fields_test.py
+++ b/acme/acme/_internal/tests/fields_test.py
@@ -2,7 +2,6 @@
 import datetime
 import sys
 import unittest
-import warnings
 
 import josepy as jose
 import pytest

--- a/acme/acme/_internal/tests/jose_test.py
+++ b/acme/acme/_internal/tests/jose_test.py
@@ -1,7 +1,6 @@
 """Tests for acme.jose shim."""
 import importlib
 import sys
-import unittest
 
 import pytest
 

--- a/acme/acme/_internal/tests/messages_test.py
+++ b/acme/acme/_internal/tests/messages_test.py
@@ -1,10 +1,8 @@
 """Tests for acme.messages."""
-import contextlib
 import sys
 from typing import Dict
 import unittest
 from unittest import mock
-import warnings
 
 import josepy as jose
 import pytest

--- a/acme/acme/_internal/tests/test_util.py
+++ b/acme/acme/_internal/tests/test_util.py
@@ -5,7 +5,6 @@
 """
 import importlib.resources
 import os
-import sys
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization

--- a/acme/acme/_internal/tests/util_test.py
+++ b/acme/acme/_internal/tests/util_test.py
@@ -1,6 +1,5 @@
 """Tests for acme.util."""
 import sys
-import unittest
 
 import pytest
 

--- a/acme/setup.py
+++ b/acme/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import find_packages
 from setuptools import setup
 

--- a/certbot-apache/certbot_apache/_internal/tests/autohsts_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/autohsts_test.py
@@ -2,7 +2,6 @@
 """Test for certbot_apache._internal.configurator AutoHSTS functionality"""
 import re
 import sys
-import unittest
 from unittest import mock
 
 import pytest
@@ -16,7 +15,7 @@ class AutoHSTSTest(util.ApacheTest):
     """Tests for AutoHSTS feature"""
     # pylint: disable=protected-access
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         super().setUp()
 
         self.config = util.get_apache_configurator(

--- a/certbot-apache/certbot_apache/_internal/tests/centos_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/centos_test.py
@@ -1,6 +1,5 @@
 """Test for certbot_apache._internal.configurator for Centos overrides"""
 import sys
-import unittest
 from unittest import mock
 
 import pytest
@@ -37,7 +36,7 @@ def get_vh_truth(temp_dir, config_name):
 class FedoraRestartTest(util.ApacheTest):
     """Tests for Fedora specific self-signed certificate override"""
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         test_dir = "centos7_apache/apache"
         config_root = "centos7_apache/apache/httpd"
         vhost_root = "centos7_apache/apache/httpd/conf.d"
@@ -90,7 +89,7 @@ class FedoraRestartTest(util.ApacheTest):
 class UseCorrectApacheExecutableTest(util.ApacheTest):
     """Make sure the various CentOS/RHEL versions use the right httpd executable"""
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         test_dir = "centos7_apache/apache"
         config_root = "centos7_apache/apache/httpd"
         vhost_root = "centos7_apache/apache/httpd/conf.d"

--- a/certbot-apache/certbot_apache/_internal/tests/complex_parsing_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/complex_parsing_test.py
@@ -1,7 +1,6 @@
 """Tests for certbot_apache._internal.parser."""
 import shutil
 import sys
-import unittest
 
 import pytest
 
@@ -13,7 +12,7 @@ from certbot_apache._internal.tests import util
 class ComplexParserTest(util.ParserTest):
     """Apache Parser Test."""
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         super().setUp("complex_parsing", "complex_parsing")
 
         self.setup_variables()

--- a/certbot-apache/certbot_apache/_internal/tests/configurator_reverter_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/configurator_reverter_test.py
@@ -1,7 +1,6 @@
 """Test for certbot_apache._internal.configurator implementations of reverter"""
 import shutil
 import sys
-import unittest
 from unittest import mock
 
 import pytest
@@ -13,7 +12,7 @@ from certbot_apache._internal.tests import util
 class ConfiguratorReverterTest(util.ApacheTest):
     """Test for ApacheConfigurator reverter methods"""
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwards):
         super().setUp()
 
         self.config = util.get_apache_configurator(

--- a/certbot-apache/certbot_apache/_internal/tests/debian_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/debian_test.py
@@ -1,7 +1,6 @@
 """Test for certbot_apache._internal.configurator for Debian overrides"""
 import shutil
 import sys
-import unittest
 from unittest import mock
 
 import pytest

--- a/certbot-apache/certbot_apache/_internal/tests/fedora_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/fedora_test.py
@@ -1,6 +1,5 @@
 """Test for certbot_apache._internal.configurator for Fedora 29+ overrides"""
 import sys
-import unittest
 from unittest import mock
 
 import pytest
@@ -41,7 +40,7 @@ class FedoraRestartTest(util.ApacheTest):
 
     # TODO: eventually, these tests should have a dedicated configuration instead
     #  of reusing the ones from centos_test
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         test_dir = "centos7_apache/apache"
         config_root = "centos7_apache/apache/httpd"
         vhost_root = "centos7_apache/apache/httpd/conf.d"
@@ -83,7 +82,7 @@ class FedoraRestartTest(util.ApacheTest):
 class MultipleVhostsTestFedora(util.ApacheTest):
     """Multiple vhost tests for CentOS / RHEL family of distros"""
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         test_dir = "centos7_apache/apache"
         config_root = "centos7_apache/apache/httpd"
         vhost_root = "centos7_apache/apache/httpd/conf.d"

--- a/certbot-apache/certbot_apache/_internal/tests/gentoo_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/gentoo_test.py
@@ -1,6 +1,5 @@
 """Test for certbot_apache._internal.configurator for Gentoo overrides"""
 import sys
-import unittest
 from unittest import mock
 
 import pytest
@@ -43,7 +42,7 @@ def get_vh_truth(temp_dir, config_name):
 class MultipleVhostsTestGentoo(util.ApacheTest):
     """Multiple vhost tests for non-debian distro"""
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         test_dir = "gentoo_apache/apache"
         config_root = "gentoo_apache/apache/apache2"
         vhost_root = "gentoo_apache/apache/apache2/vhosts.d"

--- a/certbot-apache/certbot_apache/_internal/tests/http_01_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/http_01_test.py
@@ -2,7 +2,6 @@
 import errno
 import sys
 from typing import List
-import unittest
 from unittest import mock
 
 import pytest

--- a/certbot-apache/certbot_apache/_internal/tests/parser_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/parser_test.py
@@ -1,7 +1,6 @@
 """Tests for certbot_apache._internal.parser."""
 import shutil
 import sys
-import unittest
 from unittest import mock
 
 import pytest
@@ -14,7 +13,7 @@ from certbot_apache._internal.tests import util
 class BasicParserTest(util.ParserTest):
     """Apache Parser Test."""
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         super().setUp()
 
     def tearDown(self):

--- a/certbot-apache/certbot_apache/_internal/tests/parsernode_configurator_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/parsernode_configurator_test.py
@@ -1,24 +1,23 @@
 """Tests for ApacheConfigurator for AugeasParserNode classes"""
 import sys
+
 import unittest
 from unittest import mock
+
+from importlib.util import find_spec
 
 import pytest
 
 from certbot_apache._internal.tests import util
 
-try:
-    import apacheconfig
-    HAS_APACHECONFIG = True
-except ImportError:  # pragma: no cover
-    HAS_APACHECONFIG = False
+HAS_APACHECONFIG = find_spec(name="apacheconfig", package="apacheconfig")
 
 
 @unittest.skipIf(not HAS_APACHECONFIG, reason='Tests require apacheconfig dependency')
 class ConfiguratorParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-methods
     """Test AugeasParserNode using available test configurations"""
 
-    def setUp(self):  # pylint: disable=arguments-differ
+    def setUp(self, **kwargs):
         super().setUp()
 
         self.config = util.get_apache_configurator(

--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-linode/certbot_dns_linode/_internal/tests/dns_linode_test.py
+++ b/certbot-dns-linode/certbot_dns_linode/_internal/tests/dns_linode_test.py
@@ -1,7 +1,6 @@
 """Tests for certbot_dns_linode._internal.dns_linode."""
 
 import sys
-import unittest
 from unittest import mock
 
 import pytest

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import find_packages
 from setuptools import setup

--- a/certbot-nginx/certbot_nginx/_internal/tests/display_ops_test.py
+++ b/certbot-nginx/certbot_nginx/_internal/tests/display_ops_test.py
@@ -1,6 +1,5 @@
 """Test certbot_nginx._internal.display_ops."""
 import sys
-import unittest
 
 import pytest
 

--- a/certbot-nginx/certbot_nginx/_internal/tests/http_01_test.py
+++ b/certbot-nginx/certbot_nginx/_internal/tests/http_01_test.py
@@ -1,6 +1,5 @@
 """Tests for certbot_nginx._internal.http_01"""
 import sys
-import unittest
 from unittest import mock
 
 import josepy as jose

--- a/certbot-nginx/certbot_nginx/_internal/tests/test_util.py
+++ b/certbot-nginx/certbot_nginx/_internal/tests/test_util.py
@@ -3,7 +3,6 @@ import copy
 import importlib.resources
 import shutil
 import tempfile
-import sys
 from contextlib import contextmanager
 from unittest import mock
 
@@ -15,6 +14,7 @@ from certbot.plugins import common
 from certbot.tests import util as test_util
 from certbot_nginx._internal import configurator
 from certbot_nginx._internal import nginxparser
+
 
 class NginxTest(test_util.ConfigTestCase):
 

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -1,9 +1,7 @@
 """Certbot command line argument & config processing."""
 # pylint: disable=too-many-lines
 import argparse
-import logging
 import logging.handlers
-import sys
 from typing import Any
 from typing import List
 from typing import Optional

--- a/certbot/certbot/_internal/tests/cli_test.py
+++ b/certbot/certbot/_internal/tests/cli_test.py
@@ -1,7 +1,6 @@
 """Tests for certbot._internal.cli."""
 import argparse
 import copy
-from importlib import reload as reload_module
 import io
 import sys
 import tempfile

--- a/certbot/certbot/_internal/tests/lock_test.py
+++ b/certbot/certbot/_internal/tests/lock_test.py
@@ -2,7 +2,6 @@
 import functools
 import multiprocessing
 import sys
-import unittest
 from unittest import mock
 
 import pytest
@@ -17,8 +16,6 @@ except ImportError:
     POSIX_MODE = False
 else:
     POSIX_MODE = True
-
-
 
 
 class LockDirTest(test_util.TempDirTestCase):

--- a/certbot/certbot/_internal/tests/plugins/manual_test.py
+++ b/certbot/certbot/_internal/tests/plugins/manual_test.py
@@ -1,7 +1,6 @@
 """Tests for certbot._internal.plugins.manual"""
 import sys
 import textwrap
-import unittest
 from unittest import mock
 
 import pytest

--- a/certbot/certbot/_internal/tests/renewupdater_test.py
+++ b/certbot/certbot/_internal/tests/renewupdater_test.py
@@ -1,6 +1,5 @@
 """Tests for renewal updater interfaces"""
 import sys
-import unittest
 from unittest import mock
 
 import pytest

--- a/certbot/certbot/_internal/tests/reverter_test.py
+++ b/certbot/certbot/_internal/tests/reverter_test.py
@@ -4,7 +4,6 @@ import logging
 import shutil
 import sys
 import tempfile
-import unittest
 from unittest import mock
 
 import pytest

--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -23,17 +23,13 @@ should execute successfully.
 """
 
 import argparse
-import getpass
 import glob
 import os.path
 import re
 import subprocess
 import sys
-import tempfile
-from zipfile import ZipFile
 
 from azure.devops.connection import Connection
-import requests
 
 # Path to the root directory of the Certbot repository containing this script
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -10,12 +10,10 @@ from multiprocessing.managers import SyncManager
 import os
 from os.path import basename
 from os.path import dirname
-from os.path import exists
 from os.path import join
 from os.path import realpath
 import random
 import re
-import shutil
 import string
 import subprocess
 import sys


### PR DESCRIPTION
These were mostly unused unittest and sys from test-files and setup.py files.

I could move the `# pylint: disable=arguments-differ` from the Apache tests removal to a different PR. The trick to just add `**kwargs` seems fine, and don't use it.

I have a local branch to experiment replacing pylint with [Ruff](https://docs.astral.sh/ruff/), but there are loads of things that need to be prepared. I have found https://pypi.org/project/flake8-tidy-imports/ that potentially could be used as a replacement for the custom pylint plugin to guard against `import os`.
My initial idea is to target 'E`, `W`, `F`. Ruff gives *instant* feedback, and it's pretty powerful. It's also how I found the `io.open` and `OSError` things. 

I have not done anything about this:
```
certbot/certbot/_internal/cli/__init__.py:31:45: F401 `certbot._internal.cli.cli_utils.CustomHelpFormatter` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
```

You can install `ruff` in your local virtual environment, and run:

```sh
ruff check --select "F401"
```

@bmw has expressed interest in replacing pylint with flake8 to save ~1min in each pipeline.
Besides, there are issues that pylint does not seem to find, e.g., duplicate entries in a dictionary.

## Pull Request Checklist

- [X] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
