### PR TITLE
[apache] Add type hints to apache test utils (to enable mypy --strict)

### DIFF
--- a/certbot-apache/certbot_apache/_internal/tests/util.py
+++ b/certbot-apache/certbot_apache/_internal/tests/util.py
@@ -140,71 +140,71 @@ def get_vh_truth(temp_dir: str, config_name: str) -> Optional[List[obj.VirtualHo
             obj.VirtualHost(
                 os.path.join(prefix, "encryption-example.conf"),
                 os.path.join(aug_pre, "encryption-example.conf/Virtualhost"),
-                {obj.Addr, obj.Addr.fromstring("*:80")},
+                {obj.Addr.fromstring("*:80")},
                 False, True, "encryption-example.demo"),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl.conf"),
                 os.path.join(aug_pre,
                              "default-ssl.conf/IfModule/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("_default_:443")}, True, True),
+                {obj.Addr.fromstring("_default_:443")}, True, True),
             obj.VirtualHost(
                 os.path.join(prefix, "000-default.conf"),
                 os.path.join(aug_pre, "000-default.conf/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("*:80"),
-                     obj.Addr, obj.Addr.fromstring("[::]:80")},
+                {obj.Addr.fromstring("*:80"),
+                    obj.Addr.fromstring("[::]:80")},
                 False, True, "ip-172-30-0-17"),
             obj.VirtualHost(
                 os.path.join(prefix, "certbot.conf"),
                 os.path.join(aug_pre, "certbot.conf/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
+                {obj.Addr.fromstring("*:80")}, False, True,
                 "certbot.demo", aliases={"www.certbot.demo"}),
             obj.VirtualHost(
                 os.path.join(prefix, "mod_macro-example.conf"),
                 os.path.join(aug_pre,
                              "mod_macro-example.conf/Macro/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
+                {obj.Addr.fromstring("*:80")}, False, True,
                 modmacro=True),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl-port-only.conf"),
                 os.path.join(aug_pre, ("default-ssl-port-only.conf/"
                                        "IfModule/VirtualHost")),
-                {obj.Addr, obj.Addr.fromstring("_default_:443")}, True, True),
+                {obj.Addr.fromstring("_default_:443")}, True, True),
             obj.VirtualHost(
                 os.path.join(prefix, "wildcard.conf"),
                 os.path.join(aug_pre, "wildcard.conf/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
+                {obj.Addr.fromstring("*:80")}, False, True,
                 "ip-172-30-0-17", aliases={"*.blue.purple.com"}),
             obj.VirtualHost(
                 os.path.join(prefix, "ocsp-ssl.conf"),
                 os.path.join(aug_pre, "ocsp-ssl.conf/IfModule/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("10.2.3.4:443")}, True, True,
+                {obj.Addr.fromstring("10.2.3.4:443")}, True, True,
                 "ocspvhost.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "non-symlink.conf"),
                 os.path.join(aug_pre, "non-symlink.conf/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
+                {obj.Addr.fromstring("*:80")}, False, True,
                 "nonsym.link"),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl-port-only.conf"),
                 os.path.join(aug_pre,
                              "default-ssl-port-only.conf/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("*:80")}, True, True, ""),
+                {obj.Addr.fromstring("*:80")}, True, True, ""),
             obj.VirtualHost(
                 os.path.join(temp_dir, config_name,
                              "apache2/apache2.conf"),
                 "/files" + os.path.join(temp_dir, config_name,
                                         "apache2/apache2.conf/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
+                {obj.Addr.fromstring("*:80")}, False, True,
                 "vhost.in.rootconf"),
             obj.VirtualHost(
                 os.path.join(prefix, "duplicatehttp.conf"),
                 os.path.join(aug_pre, "duplicatehttp.conf/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("10.2.3.4:80")}, False, True,
+                {obj.Addr.fromstring("10.2.3.4:80")}, False, True,
                 "duplicate.example.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "duplicatehttps.conf"),
                 os.path.join(aug_pre, "duplicatehttps.conf/IfModule/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("10.2.3.4:443")}, True, True,
+                {obj.Addr.fromstring("10.2.3.4:443")}, True, True,
                 "duplicate.example.com")]
         return vh_truth
     if config_name == "debian_apache_2_4/multi_vhosts":
@@ -215,27 +215,27 @@ def get_vh_truth(temp_dir: str, config_name: str) -> Optional[List[obj.VirtualHo
             obj.VirtualHost(
                 os.path.join(prefix, "default.conf"),
                 os.path.join(aug_pre, "default.conf/VirtualHost[1]"),
-                {obj.Addr, obj.Addr.fromstring("*:80")},
+                {obj.Addr.fromstring("*:80")},
                 False, True, "ip-172-30-0-17"),
             obj.VirtualHost(
                 os.path.join(prefix, "default.conf"),
                 os.path.join(aug_pre, "default.conf/VirtualHost[2]"),
-                {obj.Addr, obj.Addr.fromstring("*:80")},
+                {obj.Addr.fromstring("*:80")},
                 False, True, "banana.vomit.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/VirtualHost[1]"),
-                {obj.Addr, obj.Addr.fromstring("*:80")},
+                {obj.Addr.fromstring("*:80")},
                 False, True, "1.multi.vhost.tld"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/IfModule/VirtualHost"),
-                {obj.Addr, obj.Addr.fromstring("*:80")},
+                {obj.Addr.fromstring("*:80")},
                 False, True, "2.multi.vhost.tld"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/VirtualHost[2]"),
-                {obj.Addr, obj.Addr.fromstring("*:80")},
+                {obj.Addr.fromstring("*:80")},
                 False, True, "3.multi.vhost.tld")]
         return vh_truth
     return None  # pragma: no cover

--- a/certbot-apache/certbot_apache/_internal/tests/util.py
+++ b/certbot-apache/certbot_apache/_internal/tests/util.py
@@ -1,5 +1,9 @@
 """Common utilities for certbot_apache."""
 import shutil
+from typing import cast
+from typing import List
+from typing import Optional
+from typing import Tuple
 import unittest
 from unittest import mock
 
@@ -16,9 +20,10 @@ from certbot_apache._internal import obj
 
 class ApacheTest(unittest.TestCase):
 
-    def setUp(self, test_dir="debian_apache_2_4/multiple_vhosts",
-              config_root="debian_apache_2_4/multiple_vhosts/apache2",
-              vhost_root="debian_apache_2_4/multiple_vhosts/apache2/sites-available"):
+    def setUp(self, test_dir: str = "debian_apache_2_4/multiple_vhosts",
+              config_root: str = "debian_apache_2_4/multiple_vhosts/apache2",
+              vhost_root: str = "debian_apache_2_4/multiple_vhosts/apache2/sites-available"
+              ) -> None:
         # pylint: disable=arguments-differ
         self.temp_dir, self.config_dir, self.work_dir = common.dir_setup(
             test_dir=test_dir,
@@ -27,7 +32,7 @@ class ApacheTest(unittest.TestCase):
         self.config_path = os.path.join(self.temp_dir, config_root)
         self.vhost_path = os.path.join(self.temp_dir, vhost_root)
 
-        self.rsa512jwk = jose.JWKRSA.load(test_util.load_vector(
+        self.rsa512jwk = jose.jwk.JWKRSA.load(test_util.load_vector(
             "rsa512_key.pem"))
 
         self.config = get_apache_configurator(self.config_path, vhost_root,
@@ -50,7 +55,7 @@ class ApacheTest(unittest.TestCase):
                     os.path.pardir, "sites-available", vhost_basename)
                 os.symlink(target, vhost)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir)
         shutil.rmtree(self.config_dir)
         shutil.rmtree(self.work_dir)
@@ -58,9 +63,10 @@ class ApacheTest(unittest.TestCase):
 
 class ParserTest(ApacheTest):
 
-    def setUp(self, test_dir="debian_apache_2_4/multiple_vhosts",
-              config_root="debian_apache_2_4/multiple_vhosts/apache2",
-              vhost_root="debian_apache_2_4/multiple_vhosts/apache2/sites-available"):
+    def setUp(self, test_dir: str = "debian_apache_2_4/multiple_vhosts",
+              config_root: str = "debian_apache_2_4/multiple_vhosts/apache2",
+              vhost_root: str = "debian_apache_2_4/multiple_vhosts/apache2/sites-available"
+              ) -> None:
         super().setUp(test_dir, config_root, vhost_root)
 
         from certbot_apache._internal.parser import ApacheParser
@@ -73,12 +79,12 @@ class ParserTest(ApacheTest):
 
 
 def get_apache_configurator(
-        config_path, vhost_path,
-        config_dir, work_dir, version=(2, 4, 7),
-        os_info="generic",
-        conf_vhost_path=None,
-        use_parsernode=False,
-        openssl_version="1.1.1a"):
+        config_path: str, vhost_path: str,
+        config_dir: str, work_dir: str, version: Tuple[int, int, int] = (2, 4, 7),
+        os_info: str = "generic",
+        conf_vhost_path: Optional[str] = None,
+        use_parsernode: bool = False,
+        openssl_version: str = "1.1.1a") -> configurator.ApacheConfigurator:
     """Create an Apache Configurator with the specified options.
 
     :param conf: Function that returns binary paths. self.conf in Configurator
@@ -124,7 +130,7 @@ def get_apache_configurator(
     return config
 
 
-def get_vh_truth(temp_dir, config_name):
+def get_vh_truth(temp_dir: str, config_name: str) -> Optional[List[obj.VirtualHost]]:
     """Return the ground truth for the specified directory."""
     if config_name == "debian_apache_2_4/multiple_vhosts":
         prefix = os.path.join(
@@ -135,71 +141,71 @@ def get_vh_truth(temp_dir, config_name):
             obj.VirtualHost(
                 os.path.join(prefix, "encryption-example.conf"),
                 os.path.join(aug_pre, "encryption-example.conf/Virtualhost"),
-                {obj.Addr.fromstring("*:80")},
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
                 False, True, "encryption-example.demo"),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl.conf"),
                 os.path.join(aug_pre,
                              "default-ssl.conf/IfModule/VirtualHost"),
-                {obj.Addr.fromstring("_default_:443")}, True, True),
+                {cast(obj.Addr, obj.Addr.fromstring("_default_:443"))}, True, True),
             obj.VirtualHost(
                 os.path.join(prefix, "000-default.conf"),
                 os.path.join(aug_pre, "000-default.conf/VirtualHost"),
-                {obj.Addr.fromstring("*:80"),
-                     obj.Addr.fromstring("[::]:80")},
+                {cast(obj.Addr, obj.Addr.fromstring("*:80")),
+                     cast(obj.Addr, obj.Addr.fromstring("[::]:80"))},
                 False, True, "ip-172-30-0-17"),
             obj.VirtualHost(
                 os.path.join(prefix, "certbot.conf"),
                 os.path.join(aug_pre, "certbot.conf/VirtualHost"),
-                {obj.Addr.fromstring("*:80")}, False, True,
-                "certbot.demo", aliases=["www.certbot.demo"]),
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
+                "certbot.demo", aliases={"www.certbot.demo"}),
             obj.VirtualHost(
                 os.path.join(prefix, "mod_macro-example.conf"),
                 os.path.join(aug_pre,
                              "mod_macro-example.conf/Macro/VirtualHost"),
-                {obj.Addr.fromstring("*:80")}, False, True,
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
                 modmacro=True),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl-port-only.conf"),
                 os.path.join(aug_pre, ("default-ssl-port-only.conf/"
                                        "IfModule/VirtualHost")),
-                {obj.Addr.fromstring("_default_:443")}, True, True),
+                {cast(obj.Addr, obj.Addr.fromstring("_default_:443"))}, True, True),
             obj.VirtualHost(
                 os.path.join(prefix, "wildcard.conf"),
                 os.path.join(aug_pre, "wildcard.conf/VirtualHost"),
-                {obj.Addr.fromstring("*:80")}, False, True,
-                "ip-172-30-0-17", aliases=["*.blue.purple.com"]),
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
+                "ip-172-30-0-17", aliases={"*.blue.purple.com"}),
             obj.VirtualHost(
                 os.path.join(prefix, "ocsp-ssl.conf"),
                 os.path.join(aug_pre, "ocsp-ssl.conf/IfModule/VirtualHost"),
-                {obj.Addr.fromstring("10.2.3.4:443")}, True, True,
+                {cast(obj.Addr, obj.Addr.fromstring("10.2.3.4:443"))}, True, True,
                 "ocspvhost.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "non-symlink.conf"),
                 os.path.join(aug_pre, "non-symlink.conf/VirtualHost"),
-                {obj.Addr.fromstring("*:80")}, False, True,
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
                 "nonsym.link"),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl-port-only.conf"),
                 os.path.join(aug_pre,
                              "default-ssl-port-only.conf/VirtualHost"),
-                {obj.Addr.fromstring("*:80")}, True, True, ""),
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, True, True, ""),
             obj.VirtualHost(
                 os.path.join(temp_dir, config_name,
                              "apache2/apache2.conf"),
                 "/files" + os.path.join(temp_dir, config_name,
                                         "apache2/apache2.conf/VirtualHost"),
-                {obj.Addr.fromstring("*:80")}, False, True,
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
                 "vhost.in.rootconf"),
             obj.VirtualHost(
                 os.path.join(prefix, "duplicatehttp.conf"),
                 os.path.join(aug_pre, "duplicatehttp.conf/VirtualHost"),
-                {obj.Addr.fromstring("10.2.3.4:80")}, False, True,
+                {cast(obj.Addr, obj.Addr.fromstring("10.2.3.4:80"))}, False, True,
                 "duplicate.example.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "duplicatehttps.conf"),
                 os.path.join(aug_pre, "duplicatehttps.conf/IfModule/VirtualHost"),
-                {obj.Addr.fromstring("10.2.3.4:443")}, True, True,
+                {cast(obj.Addr, obj.Addr.fromstring("10.2.3.4:443"))}, True, True,
                 "duplicate.example.com")]
         return vh_truth
     if config_name == "debian_apache_2_4/multi_vhosts":
@@ -210,27 +216,27 @@ def get_vh_truth(temp_dir, config_name):
             obj.VirtualHost(
                 os.path.join(prefix, "default.conf"),
                 os.path.join(aug_pre, "default.conf/VirtualHost[1]"),
-                {obj.Addr.fromstring("*:80")},
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
                 False, True, "ip-172-30-0-17"),
             obj.VirtualHost(
                 os.path.join(prefix, "default.conf"),
                 os.path.join(aug_pre, "default.conf/VirtualHost[2]"),
-                {obj.Addr.fromstring("*:80")},
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
                 False, True, "banana.vomit.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/VirtualHost[1]"),
-                {obj.Addr.fromstring("*:80")},
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
                 False, True, "1.multi.vhost.tld"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/IfModule/VirtualHost"),
-                {obj.Addr.fromstring("*:80")},
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
                 False, True, "2.multi.vhost.tld"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/VirtualHost[2]"),
-                {obj.Addr.fromstring("*:80")},
+                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
                 False, True, "3.multi.vhost.tld")]
         return vh_truth
     return None  # pragma: no cover

--- a/certbot-apache/certbot_apache/_internal/tests/util.py
+++ b/certbot-apache/certbot_apache/_internal/tests/util.py
@@ -1,6 +1,5 @@
 """Common utilities for certbot_apache."""
 import shutil
-from typing import cast
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -141,71 +140,71 @@ def get_vh_truth(temp_dir: str, config_name: str) -> Optional[List[obj.VirtualHo
             obj.VirtualHost(
                 os.path.join(prefix, "encryption-example.conf"),
                 os.path.join(aug_pre, "encryption-example.conf/Virtualhost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
+                {obj.Addr, obj.Addr.fromstring("*:80")},
                 False, True, "encryption-example.demo"),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl.conf"),
                 os.path.join(aug_pre,
                              "default-ssl.conf/IfModule/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("_default_:443"))}, True, True),
+                {obj.Addr, obj.Addr.fromstring("_default_:443")}, True, True),
             obj.VirtualHost(
                 os.path.join(prefix, "000-default.conf"),
                 os.path.join(aug_pre, "000-default.conf/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80")),
-                     cast(obj.Addr, obj.Addr.fromstring("[::]:80"))},
+                {obj.Addr, obj.Addr.fromstring("*:80"),
+                     obj.Addr, obj.Addr.fromstring("[::]:80")},
                 False, True, "ip-172-30-0-17"),
             obj.VirtualHost(
                 os.path.join(prefix, "certbot.conf"),
                 os.path.join(aug_pre, "certbot.conf/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
+                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
                 "certbot.demo", aliases={"www.certbot.demo"}),
             obj.VirtualHost(
                 os.path.join(prefix, "mod_macro-example.conf"),
                 os.path.join(aug_pre,
                              "mod_macro-example.conf/Macro/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
+                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
                 modmacro=True),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl-port-only.conf"),
                 os.path.join(aug_pre, ("default-ssl-port-only.conf/"
                                        "IfModule/VirtualHost")),
-                {cast(obj.Addr, obj.Addr.fromstring("_default_:443"))}, True, True),
+                {obj.Addr, obj.Addr.fromstring("_default_:443")}, True, True),
             obj.VirtualHost(
                 os.path.join(prefix, "wildcard.conf"),
                 os.path.join(aug_pre, "wildcard.conf/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
+                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
                 "ip-172-30-0-17", aliases={"*.blue.purple.com"}),
             obj.VirtualHost(
                 os.path.join(prefix, "ocsp-ssl.conf"),
                 os.path.join(aug_pre, "ocsp-ssl.conf/IfModule/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("10.2.3.4:443"))}, True, True,
+                {obj.Addr, obj.Addr.fromstring("10.2.3.4:443")}, True, True,
                 "ocspvhost.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "non-symlink.conf"),
                 os.path.join(aug_pre, "non-symlink.conf/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
+                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
                 "nonsym.link"),
             obj.VirtualHost(
                 os.path.join(prefix, "default-ssl-port-only.conf"),
                 os.path.join(aug_pre,
                              "default-ssl-port-only.conf/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, True, True, ""),
+                {obj.Addr, obj.Addr.fromstring("*:80")}, True, True, ""),
             obj.VirtualHost(
                 os.path.join(temp_dir, config_name,
                              "apache2/apache2.conf"),
                 "/files" + os.path.join(temp_dir, config_name,
                                         "apache2/apache2.conf/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))}, False, True,
+                {obj.Addr, obj.Addr.fromstring("*:80")}, False, True,
                 "vhost.in.rootconf"),
             obj.VirtualHost(
                 os.path.join(prefix, "duplicatehttp.conf"),
                 os.path.join(aug_pre, "duplicatehttp.conf/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("10.2.3.4:80"))}, False, True,
+                {obj.Addr, obj.Addr.fromstring("10.2.3.4:80")}, False, True,
                 "duplicate.example.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "duplicatehttps.conf"),
                 os.path.join(aug_pre, "duplicatehttps.conf/IfModule/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("10.2.3.4:443"))}, True, True,
+                {obj.Addr, obj.Addr.fromstring("10.2.3.4:443")}, True, True,
                 "duplicate.example.com")]
         return vh_truth
     if config_name == "debian_apache_2_4/multi_vhosts":
@@ -216,27 +215,27 @@ def get_vh_truth(temp_dir: str, config_name: str) -> Optional[List[obj.VirtualHo
             obj.VirtualHost(
                 os.path.join(prefix, "default.conf"),
                 os.path.join(aug_pre, "default.conf/VirtualHost[1]"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
+                {obj.Addr, obj.Addr.fromstring("*:80")},
                 False, True, "ip-172-30-0-17"),
             obj.VirtualHost(
                 os.path.join(prefix, "default.conf"),
                 os.path.join(aug_pre, "default.conf/VirtualHost[2]"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
+                {obj.Addr, obj.Addr.fromstring("*:80")},
                 False, True, "banana.vomit.com"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/VirtualHost[1]"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
+                {obj.Addr, obj.Addr.fromstring("*:80")},
                 False, True, "1.multi.vhost.tld"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/IfModule/VirtualHost"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
+                {obj.Addr, obj.Addr.fromstring("*:80")},
                 False, True, "2.multi.vhost.tld"),
             obj.VirtualHost(
                 os.path.join(prefix, "multi-vhost.conf"),
                 os.path.join(aug_pre, "multi-vhost.conf/VirtualHost[2]"),
-                {cast(obj.Addr, obj.Addr.fromstring("*:80"))},
+                {obj.Addr, obj.Addr.fromstring("*:80")},
                 False, True, "3.multi.vhost.tld")]
         return vh_truth
     return None  # pragma: no cover


### PR DESCRIPTION
We could also leave the `jose.JWKRSA` call as-is and add `--implicit-reexport`, or explicitly export `JWKRSA` in `josepy`, but I think just cleaning the calls up is nice.

```
$ mypy --strict certbot-apache/certbot_apache/_internal/tests/util.py
Success: no issues found in 1 source file
```

I decided to just do this one file at a time to make reviewing easier, but I could also do it in bigger chunks if reviewers prefer. Why did I start here? Well, it was at the bottom of the giant list of mypy errors and I didn't want to scroll.