### PR TITLE
fix up acme & certbot standalone code

### DIFF
--- a/acme/src/acme/standalone.py
+++ b/acme/src/acme/standalone.py
@@ -1,4 +1,6 @@
 """Support for standalone client challenge solvers. """
+from __future__ import annotations
+
 import collections
 import functools
 import http.client as http_client
@@ -214,7 +216,8 @@ class HTTPServer(BaseHTTPServer.HTTPServer):
 class HTTP01Server(HTTPServer, ACMEServerMixin):
     """HTTP01 Server."""
 
-    def __init__(self, server_address: Tuple[str, int], resources: Set[challenges.HTTP01],
+    def __init__(self, server_address: Tuple[str, int],
+                 resources: Set[HTTP01RequestHandler.HTTP01Resource],
                  ipv6: bool = False, timeout: int = 30) -> None:
         super().__init__(
             server_address, HTTP01RequestHandler.partial_init(
@@ -309,8 +312,8 @@ class HTTP01RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                          self.path)
 
     @classmethod
-    def partial_init(cls, simple_http_resources: Set[challenges.HTTP01],
-                     timeout: int) -> 'functools.partial[HTTP01RequestHandler]':
+    def partial_init(cls, simple_http_resources: Set[HTTP01RequestHandler.HTTP01Resource],
+                     timeout: int) -> functools.partial[HTTP01RequestHandler]:
         """Partially initialize this handler.
 
         This is useful because `socketserver.BaseServer` takes

--- a/certbot/src/certbot/_internal/tests/plugins/standalone_test.py
+++ b/certbot/src/certbot/_internal/tests/plugins/standalone_test.py
@@ -23,13 +23,11 @@ class ServerManagerTest(unittest.TestCase):
     """Tests for certbot._internal.plugins.standalone.ServerManager."""
 
     def setUp(self):
-        from certbot._internal.plugins.standalone import ServerManager, _KeyAndCert
-        self.certs: Dict[bytes, _KeyAndCert] = {}
+        from certbot._internal.plugins.standalone import ServerManager
         self.http_01_resources: Set[acme_standalone.HTTP01RequestHandler.HTTP01Resource] = {}
-        self.mgr = ServerManager(self.certs, self.http_01_resources)
+        self.mgr = ServerManager(self.http_01_resources)
 
     def test_init(self):
-        assert self.mgr.certs is self.certs
         assert self.mgr.http_01_resources is self.http_01_resources
 
     def _test_run_stop(self, challenge_type):


### PR DESCRIPTION
certbot's standalone code contains confusing references to things like `SSLSocket` which we were hoping to deprecate in https://github.com/certbot/certbot/issues/10284. are they relevant? they're sure not!

certbot's standalone plugin only supports HTTP-01 so comments about things like `ACMETLSServer` and the completely unused `certs` variable can be deleted

furthermore, the type of the different variables named things like `http_01_resources` were wrong in multiple places. as can be seen in certbot's standalone code, the type is `Set[acme_standalone.HTTP01RequestHandler.HTTP01Resource]`. this is also [the type used in acme.standalone's tests](https://github.com/certbot/certbot/blob/723fe64d4dbc778f1e8fd0b93320c1a30dc6fa95/acme/src/acme/_internal/tests/standalone_test.py#L78-L81) despite the file's type annotations saying it takes a different type. i think the incorrect type annotations were never caught because mypy can't fully make sense of our overly complex server classes here

finally, `from __future__ import annotations` was added to make [forward references in type annotations](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#forward-references) easier