### PR TITLE
Use ubuntu-latest for mattermost-notify on azure

### DIFF
--- a/.azure-pipelines/templates/stages/notify-failure-stage.yml
+++ b/.azure-pipelines/templates/stages/notify-failure-stage.yml
@@ -5,7 +5,7 @@ stages:
         variables:
           - group: certbot-common
         pool:
-          vmImage: ubuntu-20.04
+          vmImage: ubuntu-latest
         steps:
           - bash: |
               set -e


### PR DESCRIPTION
There's no reason to be using a specific vmImage here; set it to `ubuntu-latest` so we don't have to regularly update this. Fixes https://github.com/certbot/certbot/issues/10322.