### PR TITLE
silence poetry warning

### DIFF
--- a/tools/pinning/current/pyproject.toml
+++ b/tools/pinning/current/pyproject.toml
@@ -75,9 +75,6 @@ cryptography = "!= 37.0.3"
 # version of tox to keep deterministic builds.
 tox = ">=4"
 
-
-[tool.poetry.dev-dependencies]
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tools/pinning/oldest/pyproject.toml
+++ b/tools/pinning/oldest/pyproject.toml
@@ -97,8 +97,6 @@ cython = "<3.0"
 # We add any dependencies that must be specified in this file for any another
 # reason below.
 
-[tool.poetry.dev-dependencies]
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
when reviewing https://github.com/certbot/certbot/pull/10126 and running `tools/pinning/oldest/repin.sh` using a freshly created dev environment, i was repeatedly given the message

> The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.

i believe this section was generated automatically by poetry's tooling when it created the initial boilerplate file for us, but we don't use it, so i just deleted the section which makes the warnings disappear