### PR TITLE
acme: deprecate gen_ss_cert in favor of make_self_signed_cert

### DIFF
--- a/acme/acme/_internal/tests/crypto_util_test.py
+++ b/acme/acme/_internal/tests/crypto_util_test.py
@@ -8,6 +8,8 @@ import threading
 import time
 from typing import List
 import unittest
+from unittest import mock
+import warnings
 
 import josepy as jose
 import OpenSSL
@@ -187,6 +189,96 @@ class PyOpenSSLCertOrReqSANTest(unittest.TestCase):
                          ['chicago-cubs.venafi.example', 'cubs.venafi.example']
 
 
+class GenMakeSelfSignedCertTest(unittest.TestCase):
+    """Test for make_self_signed_cert."""
+
+    def setUp(self):
+        self.cert_count = 5
+        self.serial_num: List[int] = []
+        privkey = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self.privkey = privkey.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption()
+        )
+        self.pubkey = privkey.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+    def test_sn_collisions(self):
+        from acme.crypto_util import make_self_signed_cert
+        for _ in range(self.cert_count):
+            cert = make_self_signed_cert(self.privkey, ['dummy'], force_san=True,
+                               ips=[ipaddress.ip_address("10.10.10.10")])
+            self.serial_num.append(cert.serial_number)
+        assert len(set(self.serial_num)) >= self.cert_count
+
+    def test_no_ips(self):
+        from acme.crypto_util import make_self_signed_cert
+        cert = make_self_signed_cert(self.privkey, ['dummy'])
+
+    @mock.patch("acme.crypto_util._now")
+    def test_not_before(self, mock_now):
+        from acme.crypto_util import make_self_signed_cert
+        from datetime import datetime
+        not_before = 1736200830
+        validity = 100
+        cert = make_self_signed_cert(
+            self.privkey,
+            ['dummy'],
+            not_before=not_before,
+            validity=validity,
+        )
+        self.assertEqual(cert.not_valid_after, datetime.fromtimestamp(not_before + validity))
+
+        mock_now.return_value = datetime.fromtimestamp(not_before)
+        cert = make_self_signed_cert(
+            self.privkey,
+            ['dummy'],
+            validity=validity,
+        )
+        self.assertEqual(cert.not_valid_after, datetime.fromtimestamp(not_before + validity))
+
+    def test_no_name(self):
+        from acme.crypto_util import make_self_signed_cert
+        with pytest.raises(AssertionError):
+            make_self_signed_cert(self.privkey, ips=[ipaddress.ip_address("1.1.1.1")])
+            make_self_signed_cert(self.privkey)
+
+    def test_fail_with_public_key(self):
+        from acme.crypto_util import make_self_signed_cert
+        with pytest.raises(ValueError):
+            make_self_signed_cert(self.pubkey, ips=[ipaddress.ip_address("1.1.1.1")])
+
+    def test_fail_with_wrong_key_type(self):
+        from acme.crypto_util import make_self_signed_cert
+        from cryptography.hazmat.primitives.asymmetric import x25519
+        private_key = x25519.X25519PrivateKey.generate()
+        key = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
+        )
+        with pytest.raises(ValueError):
+            make_self_signed_cert(key, ips=[ipaddress.ip_address("1.1.1.1")])
+
+    def test_extensions(self):
+        from acme.crypto_util import make_self_signed_cert
+        extension_type = x509.TLSFeature([x509.TLSFeatureType.status_request])
+        extension = x509.Extension(
+            x509.TLSFeature.oid,
+            False,
+            extension_type
+        )
+        cert = make_self_signed_cert(
+            self.privkey,
+            ips=[ipaddress.ip_address("1.1.1.1")],
+            extensions=[extension]
+        )
+        self.assertIn(extension, cert.extensions)
+
+
 class GenSsCertTest(unittest.TestCase):
     """Test for gen_ss_cert (generation of self-signed cert)."""
 
@@ -199,18 +291,27 @@ class GenSsCertTest(unittest.TestCase):
 
     def test_sn_collisions(self):
         from acme.crypto_util import gen_ss_cert
-        for _ in range(self.cert_count):
-            cert = gen_ss_cert(self.key, ['dummy'], force_san=True,
-                               ips=[ipaddress.ip_address("10.10.10.10")])
-            self.serial_num.append(cert.get_serial_number())
-        assert len(set(self.serial_num)) >= self.cert_count
-
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            for _ in range(self.cert_count):
+                cert = gen_ss_cert(self.key, ['dummy'], force_san=True,
+                                ips=[ipaddress.ip_address("10.10.10.10")])
+                self.serial_num.append(cert.get_serial_number())
+            assert len(set(self.serial_num)) >= self.cert_count
 
     def test_no_name(self):
         from acme.crypto_util import gen_ss_cert
-        with pytest.raises(AssertionError):
-            gen_ss_cert(self.key, ips=[ipaddress.ip_address("1.1.1.1")])
-            gen_ss_cert(self.key)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            with pytest.raises(AssertionError):
+                gen_ss_cert(self.key, ips=[ipaddress.ip_address("1.1.1.1")])
+                gen_ss_cert(self.key)
+
+    def test_no_ips(self):
+        from acme.crypto_util import gen_ss_cert
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            gen_ss_cert(self.key, ['dummy'])
 
 
 class MakeCSRTest(unittest.TestCase):

--- a/acme/acme/_internal/tests/crypto_util_test.py
+++ b/acme/acme/_internal/tests/crypto_util_test.py
@@ -195,16 +195,7 @@ class GenMakeSelfSignedCertTest(unittest.TestCase):
     def setUp(self):
         self.cert_count = 5
         self.serial_num: List[int] = []
-        privkey = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        self.privkey = privkey.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption()
-        )
-        self.pubkey = privkey.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
+        self.privkey = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
     def test_sn_collisions(self):
         from acme.crypto_util import make_self_signed_cert
@@ -245,23 +236,6 @@ class GenMakeSelfSignedCertTest(unittest.TestCase):
         with pytest.raises(AssertionError):
             make_self_signed_cert(self.privkey, ips=[ipaddress.ip_address("1.1.1.1")])
             make_self_signed_cert(self.privkey)
-
-    def test_fail_with_public_key(self):
-        from acme.crypto_util import make_self_signed_cert
-        with pytest.raises(ValueError):
-            make_self_signed_cert(self.pubkey, ips=[ipaddress.ip_address("1.1.1.1")])
-
-    def test_fail_with_wrong_key_type(self):
-        from acme.crypto_util import make_self_signed_cert
-        from cryptography.hazmat.primitives.asymmetric import x25519
-        private_key = x25519.X25519PrivateKey.generate()
-        key = private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption()
-        )
-        with pytest.raises(ValueError):
-            make_self_signed_cert(key, ips=[ipaddress.ip_address("1.1.1.1")])
 
     def test_extensions(self):
         from acme.crypto_util import make_self_signed_cert

--- a/acme/acme/_internal/tests/crypto_util_test.py
+++ b/acme/acme/_internal/tests/crypto_util_test.py
@@ -212,34 +212,45 @@ class GenMakeSelfSignedCertTest(unittest.TestCase):
     @mock.patch("acme.crypto_util._now")
     def test_expiry_times(self, mock_now):
         from acme.crypto_util import make_self_signed_cert
-        from datetime import datetime, timezone
+        from datetime import datetime
         not_before = 1736200830
         validity = 100
 
-        # some ugly timezone hacking to directly compare UTC timestamps
         not_before_dt = datetime.fromtimestamp(not_before)
-        not_before_dt = not_before_dt.replace(tzinfo=timezone.utc)
-        not_after_dt = datetime.fromtimestamp(not_before + validity).replace(tzinfo=timezone.utc)
-        not_after_dt = not_after_dt.replace(tzinfo=timezone.utc)
+        not_after_dt = datetime.fromtimestamp(not_before + validity)
         cert = make_self_signed_cert(
             self.privkey,
             ['dummy'],
             not_before=not_before,
             validity=validity,
         )
-        self.assertEqual(cert.not_valid_before_utc, not_before_dt)
-        self.assertEqual(cert.not_valid_after_utc, not_after_dt)
+        # TODO: This should be `not_valid_before_utc` once we raise the minimum
+        # cryptography version.
+        # https://github.com/certbot/certbot/issues/10105
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message='Properties that return.*datetime object'
+            )
+            self.assertEqual(cert.not_valid_before, not_before_dt)
+            self.assertEqual(cert.not_valid_after, not_after_dt)
 
-        mock_now.return_value = datetime.fromtimestamp(not_before)
-        zero_dt = datetime.fromtimestamp(0)
-        zero_dt = zero_dt.replace(tzinfo=timezone.utc)
+        now = not_before + 1
+        now_dt = datetime.fromtimestamp(now)
+        mock_now.return_value = now_dt
+        valid_after_now_dt = datetime.fromtimestamp(now + validity)
         cert = make_self_signed_cert(
             self.privkey,
             ['dummy'],
             validity=validity,
         )
-        self.assertEqual(cert.not_valid_before_utc, zero_dt)
-        self.assertEqual(cert.not_valid_after_utc, not_after_dt)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message='Properties that return.*datetime object'
+            )
+            self.assertEqual(cert.not_valid_before, now_dt)
+            self.assertEqual(cert.not_valid_after, valid_after_now_dt)
 
     def test_no_name(self):
         from acme.crypto_util import make_self_signed_cert

--- a/acme/acme/_internal/tests/crypto_util_test.py
+++ b/acme/acme/_internal/tests/crypto_util_test.py
@@ -212,17 +212,18 @@ class GenMakeSelfSignedCertTest(unittest.TestCase):
     @mock.patch("acme.crypto_util._now")
     def test_expiry_times(self, mock_now):
         from acme.crypto_util import make_self_signed_cert
-        from datetime import datetime
+        from datetime import datetime, timedelta, timezone
         not_before = 1736200830
         validity = 100
 
         not_before_dt = datetime.fromtimestamp(not_before)
-        not_after_dt = datetime.fromtimestamp(not_before + validity)
+        validity_td = timedelta(validity)
+        not_after_dt = not_before_dt + validity_td
         cert = make_self_signed_cert(
             self.privkey,
             ['dummy'],
-            not_before=not_before,
-            validity=validity,
+            not_before=not_before_dt,
+            validity=validity_td,
         )
         # TODO: This should be `not_valid_before_utc` once we raise the minimum
         # cryptography version.
@@ -237,12 +238,12 @@ class GenMakeSelfSignedCertTest(unittest.TestCase):
 
         now = not_before + 1
         now_dt = datetime.fromtimestamp(now)
-        mock_now.return_value = now_dt
-        valid_after_now_dt = datetime.fromtimestamp(now + validity)
+        mock_now.return_value = now_dt.replace(tzinfo=timezone.utc)
+        valid_after_now_dt = now_dt + validity_td
         cert = make_self_signed_cert(
             self.privkey,
             ['dummy'],
-            validity=validity,
+            validity=validity_td,
         )
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -443,9 +443,10 @@ class TLSALPN01Response(KeyAuthorizationChallengeResponse):
             value=x509.UnrecognizedExtension(oid, self.h)
         )
 
-        key_bytes = crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
+        cryptography_key = key.to_cryptography_key()
+        assert isinstance(cryptography_key, crypto_util.CertificateIssuerPrivateKeyTypes)
         cert = crypto_util.make_self_signed_cert(
-            key_bytes,
+            cryptography_key,
             [domain],
             force_san=True,
             extensions=[acme_extension]

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -444,7 +444,7 @@ class TLSALPN01Response(KeyAuthorizationChallengeResponse):
         )
 
         cryptography_key = key.to_cryptography_key()
-        assert isinstance(cryptography_key, crypto_util.CertificateIssuerPrivateKeyTypes)
+        assert isinstance(cryptography_key, crypto_util.CertificateIssuerPrivateKeyTypesTpl)
         cert = crypto_util.make_self_signed_cert(
             cryptography_key,
             [domain],

--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -16,7 +16,6 @@ from typing import Union
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
-from cryptography import x509
 import josepy as jose
 from OpenSSL import crypto
 from OpenSSL import SSL

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -454,15 +454,12 @@ def make_self_signed_cert(private_key: CertificateIssuerPrivateKeyTypes,
             critical=False
         )
 
-    not_before_datetime = datetime.fromtimestamp(
-        0 if not_before is None else not_before
-    )
-    builder = builder.not_valid_before(not_before_datetime)
-    validity_duration = timedelta(seconds=validity)
     if not_before is None:
-        not_valid_after = _now() + validity_duration
+        not_before_datetime = _now()
     else:
-        not_valid_after = not_before_datetime + validity_duration
+        not_before_datetime = datetime.fromtimestamp(not_before)
+    not_valid_after = not_before_datetime + timedelta(seconds=validity)
+    builder = builder.not_valid_before(not_before_datetime)
     builder = builder.not_valid_after(not_valid_after)
 
     public_key = private_key.public_key()

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -393,7 +393,7 @@ def _pyopenssl_cert_or_req_san(cert_or_req: Union[crypto.X509, crypto.X509Req]) 
 
 # Helper function that can be mocked in unit tests
 def _now() -> datetime:
-    return datetime.now()
+    return datetime.utcnow()
 
 
 def make_self_signed_cert(private_key: CertificateIssuerPrivateKeyTypes,
@@ -407,7 +407,7 @@ def make_self_signed_cert(private_key: CertificateIssuerPrivateKeyTypes,
     """Generate new self-signed certificate.
     :param buffer private_key_pem: Private key, in PEM PKCS#8 format.
     :type domains: `list` of `str`
-    :param int not_before: A POSIX timestamp after which the cert is valid
+    :param int not_before: A POSIX UTC timestamp after which the cert is valid
     :param validity: Time (in seconds) for which the cert will be valid
     :param buffer private_key_pem: One of `CertificateIssuerPrivateKeyTypes`
     :param bool force_san:
@@ -454,15 +454,15 @@ def make_self_signed_cert(private_key: CertificateIssuerPrivateKeyTypes,
             critical=False
         )
 
-    not_before_timestamp = datetime.fromtimestamp(
+    not_before_datetime = datetime.fromtimestamp(
         0 if not_before is None else not_before
     )
-    builder = builder.not_valid_before(not_before_timestamp)
+    builder = builder.not_valid_before(not_before_datetime)
     validity_duration = timedelta(seconds=validity)
     if not_before is None:
         not_valid_after = _now() + validity_duration
     else:
-        not_valid_after = not_before_timestamp + validity_duration
+        not_valid_after = not_before_datetime + validity_duration
     builder = builder.not_valid_after(not_valid_after)
 
     public_key = private_key.public_key()

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -20,7 +20,7 @@ from typing import Union
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import dsa, rsa, ec, ed25519, ed448
+from cryptography.hazmat.primitives.asymmetric import dsa, rsa, ec, ed25519, ed448, types
 import josepy as jose
 from OpenSSL import crypto
 from OpenSSL import SSL
@@ -377,12 +377,17 @@ def _pyopenssl_cert_or_req_san(cert_or_req: Union[crypto.X509, crypto.X509Req]) 
     return san_ext.value.get_values_for_type(x509.DNSName)
 
 
+<<<<<<< HEAD
 # Helper function that can be mocked in unit tests
 def _now() -> datetime:
     return datetime.now()
 
 
 def make_self_signed_cert(private_key_pem: bytes, domains: Optional[List[str]] = None,
+=======
+def make_self_signed_cert(private_key: types.CertificateIssuerPrivateKeyTypes,
+                          domains: Optional[List[str]] = None,
+>>>>>>> 6acdd9f47 (make_self_signed_cert uses cryptography key types)
                           not_before: Optional[int] = None,
                           validity: int = (7 * 24 * 60 * 60), force_san: bool = True,
                           extensions: Optional[List[x509.Extension]] = None,
@@ -390,10 +395,16 @@ def make_self_signed_cert(private_key_pem: bytes, domains: Optional[List[str]] =
                                                    ipaddress.IPv6Address]]] = None
                           ) -> x509.Certificate:
     """Generate new self-signed certificate.
+<<<<<<< HEAD
     :param buffer private_key_pem: Private key, in PEM PKCS#8 format.
     :type domains: `list` of `str`
     :param int not_before: A POSIX timestamp after which the cert is valid
     :param validity: Time (in seconds) for which the cert will be valid
+=======
+    :type domains: `list` of `str`
+    :param buffer private_key_pem: One of
+        `cryptography.hazmat.primitives.asymmetric.types.CertificateIssuerPrivateKeyTypes`
+>>>>>>> 6acdd9f47 (make_self_signed_cert uses cryptography key types)
     :param bool force_san:
     :param extensions: List of additional extensions to include in the cert.
     :type extensions: `list` of `x509.Extension[x509.ExtensionType]`
@@ -406,7 +417,7 @@ def make_self_signed_cert(private_key_pem: bytes, domains: Optional[List[str]] =
     assert domains or ips, "Must provide one or more hostnames or IPs for the cert."
 
     builder = x509.CertificateBuilder()
-    builder = builder.serial_number(int(binascii.hexlify(os.urandom(16)), 16))
+    builder = builder.serial_number(x509.random_serial_number())
 
     if extensions is not None:
         for ext in extensions:
@@ -449,9 +460,6 @@ def make_self_signed_cert(private_key_pem: bytes, domains: Optional[List[str]] =
         not_valid_after = not_before_timestamp + validity_duration
     builder = builder.not_valid_after(not_valid_after)
 
-    private_key = serialization.load_pem_private_key(private_key_pem, None)
-    if not isinstance(private_key, CertificateIssuerPrivateKeyTypes):
-        raise ValueError(f"Invalid private key type: {type(private_key)}")
     public_key = private_key.public_key()
     builder = builder.public_key(public_key)
     return builder.sign(private_key, hashes.SHA256())

--- a/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/test_driver.py
@@ -147,7 +147,7 @@ def test_installer(args: argparse.Namespace, plugin: common.Proxy, config: str,
 
 def test_deploy_cert(plugin: common.Proxy, temp_dir: str, domains: List[str]) -> bool:
     """Tests deploy_cert returning True if the tests are successful"""
-    cert = crypto_util.gen_ss_cert(util.KEY, domains).to_cryptography()
+    cert = crypto_util.make_self_signed_cert(util.KEY, domains)
     cert_path = os.path.join(temp_dir, "cert.pem")
     with open(cert_path, "wb") as f:
         f.write(cert.public_bytes(serialization.Encoding.PEM))

--- a/certbot-compatibility-test/certbot_compatibility_test/util.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/util.py
@@ -14,8 +14,8 @@ from certbot_compatibility_test import errors
 
 _KEY_BASE = "rsa2048_key.pem"
 KEY_PATH = test_util.vector_path(_KEY_BASE)
-KEY = test_util.load_private_key_pem(_KEY_BASE)
-JWK = jose.JWKRSA(key=test_util.load_rsa_private_key(_KEY_BASE))
+KEY = test_util.load_rsa_private_key_pem(_KEY_BASE)
+JWK = jose.JWKRSA(key=test_util.load_jose_rsa_private_key_pem(_KEY_BASE))
 IP_REGEX = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 
 

--- a/certbot-compatibility-test/certbot_compatibility_test/util.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/util.py
@@ -14,7 +14,7 @@ from certbot_compatibility_test import errors
 
 _KEY_BASE = "rsa2048_key.pem"
 KEY_PATH = test_util.vector_path(_KEY_BASE)
-KEY = test_util.load_pyopenssl_private_key(_KEY_BASE)
+KEY = test_util.load_private_key_pem(_KEY_BASE)
 JWK = jose.JWKRSA(key=test_util.load_rsa_private_key(_KEY_BASE))
 IP_REGEX = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 

--- a/certbot-compatibility-test/certbot_compatibility_test/validator.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/validator.py
@@ -34,7 +34,7 @@ class Validator:
         name = name if isinstance(name, bytes) else name.encode()
 
         try:
-            presented_cert = crypto_util.probe_sni(name, host, port)
+            presented_cert = crypto_util.probe_sni(name, host, port).to_cryptography()
         except acme_errors.Error as error:
             logger.exception(str(error))
             return False

--- a/certbot-compatibility-test/certbot_compatibility_test/validator.py
+++ b/certbot-compatibility-test/certbot_compatibility_test/validator.py
@@ -39,7 +39,7 @@ class Validator:
             logger.exception(str(error))
             return False
 
-        return presented_cert.to_cryptography() == cert
+        return presented_cert == cert
 
     def redirect(self, name: str, port: int = 80,
                  headers: Optional[Mapping[str, str]] = None) -> bool:

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -22,7 +22,7 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 
-import OpenSSL
+from cryptography.hazmat.primitives import serialization
 
 from acme import challenges
 from acme import crypto_util as acme_crypto_util
@@ -699,11 +699,8 @@ class NginxConfigurator(common.Configurator):
             key_size=2048, key_dir=tmp_dir, keyname="key.pem",
             strict_permissions=self.config.strict_permissions)
         assert le_key.file is not None
-        key = OpenSSL.crypto.load_privatekey(
-            OpenSSL.crypto.FILETYPE_PEM, le_key.pem)
-        cert = acme_crypto_util.gen_ss_cert(key, domains=[socket.gethostname()])
-        cert_pem = OpenSSL.crypto.dump_certificate(
-            OpenSSL.crypto.FILETYPE_PEM, cert)
+        cert = acme_crypto_util.make_self_signed_cert(le_key.pem, domains=[socket.gethostname()])
+        cert_pem = cert.public_bytes(serialization.Encoding.PEM)
         cert_file, cert_path = util.unique_file(
             os.path.join(tmp_dir, "cert.pem"), mode="wb")
         with cert_file:

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -23,6 +23,7 @@ from typing import Type
 from typing import Union
 
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from acme import challenges
 from acme import crypto_util as acme_crypto_util
@@ -696,10 +697,15 @@ class NginxConfigurator(common.Configurator):
         # TODO: generate only once
         tmp_dir = os.path.join(self.config.work_dir, "snakeoil")
         le_key = crypto_util.generate_key(
-            key_size=2048, key_dir=tmp_dir, keyname="key.pem",
+            key_type='rsa', key_size=2048, key_dir=tmp_dir, keyname="key.pem",
             strict_permissions=self.config.strict_permissions)
         assert le_key.file is not None
-        cert = acme_crypto_util.make_self_signed_cert(le_key.pem, domains=[socket.gethostname()])
+        cryptography_key = serialization.load_pem_private_key(le_key.pem, password=None)
+        assert isinstance(cryptography_key, rsa.RSAPrivateKey)
+        cert = acme_crypto_util.make_self_signed_cert(
+            cryptography_key,
+            domains=[socket.gethostname()]
+        )
         cert_pem = cert.public_bytes(serialization.Encoding.PEM)
         cert_file, cert_path = util.unique_file(
             os.path.join(tmp_dir, "cert.pem"), mode="wb")

--- a/certbot/certbot/tests/acme_util.py
+++ b/certbot/certbot/tests/acme_util.py
@@ -12,7 +12,7 @@ from certbot._internal import auth_handler
 from certbot.tests import util
 
 JWK = jose.JWK.load(util.load_vector('rsa512_key.pem'))
-KEY = util.load_rsa_private_key('rsa512_key.pem')
+KEY = util.load_jose_rsa_private_key_pem('rsa512_key.pem')
 
 # Challenges
 HTTP01 = challenges.HTTP01(

--- a/certbot/certbot/tests/util.py
+++ b/certbot/certbot/tests/util.py
@@ -139,11 +139,12 @@ def load_rsa_private_key(*names: str) -> jose.ComparableRSAKey:
              loader_fn(load_vector(*names), password=None, backend=default_backend())))
 
 
-def load_pyopenssl_private_key(*names: str) -> crypto.PKey:
+def load_private_key_pem(*names: str) -> bytes:
     """Load pyOpenSSL private key."""
     loader = _guess_loader(
         names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
-    return crypto.load_privatekey(loader, load_vector(*names))
+    key = crypto.load_privatekey(loader, load_vector(*names))
+    return crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
 
 
 def make_lineage(config_dir: str, testfile: str, ec: bool = True) -> str:

--- a/certbot/certbot/tests/util.py
+++ b/certbot/certbot/tests/util.py
@@ -126,7 +126,12 @@ def load_comparable_csr(*names: str) -> jose.ComparableX509:
     return jose.ComparableX509(load_csr(*names))
 
 
-def load_rsa_private_key(*names: str) -> jose.ComparableRSAKey:
+def load_jose_rsa_private_key_pem(*names: str) -> jose.ComparableRSAKey:
+    """Load RSA private key wrapped in jose.ComparableRSAKey"""
+    return jose.ComparableRSAKey(load_rsa_private_key_pem(*names))
+
+
+def load_rsa_private_key_pem(*names: str) -> RSAPrivateKey:
     """Load RSA private key."""
     loader = _guess_loader(names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
     loader_fn: Callable[..., Any]
@@ -134,17 +139,9 @@ def load_rsa_private_key(*names: str) -> jose.ComparableRSAKey:
         loader_fn = serialization.load_pem_private_key
     else:
         loader_fn = serialization.load_der_private_key
-    return jose.ComparableRSAKey(
-        cast(RSAPrivateKey,
-             loader_fn(load_vector(*names), password=None, backend=default_backend())))
-
-
-def load_private_key_pem(*names: str) -> bytes:
-    """Load pyOpenSSL private key."""
-    loader = _guess_loader(
-        names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
-    key = crypto.load_privatekey(loader, load_vector(*names))
-    return crypto.dump_privatekey(crypto.FILETYPE_PEM, key)
+    key = loader_fn(load_vector(*names), password=None, backend=default_backend())
+    assert isinstance(key, RSAPrivateKey)
+    return key
 
 
 def make_lineage(config_dir: str, testfile: str, ec: bool = True) -> str:


### PR DESCRIPTION
gen_ss_cert()'s signature contains deprecated pyOpenSSL API, so here we deprecate it in favor of a new function that does the same thing, except with only cryptography types: make_self_signed_cert