### PR TITLE
acme.ClientNetwork: JWK becomes optional

### DIFF
--- a/acme/src/acme/_internal/tests/client_test.py
+++ b/acme/src/acme/_internal/tests/client_test.py
@@ -693,12 +693,11 @@ class ClientNetworkTest(unittest.TestCase):
         except requests.exceptions.ConnectionError as z: #pragma: no cover
             assert "'Connection aborted.'" in str(z) or "[WinError 10061]" in str(z)
 
-
 class ClientNetworkWithMockedResponseTest(unittest.TestCase):
     """Tests for acme.client.ClientNetwork which mock out response."""
 
     def setUp(self):
-        self.net = ClientNetwork(key=None, alg=None)
+        self.net = ClientNetwork(key='fake', alg=None)
 
         self.response = mock.MagicMock(ok=True, status_code=http_client.OK)
         self.response.headers = {}
@@ -850,6 +849,16 @@ class ClientNetworkWithMockedResponseTest(unittest.TestCase):
     def test_new_nonce_uri_removed(self):
         self.content_type = None
         self.net.post('uri', self.obj, content_type=None, new_nonce_url='new_nonce_uri')
+
+    def test_no_key_error(self):
+        "A ClientNetwork with no key should error on POST but succeed on GET"
+        self.net = ClientNetwork()
+        self.net._send_request = mock.MagicMock()
+        self.net._send_request.return_value = self.response
+        with pytest.raises(errors.Error):
+            self.net.post('uri', "body")
+        assert self.response == self.net.get(
+            'uri', content_type=self.content_type, bar='baz')
 
 
 if __name__ == '__main__':

--- a/acme/src/acme/client.py
+++ b/acme/src/acme/client.py
@@ -530,14 +530,14 @@ class ClientNetwork:
     :param messages.RegistrationResource account: Account object. Required if you are
             planning to use .post() for anything other than creating a new account;
             may be set later after registering.
-    :param josepy.JWASignature alg: Algorithm to use in signing JWS. Required to use .post().
+    :param josepy.JWASignature alg: Algorithm to use in signing JWS.
     :param bool verify_ssl: Whether to verify certificates on SSL connections.
     :param str user_agent: String to send as User-Agent header.
     :param int timeout: Timeout for requests.
     """
     def __init__(self, key: Optional[jose.JWK] = None,
                  account: Optional[messages.RegistrationResource] = None,
-                 alg: Optional[jose.JWASignature] = None, verify_ssl: bool = True,
+                 alg: jose.JWASignature = jose.RS256, verify_ssl: bool = True,
                  user_agent: str = 'acme-python', timeout: int = DEFAULT_NETWORK_TIMEOUT) -> None:
         self.key = key
         self.account = account

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -11,6 +11,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 * Switched to src-layout from flat-layout to accommodate PEP 517 pip editable installs
+* acme.client.ClientNetwork now makes the "key" parameter optional.
 * Deprecated `acme.challenges.TLSALPN01Response`
 * Deprecated `acme.challenges.TLSALPN01`
 * Deprecated ivar `alpn_selection` from `acme.crypto_util.SSLSocket`

--- a/certbot/src/certbot/_internal/client.py
+++ b/certbot/src/certbot/_internal/client.py
@@ -53,23 +53,19 @@ def acme_from_config_key(config: configuration.NamespaceConfig,
                          regr: Optional[messages.RegistrationResource] = None,
                          ) -> acme_client.ClientV2:
     """Wrangle ACME client construction"""
-    if key:
-        if key.typ == 'EC':
-            public_key = key.key
-            if public_key.key_size == 256:
-                alg = ES256
-            elif public_key.key_size == 384:
-                alg = ES384
-            elif public_key.key_size == 521:
-                alg = ES512
-            else:
-                raise errors.NotSupportedError(
-                    "No matching signing algorithm can be found for the key"
-                )
+    alg = RS256
+    if key and key.typ == 'EC':
+        public_key = key.key
+        if public_key.key_size == 256:
+            alg = ES256
+        elif public_key.key_size == 384:
+            alg = ES384
+        elif public_key.key_size == 521:
+            alg = ES512
         else:
-            alg = RS256
-    else:
-        alg = None
+            raise errors.NotSupportedError(
+                "No matching signing algorithm can be found for the key"
+            )
     net = acme_client.ClientNetwork(key, alg=alg, account=regr,
                                     verify_ssl=(not config.no_verify_ssl),
                                     user_agent=determine_user_agent(config))

--- a/certbot/src/certbot/_internal/client.py
+++ b/certbot/src/certbot/_internal/client.py
@@ -49,24 +49,27 @@ logger = logging.getLogger(__name__)
 
 
 def acme_from_config_key(config: configuration.NamespaceConfig,
-                         key: jose.JWK,
+                         key: Optional[jose.JWK] = None,
                          regr: Optional[messages.RegistrationResource] = None,
                          ) -> acme_client.ClientV2:
     """Wrangle ACME client construction"""
-    if key.typ == 'EC':
-        public_key = key.key
-        if public_key.key_size == 256:
-            alg = ES256
-        elif public_key.key_size == 384:
-            alg = ES384
-        elif public_key.key_size == 521:
-            alg = ES512
+    if key:
+        if key.typ == 'EC':
+            public_key = key.key
+            if public_key.key_size == 256:
+                alg = ES256
+            elif public_key.key_size == 384:
+                alg = ES384
+            elif public_key.key_size == 521:
+                alg = ES512
+            else:
+                raise errors.NotSupportedError(
+                    "No matching signing algorithm can be found for the key"
+                )
         else:
-            raise errors.NotSupportedError(
-                "No matching signing algorithm can be found for the key"
-            )
+            alg = RS256
     else:
-        alg = RS256
+        alg = None
     net = acme_client.ClientNetwork(key, alg=alg, account=regr,
                                     verify_ssl=(not config.no_verify_ssl),
                                     user_agent=determine_user_agent(config))
@@ -225,6 +228,8 @@ def perform_registration(acme: acme_client.ClientV2, config: configuration.Names
     :returns: Registration Resource.
     :rtype: `acme.messages.RegistrationResource`
     """
+    if not acme.net.key:
+        raise errors.Error("acme client with no private key cannot register account.")
 
     eab_credentials_supplied = config.eab_kid and config.eab_hmac_key
     eab: Optional[Dict[str, Any]]


### PR DESCRIPTION
This results in a ClientNetwork that can .get() but not .post(). Useful for fetching ARI, which does not require authentication.