### PR TITLE
upgrade certbot compatibility test images

### DIFF
--- a/certbot-compatibility-test/Dockerfile
+++ b/certbot-compatibility-test/Dockerfile
@@ -1,5 +1,5 @@
-FROM docker.io/python:3.11-buster
-LABEL maintainer="Brad Warren <bmw@eff.org>"
+FROM docker.io/python:3.13-bookworm
+LABEL org.opencontainers.image.authors="certbot-dev@eff.org"
 
 # This does not include the dependencies needed to build cryptography. See
 # https://cryptography.io/en/latest/installation/#building-cryptography-on-linux
@@ -13,7 +13,7 @@ WORKDIR /opt/certbot/src
 COPY . .
 
 RUN tools/venv.py
-ENV PATH /opt/certbot/src/venv/bin:$PATH
+ENV PATH=/opt/certbot/src/venv/bin:$PATH
 
 # install in editable mode (-e) to save space: it's not possible to
 # "rm -rf /opt/certbot/src" (it's stays in the underlying image);

--- a/certbot-compatibility-test/Dockerfile-apache
+++ b/certbot-compatibility-test/Dockerfile-apache
@@ -1,5 +1,5 @@
 FROM certbot-compatibility-test
-MAINTAINER Brad Warren <bmw@eff.org>
+LABEL org.opencontainers.image.authors="certbot-dev@eff.org"
 
 RUN apt-get install apache2 -y
 

--- a/certbot-compatibility-test/Dockerfile-nginx
+++ b/certbot-compatibility-test/Dockerfile-nginx
@@ -1,5 +1,5 @@
 FROM certbot-compatibility-test
-MAINTAINER Brad Warren <bmw@eff.org>
+LABEL org.opencontainers.image.authors="certbot-dev@eff.org"
 
 RUN apt-get install nginx -y
 


### PR DESCRIPTION
i need this for some other upgrades i'm working on. using these debian buster images which were [EOL'd ages ago](https://www.debian.org/releases/) is giving me problems

while i was at it, i fixed up up the following warnings docker was printing at me:

* https://docs.docker.com/reference/build-checks/legacy-key-value-format/
* https://docs.docker.com/reference/build-checks/maintainer-deprecated/