### PR TITLE
Update url for moved image to fix readthedocs build

### DIFF
--- a/certbot/README.rst
+++ b/certbot/README.rst
@@ -6,7 +6,7 @@
    :target: https://dev.azure.com/certbot/certbot/_build?definitionId=5
    :alt: Azure Pipelines CI status
 
-.. image:: https://raw.githubusercontent.com/EFForg/design/master/logos/eff-certbot-lockup.png
+.. image:: https://raw.githubusercontent.com/EFForg/design/master/logos/certbot/eff-certbot-lockup.png
   :width: 200
   :alt: EFF Certbot Logo
 


### PR DESCRIPTION
https://readthedocs.org/projects/eff-certbot/builds/27298576/ was failing with `WARNING: Could not fetch remote image: https://raw.githubusercontent.com/EFForg/design/master/logos/eff-certbot-lockup.png [404]`

This is because the file was moved to https://raw.githubusercontent.com/EFForg/design/master/logos/certbot/eff-certbot-lockup.png as you can see here: https://github.com/EFForg/design/tree/master/logos/certbot