### PR TITLE
Improve the error message when `certbot renew` is used with the `-d` option

### DIFF
--- a/certbot/certbot/_internal/renewal.py
+++ b/certbot/certbot/_internal/renewal.py
@@ -473,10 +473,10 @@ def handle_renewal_request(config: configuration.NamespaceConfig) -> Tuple[list,
         raise errors.Error("Currently, the renew verb is capable of either "
                            "renewing all installed certificates that are due "
                            "to be renewed or renewing a single certificate specified "
-                           "by its name. If you would like to renew specific "
-                           "certificates by their domains, use the certonly command "
-                           "instead. The renew verb may provide other options "
-                           "for selecting certificates to renew in the future.")
+                           "by its name using the --cert-name option (-d is not a valid option "
+                           "for renew). If you would like to renew specific certificates by their "
+                           "domains, use the certonly command instead. The renew verb may provide "
+                           "other options for selecting certificates to renew in the future.")
 
     if config.certname:
         conf_files = [storage.renewal_file_for_certname(config, config.certname)]


### PR DESCRIPTION
I lost an unreasonable amount of time on this.

## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] ~~If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), edit the `main` section of `certbot/CHANGELOG.md` to include a description of the change being made.~~
- [ ] ~~Add or update any documentation as needed to support the changes in this PR.~~
- [ ] ~~Include your name in `AUTHORS.md` if you like.~~
