### PR TITLE
Avoid trailing dot on link problem

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -18,6 +18,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Add `make_self_signed_cert` to `acme.crypto_util` to replace `gen_ss_cert.
 * Directory hooks are now run on all commands by default, not just `renew`
 * Help output now shows `False` as default when it can be set via `cli.ini` instead of `None`
+* Changed terms of service agreement text to have a newline after the TOS link
 
 ### Fixed
 

--- a/certbot/certbot/_internal/main.py
+++ b/certbot/certbot/_internal/main.py
@@ -709,8 +709,8 @@ def _determine_account(config: configuration.NamespaceConfig
     def _tos_cb(terms_of_service: str) -> None:
         if config.tos:
             return
-        msg = ("Please read the Terms of Service at {0}. You "
-               "must agree in order to register with the ACME "
+        msg = ("Please read the Terms of Service at: {0}\n"
+               "You must agree in order to register with the ACME "
                "server. Do you agree?".format(terms_of_service))
         result = display_util.yesno(msg, cli_flag="--agree-tos", force_interactive=True)
         if not result:


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/9964.

Decided not to be fancy and just throw a newline in there.

```
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Please read the Terms of Service at:
https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf
You must agree in order to register with the ACME server. Do you agree?
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
(Y)es/(N)o: 
```