### PR TITLE
Add ARI support to acme module and to Certbot

### DIFF
--- a/acme/src/acme/_internal/tests/client_test.py
+++ b/acme/src/acme/_internal/tests/client_test.py
@@ -636,12 +636,11 @@ class ClientNetworkTest(unittest.TestCase):
         except requests.exceptions.ConnectionError as z: #pragma: no cover
             assert "'Connection aborted.'" in str(z) or "[WinError 10061]" in str(z)
 
-
 class ClientNetworkWithMockedResponseTest(unittest.TestCase):
     """Tests for acme.client.ClientNetwork which mock out response."""
 
     def setUp(self):
-        self.net = ClientNetwork(key=None, alg=None)
+        self.net = ClientNetwork(key='fake', alg=None)
 
         self.response = mock.MagicMock(ok=True, status_code=http_client.OK)
         self.response.headers = {}
@@ -797,6 +796,16 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
     def test_new_nonce_uri_removed(self):
         self.content_type = None
         self.net.post('uri', self.obj, content_type=None, new_nonce_url='new_nonce_uri')
+
+    def test_no_key_error(self):
+        "A ClientNetwork with no key should error on POST but succeed on GET"
+        self.net = ClientNetwork()
+        self.net._send_request = mock.MagicMock()
+        self.net._send_request.return_value = self.response
+        with pytest.raises(errors.Error):
+            self.net.post('uri', "body")
+        assert self.response == self.net.get(
+            'uri', content_type=self.content_type, bar='baz')
 
 
 if __name__ == '__main__':

--- a/acme/src/acme/client.py
+++ b/acme/src/acme/client.py
@@ -507,14 +507,14 @@ class ClientNetwork:
     :param messages.RegistrationResource account: Account object. Required if you are
             planning to use .post() for anything other than creating a new account;
             may be set later after registering.
-    :param josepy.JWASignature alg: Algorithm to use in signing JWS. Required to use .post().
+    :param josepy.JWASignature alg: Algorithm to use in signing JWS.
     :param bool verify_ssl: Whether to verify certificates on SSL connections.
     :param str user_agent: String to send as User-Agent header.
     :param int timeout: Timeout for requests.
     """
     def __init__(self, key: Optional[jose.JWK] = None,
                  account: Optional[messages.RegistrationResource] = None,
-                 alg: Optional[jose.JWASignature] = None, verify_ssl: bool = True,
+                 alg: jose.JWASignature = jose.RS256, verify_ssl: bool = True,
                  user_agent: str = 'acme-python', timeout: int = DEFAULT_NETWORK_TIMEOUT) -> None:
         self.key = key
         self.account = account

--- a/acme/src/acme/client.py
+++ b/acme/src/acme/client.py
@@ -316,13 +316,14 @@ class ClientV2:
         ari_url = renewal_info_base_url + '/' + _renewal_info_path_component(cert)
         try:
             resp = self.net.get(ari_url, content_type='application/json')
-        except:
+        except (requests.exceptions.RequestException, messages.Error) as error:
+            logger.warning("failed to fetch renewal_info URL (%s): %s", ari_url, error)
             return default_renewal_time, now + default_retry_after
 
         renewal_info: messages.RenewalInfo = messages.RenewalInfo.from_json(resp.json())
 
-        start = renewal_info.suggested_window.start
-        end = renewal_info.suggested_window.end
+        start = renewal_info.suggested_window.start # pylint: disable=no-member
+        end = renewal_info.suggested_window.end # pylint: disable=no-member
 
         delta_seconds = (end - start).total_seconds()
         random_seconds = random.uniform(0, delta_seconds)

--- a/acme/src/acme/client.py
+++ b/acme/src/acme/client.py
@@ -4,6 +4,8 @@ import datetime
 from email.utils import parsedate_tz
 import http.client as http_client
 import logging
+import math
+import random
 import re
 import time
 from typing import Any
@@ -278,6 +280,57 @@ class ClientV2:
         """
         self.begin_finalization(orderr)
         return self.poll_finalization(orderr, deadline, fetch_alternative_chains)
+
+    def renewal_time(self, cert_pem: bytes) -> Tuple[datetime.datetime, datetime.datetime]:
+        """Return an appropriate time to attempt renewal of the certificate,
+        and the next time to ask the ACME server for renewal info.
+
+        If the ACME directory has a "renewalInfo" field, the response will be
+        based on a fetch of the renewal info resource for the certificate
+        (https://www.ietf.org/archive/id/draft-ietf-acme-ari-08.html).
+
+        If there is no "renewalInfo" field, this function will fall back to
+        reasonable defaults based on the certificate lifetime.
+
+        This function may make other network calls in the future (e.g., OCSP
+        or CRL).
+        """
+        now = datetime.datetime.now()
+        # https://www.ietf.org/archive/id/draft-ietf-acme-ari-08.html#section-4.3.3
+        default_retry_after = datetime.timedelta(seconds=6 * 60 * 60)
+
+        cert = x509.load_pem_x509_certificate(cert_pem)
+
+        not_before = cert.not_valid_before_utc
+        lifetime = cert.not_valid_after_utc - not_before
+        if lifetime.total_seconds() < 10 * 86400:
+            default_renewal_time = not_before + lifetime / 2
+        else:
+            default_renewal_time = not_before + lifetime * 2 / 3
+
+        try:
+            renewal_info_base_url = self.directory['renewalInfo']
+        except KeyError:
+            return default_renewal_time, now + default_retry_after
+
+        ari_url = renewal_info_base_url + '/' + _renewal_info_path_component(cert)
+        try:
+            resp = self.net.get(ari_url, content_type='application/json')
+        except:
+            return default_renewal_time, now + default_retry_after
+
+        renewal_info: messages.RenewalInfo = messages.RenewalInfo.from_json(resp.json())
+
+        start = renewal_info.suggested_window.start
+        end = renewal_info.suggested_window.end
+
+        delta_seconds = (end - start).total_seconds()
+        random_seconds = random.uniform(0, delta_seconds)
+        random_time = start + datetime.timedelta(seconds=random_seconds)
+
+        retry_after = self.retry_after(resp, default_retry_after.seconds)
+        return random_time, retry_after
+
 
     def revoke(self, cert: x509.Certificate, rsn: int) -> None:
         """Revoke certificate.
@@ -758,3 +811,22 @@ class ClientNetwork:
         response = self._check_response(response, content_type=content_type)
         self._add_nonce(response)
         return response
+
+def _renewal_info_path_component(cert: x509.Certificate) -> str:
+    akid_ext = cert.extensions.get_extension_for_oid(x509.ExtensionOID.AUTHORITY_KEY_IDENTIFIER)
+    key_identifier = akid_ext.value.key_identifier # type: ignore[attr-defined]
+
+    akid_encoded = base64.urlsafe_b64encode(key_identifier).decode('ascii').replace("=", "")
+
+    # We add one to the reported bit_length so there is room for the sign bit.
+    # https://docs.python.org/3/library/stdtypes.html#int.bit_length
+    # "Return the number of bits necessary to represent an integer in binary, excluding
+    # the sign and leading zeros"
+    serial = cert.serial_number
+    encoded_serial_len = math.ceil((serial.bit_length()+1)/8)
+    # Serials are encoded as ASN.1 INTEGERS, which means big endian and signed (two's complement).
+    # https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/#integer-encoding
+    serial_bytes = serial.to_bytes(encoded_serial_len, byteorder='big', signed=True)
+    serial_encoded = base64.urlsafe_b64encode(serial_bytes).decode('ascii').replace("=", "")
+
+    return f"{akid_encoded}.{serial_encoded}"

--- a/acme/src/acme/client.py
+++ b/acme/src/acme/client.py
@@ -503,17 +503,18 @@ class ClientNetwork:
 
     """Initialize.
 
-    :param josepy.JWK key: Account private key
+    :param josepy.JWK key: Account private key. Required to use .post().
     :param messages.RegistrationResource account: Account object. Required if you are
             planning to use .post() for anything other than creating a new account;
             may be set later after registering.
-    :param josepy.JWASignature alg: Algorithm to use in signing JWS.
+    :param josepy.JWASignature alg: Algorithm to use in signing JWS. Required to use .post().
     :param bool verify_ssl: Whether to verify certificates on SSL connections.
     :param str user_agent: String to send as User-Agent header.
     :param int timeout: Timeout for requests.
     """
-    def __init__(self, key: jose.JWK, account: Optional[messages.RegistrationResource] = None,
-                 alg: jose.JWASignature = jose.RS256, verify_ssl: bool = True,
+    def __init__(self, key: Optional[jose.JWK] = None,
+                 account: Optional[messages.RegistrationResource] = None,
+                 alg: Optional[jose.JWASignature] = None, verify_ssl: bool = True,
                  user_agent: str = 'acme-python', timeout: int = DEFAULT_NETWORK_TIMEOUT) -> None:
         self.key = key
         self.account = account
@@ -549,16 +550,17 @@ class ClientNetwork:
         """
         jobj = obj.json_dumps(indent=2).encode() if obj else b''
         logger.debug('JWS payload:\n%s', jobj)
+        assert self.key
         kwargs = {
             "alg": self.alg,
             "nonce": nonce,
-            "url": url
+            "url": url,
+            "key": self.key
         }
         # newAccount and revokeCert work without the kid
         # newAccount must not have kid
         if self.account is not None:
             kwargs["kid"] = self.account["uri"]
-        kwargs["key"] = self.key
         return jws.JWS.sign(jobj, **cast(Mapping[str, Any], kwargs)).json_dumps(indent=2)
 
     @classmethod
@@ -748,6 +750,8 @@ class ClientNetwork:
     def _post_once(self, url: str, obj: jose.JSONDeSerializable,
                    content_type: str = JOSE_CONTENT_TYPE, **kwargs: Any) -> requests.Response:
         new_nonce_url = kwargs.pop('new_nonce_url', None)
+        if not self.key:
+            raise errors.Error("acme.ClientNetwork with no private key can't POST.")
         data = self._wrap_in_jws(obj, self._get_nonce(url, new_nonce_url), url)
         kwargs.setdefault('headers', {'Content-Type': content_type})
         response = self._send_request('POST', url, data=data, **kwargs)

--- a/acme/src/acme/messages.py
+++ b/acme/src/acme/messages.py
@@ -684,3 +684,19 @@ class OrderResource(ResourceWithURI):
 
 class NewOrder(Order):
     """New order."""
+
+
+class RenewalInfo(ResourceBody):
+    """Renewal Info Resource Body.
+    :ivar acme.messages.SuggestedWindow window: The suggested renewal window.
+    """
+    class SuggestedWindow(jose.JSONObjectWithFields):
+        """Suggested Renewal Window, sub-resource of Renewal Info Resource.
+        :ivar datetime.datetime start: Beginning of suggested renewal window
+        :ivar datetime.datetime end: End of suggested renewal window (inclusive)
+        """
+        start: datetime.datetime = fields.rfc3339('start', omitempty=True)
+        end: datetime.datetime = fields.rfc3339('end', omitempty=True)
+
+    suggested_window: SuggestedWindow = jose.field('suggestedWindow',
+                                                   decoder=SuggestedWindow.from_json)

--- a/certbot-ci/src/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/src/certbot_integration_tests/utils/certbot_call.py
@@ -135,7 +135,7 @@ def main() -> None:
 
     # Invoke certbot in test mode, without capturing output so users see directly the outcome.
     command, env = _prepare_args_env(args, directory_url, http_01_port, tls_alpn_01_port,
-                                     config_dir, workspace, True)
+                                     config_dir, workspace, False)
     subprocess.check_call(command, universal_newlines=True, cwd=workspace, env=env)
 
 

--- a/certbot/src/certbot/_internal/client.py
+++ b/certbot/src/certbot/_internal/client.py
@@ -53,23 +53,19 @@ def acme_from_config_key(config: configuration.NamespaceConfig,
                          regr: Optional[messages.RegistrationResource] = None,
                          ) -> acme_client.ClientV2:
     """Wrangle ACME client construction"""
-    if key:
-        if key.typ == 'EC':
-            public_key = key.key
-            if public_key.key_size == 256:
-                alg = ES256
-            elif public_key.key_size == 384:
-                alg = ES384
-            elif public_key.key_size == 521:
-                alg = ES512
-            else:
-                raise errors.NotSupportedError(
-                    "No matching signing algorithm can be found for the key"
-                )
+    alg = RS256
+    if key and key.typ == 'EC':
+        public_key = key.key
+        if public_key.key_size == 256:
+            alg = ES256
+        elif public_key.key_size == 384:
+            alg = ES384
+        elif public_key.key_size == 521:
+            alg = ES512
         else:
-            alg = RS256
-    else:
-        alg = None
+            raise errors.NotSupportedError(
+                "No matching signing algorithm can be found for the key"
+            )
     net = acme_client.ClientNetwork(key, alg=alg, account=regr,
                                     verify_ssl=(not config.no_verify_ssl),
                                     user_agent=determine_user_agent(config))

--- a/certbot/src/certbot/_internal/client.py
+++ b/certbot/src/certbot/_internal/client.py
@@ -49,24 +49,27 @@ logger = logging.getLogger(__name__)
 
 
 def acme_from_config_key(config: configuration.NamespaceConfig,
-                         key: jose.JWK,
+                         key: Optional[jose.JWK] = None,
                          regr: Optional[messages.RegistrationResource] = None,
                          ) -> acme_client.ClientV2:
     """Wrangle ACME client construction"""
-    if key.typ == 'EC':
-        public_key = key.key
-        if public_key.key_size == 256:
-            alg = ES256
-        elif public_key.key_size == 384:
-            alg = ES384
-        elif public_key.key_size == 521:
-            alg = ES512
+    if key:
+        if key.typ == 'EC':
+            public_key = key.key
+            if public_key.key_size == 256:
+                alg = ES256
+            elif public_key.key_size == 384:
+                alg = ES384
+            elif public_key.key_size == 521:
+                alg = ES512
+            else:
+                raise errors.NotSupportedError(
+                    "No matching signing algorithm can be found for the key"
+                )
         else:
-            raise errors.NotSupportedError(
-                "No matching signing algorithm can be found for the key"
-            )
+            alg = RS256
     else:
-        alg = RS256
+        alg = None
     net = acme_client.ClientNetwork(key, alg=alg, account=regr,
                                     verify_ssl=(not config.no_verify_ssl),
                                     user_agent=determine_user_agent(config))
@@ -225,6 +228,8 @@ def perform_registration(acme: acme_client.ClientV2, config: configuration.Names
     :returns: Registration Resource.
     :rtype: `acme.messages.RegistrationResource`
     """
+    if not acme.net.key:
+        raise errors.Error("acme client with no private key cannot register account.")
 
     eab_credentials_supplied = config.eab_kid and config.eab_hmac_key
     eab: Optional[Dict[str, Any]]

--- a/certbot/src/certbot/_internal/main.py
+++ b/certbot/src/certbot/_internal/main.py
@@ -265,8 +265,14 @@ def _handle_identical_cert_request(config: configuration.NamespaceConfig,
 
     if not lineage.ensure_deployed():
         return "reinstall", lineage
-    if is_key_type_changing or renewal.should_renew(config, lineage):
+    if is_key_type_changing:
         return "renew", lineage
+
+    acme_client = client.acme_from_config_key(config)
+
+    if renewal.should_renew(config, lineage, acme_client):
+        return "renew", lineage
+
     if config.reinstall:
         # Set with --reinstall, force an identical certificate to be
         # reinstalled without further prompting.

--- a/certbot/src/certbot/_internal/main.py
+++ b/certbot/src/certbot/_internal/main.py
@@ -268,9 +268,9 @@ def _handle_identical_cert_request(config: configuration.NamespaceConfig,
     if is_key_type_changing:
         return "renew", lineage
 
-    acme_client = client.acme_from_config_key(config)
+    acme = client.acme_from_config_key(config)
 
-    if renewal.should_renew(config, lineage, acme_client):
+    if renewal.should_renew(config, lineage, acme):
         return "renew", lineage
 
     if config.reinstall:

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -4,7 +4,6 @@ import copy
 import datetime
 import itertools
 import logging
-import pytz
 import random
 import sys
 import time
@@ -369,7 +368,8 @@ def should_autorenew(lineage: storage.RenewableCert, acme_client: acme_client.Cl
         lifetime = notAfter - notBefore
 
         config_interval = lineage.configuration.get("renew_before_expiry")
-        if config_interval is not None and notAfter < storage.add_time_interval(now, config_interval):
+        if (config_interval is not None and
+            notAfter < storage.add_time_interval(now, config_interval)):
             logger.debug("Should renew, less than %s before certificate "
                             "expiry %s.", config_interval,
                             notAfter.strftime("%Y-%m-%d %H:%M:%S %Z"))

--- a/certbot/src/certbot/_internal/storage.py
+++ b/certbot/src/certbot/_internal/storage.py
@@ -24,8 +24,6 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 import parsedatetime
 import pytz
 
-import josepy as jose
-
 import certbot
 from certbot import configuration
 from certbot import crypto_util

--- a/certbot/src/certbot/_internal/storage.py
+++ b/certbot/src/certbot/_internal/storage.py
@@ -977,58 +977,6 @@ class RenewableCert(interfaces.RenewableCert):
         return ("autorenew" not in self.configuration["renewalparams"] or
                 self.configuration["renewalparams"].as_bool("autorenew"))
 
-    def should_autorenew(self) -> bool:
-        """Should we now try to autorenew the most recent cert version?
-
-        This is a policy question and does not only depend on whether
-        the cert is expired. (This considers whether autorenewal is
-        enabled, whether the cert is revoked, and whether the time
-        interval for autorenewal has been reached.)
-
-        Note that this examines the numerically most recent cert version,
-        not the currently deployed version.
-
-        :returns: whether an attempt should now be made to autorenew the
-            most current cert version in this lineage
-        :rtype: bool
-
-        """
-        if self.autorenewal_is_enabled():
-            # Consider whether to attempt to autorenew this cert now
-
-            # Renewals on the basis of revocation
-            if self.ocsp_revoked(self.latest_common_version()):
-                logger.debug("Should renew, certificate is revoked.")
-                return True
-
-            cert = self.version("cert", self.latest_common_version())
-            notBefore = crypto_util.notBefore(cert)
-            notAfter = crypto_util.notAfter(cert)
-            lifetime = notAfter - notBefore
-
-            config_interval = self.configuration.get("renew_before_expiry")
-            now = datetime.datetime.now(pytz.UTC)
-            if config_interval is not None and notAfter < add_time_interval(now, config_interval):
-                logger.debug("Should renew, less than %s before certificate "
-                             "expiry %s.", config_interval,
-                             notAfter.strftime("%Y-%m-%d %H:%M:%S %Z"))
-                return True
-
-            # No config for "renew_before_expiry", provide default behavior.
-            # For most certs, renew with 1/3 of certificate lifetime remaining.
-            # For short lived certificates, renew at 1/2 of certificate lifetime.
-            default_interval = lifetime / 3
-            if lifetime.total_seconds() < 10 * 86400:
-                default_interval = lifetime / 2
-            remaining_time = notAfter - now
-            if remaining_time < default_interval:
-                logger.debug("Should renew, less than %ss before certificate "
-                             "expiry %s.", default_interval,
-                             notAfter.strftime("%Y-%m-%d %H:%M:%S %Z"))
-                return True
-
-        return False
-
     @classmethod
     def new_lineage(cls, lineagename: str, cert: bytes, privkey: bytes, chain: bytes,
                     cli_config: configuration.NamespaceConfig) -> "RenewableCert":

--- a/certbot/src/certbot/_internal/storage.py
+++ b/certbot/src/certbot/_internal/storage.py
@@ -24,6 +24,8 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 import parsedatetime
 import pytz
 
+import josepy as jose
+
 import certbot
 from certbot import configuration
 from certbot import crypto_util

--- a/certbot/src/certbot/_internal/tests/storage_test.py
+++ b/certbot/src/certbot/_internal/tests/storage_test.py
@@ -19,33 +19,8 @@ from certbot.compat import filesystem
 from certbot.compat import os
 import certbot.tests.util as test_util
 
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives import serialization, hashes
-from cryptography import x509
-from cryptography.x509 import Certificate
-
 import datetime
 from typing import Optional, Any
-
-def make_cert_with_lifetime(not_before: datetime.datetime, lifetime_days: int) -> bytes:
-    """Return PEM of a self-signed certificate with the given notBefore and lifetime."""
-    key = ec.generate_private_key(ec.SECP256R1())
-    not_after=not_before + datetime.timedelta(days=lifetime_days)
-    cert = x509.CertificateBuilder(
-        issuer_name=x509.Name([]),
-        subject_name=x509.Name([]),
-        public_key=key.public_key(),
-        serial_number=x509.random_serial_number(),
-        not_valid_before=not_before,
-        not_valid_after=not_after,
-    ).add_extension(
-        x509.SubjectAlternativeName([x509.DNSName("example.com")]),
-        critical=False,
-    ).sign(
-        private_key=key,
-        algorithm=hashes.SHA256(),
-    )
-    return cert.public_bytes(serialization.Encoding.PEM)
 
 def unlink_all(rc_object):
     """Unlink all four items associated with this RenewableCert."""
@@ -466,86 +441,6 @@ class RenewableCertTests(BaseRenewableCertTest):
         with pytest.raises(errors.CertStorageError):
             self.test_rc.names()
 
-    @mock.patch.object(configuration.NamespaceConfig, 'set_by_user')
-    @mock.patch("certbot._internal.storage.datetime")
-    def test_time_interval_judgments(self, mock_datetime, mock_set_by_user):
-        """Test should_autorenew() on the basis of expiry time windows."""
-        # Note: this certificate happens to have a lifetime of 7 days,
-        # and the tests below that use a "None" interval (i.e. choose a
-        # default) rely on that fact.
-        #
-        # Not Before: Dec 11 22:34:45 2014 GMT
-        # Not After : Dec 18 22:34:45 2014 GMT
-        not_before = datetime.datetime(2014, 12, 11, 22, 34, 45)
-        short_cert = make_cert_with_lifetime(not_before, 7)
-
-        self._write_out_ex_kinds()
-
-        self.test_rc.update_all_links_to(12)
-        with open(self.test_rc.cert, "wb") as f:
-            f.write(short_cert)
-        self.test_rc.update_all_links_to(11)
-        with open(self.test_rc.cert, "wb") as f:
-            f.write(short_cert)
-
-        mock_datetime.timedelta = datetime.timedelta
-        mock_set_by_user.return_value = False
-        self.test_rc.configuration["renewalparams"] = {}
-
-        for (current_time, interval, result) in [
-                # 2014-12-13 12:00 (about 5 days prior to expiry)
-                # Times that should result in autorenewal/autodeployment
-                (1418472000, "2 months", True), (1418472000, "1 week", True),
-                # With the "default" logic, this 7-day certificate should autorenew
-                # at 3.5 days prior to expiry. We haven't reached that yet,
-                # so don't renew.
-                (1418472000, None, False),
-                # 2014-12-16 03:20, a little less than 3.5 days to expiry.
-                (1418700000, None, True),
-                # Times that should not renew
-                (1418472000, "4 days", False), (1418472000, "2 days", False),
-                # 2009-05-01 12:00:00+00:00 (about 5 years prior to expiry)
-                # Times that should result in autorenewal/autodeployment
-                (1241179200, "7 years", True),
-                (1241179200, "11 years 2 months", True),
-                # Times that should not renew
-                (1241179200, "8 hours", False), (1241179200, "2 days", False),
-                (1241179200, "40 days", False), (1241179200, "9 months", False),
-                # 2015-01-01 (after expiry has already happened, so all
-                #            intervals should cause autorenewal/autodeployment)
-                (1420070400, "0 seconds", True),
-                (1420070400, "10 seconds", True),
-                (1420070400, "10 minutes", True),
-                (1420070400, "10 weeks", True), (1420070400, "10 months", True),
-                (1420070400, "10 years", True), (1420070400, "99 months", True),
-                (1420070400, None, True)
-        ]:
-            sometime = datetime.datetime.fromtimestamp(current_time, pytz.UTC)
-            mock_datetime.datetime.now.return_value = sometime
-            self.test_rc.configuration["renew_before_expiry"] = interval
-            assert self.test_rc.should_autorenew() == result
-
-        # Lifetime: 31 years
-        # Default renewal: about 10 years from expiry
-        # Not Before: May 29 07:42:01 2017 GMT
-        # Not After : Mar 30 07:42:01 2048 GMT
-        not_before=datetime.datetime(2017, 5, 29, 7, 42, 1)
-        long_cert = make_cert_with_lifetime(not_before, 31 * 365)
-        self.test_rc.update_all_links_to(12)
-        with open(self.test_rc.cert, "wb") as f:
-            f.write(long_cert)
-        self.test_rc.update_all_links_to(11)
-        with open(self.test_rc.cert, "wb") as f:
-            f.write(long_cert)
-        for (current_time, result) in [
-            (2114380800, False), # 2037-01-01
-            (2148000000, True), # 2038-01-25
-        ]:
-            sometime = datetime.datetime.fromtimestamp(current_time, pytz.UTC)
-            mock_datetime.datetime.now.return_value = sometime
-            self.test_rc.configuration["renew_before_expiry"] = interval
-            assert self.test_rc.should_autorenew() == result
-
     def test_autorenewal_is_enabled(self):
         self.test_rc.configuration["renewalparams"] = {}
         assert self.test_rc.autorenewal_is_enabled()
@@ -554,23 +449,6 @@ class RenewableCertTests(BaseRenewableCertTest):
 
         self.test_rc.configuration["renewalparams"]["autorenew"] = "False"
         assert not self.test_rc.autorenewal_is_enabled()
-
-    @mock.patch.object(configuration.NamespaceConfig, 'set_by_user')
-    @mock.patch("certbot._internal.storage.RenewableCert.ocsp_revoked")
-    def test_should_autorenew(self, mock_ocsp, mock_set_by_user):
-        """Test should_autorenew on the basis of reasons other than
-        expiry time window."""
-        mock_set_by_user.return_value = False
-        # Autorenewal turned off
-        self.test_rc.configuration["renewalparams"] = {"autorenew": "False"}
-        assert not self.test_rc.should_autorenew()
-        self.test_rc.configuration["renewalparams"]["autorenew"] = "True"
-        for kind in ALL_FOUR:
-            self._write_out_kind(kind, 12)
-        # Mandatory renewal on the basis of OCSP revocation
-        mock_ocsp.return_value = True
-        assert self.test_rc.should_autorenew()
-        mock_ocsp.return_value = False
 
     @mock.patch("certbot._internal.storage.relevant_values")
     def test_save_successor(self, mock_rv):


### PR DESCRIPTION
Follow-up to #10241. The acme module code is mostly the same, except the switch to return a tuple containing Retry-After.

This includes the CLI-side work to call out to the new `renewal_time` method when checking for renewal.

I moved `should_autorenew` from `storage.py` into `renewal.py`, where it fits better (and also this solves an import cycle problem). To make the edits more visible I split this into one commit for the move and [one commit for the subsequent edits](https://github.com/certbot/certbot/pull/10272/commits/4e137d9b00fb0a299723978d7a289b881716d36b#diff-fad906e31304c767d620bfd243f4c7adf1e63a3420fd634ee57a0f6651c182cf).

This does not yet attempt to store the Retry-After info, or failure retries, in renewal configs. I figured since that's a pretty big chunk of work and design on its own, I wanted to get interim feedback as is. I think this PR would be okay to land with the current default crons / systemd timers that run twice a day. I think we should implement storage of retry information before increasing the frequency of runs. And if the team would like to hold off on landing any ARI until that storage is done, I'm good with that too. 👍🏻 