### PR TITLE
make integration tests crossplatform

### DIFF
--- a/certbot-ci/certbot_integration_tests/conftest.py
+++ b/certbot-ci/certbot_integration_tests/conftest.py
@@ -64,7 +64,6 @@ def _setup_primary_node(config):
     Setup the environment for integration tests.
 
     This function will:
-        - check runtime compatibility (Docker, docker compose, Nginx)
         - create a temporary workspace and the persistent GIT repositories space
         - configure and start a DNS server using Docker, if configured
         - configure and start paralleled ACME CA servers using Docker

--- a/certbot-ci/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/certbot_integration_tests/utils/acme_server.py
@@ -108,8 +108,7 @@ class ACMEServer:
         """Generate and return the acme_xdist dict"""
         acme_xdist: Dict[str, Any] = {}
 
-        # Directory and ACME port are set implicitly in the docker-compose.yml
-        # files of Pebble.
+        # Directory and ACME port are set implicitly in Pebble
         acme_xdist['directory_url'] = PEBBLE_DIRECTORY_URL
         acme_xdist['challtestsrv_url'] = PEBBLE_CHALLTESTSRV_URL
         acme_xdist['http_port'] = dict(zip(nodes, range(5200, 5200 + len(nodes))))

--- a/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
+++ b/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
@@ -34,12 +34,15 @@ def fetch(workspace: str, http_01_port: int = DEFAULT_HTTP_01_PORT) -> Tuple[str
 
 def _fetch_asset(asset: str, assets_path: str) -> str:
     base_url = 'https://github.com/letsencrypt/pebble/releases/download'
-    system = platform.system().lower()  # this will be something like "darwin" or "linux"
-    # we default to arm64 here because ARM can show up as arm64 or aarch64
-    machine = 'amd64' if platform.machine() == 'x86_64' else 'arm64'
-    asset_path = os.path.join(assets_path, f'{asset}_{PEBBLE_VERSION}_{system}_{machine}')
+    os_type = platform.system().lower()  # this will be something like "darwin" or "linux"
+    architecture = platform.machine()
+    if architecture == 'x86_64':
+        architecture = 'amd64'
+    elif architecture == 'aarch64':
+        architecture = 'arm64'
+    asset_path = os.path.join(assets_path, f'{asset}_{PEBBLE_VERSION}_{os_type}_{architecture}')
     if not os.path.exists(asset_path):
-        asset_url = f'{base_url}/{PEBBLE_VERSION}/{asset}-{system}-{machine}.zip'
+        asset_url = f'{base_url}/{PEBBLE_VERSION}/{asset}-{os_type}-{architecture}.zip'
         response = requests.get(asset_url, timeout=30)
         response.raise_for_status()
         asset_data = _unzip_asset(response.content, asset)

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -125,10 +125,6 @@ You can test your code in several ways:
 - running the `automated integration`_ tests
 - running an *ad hoc* `manual integration`_ test
 
-.. note:: Running integration tests does not currently work on macOS. See
-   https://github.com/certbot/certbot/issues/6959. In the meantime, we
-   recommend developers on macOS open a PR to run integration tests.
-
 .. _automated unit:
 
 Running automated unit tests
@@ -164,12 +160,12 @@ Running automated integration tests
 
 Generally it is sufficient to open a pull request and let Github and Azure Pipelines run
 integration tests for you. However, you may want to run them locally before submitting
-your pull request. You need Docker installed and working.
+your pull request.
 
 The tox environment `integration` will setup `Pebble`_, the Let's Encrypt ACME CA server
 for integration testing, then launch the Certbot integration tests.
 
-With a user allowed to access your local Docker daemon, run:
+To do this, run:
 
 .. code-block:: shell
 
@@ -188,13 +184,8 @@ Running manual integration tests
 You can also manually execute Certbot against a local instance of the `Pebble`_ ACME server.
 This is useful to verify that the modifications done to the code makes Certbot behave as expected.
 
-To do so you need:
-
-- Docker installed, and a user with access to the Docker client,
-- an available `local copy`_ of Certbot.
-
-The virtual environment set up with `python tools/venv.py` contains two CLI tools
-that can be used once the virtual environment is activated:
+The virtual environment set up with the `local copy`_ of Certbot contains two
+CLI tools that can be used once the virtual environment is activated:
 
 .. code-block:: shell
 
@@ -221,8 +212,6 @@ using an HTTP-01 challenge on a machine with Python 3:
 
 .. code-block:: shell
 
-    python tools/venv.py
-    source venv/bin/activate
     run_acme_server &
     certbot_test certonly --standalone -d test.example.com
     # To stop Pebble, launch `fg` to get back the background job, then press CTRL+C

--- a/tox.ini
+++ b/tox.ini
@@ -233,7 +233,6 @@ commands =
         --cov-config=certbot-ci/certbot_integration_tests/.coveragerc
     coverage report --include 'certbot/*' --show-missing --fail-under=65
     coverage report --include 'certbot-nginx/*' --show-missing --fail-under=74
-passenv = DOCKER_*
 
 [testenv:integration-certbot]
 deps =
@@ -267,7 +266,6 @@ deps =
     -e certbot-ci
 commands =
     {[base]pytest} certbot-ci/certbot_integration_tests
-passenv = DOCKER_*
 
 [testenv:integration-certbot-oldest]
 deps =
@@ -278,7 +276,6 @@ basepython =
     {[testenv:oldest]basepython}
 commands =
     {[base]pytest} certbot-ci/certbot_integration_tests/certbot_tests
-passenv = DOCKER_*
 setenv = {[testenv:oldest]setenv}
 
 [testenv:integration-nginx-oldest]
@@ -291,7 +288,6 @@ basepython =
     {[testenv:oldest]basepython}
 commands =
     {[base]pytest} certbot-ci/certbot_integration_tests/nginx_tests
-passenv = DOCKER_*
 setenv = {[testenv:oldest]setenv}
 
 [testenv:test-farm-apache2]


### PR DESCRIPTION
i wanted this for testing https://github.com/certbot/certbot/issues/10190

alex started working on this in https://github.com/certbot/certbot/pull/9207 years ago, but pebble didn't end up doing a release containing his work while he was still regularly contributing to certbot. this has now changed though

before this PR, our integration tests only worked on amd64 linux systems. with this PR, i've successfully run our integration tests on all combinations of the architectures amd64 and arm64 and the OSes linux and macos

as part of updating the docs, i noticed we still had a lot of references to docker around our integration tests. when these tests were initially written, we heavily used docker, using it to run both pebble and boulder. this is no longer true though with the only use of docker being in https://github.com/certbot/certbot/blob/487dd53103efd957838dc72124455e9bd7110c39/tox.ini#L249-L262
where the flag --dns-server=bind causes a docker image to be spun up running bind

since this is never done in the normal case nor is this flag or tox environment mentioned in the docs, i removed all references to docker. in the (i suspect very unlikely) event a dev tries running this locally without docker installed, i think the error message isn't so bad and it greatly simplifies things in the most common uses of our integration tests
```
# tox -e integration-dns-rfc2136
integration-dns-rfc2136 create: /root/certbot/.tox/integration-dns-rfc2136
integration-dns-rfc2136 installdeps: -eacme, -ecertbot, -ecertbot-dns-rfc2136, -ecertbot-ci
integration-dns-rfc2136 installed: -e git+https://github.com/certbot/certbot@3f003851b72e12403c7e6831df27cb2674f6e061#egg=acme&subdirectory=acme,-e git+https://github.com/certbot/certbot@3f003851b72e12403c7e6831df27cb2674f6e061#egg=certbot&subdirectory=certbot,-e git+https://github.com/certbot/certbot@3f003851b72e12403c7e6831df27cb2674f6e061#egg=certbot_ci&subdirectory=certbot-ci,-e git+https://github.com/certbot/certbot@3f003851b72e12403c7e6831df27cb2674f6e061#egg=certbot_dns_rfc2136&subdirectory=certbot-dns-rfc2136,certifi==2024.12.14,cffi==1.17.1,charset-normalizer==3.4.1,ConfigArgParse==1.7,configobj==5.0.9,coverage==7.6.10,cryptography==43.0.3,distro==1.9.0,dnspython==2.7.0,exceptiongroup==1.2.2,execnet==2.1.1,idna==3.10,importlib_metadata==8.6.1,iniconfig==2.0.0,josepy==1.15.0,packaging==24.2,parsedatetime==2.6,pluggy==1.5.0,pycparser==2.22,pyOpenSSL==25.0.0,pyRFC3339==2.0.1,pytest==8.3.4,pytest-cov==6.0.0,pytest-xdist==3.6.1,python-dateutil==2.9.0.post0,pytz==2024.2,PyYAML==6.0.2,requests==2.32.3,six==1.17.0,tomli==2.2.1,types-python-dateutil==2.9.0.20241206,typing_extensions==4.12.2,urllib3==1.26.20,zipp==3.21.0
integration-dns-rfc2136 run-test-pre: PYTHONHASHSEED='0'
integration-dns-rfc2136 run-test: commands[0] | python -m pytest certbot-ci/certbot_integration_tests/rfc2136_tests --dns-server=bind --numprocesses=1 --cov=acme --cov=certbot --cov=certbot_dns_rfc2136 --cov-report= --cov-config=certbot-ci/certbot_integration_tests/.coveragerc
DNS xdist config:
{'address': '127.0.0.1', 'port': 45953}
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/root/certbot/.tox/integration-dns-rfc2136/lib/python3.9/site-packages/_pytest/main.py", line 279, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/root/certbot/.tox/integration-dns-rfc2136/lib/python3.9/site-packages/_pytest/config/__init__.py", line 1118, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/root/certbot/.tox/integration-dns-rfc2136/lib/python3.9/site-packages/pluggy/_hooks.py", line 535, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self._hookimpls.copy(), kwargs, False)
INTERNALERROR>   File "/root/certbot/.tox/integration-dns-rfc2136/lib/python3.9/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/root/certbot/.tox/integration-dns-rfc2136/lib/python3.9/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
INTERNALERROR>   File "/root/certbot/.tox/integration-dns-rfc2136/lib/python3.9/site-packages/pluggy/_callers.py", line 103, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/root/certbot/certbot-ci/certbot_integration_tests/conftest.py", line 35, in pytest_configure
INTERNALERROR>     _setup_primary_node(config)
INTERNALERROR>   File "/root/certbot/certbot-ci/certbot_integration_tests/conftest.py", line 89, in _setup_primary_node
INTERNALERROR>     dns_server.start()
INTERNALERROR>   File "/root/certbot/certbot-ci/certbot_integration_tests/utils/dns_server.py", line 61, in start
INTERNALERROR>     self._start_bind()
INTERNALERROR>   File "/root/certbot/certbot-ci/certbot_integration_tests/utils/dns_server.py", line 93, in _start_bind
INTERNALERROR>     self.process = subprocess.Popen(
INTERNALERROR>   File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
INTERNALERROR>     self._execute_child(args, executable, preexec_fn, close_fds,
INTERNALERROR>   File "/usr/lib64/python3.9/subprocess.py", line 1837, in _execute_child
INTERNALERROR>     raise child_exception_type(errno_num, err_msg, err_filename)
INTERNALERROR> FileNotFoundError: [Errno 2] No such file or directory: 'docker'
ERROR: InvocationError for command /root/certbot/.tox/integration-dns-rfc2136/bin/python -m pytest certbot-ci/certbot_integration_tests/rfc2136_tests --dns-server=bind --numprocesses=1 --cov=acme --cov=certbot --cov=certbot_dns_rfc2136 --cov-report= --cov-config=certbot-ci/certbot_integration_tests/.coveragerc (exited with code 3)
__________________________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________________________
ERROR:   integration-dns-rfc2136: commands failed
