### PR TITLE
Simplify typing for a local variable

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -89,7 +89,7 @@ class _TokenChallenge(Challenge):
     :ivar bytes token:
 
     """
-    TOKEN_SIZE = 128 / 8  # Based on the entropy value from the spec
+    TOKEN_SIZE = 128 // 8  # Based on the entropy value from the spec
     """Minimum size of the :attr:`token` in bytes."""
 
     # TODO: acme-spec doesn't specify token as base64-encoded value

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -96,13 +96,9 @@ class SSLSocket:  # pylint: disable=too-few-public-methods
             raise ValueError("Neither cert_selection or certs specified.")
         if cert_selection and certs:
             raise ValueError("Both cert_selection and certs specified.")
-        actual_cert_selection: Union[_DefaultCertSelection,
-                                     Optional[Callable[[SSL.Connection],
-                                                       Optional[Tuple[crypto.PKey,
-                                                                crypto.X509]]]]] = cert_selection
-        if actual_cert_selection is None:
-            actual_cert_selection = _DefaultCertSelection(certs if certs else {})
-        self.cert_selection = actual_cert_selection
+        if cert_selection is None:
+            cert_selection = _DefaultCertSelection(certs if certs else {})
+        self.cert_selection = cert_selection
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.sock, name)


### PR DESCRIPTION
`_DefaultCertSelection` _is_ a `Callable` of the appropriate signature.

Also fixed a mypy error I see locally, `TOKEN_SIZE` should be an integer.
