### PR TITLE
Introduce a `Format` enum to help us migrate away from pyOpenSSL's constants

### DIFF
--- a/acme/acme/_internal/tests/crypto_util_test.py
+++ b/acme/acme/_internal/tests/crypto_util_test.py
@@ -20,6 +20,13 @@ from acme import errors
 from acme._internal.tests import test_util
 
 
+class FormatTest(unittest.TestCase):
+    def test_to_cryptography_encoding(self):
+        from acme.crypto_util import Format
+        assert Format.DER.to_cryptography_encoding() == serialization.Encoding.DER
+        assert Format.PEM.to_cryptography_encoding() == serialization.Encoding.PEM
+
+
 class SSLSocketAndProbeSNITest(unittest.TestCase):
     """Tests for acme.crypto_util.SSLSocket/probe_sni."""
 

--- a/certbot/certbot/crypto_util.py
+++ b/certbot/certbot/crypto_util.py
@@ -482,8 +482,10 @@ def get_names_from_req(csr: bytes, typ: int = crypto.FILETYPE_PEM) -> List[str]:
     return _get_names_from_cert_or_req(csr, crypto.load_certificate_request, typ)
 
 
-def dump_pyopenssl_chain(chain: Union[List[crypto.X509], List[josepy.ComparableX509]],
-                         filetype: int = crypto.FILETYPE_PEM) -> bytes:
+def dump_pyopenssl_chain(
+    chain: Union[List[crypto.X509], List[josepy.ComparableX509]],
+    filetype: Union[acme_crypto_util.Format, int] = acme_crypto_util.Format.PEM,
+) -> bytes:
     """Dump certificate chain into a bundle.
 
     :param list chain: List of `crypto.X509` (or wrapped in


### PR DESCRIPTION
…nstants

Begin using it in `dump_pyopenssl_chain`

