### PR TITLE
[apache] Add type hints to apache dualparser.py (to enable mypy --strict)

### DIFF
--- a/certbot-apache/certbot_apache/_internal/dualparser.py
+++ b/certbot-apache/certbot_apache/_internal/dualparser.py
@@ -6,7 +6,6 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
-from typing import Type
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
@@ -21,7 +20,8 @@ if TYPE_CHECKING:
 
 GenericAugeasParserNode = TypeVar("GenericAugeasParserNode", bound="AugeasParserNode")
 GenericApacheParserNode = TypeVar("GenericApacheParserNode", bound="ApacheParserNode")
-GenericDualNode = TypeVar("GenericDualNode", bound="DualNodeBase")
+# Circular imports needs Any, see https://github.com/python/mypy/issues/11910
+GenericDualNode = TypeVar("GenericDualNode", bound="DualNodeBase[Any, Any]")
 
 
 class DualNodeBase(Generic[GenericAugeasParserNode, GenericApacheParserNode]):
@@ -53,11 +53,11 @@ class DualNodeBase(Generic[GenericAugeasParserNode, GenericApacheParserNode]):
             assertions.assertEqualSimple(firstval, secondval)
         return firstval
 
-    def find_ancestors(self, name: str) -> List["DualNodeBase"]:
+    def find_ancestors(self, name: str) -> List["DualBlockNode"]:
         """ Traverses the ancestor tree and returns ancestors matching name """
         return self._find_helper(DualBlockNode, "find_ancestors", name)
 
-    def _find_helper(self, nodeclass: Type[GenericDualNode], findfunc: str, search: str,
+    def _find_helper(self, nodeclass: type[GenericDualNode], findfunc: str, search: str,
                      **kwargs: Any) -> List[GenericDualNode]:
         """A helper for find_* functions. The function specific attributes should
         be passed as keyword arguments.


### PR DESCRIPTION
`typing.Type` is deprecated in favor of built-in `type`. In strict mode,`find_ancestors` needs to be more specific about what it actually returns, due to covariance and generics and such.

```
$ mypy --strict certbot-apache/certbot_apache/_internal/dualparser.py 
Success: no issues found in 1 source file
```