### PR TITLE
Why do we have this? It means warnings aren't filtered in acme tests

### DIFF
--- a/acme/MANIFEST.in
+++ b/acme/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE.txt
 include README.rst
-include pytest.ini
 recursive-include docs *
 recursive-include examples *
 recursive-include src/acme/_internal/tests/testdata *

--- a/acme/pytest.ini
+++ b/acme/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-norecursedirs = .* build dist CVS _darcs {arch} *.egg


### PR DESCRIPTION
This was added in https://github.com/certbot/certbot/pull/6091 to make tests pass in EPEL and older ubuntus, 7 years ago. It is probably no longer needed.

If it is needed in some way that the full test suite didn't catch, the line could possibly be moved to the top-level `pytest.ini`.

The test in the PR that added this set `pytest<3`. 

| pytest version | min. Python version |
|---------------|---------------------|
|8.0+ | 3.8+|
| 7.1+ | 3.7+ |
| 6.2 - 7.0 | 3.6+ |
| 5.0 - 6.1 | 3.5+ |
| 3.3 - 4.6 | 2.7, 3.4+ |

That version is [no longer supported](https://docs.pytest.org/en/stable/backwards-compatibility.html).

Probably therefore we can just get rid of this.

