### PR TITLE
use pull_request_target

### DIFF
--- a/.github/workflows/assigned.yaml
+++ b/.github/workflows/assigned.yaml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [assigned]
 
-  pull_request:
+  pull_request_target:
      types: [assigned]
 jobs:
   send-mattermost-message:


### PR DESCRIPTION
switches this to `pull_request_target` for the same reason we used it at https://github.com/certbot/certbot/pull/10101

this should fix failures like https://github.com/certbot/certbot/actions/runs/13574146174