### PR TITLE
[apache] Add type hints to apache obj and http_01 for mypy --strict

### DIFF
--- a/certbot-apache/certbot_apache/_internal/http_01.py
+++ b/certbot-apache/certbot_apache/_internal/http_01.py
@@ -172,6 +172,7 @@ class ApacheHttp01(common.ChallengePerformer):
 
     def _set_up_challenge(self, achall: KeyAuthorizationAnnotatedChallenge
                           ) -> KeyAuthorizationChallengeResponse:
+        response: KeyAuthorizationChallengeResponse
         response, validation = achall.response_and_validation()
 
         name: str = os.path.join(self.challenge_dir, achall.chall.encode("token"))

--- a/certbot-apache/certbot_apache/_internal/obj.py
+++ b/certbot-apache/certbot_apache/_internal/obj.py
@@ -3,7 +3,6 @@ import re
 from typing import Any
 from typing import Iterable
 from typing import Optional
-from typing import Pattern
 from typing import Set
 from typing import Union
 
@@ -126,7 +125,7 @@ class VirtualHost:
 
     """
     # ?: is used for not returning enclosed characters
-    strip_name: Pattern = re.compile(r"^(?:.+://)?([^ :$]*)")
+    strip_name: re.Pattern[str] = re.compile(r"^(?:.+://)?([^ :$]*)")
 
     def __init__(self, filepath: str, path: str, addrs: Set["Addr"], ssl: bool,
                  enabled: bool, name: Optional[str] = None, aliases: Optional[Set[str]] = None,

--- a/certbot/certbot/achallenges.py
+++ b/certbot/certbot/achallenges.py
@@ -19,6 +19,7 @@ Note, that all annotated challenges act as a proxy objects::
 """
 import logging
 from typing import Any
+from typing import Tuple
 from typing import Type
 
 import josepy as jose
@@ -49,7 +50,8 @@ class KeyAuthorizationAnnotatedChallenge(AnnotatedChallenge):
     """Client annotated `KeyAuthorizationChallenge` challenge."""
     __slots__ = ('challb', 'domain', 'account_key') # pylint: disable=redefined-slots-in-subclass
 
-    def response_and_validation(self, *args: Any, **kwargs: Any) -> Any:
+    def response_and_validation(self, *args: Any, **kwargs: Any
+        ) -> Tuple['challenges.KeyAuthorizationChallengeResponse', Any]:
         """Generate response and validation."""
         return self.challb.chall.response_and_validation(
             self.account_key, *args, **kwargs)


### PR DESCRIPTION
```
$ mypy --strict certbot-apache/certbot_apache/_internal/http_01.py 
Success: no issues found in 1 source file
$ mypy --strict certbot-apache/certbot_apache/_internal/obj.py 
Success: no issues found in 1 source file
```

PEP 526 says to declare types of unpacked tuples beforehand: https://peps.python.org/pep-0526/#global-and-local-variable-annotations. Could have just declared it in apache, but improved the acme return type while I was at it.

Once again, `typing.Pattern` is deprecated in favor of `re.Pattern` so changing that while parametrizing the type