### PR TITLE
fix mypy on 3.9

### DIFF
--- a/certbot-dns-google/certbot_dns_google/_internal/tests/dns_google_test.py
+++ b/certbot-dns-google/certbot_dns_google/_internal/tests/dns_google_test.py
@@ -1,5 +1,5 @@
 """Tests for certbot_dns_google._internal.dns_google."""
-
+from __future__ import annotations
 import sys
 from typing import Optional
 from typing import Tuple


### PR DESCRIPTION
in https://github.com/certbot/certbot/pull/10160/files#diff-f14c5058a01d9c9f8e0215ae6378c1d99fcfe2dd71d5cea207a7d610b31c149bR123 we used the nice & clean `|` syntax for unions but this caused tests to fail for me locally where i was using python 3.9. this fixes that using the same approach as was used in https://github.com/certbot/certbot/pull/10178

i think we want this regardless, but by the same logic as https://github.com/certbot/certbot/commit/a00e34345993f0724a05cc2dd0f6e8ea6a4299a5, i think we could consider deprecating & dropping python 3.9 support early