### PR TITLE
minor acme doc & comment fixes

### DIFF
--- a/acme/acme/challenges.py
+++ b/acme/acme/challenges.py
@@ -478,8 +478,6 @@ class TLSALPN01Response(KeyAuthorizationChallengeResponse):
         names = crypto_util.get_names_from_subject_and_extensions(
             cert.subject, cert.extensions
         )
-        # Type ignore needed due to
-        # https://github.com/pyca/pyopenssl/issues/730.
         logger.debug(
             "Certificate %s. SANs: %s", cert.fingerprint(hashes.SHA256()), names
         )

--- a/acme/acme/crypto_util.py
+++ b/acme/acme/crypto_util.py
@@ -248,14 +248,18 @@ def make_csr(
 ) -> bytes:
     """Generate a CSR containing domains or IPs as subjectAltNames.
 
+    Parameters are ordered this way for backwards compatibility when called using positional
+    arguments.
+
     :param buffer private_key_pem: Private key, in PEM PKCS#8 format.
     :param list domains: List of DNS names to include in subjectAltNames of CSR.
     :param bool must_staple: Whether to include the TLS Feature extension (aka
         OCSP Must Staple: https://tools.ietf.org/html/rfc7633).
     :param list ipaddrs: List of IPaddress(type ipaddress.IPv4Address or ipaddress.IPv6Address)
-    names to include in subbjectAltNames of CSR.
-    params ordered this way for backward competablity when called by positional argument.
+        names to include in subbjectAltNames of CSR.
+
     :returns: buffer PEM-encoded Certificate Signing Request.
+
     """
     private_key = serialization.load_pem_private_key(private_key_pem, password=None)
     # There are a few things that aren't valid for x509 signing. mypy

--- a/acme/docs/api/crypto_util.rst
+++ b/acme/docs/api/crypto_util.rst
@@ -1,0 +1,5 @@
+Crypto_util
+-----------
+
+.. automodule:: acme.crypto_util
+   :members:

--- a/acme/docs/api/jws.rst
+++ b/acme/docs/api/jws.rst
@@ -1,0 +1,5 @@
+JWS
+---
+
+.. automodule:: acme.jws
+   :members:

--- a/acme/docs/api/util.rst
+++ b/acme/docs/api/util.rst
@@ -1,0 +1,5 @@
+Util
+----
+
+.. automodule:: acme.util
+   :members:


### PR DESCRIPTION
this fixes two tiny things i noticed when reviewing https://github.com/certbot/certbot/pull/10120

1. not all of our `acme` modules were generating API documentation
2. the deleted commend about a "type ignore" should have been deleted in https://github.com/certbot/certbot/pull/9197 but will and i missed it