### PR TITLE
Improve help output for default-None constants

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -16,6 +16,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Deprecated `gen_ss_cert` in `acme.crypto_util` as it uses deprecated
   pyOpenSSL API.
 * Add `make_self_signed_cert` to `acme.crypto_util` to replace `gen_ss_cert.
+* Help output now shows `False` as default when it can be set via `cli.ini` instead of `None`
 
 ### Fixed
 

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -182,7 +182,7 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
         help=config_help("email"))
     helpful.add(["register", "update_account", "automation"], "--eff-email", action="store_true",
                 default=flag_default("eff_email"), dest="eff_email",
-                help="Share your e-mail address with EFF")
+                help="Share your e-mail address with EFF (default: False)")
     helpful.add(["register", "update_account", "automation"], "--no-eff-email",
                 action="store_false", default=flag_default("eff_email"), dest="eff_email",
                 help="Don't share your e-mail address with EFF")
@@ -336,7 +336,7 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
         "--hsts", action="store_true", dest="hsts", default=flag_default("hsts"),
         help="Add the Strict-Transport-Security header to every HTTP response."
              " Forcing browser to always use SSL for the domain."
-             " Defends against SSL Stripping.")
+             " Defends against SSL Stripping. (default: False)")
     helpful.add(
         "security", "--no-hsts", action="store_false", dest="hsts",
         default=flag_default("hsts"), help=argparse.SUPPRESS)
@@ -345,7 +345,7 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
         "--uir", action="store_true", dest="uir", default=flag_default("uir"),
         help='Add the "Content-Security-Policy: upgrade-insecure-requests"'
              ' header to every HTTP response. Forcing the browser to use'
-             ' https:// for every http:// resource.')
+             ' https:// for every http:// resource. (default: False)')
     helpful.add(
         "security", "--no-uir", action="store_false", dest="uir", default=flag_default("uir"),
         help=argparse.SUPPRESS)
@@ -353,7 +353,7 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
         "security", "--staple-ocsp", action="store_true", dest="staple",
         default=flag_default("staple"),
         help="Enables OCSP Stapling. A valid OCSP response is stapled to"
-        " the certificate that the server offers during TLS.")
+        " the certificate that the server offers during TLS. (default: False)")
     helpful.add(
         "security", "--no-staple-ocsp", action="store_false", dest="staple",
         default=flag_default("staple"), help=argparse.SUPPRESS)

--- a/certbot/certbot/_internal/cli/__init__.py
+++ b/certbot/certbot/_internal/cli/__init__.py
@@ -182,10 +182,10 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: List[st
         help=config_help("email"))
     helpful.add(["register", "update_account", "automation"], "--eff-email", action="store_true",
                 default=flag_default("eff_email"), dest="eff_email",
-                help="Share your e-mail address with EFF (default: False)")
+                help="Share your e-mail address with EFF (default: Ask)")
     helpful.add(["register", "update_account", "automation"], "--no-eff-email",
                 action="store_false", default=flag_default("eff_email"), dest="eff_email",
-                help="Don't share your e-mail address with EFF")
+                help="Don't share your e-mail address with EFF (default: Ask)")
     helpful.add(
         ["automation", "certonly", "run"],
         "--keep-until-expiring", "--keep", "--reinstall",

--- a/certbot/certbot/_internal/cli/subparsers.py
+++ b/certbot/certbot/_internal/cli/subparsers.py
@@ -44,7 +44,7 @@ def _create_subparsers(helpful: "helpful.HelpfulArgumentParser") -> None:
                 "--delete-after-revoke", action="store_true",
                 default=flag_default("delete_after_revoke"),
                 help="Delete certificates after revoking them, along with all previous and later "
-                "versions of those certificates. (default: False)")
+                "versions of those certificates. (default: Ask)")
     helpful.add("revoke",
                 "--no-delete-after-revoke", action="store_false",
                 dest="delete_after_revoke",
@@ -52,7 +52,7 @@ def _create_subparsers(helpful: "helpful.HelpfulArgumentParser") -> None:
                 help="Do not delete certificates after revoking them. This "
                      "option should be used with caution because the 'renew' "
                      "subcommand will attempt to renew undeleted revoked "
-                     "certificates. (default: True)")
+                     "certificates. (default: Ask)")
     helpful.add("rollback",
                 "--checkpoints", type=int, metavar="N",
                 default=flag_default("rollback_checkpoints"),

--- a/certbot/certbot/_internal/cli/subparsers.py
+++ b/certbot/certbot/_internal/cli/subparsers.py
@@ -44,7 +44,7 @@ def _create_subparsers(helpful: "helpful.HelpfulArgumentParser") -> None:
                 "--delete-after-revoke", action="store_true",
                 default=flag_default("delete_after_revoke"),
                 help="Delete certificates after revoking them, along with all previous and later "
-                "versions of those certificates.")
+                "versions of those certificates. (default: False)")
     helpful.add("revoke",
                 "--no-delete-after-revoke", action="store_false",
                 dest="delete_after_revoke",
@@ -52,7 +52,7 @@ def _create_subparsers(helpful: "helpful.HelpfulArgumentParser") -> None:
                 help="Do not delete certificates after revoking them. This "
                      "option should be used with caution because the 'renew' "
                      "subcommand will attempt to renew undeleted revoked "
-                     "certificates.")
+                     "certificates. (default: True)")
     helpful.add("rollback",
                 "--checkpoints", type=int, metavar="N",
                 default=flag_default("rollback_checkpoints"),

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -37,7 +37,7 @@ CLI_DEFAULTS: Dict[str, Any] = dict(  # pylint: disable=use-dict-literal
     dry_run=False,
     register_unsafely_without_email=False,
     email=None,
-    eff_email=None, # listed as False in help output
+    eff_email=None, # listed as Ask in help output
     reinstall=False,
     expand=False,
     renew_by_default=False,
@@ -89,7 +89,7 @@ CLI_DEFAULTS: Dict[str, Any] = dict(  # pylint: disable=use-dict-literal
     user_agent_comment=None,
     csr=None,
     reason=0,
-    delete_after_revoke=None, # listed as False in help output
+    delete_after_revoke=None, # listed as Ask in help output
     rollback_checkpoints=1,
     init=False,
     prepare=False,

--- a/certbot/certbot/_internal/constants.py
+++ b/certbot/certbot/_internal/constants.py
@@ -37,7 +37,7 @@ CLI_DEFAULTS: Dict[str, Any] = dict(  # pylint: disable=use-dict-literal
     dry_run=False,
     register_unsafely_without_email=False,
     email=None,
-    eff_email=None,
+    eff_email=None, # listed as False in help output
     reinstall=False,
     expand=False,
     renew_by_default=False,
@@ -64,11 +64,11 @@ CLI_DEFAULTS: Dict[str, Any] = dict(  # pylint: disable=use-dict-literal
     elliptic_curve="secp256r1",
     key_type="ecdsa",
     must_staple=False,
-    redirect=None,
+    redirect=None, # default described manually in text in help output
     auto_hsts=False,
-    hsts=None,
-    uir=None,
-    staple=None,
+    hsts=None, # listed as False in help output
+    uir=None, # listed as False in help output
+    staple=None, # listed as False in help output
     strict_permissions=False,
     preferred_chain=None,
     pref_challs=[],
@@ -89,7 +89,7 @@ CLI_DEFAULTS: Dict[str, Any] = dict(  # pylint: disable=use-dict-literal
     user_agent_comment=None,
     csr=None,
     reason=0,
-    delete_after_revoke=None,
+    delete_after_revoke=None, # listed as False in help output
     rollback_checkpoints=1,
     init=False,
     prepare=False,


### PR DESCRIPTION
Fixes #10000.

To create this PR, I looked through `constants.py` for defaults set to `None`. If the action for the cli flag was `store_true` and there wasn't other custom manual default specification, I changed it to report `False`, and added a comment in `constants.py`. Adding `(default:` in the help text suppresses listing of the actual default (done by `cli_utils.py:CustomHelpFormatter`). Also added a comment for `redirect` which is described manually since I noticed it while I was going through.