### PR TITLE
update developer OS dependency list

### DIFF
--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -44,11 +44,11 @@ Install and configure the OS system dependencies required to run Certbot.
 
    # For APT-based distributions (e.g. Debian, Ubuntu ...)
    sudo apt update
-   sudo apt install python3-venv libaugeas-dev
+   sudo apt install python3-dev python3-venv libaugeas-dev gcc
    # For RPM-based distributions (e.g. Fedora, CentOS ...)
    # NB1: old distributions will use yum instead of dnf
    # NB2: RHEL-based distributions use python3X instead of python3 (e.g. python38)
-   sudo dnf install python3 augeas-devel
+   sudo dnf install python3 python3-devel augeas-devel gcc
    # For macOS installations with Homebrew already installed and configured
    # NB: CFLAGS are needed to compile and link to Augeas installed through
    #     Homebrew and some of our developer scripts expect GNU coreutils be first in


### PR DESCRIPTION
this is a follow up from https://github.com/certbot/certbot/pull/10286 and related to https://github.com/certbot/certbot/issues/10302

sorry i initially missed this! in #10286 our tests were just yelling at me about the different augeas package needed, but python headers and a compiler are also needed for things to work with an updated version of python-augeas

i don't believe we need this change in our macOS instructions because:

1. homebrew doesn't split up python packages the way many linux distros do. there is no equivalent python-dev package
2. if you're using homebrew, you already have a compiler because [homebrew requires command line tools for xcode](https://docs.brew.sh/Installation#macos-requirements)
3. "it works on my machine"