### PR TITLE
store preferred/required_profile in renewal config

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -24,6 +24,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   certificate. This conforms to RFC 8555 more accurately and avoids race conditions where
   all authorizations are fulfilled but order has not yet transitioned to ready state on
   the server when the finalization request is sent.
+* The --preferred-profile and --required-profile flags now have their values stored in
+  the renewal configuration so the same setting will be used on renewal.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -45,7 +45,8 @@ logger = logging.getLogger(__name__)
 STR_CONFIG_ITEMS = ["config_dir", "logs_dir", "work_dir", "user_agent",
                     "server", "account", "authenticator", "installer",
                     "renew_hook", "pre_hook", "post_hook", "http01_address",
-                    "preferred_chain", "key_type", "elliptic_curve"]
+                    "preferred_chain", "key_type", "elliptic_curve",
+                    "preferred_profile", "required_profile"]
 INT_CONFIG_ITEMS = ["rsa_key_size", "http01_port"]
 BOOL_CONFIG_ITEMS = ["must_staple", "allow_subset_of_names", "reuse_key",
                      "autorenew"]

--- a/certbot/src/certbot/_internal/tests/storage_test.py
+++ b/certbot/src/certbot/_internal/tests/storage_test.py
@@ -122,16 +122,22 @@ class RelevantValuesTest(unittest.TestCase):
         namespace = cli.prepare_and_parse_args(PLUGINS, [
             '--allow-subset-of-names',
             '--authenticator', 'apache',
+            '--preferred-profile', 'fancyprofile',
         ])
         expected_relevant_values = {
             'server': constants.CLI_DEFAULTS['server'],
             'key_type': 'ecdsa',
             'allow_subset_of_names': True,
             'authenticator': 'apache',
+            'preferred_profile': 'fancyprofile',
         }
 
         assert relevant_values(namespace) == expected_relevant_values
 
+    def test_with_required_profile(self):
+        self.values["required_profile"] = "shortlived"
+        expected_relevant_values = self.values.copy()
+        assert self._call(self.values) == expected_relevant_values
 
 class BaseRenewableCertTest(test_util.ConfigTestCase):
     """Base class for setting up Renewable Cert tests.


### PR DESCRIPTION
This ensures that renewals of certificates will use the same profile settings.

Fixes #10271
