### PR TITLE
Use ubuntu 24 to build docker

### DIFF
--- a/.azure-pipelines/templates/jobs/packaging-jobs.yml
+++ b/.azure-pipelines/templates/jobs/packaging-jobs.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: docker_build
     pool:
-      vmImage: ubuntu-22.04
+      vmImage: ubuntu-24.04
     strategy:
       matrix:
         arm32v6:


### PR DESCRIPTION
Maybe addresses https://github.com/certbot/certbot/issues/10020

#10020 claims that without the verbose settings, build fail almost every time. In my one (1) test removing verbosity, it passed, so idk. BUT! It took [56 minutes](https://dev.azure.com/certbot/certbot/_build/results?buildId=8766&view=logs&j=fdd3565a-f3c6-5154-eca9-9ae03666f7bd&t=5dbd9851-46a4-524f-73a8-4028241afcde) instead of [37 on ubuntu 24](https://dev.azure.com/certbot/certbot/_build/results?buildId=8768&view=logs&j=fdd3565a-f3c6-5154-eca9-9ae03666f7bd&t=5dbd9851-46a4-524f-73a8-4028241afcde). Whether or not this actually fixes the underlying problem (still looking into that), that seems worthwhile to speed up.