### PR TITLE
[REPO] Modify Stalebot Labels for Better Filters

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,10 @@ jobs:
           exempt-all-issue-assignees: true
 
           # Label to use when marking as stale
-          stale-issue-label: needs-update
+          stale-issue-label: stale-needs-update
+
+          # Label to use when issue is automatically closed
+          close-issue-label: auto-closed
 
           stale-issue-message: >
             We've made a lot of changes to Certbot since this issue was opened. If you


### PR DESCRIPTION
- Better labels upon an issue going stale will help triage better. There other PRs with "needs update" that are manually put and therefore we can't explicitly filter for stalebot.
- For management purposes, being able to view how many issues are auto-closed helps as well.