### PR TITLE
[nginx] Add type hints to nginx configurator for mypy --strict

### DIFF
--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -21,6 +21,7 @@ from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import Union
+from typing import cast
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -475,9 +476,9 @@ class NginxConfigurator(common.Configurator):
             # Wildcard match - need to find the longest one
             rank = matches[0]['rank']
             wildcards = [x for x in matches if x['rank'] == rank]
-            return max(wildcards, key=lambda x: len(x['name']))['vhost']
+            return cast(obj.VirtualHost, max(wildcards, key=lambda x: len(x['name']))['vhost'])
         # Exact or regex match
-        return matches[0]['vhost']
+        return cast(obj.VirtualHost, matches[0]['vhost'])
 
     def _rank_matches_by_name(self, vhost_list: Iterable[obj.VirtualHost],
                               target_name: str) -> List[Dict[str, Any]]:
@@ -1094,7 +1095,7 @@ class NginxConfigurator(common.Configurator):
         """
         text = self._nginx_version()
 
-        matches = re.findall(r"running with OpenSSL ([^ ]+) ", text)
+        matches: List[str] = re.findall(r"running with OpenSSL ([^ ]+) ", text)
         if not matches:
             matches = re.findall(r"built with OpenSSL ([^ ]+) ", text)
             if not matches:


### PR DESCRIPTION
Decided that imports should be in ascii, not caseless, order. If we've done otherwise elsewhere I'll change it.

The cast isn't the best but that's what we get for using a dict holding various objects -- the thing marked by `vhost` is going to be a virtualhost so 🤷

`re.findall` can [return](https://docs.python.org/3/library/re.html#re.findall) either a list of strings or a list of tuples of strings, depending what you specify in the regex. In our case it's going to be a list of strings.