### PR TITLE
make integration tests crossplatform

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
+++ b/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
@@ -34,12 +34,15 @@ def fetch(workspace: str, http_01_port: int = DEFAULT_HTTP_01_PORT) -> Tuple[str
 
 def _fetch_asset(asset: str, assets_path: str) -> str:
     base_url = 'https://github.com/letsencrypt/pebble/releases/download'
-    system = platform.system().lower()  # this will be something like "darwin" or "linux"
-    # we default to arm64 here because ARM can show up as arm64 or aarch64
-    machine = 'amd64' if platform.machine() == 'x86_64' else 'arm64'
-    asset_path = os.path.join(assets_path, f'{asset}_{PEBBLE_VERSION}_{system}_{machine}')
+    os_type = platform.system().lower()  # this will be something like "darwin" or "linux"
+    architecture = platform.machine()
+    if architecture == 'x86_64':
+        architecture = 'amd64'
+    elif architecture == 'aarch64':
+        architecture = 'arm64'
+    asset_path = os.path.join(assets_path, f'{asset}_{PEBBLE_VERSION}_{os_type}_{architecture}')
     if not os.path.exists(asset_path):
-        asset_url = f'{base_url}/{PEBBLE_VERSION}/{asset}-{system}-{machine}.zip'
+        asset_url = f'{base_url}/{PEBBLE_VERSION}/{asset}-{os_type}-{architecture}.zip'
         response = requests.get(asset_url, timeout=30)
         response.raise_for_status()
         asset_data = _unzip_asset(response.content, asset)

--- a/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
+++ b/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
@@ -44,7 +44,11 @@ def _fetch_asset(asset: str, assets_path: str) -> str:
     if not os.path.exists(asset_path):
         asset_url = f'{base_url}/{PEBBLE_VERSION}/{asset}-{os_type}-{architecture}.zip'
         response = requests.get(asset_url, timeout=30)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            raise ValueError(f'Unable to obtain pebble artifact for {os_type} {architecture}. Is '
+                              'your platform supported?')
         asset_data = _unzip_asset(response.content, asset)
         if asset_data is None:
             raise ValueError(f"zipfile {asset_url} didn't contain file {asset}")

--- a/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
+++ b/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
@@ -34,12 +34,7 @@ def fetch(workspace: str, http_01_port: int = DEFAULT_HTTP_01_PORT) -> Tuple[str
 
 def _fetch_asset(asset: str, assets_path: str) -> str:
     base_url = 'https://github.com/letsencrypt/pebble/releases/download'
-    os_type = platform.system().lower()  # this will be something like "darwin" or "linux"
-    architecture = platform.machine()
-    if architecture == 'x86_64':
-        architecture = 'amd64'
-    elif architecture == 'aarch64':
-        architecture = 'arm64'
+    os_type, architecture = _get_validated_os_and_architecture()
     asset_path = os.path.join(assets_path, f'{asset}_{PEBBLE_VERSION}_{os_type}_{architecture}')
     if not os.path.exists(asset_path):
         asset_url = f'{base_url}/{PEBBLE_VERSION}/{asset}-{os_type}-{architecture}.zip'
@@ -53,6 +48,22 @@ def _fetch_asset(asset: str, assets_path: str) -> str:
     os.chmod(asset_path, os.stat(asset_path).st_mode | stat.S_IEXEC)
 
     return asset_path
+
+
+def _get_validated_os_and_architecture() -> Tuple[str, str]:
+    os_type = platform.system().lower()
+    if os_type not in ('darwin', 'linux'):
+        raise ValueError(f'this code has not been tested on {os_type} systems')
+
+    architecture = platform.machine()
+    if architecture in ('amd64', 'x86_64'):
+        architecture = 'amd64'
+    elif architecture in ('aarch64' 'arm64'):
+        architecture = 'arm64'
+    else:
+        raise ValueError(f'this code has not been tested on {architecture} systems')
+
+    return os_type, architecture
 
 
 def _unzip_asset(zipped_data: bytes, asset_name: str) -> Optional[bytes]:

--- a/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
+++ b/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
@@ -44,11 +44,7 @@ def _fetch_asset(asset: str, assets_path: str) -> str:
     if not os.path.exists(asset_path):
         asset_url = f'{base_url}/{PEBBLE_VERSION}/{asset}-{os_type}-{architecture}.zip'
         response = requests.get(asset_url, timeout=30)
-        try:
-            response.raise_for_status()
-        except requests.HTTPError:
-            raise ValueError(f'Unable to obtain pebble artifact for {os_type} {architecture}. Is '
-                              'your platform supported?')
+        response.raise_for_status()
         asset_data = _unzip_asset(response.content, asset)
         if asset_data is None:
             raise ValueError(f"zipfile {asset_url} didn't contain file {asset}")

--- a/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
+++ b/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
@@ -50,7 +50,7 @@ def _fetch_asset(asset: str, assets_path: str) -> str:
     return asset_path
 
 
-def _get_validated_os_and_architecture() -> Tuple[str, str]:
+def _get_validated_os_and_architecture() -> tuple[str, str]:
     os_type = platform.system().lower()
     if os_type not in ('darwin', 'linux'):
         raise ValueError(f'this code has not been tested on {os_type} systems')

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -125,10 +125,6 @@ You can test your code in several ways:
 - running the `automated integration`_ tests
 - running an *ad hoc* `manual integration`_ test
 
-.. note:: Running integration tests does not currently work on macOS. See
-   https://github.com/certbot/certbot/issues/6959. In the meantime, we
-   recommend developers on macOS open a PR to run integration tests.
-
 .. _automated unit:
 
 Running automated unit tests


### PR DESCRIPTION
i wanted this for testing https://github.com/certbot/certbot/issues/10190

alex started working on this in https://github.com/certbot/certbot/pull/9207 years ago, but pebble didn't end up doing a release containing his work while he was still regularly contributing to certbot. this has now changed though

before this PR, our integration tests only worked on amd64 linux systems. with this PR, i've successfully run our integration tests on all combinations of the architectures amd64 and arm64 and the OSes linux and macos