### PR TITLE
Avoid ari mismatch problem during dry-run

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -15,6 +15,9 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 * Fixed a bug where issuance error details where not printed
+* No longer checks ARI during certbot --dry-run, because --dry-run uses staging when used
+  with let's encrypt but the cert was issued against the default server. This would emit
+  a scary warning, even though the cert would renew successfully.
 
 More details about these changes can be found on our GitHub repo.
 

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -320,11 +320,11 @@ def should_renew(config: configuration.NamespaceConfig,
     if config.renew_by_default:
         logger.debug("Auto-renewal forced with --force-renewal...")
         return True
-    if should_autorenew(lineage, acme):
-        logger.info("Certificate is due for renewal, auto-renewing...")
-        return True
     if config.dry_run:
         logger.info("Certificate not due for renewal, but simulating renewal for dry run")
+        return True
+    if should_autorenew(lineage, acme):
+        logger.info("Certificate is due for renewal, auto-renewing...")
         return True
     display_util.notify("Certificate not yet due for renewal")
     return False

--- a/certbot/src/certbot/_internal/tests/renewal_test.py
+++ b/certbot/src/certbot/_internal/tests/renewal_test.py
@@ -244,6 +244,14 @@ class RenewalTest(test_util.ConfigTestCase):
         assert expected_server != config.server
         assert mock_acme_from_config.call_args[0][0].server == expected_server
 
+    @mock.patch('acme.client.ClientV2')
+    def test_dry_run_no_ari_call(self, mock_acme):
+        from certbot._internal import renewal
+        self.config.dry_run = True
+        with mock.patch('time.sleep') as sleep:
+            renewal.should_renew(self.config, mock.Mock(), mock_acme)
+        assert mock_acme.renewal_time.call_count == 0
+
     def test_default_renewal_time(self):
         from certbot._internal import renewal
         cert_pem = make_cert_with_lifetime(datetime.datetime(2025, 3, 12, 00, 00, 00), 8)


### PR DESCRIPTION
This is one solution to https://github.com/certbot/certbot/issues/10327. It won't test an ARI check during a dry run, since it will just avoid the mismatch problem by checking for dry run first and returning before checking ARI. This PR will make the big error (actually a warning, but red and scary) go away though. 