### PR TITLE
Add new style of issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,31 @@
+---
+name: General issue
+about: General template for creating new issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+If you're having trouble using Certbot and aren't sure you've found a bug or
+request for a new feature, please first try asking for help at
+https://community.letsencrypt.org/. There is a much larger community there of
+people familiar with the project who will be able to more quickly answer your
+questions.
+
+## My operating system is (include version):
+
+
+## I installed Certbot with (snap, OS package manager, pip, certbot-auto, etc):
+
+
+## I ran this command and it produced this output:
+
+
+## Certbot's behavior differed from what I expected because:
+
+
+## Here is a Certbot log showing the issue (if available):
+###### Logs are stored in `/var/log/letsencrypt` by default. Feel free to redact domains, e-mail and IP addresses as you see fit.
+
+## Here is the relevant nginx server block or Apache virtualhost for the domain I am configuring:


### PR DESCRIPTION
Pasted from the old one. Maybe we can just rename it but this is what github's web interface led me to create.

I want to make sure that they at least create the template so that they read it. If they then choose to ignore it that's fine, but it should always pop up. Basically I want to keep the old behavior. Open to alternatives.

We could also play around with the new issue forms: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

Or label this one the "bug" template, and create a second one that is blank but has the header text paragraph. I haven't seen a way to make something appear in all templates, including the "blank" one, other than just turning off blank templates.