### PR TITLE
Add template for code maintenance task

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,0 +1,15 @@
+name: Task
+description: A codebase upkeep task such as managing deprecations and refactoring
+title: "[Task]: "
+type: Task
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Task description
+      description: Describe the work that needs to happen, and why.
+      placeholder: >
+        For example, "In issue [link here], we noted that we cannot update [dependency] until
+        [something happens]. That thing has happened, so now we should update [dependency]."
+    validations:
+      required: true


### PR DESCRIPTION
We need this to create issues to track work like "update venv.py to address upcoming pip build system deprecation" since we no longer have a blank issue template.

Here's the github preview; in the issue creator, the description will be above not below the box.
![image](https://github.com/user-attachments/assets/444e8b62-49c6-463f-b897-a223ec35a4cd)
