### PR TITLE
[apache] Add type hints to apache configurator for mypy --strict

### DIFF
--- a/certbot-apache/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/certbot_apache/_internal/configurator.py
@@ -271,10 +271,10 @@ class ApacheConfigurator(common.Configurator):
         self.parser: parser.ApacheParser
         self.parser_root: Optional[dualparser.DualBlockNode] = None
         self.version = version
-        self._openssl_version = openssl_version
+        self._openssl_version: Optional[str] = openssl_version
         self.vhosts: List[obj.VirtualHost]
         self.options = copy.deepcopy(self.OS_DEFAULTS)
-        self._enhance_func: Dict[str, Callable] = {
+        self._enhance_func: Dict[str, Callable[[obj.VirtualHost, Any], None]] = {
             "redirect": self._enable_redirect,
             "ensure-http-header": self._set_http_header,
             "staple-ocsp": self._enable_ocsp_stapling,
@@ -599,7 +599,7 @@ class ApacheConfigurator(common.Configurator):
         """Prompts user to choose vhosts to install a wildcard certificate for"""
 
         # Get all vhosts that are covered by the wildcard domain
-        vhosts: List = self._vhosts_for_wildcard(domain)
+        vhosts: List[obj.VirtualHost] = self._vhosts_for_wildcard(domain)
 
         # Go through the vhosts, making sure that we cover all the names
         # present, but preferring the SSL vhosts


### PR DESCRIPTION
I don't love the `Any` in that `Callable`, but I can't find a way to fix it. In practice, it's either going to be `str` or `None`, but we pass an `options` that's typed as `List[str] | str | None`, and one of the functions has a header with a strict `str`. I tried various unions of things and it wasn't working and I decided it's not worth it.