### PR TITLE
Be consistent with checking capitalization in rfc2136 plugin

### DIFF
--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/dns_rfc2136.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/dns_rfc2136.py
@@ -91,12 +91,13 @@ class Authenticator(dns_common.DNSAuthenticator):
         if not self.credentials:  # pragma: no cover
             raise errors.Error("Plugin has not been prepared.")
 
+        algorithm: str = (self.credentials.conf('algorithm') or '').upper()
+
         return _RFC2136Client(cast(str, self.credentials.conf('server')),
                               int(cast(str, self.credentials.conf('port')) or self.PORT),
                               cast(str, self.credentials.conf('name')),
                               cast(str, self.credentials.conf('secret')),
-                              self.ALGORITHMS.get(self.credentials.conf('algorithm') or '',
-                                                  dns.tsig.HMAC_MD5),
+                              self.ALGORITHMS.get(algorithm, dns.tsig.HMAC_MD5),
                               (self.credentials.conf('sign_query') or '').upper() == "TRUE")
 
 

--- a/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py
+++ b/certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py
@@ -79,12 +79,17 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
             self.auth.perform([self.achall])
 
     @test_util.patch_display_util()
-    def test_valid_algorithm_passes(self, unused_mock_get_utility):
+    @mock.patch('certbot_dns_rfc2136._internal.dns_rfc2136._RFC2136Client')
+    def test_valid_algorithm_passes(self, client, unused_mock_get_utility):
+        from certbot_dns_rfc2136._internal.dns_rfc2136 import Authenticator
+
         config = VALID_CONFIG.copy()
         config["rfc2136_algorithm"] = "HMAC-sha512"
         dns_test_common.write(config, self.config.rfc2136_credentials)
+        self.auth = Authenticator(self.config, "rfc2136")
 
         self.auth.perform([self.achall])
+        assert dns.tsig.HMAC_SHA512 in client.call_args.args
 
     def test_invalid_server_raises(self):
         config = VALID_CONFIG.copy()


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/10177.

Thanks for catching this @JulienPalard.

We were using `.upper()` when validating the config but not when actually creating the object. Now we call it in both places. I updated a test to work as a regression test here.

It fails before the change:
```Python
certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py ........F..............

==================================================================================== FAILURES =====================================================================================
__________________________________________________________________ AuthenticatorTest.test_valid_algorithm_passes __________________________________________________________________

self = <certbot_dns_rfc2136._internal.tests.dns_rfc2136_test.AuthenticatorTest testMethod=test_valid_algorithm_passes>, client = <MagicMock name='_RFC2136Client' id='4344931360'>
unused_mock_get_utility = <certbot.tests.util.FreezableMock object at 0x102fac260>

    @test_util.patch_display_util()
    @mock.patch('certbot_dns_rfc2136._internal.dns_rfc2136._RFC2136Client')
    def test_valid_algorithm_passes(self, client, unused_mock_get_utility):
        from certbot_dns_rfc2136._internal.dns_rfc2136 import Authenticator
    
        config = VALID_CONFIG.copy()
        config["rfc2136_algorithm"] = "HMAC-sha512"
        dns_test_common.write(config, self.config.rfc2136_credentials)
        self.auth = Authenticator(self.config, "rfc2136")
    
        self.auth.perform([self.achall])
>       assert dns.tsig.HMAC_SHA512 in client.call_args.args
E       AssertionError: assert <DNS name hmac-sha512.> in ('192.0.2.1', 53, 'a-tsig-key.', 'SSB3b25kZXIgd2hvIHdpbGwgYm90aGVyIHRvIGRlY29kZSB0aGlzIHRleHQK', <DNS name HMAC-MD5.SIG-ALG.REG.INT.>, False)
E        +  where <DNS name hmac-sha512.> = <module 'dns.tsig' from '/Users/erica/certbot/venv/lib/python3.12/site-packages/dns/tsig.py'>.HMAC_SHA512
E        +    where <module 'dns.tsig' from '/Users/erica/certbot/venv/lib/python3.12/site-packages/dns/tsig.py'> = dns.tsig
E        +  and   ('192.0.2.1', 53, 'a-tsig-key.', 'SSB3b25kZXIgd2hvIHdpbGwgYm90aGVyIHRvIGRlY29kZSB0aGlzIHRleHQK', <DNS name HMAC-MD5.SIG-ALG.REG.INT.>, False) = call('192.0.2.1', 53, 'a-tsig-key.', 'SSB3b25kZXIgd2hvIHdpbGwgYm90aGVyIHRvIGRlY29kZSB0aGlzIHRleHQK', <DNS name HMAC-MD5.SIG-ALG.REG.INT.>, False).args
E        +    where call('192.0.2.1', 53, 'a-tsig-key.', 'SSB3b25kZXIgd2hvIHdpbGwgYm90aGVyIHRvIGRlY29kZSB0aGlzIHRleHQK', <DNS name HMAC-MD5.SIG-ALG.REG.INT.>, False) = <MagicMock name='_RFC2136Client' id='4344931360'>.call_args

certbot-dns-rfc2136/certbot_dns_rfc2136/_internal/tests/dns_rfc2136_test.py:92: AssertionError
```

And passes after (all tests passing in tox).