### PR TITLE
acme/client: add renewal_time() method.

### DIFF
--- a/acme/acme/_internal/tests/client_test.py
+++ b/acme/acme/_internal/tests/client_test.py
@@ -22,6 +22,11 @@ from acme._internal.tests import test_util
 from acme.client import ClientNetwork
 from acme.client import ClientV2
 
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import serialization, hashes
+from acme.client import _renewal_info_path_component
+
 CERT_SAN_PEM = test_util.load_vector('cert-san.pem')
 CSR_MIXED_PEM = test_util.load_vector('csr-mixed.pem')
 CSR_NO_SANS_PEM = test_util.load_vector('csr-nosans.pem')
@@ -448,9 +453,6 @@ class ClientV2Test(unittest.TestCase):
         assert t <= datetime.datetime(2025, 3, 17, 1, 1, 1, tzinfo=datetime.timezone.utc)
 
 def test_renewal_info_path_component():
-    from cryptography import x509
-    from acme.client import _renewal_info_path_component
-
     cert = x509.load_pem_x509_certificate(test_util.load_vector('rsa2048_cert.pem'))
 
     assert _renewal_info_path_component(cert) == "fL5sRirC8VS5AtOQh9DfoAzYNCI.ALVG_VbBb5U7"
@@ -478,9 +480,6 @@ def make_cert_for_renewal(not_before, not_after) -> bytes:
     """
     Return a PEM-encoded, self-signed certificate with the given dates.
     """
-    from cryptography import x509
-    from cryptography.hazmat.primitives.asymmetric import ec
-    from cryptography.hazmat.primitives import serialization, hashes
     # AKID and serial are the inputs to constructing the renewalInfo URL
     akid = x509.AuthorityKeyIdentifier(b"1234", None, None)
     serial = 56789

--- a/acme/acme/_internal/tests/client_test.py
+++ b/acme/acme/_internal/tests/client_test.py
@@ -395,6 +395,114 @@ class ClientV2Test(unittest.TestCase):
         assert DIRECTORY_V2.to_partial_json() == \
             ClientV2.get_directory('https://example.com/dir', self.net).to_partial_json()
 
+    def test_renewal_time_no_renewal_info(self):
+        # A directory with no 'renewalInfo' should result in default renewal periods.
+        self.client.directory =  messages.Directory({})
+        cert_pem = make_cert_for_renewal(
+            not_before=datetime.datetime(2025, 3, 12, 00, 00, 00),
+            not_after=datetime.datetime(2025, 3, 20, 00, 00, 00),
+        )
+        t = self.client.renewal_time(cert_pem)
+        assert t == datetime.datetime(2025, 3, 16, 00, 00, 00, tzinfo=datetime.timezone.utc)
+
+        cert_pem = make_cert_for_renewal(
+            not_before=datetime.datetime(2025, 3, 12, 00, 00, 00),
+            not_after=datetime.datetime(2025, 3, 30, 00, 00, 00),
+        )
+        t = self.client.renewal_time(cert_pem)
+        assert t == datetime.datetime(2025, 3, 24, 00, 00, 00, tzinfo=datetime.timezone.utc)
+
+    def test_renewal_time_with_renewal_info(self):
+        cert_pem = make_cert_for_renewal(
+            not_before=datetime.datetime(2025, 3, 12, 00, 00, 00),
+            not_after=datetime.datetime(2025, 3, 20, 00, 00, 00),
+        )
+
+        self.client.directory =  messages.Directory({
+            'renewalInfo': 'https://www.letsencrypt-demo.org/acme/renewal-info',
+        })
+
+        self.response.json.return_value = {
+            "suggestedWindow": {
+                "start": "2025-03-14T01:01:01Z",
+                "end": "2025-03-14T01:01:01Z",
+            },
+            "message": "Keep those certs fresh"
+        }
+        t = self.client.renewal_time(cert_pem)
+        self.net.get.assert_called_once_with("https://www.letsencrypt-demo.org/acme/renewal-info/MTIzNA.AN3V", content_type='application/json')
+        assert t == datetime.datetime(2025, 3, 14, 1, 1, 1, tzinfo=datetime.timezone.utc)
+
+        self.net.reset_mock()
+
+        self.response.json.return_value = {
+            "suggestedWindow": {
+                "start": "2025-03-16T01:01:01Z",
+                "end": "2025-03-17T01:01:01Z",
+            },
+            "message": "Keep those certs fresh"
+        }
+        t = self.client.renewal_time(cert_pem)
+        self.net.get.assert_called_once_with("https://www.letsencrypt-demo.org/acme/renewal-info/MTIzNA.AN3V", content_type='application/json')
+        assert t >= datetime.datetime(2025, 3, 16, 1, 1, 1, tzinfo=datetime.timezone.utc)
+        assert t <= datetime.datetime(2025, 3, 17, 1, 1, 1, tzinfo=datetime.timezone.utc)
+
+def test_renewal_info_path_component():
+    from cryptography import x509
+    from acme.client import _renewal_info_path_component
+
+    cert = x509.load_pem_x509_certificate(test_util.load_vector('rsa2048_cert.pem'))
+
+    assert _renewal_info_path_component(cert) == "fL5sRirC8VS5AtOQh9DfoAzYNCI.ALVG_VbBb5U7"
+
+    # From https://www.ietf.org/archive/id/draft-ietf-acme-ari-08.html appendix A.
+    ARI_TEST_CERT = b"""
+-----BEGIN CERTIFICATE-----
+MIIBQzCB66ADAgECAgUAh2VDITAKBggqhkjOPQQDAjAVMRMwEQYDVQQDEwpFeGFt
+cGxlIENBMCIYDzAwMDEwMTAxMDAwMDAwWhgPMDAwMTAxMDEwMDAwMDBaMBYxFDAS
+BgNVBAMTC2V4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeBZu
+7cbpAYNXZLbbh8rNIzuOoqOOtmxA1v7cRm//AwyMwWxyHz4zfwmBhcSrf47NUAFf
+qzLQ2PPQxdTXREYEnKMjMCEwHwYDVR0jBBgwFoAUaYhba4dGQEHhs3uEe6CuLN4B
+yNQwCgYIKoZIzj0EAwIDRwAwRAIge09+S5TZAlw5tgtiVvuERV6cT4mfutXIlwTb
++FYN/8oCIClDsqBklhB9KAelFiYt9+6FDj3z4KGVelYM5MdsO3pK
+-----END CERTIFICATE-----
+"""
+
+    cert = x509.load_pem_x509_certificate(ARI_TEST_CERT)
+    assert _renewal_info_path_component(cert) == "aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE"
+
+if __name__ == '__main__':
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover
+
+def make_cert_for_renewal(not_before, not_after) -> bytes:
+    """
+    Return a PEM-encoded, self-signed certificate with the given dates.
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization, hashes
+    # AKID and serial are the inputs to constructing the renewalInfo URL
+    akid = x509.AuthorityKeyIdentifier(b"1234", None, None)
+    serial = 56789
+    key = ec.generate_private_key(ec.SECP256R1())
+    cert = x509.CertificateBuilder(
+        issuer_name=x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "Some Issuer")]),
+        subject_name=x509.Name([]),
+        public_key=key.public_key(),
+        serial_number=serial,
+        not_valid_before=not_before,
+        not_valid_after=not_after,
+    ).add_extension(
+        x509.SubjectAlternativeName([x509.DNSName('example.com')]),
+        critical=False,
+    ).add_extension(
+        akid,
+        critical=False,
+    ).sign(
+        private_key=key,
+        algorithm=hashes.SHA256(),
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
 
 class MockJSONDeSerializable(jose.JSONDeSerializable):
     # pylint: disable=missing-docstring

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -4,6 +4,8 @@ import datetime
 from email.utils import parsedate_tz
 import http.client as http_client
 import logging
+import math
+import random
 import re
 import time
 from typing import Any
@@ -317,7 +319,6 @@ class ClientV2:
         end = renewal_info.suggested_window.end # type: ignore[attr-defined]
 
         delta_seconds = (end - start).total_seconds()
-        import random
         random_seconds = random.uniform(0, delta_seconds)
         random_time = start + datetime.timedelta(seconds=random_seconds)
 
@@ -802,8 +803,6 @@ class ClientNetwork:
         return response
 
 def _renewal_info_path_component(cert: x509.Certificate) -> str:
-    import math
-
     akid_ext = cert.extensions.get_extension_for_oid(x509.ExtensionOID.AUTHORITY_KEY_IDENTIFIER)
     key_identifier = akid_ext.value.key_identifier # type: ignore[attr-defined]
 

--- a/acme/acme/client.py
+++ b/acme/acme/client.py
@@ -693,7 +693,6 @@ class ClientNetwork:
         kwargs['headers'].setdefault('User-Agent', self.user_agent)
         kwargs.setdefault('timeout', self._default_timeout)
         try:
-            print("self session", self, self.session)
             response = self.session.request(method, url, *args, **kwargs)
         except requests.exceptions.RequestException as e:
             # pylint: disable=pointless-string-statement

--- a/acme/acme/messages.py
+++ b/acme/acme/messages.py
@@ -695,3 +695,18 @@ class OrderResource(ResourceWithURI):
 
 class NewOrder(Order):
     """New order."""
+
+
+class RenewalInfo(ResourceBody):
+    """Renewal Info Resource Body.
+    :ivar acme.messages.SuggestedWindow window: The suggested renewal window.
+    """
+    class SuggestedWindow(jose.JSONObjectWithFields):
+        """Suggested Renewal Window, sub-resource of Renewal Info Resource.
+        :ivar datetime.datetime start: Beginning of suggested renewal window
+        :ivar datetime.datetime end: End of suggested renewal window (inclusive)
+        """
+        start = fields.RFC3339Field('start', omitempty=True)
+        end = fields.RFC3339Field('end', omitempty=True)
+
+    suggested_window = jose.Field('suggestedWindow', decoder=SuggestedWindow.from_json)


### PR DESCRIPTION
Return an appropriate time to attempt renewal of the certificate.

If the ACME directory has a "renewalInfo" field, the response will be based on a fetch of the renewal info resource for the certificate (https://www.ietf.org/archive/id/draft-ietf-acme-ari-08.html).

If there is no "renewalInfo" field, this function will fall back to reasonable defaults based on the certificate lifetime.

This function may make other network calls in the future (e.g., OCSP or CRL).

Follows up on #9102, #9945. Implements https://www.ietf.org/archive/id/draft-ietf-acme-ari-08.html.