### PR TITLE
integration: add test for early renewal from ARI

### DIFF
--- a/certbot-ci/src/certbot_integration_tests/utils/acme_server.py
+++ b/certbot-ci/src/certbot_integration_tests/utils/acme_server.py
@@ -123,6 +123,7 @@ class ACMEServer:
         print('=> Starting pebble instance deployment...')
         pebble_artifacts_rv = pebble_artifacts.fetch(self._workspace, self._http_01_port)
         pebble_path, challtestsrv_path, pebble_config_path = pebble_artifacts_rv
+        pebble_path = "/tmp/pebble"
 
         # Configure Pebble at full speed (PEBBLE_VA_NOSLEEP=1) and not randomly refusing valid
         # nonce (PEBBLE_WFE_NONCEREJECT=0) to have a stable test environment.

--- a/certbot-ci/src/certbot_integration_tests/utils/misc.py
+++ b/certbot-ci/src/certbot_integration_tests/utils/misc.py
@@ -44,7 +44,7 @@ RSA_KEY_TYPE = 'rsa'
 ECDSA_KEY_TYPE = 'ecdsa'
 
 
-def _suppress_x509_verification_warnings() -> None:
+def suppress_x509_verification_warnings() -> None:
     import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -57,7 +57,7 @@ def check_until_timeout(url: str, attempts: int = 30) -> None:
     :param int attempts: the number of times to try to connect to the URL
     :raise ValueError: exception raised if unable to reach the URL
     """
-    _suppress_x509_verification_warnings()
+    suppress_x509_verification_warnings()
     for _ in range(attempts):
         time.sleep(1)
         try:
@@ -308,7 +308,7 @@ def get_acme_issuers() -> List[Certificate]:
     :param context: the testing context.
     :return: the `list of x509.Certificate` representing the list of issuers.
     """
-    _suppress_x509_verification_warnings()
+    suppress_x509_verification_warnings()
 
     issuers = []
     for i in range(PEBBLE_ALTERNATE_ROOTS + 1):


### PR DESCRIPTION
This depends on a pending Pebble pull request and so will fail integration tests until/unless that lands: https://github.com/letsencrypt/pebble/pull/501

However, I'd appreciate some eyes on this PR in this regard: is the interface we're using in Pebble useful and appropriate? If not, we can adjust the Pebble PR.

Inspired based on conversation on https://github.com/certbot/certbot/pull/10307, but note that this just tests the general case; it does not test the "default server differs from lineage server" case yet; when I try adding that I get some bugs that may reflect a problem in #10307 I need to fix (or may reflect that I need to inhibit the `--server` flag rather than trying to override it late in the command line).