### PR TITLE
Nginx plugin proposal

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,6 +17,7 @@ Authors
 * [Alex Halderman](https://github.com/jhalderm)
 * [Alex Jordan](https://github.com/strugee)
 * [Alex Zorin](https://github.com/alexzorin)
+* [Alexey Vesnin](https://github.com/netsafe)
 * [Alexis Hancock](https://github.com/zoracon)
 * [Amir Omidi](https://github.com/aaomidi)
 * [Amjad Mashaal](https://github.com/TheNavigat)

--- a/certbot-nginx/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/certbot_nginx/_internal/configurator.py
@@ -1053,7 +1053,7 @@ class NginxConfigurator(common.Configurator):
                 universal_newlines=True,
                 check=False,
                 env=util.env_no_snap_for_external_calls())
-            text = proc.stderr  # nginx prints output to stderr
+            text = proc.stdout + proc.stderr  # nginx prints output to stderr
         except (OSError, ValueError) as error:
             logger.debug(str(error), exc_info=True)
             raise errors.PluginError(


### PR DESCRIPTION
The NginX process writes it's version output to stderr, but if it's wrapped in a script - like interacting with the Docker container like this:

```
# cat /usr/sbin/nginx
#!/bin/bash

/usr/bin/docker exec -it nginx $0 $@
```

then all the stuff goes to stdout, and a locally installed certbot is issuing an error 

     The error was: PluginError('Unable to find Nginx version')

so this tiny patch fixes things up and expands the integration ability of Certbot out of the box