### PR TITLE
Restore le-auto, which should not be modified

### DIFF
--- a/letsencrypt-auto-source/letsencrypt-auto
+++ b/letsencrypt-auto-source/letsencrypt-auto
@@ -162,7 +162,7 @@ SuSudo() {
 }
 
 # Sets the environment variable SUDO to be the name of the program or function
-# to call to get root access. If this script already has root privileges, SUDO
+# to call to get root access. If this script already has root privleges, SUDO
 # is set to an empty string. The value in SUDO should be run with the command
 # to called with root privileges as arguments.
 SetRootAuthMechanism() {


### PR DESCRIPTION
https://github.com/certbot/certbot/pull/10297 modified `letsencrypt-auto-source/letsencrypt-auto`. It should never be modified except during a release, and we have a test to make sure of it. Old scripts pull directly from that file on github, so let's put that back asap.