### PR TITLE
Preserve IP addresses when adding ssl listen directives in nginx server blocks

### DIFF
--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -392,7 +392,7 @@ class NginxConfigurator(common.Configurator):
             for addr in vh.addrs:
                 if addr.ipv6:
                     ipv6_active = True
-                if addr.ipv6only and addr.get_port() == port:
+                if addr.ipv6only and addr.get_port() == port and addr.get_addr() == host:
                     ipv6only_present = True
         return ipv6_active, ipv6only_present
 

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -726,6 +726,9 @@ class NginxConfigurator(common.Configurator):
         https_port = self.config.https_port
         http_port = self.config.http01_port
 
+        # no addresses should have ssl turned on here
+        assert not vhost.ssl
+
         sslified_addrs: List[obj.Addr] = [obj.Addr(addr.get_addr(), str(https_port), True, False,
                                                addr.ipv6, False)
                                          for addr in vhost.addrs

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -21,6 +21,7 @@ from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import Union
+from typing import cast
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -730,7 +731,7 @@ class NginxConfigurator(common.Configurator):
         assert not vhost.ssl
 
         addrs_to_insert: List[obj.Addr] = [
-            obj.Addr.fromstring(f'{addr.get_addr()}:{https_port} ssl')
+            cast(obj.Addr, obj.Addr.fromstring(f'{addr.get_addr()}:{https_port} ssl'))
             for addr in vhost.addrs
             if addr.get_port() == str(http_port)
         ]
@@ -744,9 +745,9 @@ class NginxConfigurator(common.Configurator):
         if not addrs_to_insert:
             # there are no existing addresses listening on 80
             if vhost.ipv6_enabled():
-                addrs_to_insert += [obj.Addr.fromstring(f'[::]:{https_port} ssl')]
+                addrs_to_insert += [cast(obj.Addr, obj.Addr.fromstring(f'[::]:{https_port} ssl'))]
             if vhost.ipv4_enabled():
-                addrs_to_insert += [obj.Addr.fromstring(f'{https_port} ssl')]
+                addrs_to_insert += [cast(obj.Addr, obj.Addr.fromstring(f'{https_port} ssl'))]
 
         addr_blocks: List[List[str]] = []
         ipv6only_set_here: Set[Tuple[str, str]] = set()

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -762,7 +762,7 @@ class NginxConfigurator(common.Configurator):
                               'ssl']
                 ipv6only_exists = self.ipv6_info(host, port)[1]
                 if not ipv6only_exists and (host, port) not in ipv6only_set_here:
-                    addr.ipv6only = True
+                    addr.ipv6only = True # bookkeeping in case we switch output implementation
                     ipv6only_set_here.add((host, port))
                     addr_block.append(' ')
                     addr_block.append('ipv6only=on')

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -745,7 +745,7 @@ class NginxConfigurator(common.Configurator):
                 sslified_addrs += [obj.Addr('', str(https_port), True, False, False, False)]
 
         addr_blocks: List[List[str]] = []
-        ipv6only_set_for_tuples_by_this_function: Set[Tuple[str, str]] = set()
+        ipv6only_set_here: Set[Tuple[str, str]] = set()
         for addr in sslified_addrs:
             host = addr.get_addr()
             port = addr.get_port()
@@ -757,9 +757,9 @@ class NginxConfigurator(common.Configurator):
                               ' ',
                               'ssl']
                 ipv6only_exists = self.ipv6_info(host, port)[1]
-                if not ipv6only_exists and (host, port) not in ipv6only_set_for_tuples_by_this_function:
+                if not ipv6only_exists and (host, port) not in ipv6only_set_here:
                     addr.ipv6only = True
-                    ipv6only_set_for_tuples_by_this_function.add((host, port))
+                    ipv6only_set_here.add((host, port))
                     addr_block.append(' ')
                     addr_block.append('ipv6only=on')
                 addr_blocks.append(addr_block)

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -741,7 +741,7 @@ class NginxConfigurator(common.Configurator):
             self.parser.add_server_directives(vhost, listen_block)
 
         if not sslified_addrs:
-            # there are no existing addressing listening on 80
+            # there are no existing addresses listening on 80
             if vhost.ipv6_enabled():
                 sslified_addrs += [obj.Addr('[::]', str(https_port), True, False, True, False)]
             if vhost.ipv4_enabled():

--- a/certbot-nginx/certbot_nginx/_internal/http_01.py
+++ b/certbot-nginx/certbot_nginx/_internal/http_01.py
@@ -152,7 +152,7 @@ class NginxHttp01(common.ChallengePerformer):
             self.configurator.config.http01_port)
         port = self.configurator.config.http01_port
 
-        ipv6, ipv6only = self.configurator.ipv6_info(str(port))
+        ipv6, ipv6only = self.configurator.ipv6_info("[::]", str(port))
 
         if ipv6:
             # If IPv6 is active in Nginx configuration

--- a/certbot-nginx/certbot_nginx/_internal/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/_internal/tests/configurator_test.py
@@ -201,6 +201,19 @@ class NginxConfiguratorTest(util.NginxTest):
                 with pytest.raises(errors.MisconfigurationError):
                     self.config.choose_vhosts(name)
 
+    def test_choose_vhosts_keep_ip_address(self):
+        name = 'example.com'
+        conf_path = os.path.normpath('etc_nginx/sites-enabled/example.com')
+
+        vhost = self.config.choose_vhosts(name)[0]
+        path = os.path.relpath(vhost.filep, self.temp_dir)
+
+        assert vhost.names == {'.example.com', 'example.*'}
+        assert path == conf_path
+
+        import ipdb; ipdb.set_trace()
+
+
     def test_ipv6only(self):
         # ipv6_info: (ipv6_active, ipv6only_present)
         assert (True, False) == self.config.ipv6_info("80")

--- a/certbot-nginx/certbot_nginx/_internal/tests/configurator_test.py
+++ b/certbot-nginx/certbot_nginx/_internal/tests/configurator_test.py
@@ -211,14 +211,12 @@ class NginxConfiguratorTest(util.NginxTest):
         assert vhost.names == {'.example.com', 'example.*'}
         assert path == conf_path
 
-        import ipdb; ipdb.set_trace()
-
 
     def test_ipv6only(self):
         # ipv6_info: (ipv6_active, ipv6only_present)
-        assert (True, False) == self.config.ipv6_info("80")
+        assert (True, False) == self.config.ipv6_info("[::]", "80")
         # Port 443 has ipv6only=on because of ipv6ssl.com vhost
-        assert (True, True) == self.config.ipv6_info("443")
+        assert (True, True) == self.config.ipv6_info("[::]", "443")
 
     def test_ipv6only_detection(self):
         self.config.version = (1, 3, 1)
@@ -598,7 +596,7 @@ class NginxConfiguratorTest(util.NginxTest):
         generated_conf = self.config.parser.parsed[example_conf]
         assert [[['server'], [
                ['server_name', '.example.com'],
-               ['server_name', 'example.*'], [],
+               ['server_name', 'example.*'],
                ['listen', '5001', 'ssl'], ['#', ' managed by Certbot'],
                ['ssl_certificate', 'example/fullchain.pem'], ['#', ' managed by Certbot'],
                ['ssl_certificate_key', 'example/key.pem'], ['#', ' managed by Certbot'],
@@ -628,7 +626,7 @@ class NginxConfiguratorTest(util.NginxTest):
         generated_conf = self.config.parser.parsed[example_conf]
         assert [[['server'], [
                ['server_name', '.example.com'],
-               ['server_name', 'example.*'], [],
+               ['server_name', 'example.*'],
                ['listen', '5001', 'ssl'], ['#', ' managed by Certbot'],
                ['ssl_certificate', 'example/fullchain.pem'], ['#', ' managed by Certbot'],
                ['ssl_certificate_key', 'example/key.pem'], ['#', ' managed by Certbot'],
@@ -643,7 +641,7 @@ class NginxConfiguratorTest(util.NginxTest):
                ['listen', '127.0.0.1'],
                ['server_name', '.example.com'],
                ['server_name', 'example.*'],
-               [], [], []]]] == \
+               [], []]]] == \
             generated_conf
 
     def test_http_header_hsts(self):

--- a/certbot-nginx/certbot_nginx/_internal/tests/parser_test.py
+++ b/certbot-nginx/certbot_nginx/_internal/tests/parser_test.py
@@ -62,7 +62,8 @@ class NginxParserTest(util.NginxTest):
                            'sites-enabled/globalssl.com',
                            'sites-enabled/ipv6.com',
                            'sites-enabled/ipv6ssl.com',
-                           'sites-enabled/example.net']} == \
+                           'sites-enabled/example.net',
+                           'sites-enabled/addr-80.com']} == \
                          set(nparser.parsed.keys())
         assert [['server_name', 'somename', 'alias', 'another.alias']] == \
                          nparser.parsed[nparser.abs_path('server.conf')]
@@ -92,7 +93,7 @@ class NginxParserTest(util.NginxTest):
         parsed = nparser._parse_files(nparser.abs_path(
             'sites-enabled/example.com.test'))
         assert 4 == len(glob.glob(nparser.abs_path('*.test')))
-        assert 10 == len(
+        assert 11 == len(
             glob.glob(nparser.abs_path('sites-enabled/*.test')))
         assert [[['server'], [['listen', '69.50.225.155:9000'],
                                         ['listen', '127.0.0.1'],
@@ -175,7 +176,7 @@ class NginxParserTest(util.NginxTest):
                                                   '*.www.example.com'},
                                  [], [2, 1, 0])
 
-        assert 19 == len(vhosts)
+        assert 20 == len(vhosts)
         example_com = [x for x in vhosts if 'example.com' in x.filep][0]
         assert vhost3 == example_com
         default = [x for x in vhosts if 'default' in x.filep][0]

--- a/certbot-nginx/certbot_nginx/_internal/tests/testdata/etc_nginx/sites-enabled/addr-80.com
+++ b/certbot-nginx/certbot_nginx/_internal/tests/testdata/etc_nginx/sites-enabled/addr-80.com
@@ -1,0 +1,5 @@
+server {
+    listen 1.2.3.4:80;
+    listen [1:20::300]:80;
+    server_name addr-80.com;
+}

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -25,6 +25,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Honor --reuse-key when --allow-subset-of-names is set
 * Fixed regression in symlink parsing on Windows that was introduced in Certbot
   3.1.0.
+* When adding ssl listen directives in nginx server blocks, IP addresses are now
+  preserved.
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
Fixes #10011

When we take a server block with no ssl addresses in and and enable ssl, if it has any listens on the http port, use those host addresses when creating a directive to listen on ssl. Addresses with no port and on other ports will be ignored.