### PR TITLE
Enable strict mypy for certbot-ci/certbot_integration_tests

### DIFF
--- a/certbot-ci/certbot_integration_tests/nginx_tests/context.py
+++ b/certbot-ci/certbot_integration_tests/nginx_tests/context.py
@@ -49,7 +49,7 @@ class IntegrationTestsContext(certbot_context.IntegrationTestsContext):
             command, self.directory_url, self.http_01_port, self.tls_alpn_01_port,
             self.config_dir, self.workspace, force_renew=True)
 
-    def _start_nginx(self, default_server: bool) -> subprocess.Popen:
+    def _start_nginx(self, default_server: bool) -> subprocess.Popen[bytes]:
         self.nginx_config = config.construct_nginx_config(
             self.nginx_root, self.webroot, self.http_01_port, self.tls_alpn_01_port,
             self.other_port, default_server, wtf_prefix=self.worker_id)

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -55,7 +55,7 @@ class ACMEServer:
 
         self._proxy = http_proxy
         self._workspace = tempfile.mkdtemp()
-        self._processes: List[subprocess.Popen] = []
+        self._processes: List[subprocess.Popen[bytes]] = []
         self._stdout = sys.stdout if stdout else open(os.devnull, 'w') # pylint: disable=consider-using-with
         self._dns_server = dns_server
         self._http_01_port = DEFAULT_HTTP_01_PORT
@@ -165,7 +165,7 @@ class ACMEServer:
 
     def _launch_process(self, command: List[str], cwd: str = os.getcwd(),
                         env: Optional[Mapping[str, str]] = None,
-                        force_stderr: bool = False) -> subprocess.Popen:
+                        force_stderr: bool = False) -> subprocess.Popen[bytes]:
         """Launch silently a subprocess OS command"""
         if not env:
             env = os.environ

--- a/certbot-ci/certbot_integration_tests/utils/dns_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/dns_server.py
@@ -45,7 +45,7 @@ class DNSServer:
 
         self.bind_root = tempfile.mkdtemp()
 
-        self.process: Optional[subprocess.Popen] = None
+        self.process: Optional[subprocess.Popen[bytes]] = None
 
         self.dns_xdist = {"address": BIND_BIND_ADDRESS[0], "port": BIND_BIND_ADDRESS[1]}
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ pytest = python -m pytest {posargs}
 # Paths are listed on one line because tox seems to have inconsistent
 # behavior with substitutions that contain line continuations, see
 # https://github.com/tox-dev/tox/issues/2069 for more info.
-source_paths = acme/acme certbot/certbot certbot-apache/certbot_apache certbot-ci/certbot_integration_tests certbot-ci/snap_integration_tests certbot-compatibility-test/certbot_compatibility_test certbot-dns-cloudflare/certbot_dns_cloudflare certbot-dns-digitalocean/certbot_dns_digitalocean certbot-dns-dnsimple/certbot_dns_dnsimple certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy certbot-dns-gehirn/certbot_dns_gehirn certbot-dns-google/certbot_dns_google certbot-dns-linode/certbot_dns_linode certbot-dns-luadns/certbot_dns_luadns certbot-dns-nsone/certbot_dns_nsone certbot-dns-ovh/certbot_dns_ovh certbot-dns-rfc2136/certbot_dns_rfc2136 certbot-dns-route53/certbot_dns_route53 certbot-dns-sakuracloud/certbot_dns_sakuracloud certbot-nginx/certbot_nginx
+mypy_strict_source_paths = certbot-ci/snap_integration_tests certbot-dns-cloudflare/certbot_dns_cloudflare certbot-dns-digitalocean/certbot_dns_digitalocean certbot-dns-dnsimple/certbot_dns_dnsimple certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy certbot-dns-gehirn/certbot_dns_gehirn certbot-dns-google/certbot_dns_google certbot-dns-linode/certbot_dns_linode certbot-dns-luadns/certbot_dns_luadns certbot-dns-nsone/certbot_dns_nsone certbot-dns-ovh/certbot_dns_ovh certbot-dns-rfc2136/certbot_dns_rfc2136 certbot-dns-route53/certbot_dns_route53 certbot-dns-sakuracloud/certbot_dns_sakuracloud
+mypy_no_strict_source_paths = acme/acme certbot/certbot certbot-apache/certbot_apache certbot-ci/certbot_integration_tests certbot-compatibility-test/certbot_compatibility_test certbot-nginx/certbot_nginx
+source_paths = {[base]mypy_strict_source_paths} {[base]mypy_no_strict_source_paths}
 
 [testenv]
 platform =
@@ -102,7 +104,9 @@ commands = python -m pylint --reports=n --rcfile=.pylintrc {[base]source_paths}
 deps =
     {[testenv]deps}
     -e certbot-ci
-commands = mypy {[base]source_paths} --strict-equality
+commands =
+    mypy {[base]mypy_no_strict_source_paths} --strict-equality
+    mypy {[base]mypy_strict_source_paths} --strict-equality --strict
 
 [testenv:isolated-acme]
 description = Tests acme without any Certbot components installed

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ pytest = python -m pytest {posargs}
 # Paths are listed on one line because tox seems to have inconsistent
 # behavior with substitutions that contain line continuations, see
 # https://github.com/tox-dev/tox/issues/2069 for more info.
-mypy_strict_source_paths = certbot-ci/snap_integration_tests certbot-dns-cloudflare/certbot_dns_cloudflare certbot-dns-digitalocean/certbot_dns_digitalocean certbot-dns-dnsimple/certbot_dns_dnsimple certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy certbot-dns-gehirn/certbot_dns_gehirn certbot-dns-google/certbot_dns_google certbot-dns-linode/certbot_dns_linode certbot-dns-luadns/certbot_dns_luadns certbot-dns-nsone/certbot_dns_nsone certbot-dns-ovh/certbot_dns_ovh certbot-dns-rfc2136/certbot_dns_rfc2136 certbot-dns-route53/certbot_dns_route53 certbot-dns-sakuracloud/certbot_dns_sakuracloud
-mypy_no_strict_source_paths = acme/acme certbot/certbot certbot-apache/certbot_apache certbot-ci/certbot_integration_tests certbot-compatibility-test/certbot_compatibility_test certbot-nginx/certbot_nginx
+mypy_strict_source_paths = certbot-ci/certbot_integration_tests certbot-ci/snap_integration_tests certbot-dns-cloudflare/certbot_dns_cloudflare certbot-dns-digitalocean/certbot_dns_digitalocean certbot-dns-dnsimple/certbot_dns_dnsimple certbot-dns-dnsmadeeasy/certbot_dns_dnsmadeeasy certbot-dns-gehirn/certbot_dns_gehirn certbot-dns-google/certbot_dns_google certbot-dns-linode/certbot_dns_linode certbot-dns-luadns/certbot_dns_luadns certbot-dns-nsone/certbot_dns_nsone certbot-dns-ovh/certbot_dns_ovh certbot-dns-rfc2136/certbot_dns_rfc2136 certbot-dns-route53/certbot_dns_route53 certbot-dns-sakuracloud/certbot_dns_sakuracloud
+mypy_no_strict_source_paths = acme/acme certbot/certbot certbot-apache/certbot_apache certbot-compatibility-test/certbot_compatibility_test certbot-nginx/certbot_nginx
 source_paths = {[base]mypy_strict_source_paths} {[base]mypy_no_strict_source_paths}
 
 [testenv]


### PR DESCRIPTION
This PR is based on https://github.com/certbot/certbot/pull/10166 so that the module can immediately added to the strict section; that one should ideally by reviewed and merged first for a cleaner commit history.