### PR TITLE
improve repin experience on macOS

### DIFF
--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -50,14 +50,22 @@ Install and configure the OS system dependencies required to run Certbot.
    # NB2: RHEL-based distributions use python3X instead of python3 (e.g. python38)
    sudo dnf install python3 augeas-libs
    # For macOS installations with Homebrew already installed and configured
-   # NB: If you also run `brew install python` you don't need the ~/lib
-   #     directory created below, however, without this directory and symlinks
-   #     to augeas, Certbot's Apache plugin won't work if you use Python
-   #     installed from other sources such as pyenv or the version provided by
-   #     Apple.
-   brew install augeas
+   # NB1: If you also run `brew install python` you don't need the ~/lib
+   #      directory created below, however, without this directory and symlinks
+   #      to augeas, Certbot's Apache plugin won't work if you use Python
+   #      installed from other sources such as pyenv or the version provided by
+   #      Apple.
+   # NB2: Some of our developer scripts expect GNU coreutils be first in your
+   #      PATH. The commands below set this up for bash and zsh, but your
+   #      instructions may be slightly different if you use an alternate shell.
+   brew install augeas coreutils gnu-sed
    mkdir ~/lib
-   ln -s $(brew --prefix)/lib/libaugeas* ~/lib
+   BREW_PREFIX=$(brew --prefix)
+   ln -s "$BREW_PREFIX"/lib/libaugeas* ~/lib
+   RC_LINE="export PATH=\"$BREW_PREFIX/opt/coreutils/libexec/gnubin:"
+   RC_LINE+="$BREW_PREFIX/opt/gnu-sed/libexec/gnubin:\$PATH\""
+   echo "$RC_LINE" >> ~/.bashrc  # for bash
+   echo "$RC_LINE" >> ~/.zshrc  # for zsh
 
 .. note:: If you have trouble creating the virtual environment below, you may
    need to install additional dependencies. See the `cryptography project's

--- a/tools/pinning/current/repin.sh
+++ b/tools/pinning/current/repin.sh
@@ -9,7 +9,11 @@ set -euo pipefail
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 COMMON_DIR="$(dirname "${WORK_DIR}")/common"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-RELATIVE_SCRIPT_PATH="$(realpath --relative-to "$REPO_ROOT" "$WORK_DIR")/$(basename "${BASH_SOURCE[0]}")"
+if ! RELATIVE_WORK_DIR="$(realpath --relative-to "$REPO_ROOT" "$WORK_DIR")"; then
+    echo this script needs GNU coreutils to be first in your PATH rather than macOS/BSD versions
+    exit 1
+fi
+RELATIVE_SCRIPT_PATH="$RELATIVE_WORK_DIR/$(basename "${BASH_SOURCE[0]}")"
 REQUIREMENTS_FILE="$REPO_ROOT/tools/requirements.txt"
 
 PINNINGS=$("${COMMON_DIR}/export-pinned-dependencies.sh" "${WORK_DIR}" "$@")

--- a/tools/pinning/oldest/repin.sh
+++ b/tools/pinning/oldest/repin.sh
@@ -9,7 +9,11 @@ set -euo pipefail
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 COMMON_DIR="$(dirname "${WORK_DIR}")/common"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-RELATIVE_SCRIPT_PATH="$(realpath --relative-to "$REPO_ROOT" "$WORK_DIR")/$(basename "${BASH_SOURCE[0]}")"
+if ! RELATIVE_WORK_DIR="$(realpath --relative-to "$REPO_ROOT" "$WORK_DIR")"; then
+    echo this script needs GNU coreutils to be first in your PATH rather than macOS/BSD versions
+    exit 1
+fi
+RELATIVE_SCRIPT_PATH="$RELATIVE_WORK_DIR/$(basename "${BASH_SOURCE[0]}")"
 CONSTRAINTS_FILE="$REPO_ROOT/tools/oldest_constraints.txt"
 
 PINNINGS=$("${COMMON_DIR}/export-pinned-dependencies.sh" "${WORK_DIR}" "$@")


### PR DESCRIPTION
this hopefully at least helps the problem hit at https://github.com/certbot/certbot/pull/10126#discussion_r1909714276

i took this approach because in my experience, linux specific shell commands have crept into our scripts repeatedly over the years so i think just having macOS devs use the linux versions is much more reliable. it's what i've personally been doing for years now