### PR TITLE
Replace pyparsing error that usually misdirects people with a more helpful message

### DIFF
--- a/certbot-nginx/src/certbot_nginx/_internal/parser.py
+++ b/certbot-nginx/src/certbot_nginx/_internal/parser.py
@@ -233,7 +233,7 @@ class NginxParser:
                 logger.warning("Could not read file: %s due to invalid "
                                "character. Only UTF-8 encoding is "
                                "supported.", filename)
-            except pyparsing.ParseException as err:
+            except pyparsing.ParseException:
                 logger.warning("Could not parse file: %s. This is usually due to a comment that "
                     "certbot cannot parse, such as between a block's name and definition or "
                     "within a string literal. Moving the comment to another location in the file "

--- a/certbot-nginx/src/certbot_nginx/_internal/parser.py
+++ b/certbot-nginx/src/certbot_nginx/_internal/parser.py
@@ -234,7 +234,10 @@ class NginxParser:
                                "character. Only UTF-8 encoding is "
                                "supported.", filename)
             except pyparsing.ParseException as err:
-                logger.warning("Could not parse file: %s due to %s", filename, err)
+                logger.warning("Could not parse file: %s. This is usually due to a comment that "
+                    "certbot cannot parse, such as between a block's name and definition or "
+                    "within a string literal. Moving the comment to another location in the file "
+                    "or deleting it may resolve the issue.", filename)
         return trees
 
     def _find_config_root(self) -> str:

--- a/certbot-nginx/src/certbot_nginx/_internal/tests/nginxparser_test.py
+++ b/certbot-nginx/src/certbot_nginx/_internal/tests/nginxparser_test.py
@@ -374,6 +374,49 @@ class TestRawNginxParser(unittest.TestCase):
         """
         loads(test)
 
+    def test_location_comment_issue(self):
+        # See discussion at https://github.com/certbot/certbot/issues/10264
+        already_good = '''
+        location = /resume
+        # x
+        { rewrite .* /Files/Adam_Lein_resume.pdf redirect; }
+        '''
+        loads(already_good)
+        already_good = '''
+        location = /resume
+        { rewrite .* /Files/Adam_Lein_resume.pdf redirect; }
+        # {
+        '''
+        loads(already_good)
+        needs_fixing = '''
+        location = /resume
+        # {
+        { rewrite .* /Files/Adam_Lein_resume.pdf redirect; }
+        '''
+        with pytest.raises(ParseException):
+            loads(needs_fixing) # fails
+        needs_fixing = '''
+        location = /resume
+        # x{
+        { rewrite .* /Files/Adam_Lein_resume.pdf redirect; }
+        '''
+        with pytest.raises(ParseException):
+            loads(needs_fixing) # fails
+        needs_fixing = '''
+        location = /resume
+        #{
+        { rewrite .* /Files/Adam_Lein_resume.pdf redirect; }
+        '''
+        with pytest.raises(ParseException):
+            loads(needs_fixing) # fails
+        needs_fixing = '''
+        location = /resume
+        # {x
+        { rewrite .* /Files/Adam_Lein_resume.pdf redirect; }
+        '''
+        with pytest.raises(ParseException):
+            loads(needs_fixing) # fails
+
 
 class TestUnspacedList(unittest.TestCase):
     """Test the UnspacedList data structure"""


### PR DESCRIPTION
I created the label `area: nginx-parsing`, and considered telling people to check that label in the message, but I think we've made it clear enough how to contact us that that wouldn't be helpful, and would just lock the message into this version if we ever change it.

Addresses #10264, though I could not actually find a way to fix that particular issue. So, fixes #10264 is not actually accurate, but I would like github to link them.