### PR TITLE
renewal: use lineage-specific server for ARI

### DIFF
--- a/certbot-ci/src/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/src/certbot_integration_tests/certbot_tests/test_main.py
@@ -335,7 +335,7 @@ def test_renew_when_ari_says_its_time(context: IntegrationTestsContext) -> None:
     # URL in its config from the issuance earlier in this test case. If there's a bug
     # an ARI _is_ called against that URL it will fail because Let's Encrypt doesn't
     # know about certificates issued by Pebble.
-    context.directory_url = ""
+    context.directory_url = None
     context.certbot(['renew', '--deploy-hook', misc.echo('deploy', context.hook_probe)],
                     force_renew=False)
 

--- a/certbot-ci/src/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/src/certbot_integration_tests/certbot_tests/test_main.py
@@ -1,5 +1,4 @@
 """Module executing integration tests against certbot core."""
-import json
 import os
 from os.path import exists
 from os.path import join
@@ -329,6 +328,13 @@ def test_renew_when_ari_says_its_time(context: IntegrationTestsContext) -> None:
         }
     }))
 
+    # For the renew call only, avoid passing `--server` to the `certbot` command, so
+    # we fall back on the hardcoded default of `https://acme-v02.api.letsencrypt.org`.
+    # No requests should be made to that URL because the lineage has a baked-in Pebble
+    # URL in its config from the issuance earlier in this test case. If there's a bug
+    # an ARI _is_ called against that URL it will fail because Let's Encrypt doesn't
+    # know about certificates issued by Pebble.
+    context.directory_url = ""
     context.certbot(['renew', '--deploy-hook', misc.echo('deploy', context.hook_probe)],
                     force_renew=False)
 

--- a/certbot-ci/src/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/src/certbot_integration_tests/certbot_tests/test_main.py
@@ -1,4 +1,5 @@
 """Module executing integration tests against certbot core."""
+import json
 import os
 from os.path import exists
 from os.path import join

--- a/certbot-ci/src/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/src/certbot_integration_tests/utils/certbot_call.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import certbot_integration_tests
@@ -13,7 +14,7 @@ import certbot_integration_tests
 from certbot_integration_tests.utils.constants import *
 
 
-def certbot_test(certbot_args: List[str], directory_url: str, http_01_port: int,
+def certbot_test(certbot_args: List[str], directory_url: Optional[str], http_01_port: int,
                  tls_alpn_01_port: int, config_dir: str, workspace: str,
                  force_renew: bool = True) -> Tuple[str, str]:
     """
@@ -81,7 +82,7 @@ def _prepare_environ(workspace: str) -> Dict[str, str]:
     return new_environ
 
 
-def _prepare_args_env(certbot_args: List[str], directory_url: str, http_01_port: int,
+def _prepare_args_env(certbot_args: List[str], directory_url: Optional[str], http_01_port: int,
                       tls_alpn_01_port: int, config_dir: str, workspace: str,
                       force_renew: bool) -> Tuple[List[str], Dict[str, str]]:
 
@@ -90,7 +91,7 @@ def _prepare_args_env(certbot_args: List[str], directory_url: str, http_01_port:
     if force_renew:
         additional_args.append('--renew-by-default')
 
-    if directory_url != "":
+    if directory_url:
         additional_args.extend(['--server', directory_url])
 
 

--- a/certbot-ci/src/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/src/certbot_integration_tests/utils/certbot_call.py
@@ -90,9 +90,12 @@ def _prepare_args_env(certbot_args: List[str], directory_url: str, http_01_port:
     if force_renew:
         additional_args.append('--renew-by-default')
 
+    if directory_url != "":
+        additional_args.extend(['--server', directory_url])
+
+
     command = [
         'certbot',
-        '--server', directory_url,
         '--no-verify-ssl',
         '--http-01-port', str(http_01_port),
         '--https-port', str(tls_alpn_01_port),

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -6,7 +6,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-*
+* ACME Renewal Info (ARI) support. https://datatracker.ietf.org/doc/draft-ietf-acme-ari/
+  `certbot renew` will automatically check ARI when using an ACME server that supports it,
+  and may renew early based on the ARI information.
 
 ### Changed
 
@@ -33,8 +35,6 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   polling for finalization readiness.
 * The --preferred-profile and --required-profile flags now have their values stored in
   the renewal configuration so the same setting will be used on renewal.
-* Checks for ACME Renewal Info (ARI) now use the ACME server URL configured for each
-  certificate, instead of the global default server.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -8,7 +8,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 * ACME Renewal Info (ARI) support. https://datatracker.ietf.org/doc/draft-ietf-acme-ari/
   `certbot renew` will automatically check ARI when using an ACME server that supports it,
-  and may renew early based on the ARI information.
+  and may renew early based on the ARI information. For Let's Encrypt certificates this
+  will typically cause renewal at around 2/3rds of the certificate's lifetime, even if
+  the renew_before_expiry field of a lineage config is set to something shorter.
 
 ### Changed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,7 +10,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   `certbot renew` will automatically check ARI when using an ACME server that supports it,
   and may renew early based on the ARI information. For Let's Encrypt certificates this
   will typically cause renewal at around 2/3rds of the certificate's lifetime, even if
-  the renew_before_expiry field of a lineage config is set to something shorter.
+  the renew_before_expiry field of a lineage renewal config is set a later date.
 
 ### Changed
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -33,6 +33,8 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   polling for finalization readiness.
 * The --preferred-profile and --required-profile flags now have their values stored in
   the renewal configuration so the same setting will be used on renewal.
+* Checks for ACME Renewal Info (ARI) now use the ACME server URL configured for each
+  certificate, instead of the global default server.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -614,7 +614,7 @@ def handle_renewal_request(config: configuration.NamespaceConfig) -> Tuple[list,
                 if not server:
                     raise errors.Error(f"Renewal config for {lineage_config.names} has no server.")
                 if server not in acme_clients:
-                    acme_clients[server] = client.acme_from_config_key(config)
+                    acme_clients[server] = client.acme_from_config_key(lineage_config)
 
                 renewal_candidate.ensure_deployed()
                 from certbot._internal import main

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -610,6 +610,10 @@ def handle_renewal_request(config: configuration.NamespaceConfig) -> Tuple[list,
             if not renewal_candidate:
                 parse_failures.append(renewal_file)
             else:
+                # We check ARI against the server stored in the lineage config even if the user
+                # specified a different `--server` on the command line. That's the server that
+                # issued the existing certificate, so it's the only server that can respond to
+                # ARI requests for it.
                 server = lineage_config.server
                 if not server:
                     raise errors.Error(f"Renewal config for {lineage_config.names} has no server.")


### PR DESCRIPTION
Previously, we were constructing an ACME client for ARI checking that used the global value for `server`, not the one recorded in a lineage's renewal file.

This resulted in errors in the logs and failure to observe ARI for lineages that used a non-default `--server` (e.g. staging or non-Let's Encrypt CAs).