### PR TITLE
Add a changelog entry describing the impacts of ARI on short `renew_before_expiry`

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -43,7 +43,7 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   an early ARI response will override a later `renew_before_expiry` time, to account for
   notifications in case of certificate revocation, especially with the impending deprecation
   of OCSP (https://letsencrypt.org/2024/12/05/ending-ocsp/). To force a later date, users
-  should remove the cron job installed by default and replace it with one of their own timing.
+  can replace certbot's default cron job and/or systemd timer with one of their own timing.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -37,6 +37,13 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   polling for finalization readiness.
 * The --preferred-profile and --required-profile flags now have their values stored in
   the renewal configuration so the same setting will be used on renewal.
+* Fixed an unintended change introduced in 4.0.0 where `renew_before_expiry` could not be
+  shorter than certbot's default renewal time. If the server does not provide an ARI
+  response, `renew_before_expiry` will continue to override certbot's default. However,
+  an early ARI response will override a later `renew_before_expiry` time, to account for
+  notifications in case of certificate revocation, especially with the impending deprecation
+  of OCSP (https://letsencrypt.org/2024/12/05/ending-ocsp/). To force a later date, users
+  should remove the cron job installed by default and replace it with one of their own timing.
 
 More details about these changes can be found on our GitHub repo.
 


### PR DESCRIPTION
Fixes #10312. This is perhaps overly detailed, but I was hoping that by giving a viable path forward it would forestall requests to change it back, add a flag to ignore ari, or otherwise change the behavior. Very open to suggestions on wording/content/length/etc.