### PR TITLE
Deprecate parameter enforce_openssl_binary_usage

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -18,6 +18,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 * Deprecated `acme.crypto_util.SSLSocket`
 * Deprecated `acme.standalone.TLSServer`
 * Deprecated `acme.standalone.TLSALPN01Server`
+* Deprecated parameter `enforce_openssl_binary_usage` from certbot.ocsp.RevocationChecker.
 * Dropped support for Python 3.9.0 and 3.9.1 for compatibility with newer
   versions of the cryptography Python package. Python 3.9.2+ is still
   supported.

--- a/certbot/src/certbot/ocsp.py
+++ b/certbot/src/certbot/ocsp.py
@@ -7,6 +7,7 @@ import subprocess
 from subprocess import PIPE
 from typing import Optional
 from typing import Tuple
+import warnings
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
@@ -32,6 +33,10 @@ class RevocationChecker:
 
     def __init__(self, enforce_openssl_binary_usage: bool = False) -> None:
         self.broken = False
+        if enforce_openssl_binary_usage:
+            warnings.warn("enforce_openssl_binary_usage parameter is deprecated "
+                "and will be removed in an upcoming certbot major version update",
+                DeprecationWarning)
         self.use_openssl_binary = enforce_openssl_binary_usage
 
         if self.use_openssl_binary:

--- a/pytest.ini
+++ b/pytest.ini
@@ -38,3 +38,4 @@ filterwarnings =
     ignore:TLSALPN01Response is deprecated:DeprecationWarning
     ignore:TLSALPN01 is deprecated:DeprecationWarning
     ignore:TLSServer is deprecated:DeprecationWarning
+    ignore:enforce_openssl_binary_usage parameter is deprecated:DeprecationWarning


### PR DESCRIPTION
Part of https://github.com/certbot/certbot/issues/10291