### PR TITLE
notify about PRs from forks

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -1,14 +1,13 @@
 name: Merge Event
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 
 jobs:
   if_merged:
-    # Forked repos can not access Mattermost secret.
-    if: github.event.pull_request.merged == true && !github.event.pull_request.head.repo.fork
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - uses: mattermost/action-mattermost-notify@master


### PR DESCRIPTION
i was struck by the difference in our github notifications mattermost channel and [link from our weekly update bot](https://github.com/pulls?q=merged%3A%3E2024-12-12+org%3Acertbot) and wanted to see if i could change this

i found https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target which says:

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks.

[making this change on my fork](https://github.com/certbot/certbot/commit/53faf5339896c798dfc91873b7daf08309601f37) and merging [a PR](https://github.com/bmw/letsencrypt/pull/16) from a separate GH account resulted in [this output](https://github.com/bmw/letsencrypt/actions/runs/12415993728/job/34663597709#step:2:5). i believe it shows up as `***` because [github redacts secrets from logs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#redacting-secrets-from-workflow-run-logs)