### PR TITLE
Fix filesystem.compat.readlink on Windows

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Allow nginx plugin to parse non-breaking spaces in nginx configuration files.
+* Test potentially incorrect assumption during symlink validation on Windows
 *
 
 More details about these changes can be found on our GitHub repo.

--- a/certbot/certbot/compat/filesystem.py
+++ b/certbot/certbot/compat/filesystem.py
@@ -392,7 +392,7 @@ def readlink(link_path: str) -> str:
     if POSIX_MODE:
         return path
 
-    # At this point, we know we are on Windows and that the path returned uses
+    # At this point, we know we are on Windows and that the path returned might use
     # the extended form which begins with the prefix \\?\
 
     # Max length of a normal path is 260 characters on Windows, including the non printable
@@ -400,7 +400,7 @@ def readlink(link_path: str) -> str:
     # strings, giving a max length of 259 characters, + 4 characters for the extended form
     # prefix, to an effective max length 263 characters on a string representing a normal path.
     if len(path) < 264:
-        return path[4:]
+        return path[4:] if path.startswith('\\\\?\\') else path
 
     raise ValueError("Long paths are not supported by Certbot on Windows.")
 


### PR DESCRIPTION
Today, we installed certbot 3.1.0 on a machine running Windows Server 2022 and Python 3.13.1 and tried to renew a certificate. certbot failed while trying to validate the symlinks it created, despite the relative symlinks having been created correctly. The backtrace and error message were:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "D:\Python313\Scripts\certbot.exe\__main__.py", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "D:\Python313\Lib\site-packages\certbot\main.py", line 19, in main
    return internal_main.main(cli_args)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "D:\Python313\Lib\site-packages\certbot\_internal\main.py", line 1873, in main
    return config.func(config, plugins)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "D:\Python313\Lib\site-packages\certbot\_internal\main.py", line 1579, in certonly
    lineage = _get_and_save_cert(le_client, config, domains, certname, lineage)
  File "D:\Python313\Lib\site-packages\certbot\_internal\main.py", line 142, in _get_and_save_cert
    lineage = le_client.obtain_and_enroll_certificate(domains, certname)
  File "D:\Python313\Lib\site-packages\certbot\_internal\client.py", line 529, in obtain_and_enroll_certificate
    return storage.RenewableCert.new_lineage(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        new_name, cert,
        ^^^^^^^^^^^^^^^
        key.pem, chain,
        ^^^^^^^^^^^^^^^
        self.config)
        ^^^^^^^^^^^^
  File "D:\Python313\Lib\site-packages\certbot\_internal\storage.py", line 1111, in new_lineage
    return cls(new_config.filename, cli_config)
  File "D:\Python313\Lib\site-packages\certbot\_internal\storage.py", line 507, in __init__
    self._check_symlinks()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "D:\Python313\Lib\site-packages\certbot\_internal\storage.py", line 590, in _check_symlinks
    raise errors.CertStorageError("target {0} of symlink {1} does "
                                  "not exist".format(target, link))
certbot.errors.CertStorageError: target C:\Certbot\live\[server]\archive\[server]\cert1.pem of symlink C:\Certbot\live\[server]\cert.pem does not exist
```

Some quick debugging revealed that `certbot.filesystem.compat.readlink` turned the symlink target `..\..\archive\[server]\cert1.pem` into `.\archive\[server]\cert1.pem`. The fix should be pretty self-explanatory.

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [X] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `main` section of `certbot/CHANGELOG.md` to include a description of the change being made.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [ ] Include your name in `AUTHORS.md` if you like.
