### PR TITLE
double failing timeout

### DIFF
--- a/certbot/certbot/tests/util.py
+++ b/certbot/certbot/tests/util.py
@@ -449,7 +449,7 @@ def lock_and_call(callback: Callable[[], Any], path_to_lock: str) -> None:
     process.start()
 
     # Wait confirmation that lock is acquired
-    assert receive_event.wait(timeout=10), 'Timeout while waiting to acquire the lock.'
+    assert receive_event.wait(timeout=20), 'Timeout while waiting to acquire the lock.'
     # Execute the callback
     callback()
     # Trigger unlock from foreign process


### PR DESCRIPTION
our macOS tests recently started failing (more?) often hitting the timeout modified in this PR. an example of this can be seen at https://dev.azure.com/certbot/certbot/_build/results?buildId=8459&view=logs&j=1ae398a1-7dc9-5ade-0f59-912b32975b53&t=0ec28dfb-4593-5e04-05b6-bb502ec0a017&s=96ac2280-8cb4-5df5-99de-dd2da759617d. this has affected at least https://github.com/certbot/certbot/pull/10138, https://github.com/certbot/certbot/pull/10130, and https://github.com/certbot/certbot/pull/10136

i'm not sure whether the failing tests are actually getting stuck or just hitting the timeout i bumped here, but i suspect it may be the latter. our tests on macOS in CI are unreasonably slow for some reason. i do not have this problem on my macbook locally

this PR does the simple/lazy thing of bumping the timeout which may help avoid the now regularly occuring problem and/or help us get more certainty whether the tests are actually getting stuck or not