### PR TITLE
Improve instructions for updating github releases token

### DIFF
--- a/.azure-pipelines/templates/stages/release-deploy-stage.yml
+++ b/.azure-pipelines/templates/stages/release-deploy-stage.yml
@@ -15,22 +15,11 @@ stages:
         - task: GitHubRelease@1
           inputs:
             # this "github-releases" credential is what azure pipelines calls a
-            # "service connection". it was created using the instructions at
-            # https://learn.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#github-service-connection
-            # with a fine-grained personal access token from github to limit
-            # the permissions given to azure pipelines. the connection on azure
-            # needs permissions for the "release" pipeline (and maybe the
-            # "full-test-suite" pipeline to simplify testing it). information
-            # on how to set up these permissions can be found at
-            # https://learn.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#secure-a-service-connection.
-            # the github token that is used needs "contents:write" and
-            # "workflows:write" permissions for the certbot repo
+            # "service connection". it needs to be recreated annually. instructions
+            # to do so and further information about the token are available at
+            # https://github.com/EFForg/certbot-misc/wiki/Azure-Pipelines-setup#regenerating-github-release-credentials-for-use-on-azure
             #
-            # as of writing this, the current token will expire on 3/15/2025.
-            # when recreating it, you may also want to create it using the
-            # shared "certbotbot" github account so the credentials aren't tied
-            # to any one dev's github account and their access to the certbot
-            # repo
+            # as of writing this, the current token will expire on Wed, Feb 25 2026.
             gitHubConnection: github-releases
             title: ${{ format('Certbot {0}', replace(variables['Build.SourceBranchName'], 'v', '')) }}
             releaseNotesFilePath: '$(Pipeline.Workspace)/release_notes.md'


### PR DESCRIPTION
The token is now owned by the team account and can simply be regenerated, so we don't need the info about perhaps doing that. Plus, there are now more clear instructions on the wiki. And the date was updated.