### PR TITLE
fix propagation of openssl env vars

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -18,7 +18,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Fixed a bug introduced in Certbot 3.1.0 where OpenSSL environment variables
+  needed in our snap configuration were persisted in calls to external programs
+  like nginx which could cause them to fail to load OpenSSL.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/certbot/util.py
+++ b/certbot/certbot/util.py
@@ -165,6 +165,12 @@ def env_no_snap_for_external_calls() -> Dict[str, str]:
     # Avoid accidentally modifying env
     if 'SNAP' not in env or 'CERTBOT_SNAPPED' not in env:
         return env
+
+    # These environment variables being set when running external programs can cause issues if these
+    # programs also use OpenSSL. See https://github.com/certbot/certbot/issues/10190.
+    env.pop('OPENSSL_FORCE_FIPS_MODE', None)
+    env.pop('OPENSSL_MODULES', None)
+
     for path_name in ('PATH', 'LD_LIBRARY_PATH'):
         if path_name in env:
             env[path_name] = ':'.join(x for x in env[path_name].split(':') if env['SNAP'] not in x)


### PR DESCRIPTION
this should fix https://github.com/certbot/certbot/issues/10190

i unfortunately wasn't able to reproduce the nginx problem, but i did audit all subprocess calls in certbot and all of its plugins and confirmed that they use this `env_no_snap_for_external_calls` function. with `OPENSSL_MODULES` no longer pointing inside the snap, this problem should go away

i also cleared `OPENSSL_FORCE_FIPS_MODE` because of the report [here](https://community.letsencrypt.org/t/certbot-snap-error-while-renewing-openssl-init-ssl/232145/16)