### PR TITLE
Enable strict typing in certbot-dns-digitalocean

### DIFF
--- a/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/tests/dns_digitalocean_test.py
+++ b/certbot-dns-digitalocean/certbot_dns_digitalocean/_internal/tests/dns_digitalocean_test.py
@@ -34,7 +34,10 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
         self.mock_client = mock.MagicMock()
         # _get_digitalocean_client | pylint: disable=protected-access
-        self.auth._get_digitalocean_client = mock.MagicMock(return_value=self.mock_client)
+        # workaround for wont-fix https://github.com/python/mypy/issues/2427 that works with
+        # both strict and non-strict mypy
+        setattr(self.auth, '_get_digitalocean_client',
+            mock.MagicMock(return_value=self.mock_client))
 
     @test_util.patch_display_util()
     def test_perform(self, unused_mock_get_utility):


### PR DESCRIPTION
If we do `type: ignore` but don't set `--strict`, mypy gets mad. Flake8 doesn't like this but luckily we don't use that here (yet?). The other option is to add `# type: ignore [method-assign, unused-ignore]`; I can change it to that if that's preferred.

```
$ mypy --strict certbot-dns-digitalocean/certbot_dns_digitalocean
Success: no issues found in 5 source files
```