### PR TITLE
fix mac dev augeas setup

### DIFF
--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -50,22 +50,17 @@ Install and configure the OS system dependencies required to run Certbot.
    # NB2: RHEL-based distributions use python3X instead of python3 (e.g. python38)
    sudo dnf install python3 augeas-devel
    # For macOS installations with Homebrew already installed and configured
-   # NB1: If you also run `brew install python` you don't need the ~/lib
-   #      directory created below, however, without this directory and symlinks
-   #      to augeas, Certbot's Apache plugin won't work if you use Python
-   #      installed from other sources such as pyenv or the version provided by
-   #      Apple.
-   # NB2: Some of our developer scripts expect GNU coreutils be first in your
-   #      PATH. The commands below set this up for bash and zsh, but your
-   #      instructions may be slightly different if you use an alternate shell.
+   # NB: CFLAGS are needed to compile and link to Augeas installed through
+   #     Homebrew and some of our developer scripts expect GNU coreutils be first in
+   #     your PATH. The commands below set this up for bash and zsh, but your
+   #     instructions may be slightly different if you use an alternate shell.
    brew install augeas coreutils gnu-sed
-   mkdir ~/lib
    BREW_PREFIX=$(brew --prefix)
-   ln -s "$BREW_PREFIX"/lib/libaugeas* ~/lib
-   RC_LINE="export PATH=\"$BREW_PREFIX/opt/coreutils/libexec/gnubin:"
-   RC_LINE+="$BREW_PREFIX/opt/gnu-sed/libexec/gnubin:\$PATH\""
-   echo "$RC_LINE" >> ~/.bashrc  # for bash
-   echo "$RC_LINE" >> ~/.zshrc  # for zsh
+   RC_LINES="export CFLAGS=\"\$CFLAGS -I$BREW_PREFIX/include -L$BREW_PREFIX/lib\"\n"
+   RC_LINES+="export PATH=\"$BREW_PREFIX/opt/coreutils/libexec/gnubin:"
+   RC_LINES+="$BREW_PREFIX/opt/gnu-sed/libexec/gnubin:\$PATH\"\n"
+   printf "$RC_LINES" >> ~/.bashrc  # for bash
+   printf "$RC_LINES" >> ~/.zshrc  # for zsh
 
 .. note:: If you have trouble creating the virtual environment below, you may
    need to install additional dependencies. See the `cryptography project's


### PR DESCRIPTION
it appears these changes are also needed to work with python-augeas 1.2.0. i didn't catch this in https://github.com/certbot/certbot/pull/10286 because the problem only affects ARM macs and it appears [our CI only offers intel macs](https://learn.microsoft.com/en-us/azure/devops/release-notes/roadmap/macos-agents-apple-silicon)

the issue here is described in homebrew issues like https://github.com/Homebrew/brew/issues/13481 and https://github.com/orgs/Homebrew/discussions/868. essentially, homebrew on intel macs puts files in /usr/local which is then found by other software by default while on arm macs it uses /opt/homebrew meaning we have to set additional flags for things like C compilers to find headers and libraries installed through homebrew. there was a little discussion in https://github.com/Homebrew/brew/issues/13481 of having homebrew fixup environment variables like `CFLAGS` by default on ARM systems, but the issue was closed ☹️ 

in the meantime, this PR should fix things for certbot devs and removes the need for the ~/lib symlinks with both new and old versions of python-augeas