### PR TITLE
Enable strict typing in certbot-dns-cloudflare

### DIFF
--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/dns_cloudflare.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/dns_cloudflare.py
@@ -5,6 +5,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import cast
 
 import CloudFlare
 
@@ -220,7 +221,7 @@ class _CloudflareClient:
                                  'Continuing with next zone guess...', e, e)
 
             if zones:
-                zone_id = zones[0]['id']
+                zone_id: str = zones[0]['id']
                 logger.debug('Found zone_id of %s for %s using name %s', zone_id, domain, zone_name)
                 return zone_id
 
@@ -267,6 +268,6 @@ class _CloudflareClient:
         if records:
             # Cleanup is returning the system to the state we found it. If, for some reason,
             # there are multiple matching records, we only delete one because we only added one.
-            return records[0]['id']
+            return cast(str, records[0]['id'])
         logger.debug('Unable to find TXT record.')
         return None

--- a/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/tests/dns_cloudflare_test.py
+++ b/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/tests/dns_cloudflare_test.py
@@ -38,7 +38,9 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
         self.mock_client = mock.MagicMock()
         # _get_cloudflare_client | pylint: disable=protected-access
-        self.auth._get_cloudflare_client = mock.MagicMock(return_value=self.mock_client)
+        # workaround for wont-fix https://github.com/python/mypy/issues/2427 that works with
+        # both strict and non-strict mypy
+        setattr(self.auth, '_get_cloudflare_client', mock.MagicMock(return_value=self.mock_client))
 
     @test_util.patch_display_util()
     def test_perform(self, unused_mock_get_utility):


### PR DESCRIPTION
```
$ mypy --strict certbot-dns-cloudflare/certbot_dns_cloudflare
Success: no issues found in 5 source files
```

If we do `type: ignore` but don't set `--strict`, mypy gets mad. Flake8 doesn't like this but luckily we don't use that here (yet?). The other option is to add `# type: ignore [method-assign, unused-ignore]`; I can change it to that if that's preferred.