### PR TITLE
Allow notification of two reviewers being assigned to a PR and two issue assignees

### DIFF
--- a/.github/workflows/assigned.yaml
+++ b/.github/workflows/assigned.yaml
@@ -3,9 +3,6 @@ name: Issue Assigned
 on:
   issues:
     types: [assigned]
-
-  pull_request_target:
-     types: [assigned]
 jobs:
   send-mattermost-message:
     runs-on: ubuntu-latest
@@ -14,4 +11,4 @@ jobs:
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_ASSIGN_WEBHOOK }}
         TEXT: >
-            ${{ github.event.issue.assignee.login || github.event.pull_request.assignee.login }} assigned to "${{ github.event.issue.title || github.event.pull_request.title }}": ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+            ${{ github.event.issue.assignee.login }} assigned to "${{ github.event.issue.title }}": ${{ github.event.issue.html_url }}

--- a/.github/workflows/assigned.yaml
+++ b/.github/workflows/assigned.yaml
@@ -11,4 +11,4 @@ jobs:
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_ASSIGN_WEBHOOK }}
         TEXT: >
-            ${{ github.event.issue.assignee.login }} assigned to "${{ github.event.issue.title }}": ${{ github.event.issue.html_url }}
+            ${{ github.event.assignee.login }} assigned to "${{ github.event.issue.title }}": ${{ github.event.issue.html_url }}

--- a/.github/workflows/review_requested.yaml
+++ b/.github/workflows/review_requested.yaml
@@ -5,6 +5,7 @@ on:
     types: [review_requested]
 jobs:
   send-mattermost-message:
+    if: ${{ github.event.requested_reviewer.login != ''}}
     runs-on: ubuntu-latest
     steps:
     - uses: mattermost/action-mattermost-notify@master

--- a/.github/workflows/review_requested.yaml
+++ b/.github/workflows/review_requested.yaml
@@ -5,6 +5,7 @@ on:
     types: [review_requested]
 jobs:
   send-mattermost-message:
+    # Don't notify for the interim step of certbot/eff-devs being assigned
     if: ${{ github.event.requested_reviewer.login != ''}}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/review_requested.yaml
+++ b/.github/workflows/review_requested.yaml
@@ -1,0 +1,14 @@
+name: Review Requested
+
+on:
+  pull_request:
+    types: [review_requested]
+jobs:
+  send-mattermost-message:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: mattermost/action-mattermost-notify@master
+      with:
+        MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_ASSIGN_WEBHOOK }}
+        TEXT: >
+            Review requested from ${{ github.event.requested_reviewer.login }} for "${{ github.event.pull_request.title }}": ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/review_requested.yaml
+++ b/.github/workflows/review_requested.yaml
@@ -1,7 +1,7 @@
 name: Review Requested
 
 on:
-  pull_request:
+  pull_request_target:
     types: [review_requested]
 jobs:
   send-mattermost-message:


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/10344

You can see this working in the mattermost "Test" channel, where I ran this code from my test repo.

The documentation for the PR reviewer syntax is here: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=review_requested#pull_request

We now no longer notify on PR assignees. But I think that is the correct behavior.

This PR also fixes a bug in the issue assigned notification code, and now lets you see when two different people were assigned. That documentation is here: https://docs.github.com/en/webhooks/webhook-events-and-payloads#

After this is in, I'll make the same changes to the josepy repo.

You can see the `if` syntax here: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows

```
on:
  pull_request:
    types: [review_requested]
jobs:
  specific_review_requested:
    runs-on: ubuntu-latest
    if: ${{ github.event.requested_team.name == 'octo-team'}}
    steps:
      - run: echo 'A review from octo-team was requested'
```