### PR TITLE
Add RewriteEngine on directive also in post

### DIFF
--- a/certbot-apache/certbot_apache/_internal/http_01.py
+++ b/certbot-apache/certbot_apache/_internal/http_01.py
@@ -28,6 +28,7 @@ class ApacheHttp01(common.ChallengePerformer):
         RewriteRule ^/\\.well-known/acme-challenge/([A-Za-z0-9-_=]+)$ {0}/$1 [END]
     """
     CONFIG_TEMPLATE24_POST = """\
+        RewriteEngine on
         <Directory {0}>
             Require all granted
         </Directory>

--- a/certbot-apache/certbot_apache/_internal/http_01.py
+++ b/certbot-apache/certbot_apache/_internal/http_01.py
@@ -24,7 +24,6 @@ class ApacheHttp01(common.ChallengePerformer):
     """Class that performs HTTP-01 challenges within the Apache configurator."""
 
     CONFIG_TEMPLATE24_PRE = """\
-        RewriteEngine on
         RewriteRule ^/\\.well-known/acme-challenge/([A-Za-z0-9-_=]+)$ {0}/$1 [END]
     """
     CONFIG_TEMPLATE24_POST = """\

--- a/certbot-apache/certbot_apache/_internal/tests/http_01_test.py
+++ b/certbot-apache/certbot_apache/_internal/tests/http_01_test.py
@@ -209,7 +209,7 @@ class ApacheHttp01Test(util.ApacheTest):
         with open(self.http.challenge_conf_post) as f:
             post_conf_contents = f.read()
 
-        assert "RewriteEngine on" in pre_conf_contents
+        assert "RewriteEngine on" in post_conf_contents
         assert "RewriteRule" in pre_conf_contents
 
         assert self.http.challenge_dir in post_conf_contents

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -17,7 +17,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-*
+* Moved `RewriteEngine on` directive added during apache http01 authentication
+  to the end of the virtual host, so that it overwrites any `RewriteEngine off`
+  directives that already exist and allows redirection to the challenge URL.
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/9835#issuecomment-2717096178, where our `RewriteEngine on` directive inserted at the beginning of a virtualhost was overridden a `RewriteEngine Off` directive later. This PR does the easy thing of also placing `RewriteEngine on` in our post-insert.

I do not understand from the description why https://github.com/certbot/certbot/pull/5461 found it necessary to split the directive in the first place, so it's possible this will cause errors I do not understand.

The fix does work with the given apache config that was previously broken though.