### PR TITLE
cherry pick changelog fix to point release branch

### DIFF
--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -15,5 +15,6 @@ variables:
 
 stages:
   - template: templates/stages/test-and-package-stage.yml
+  - template: templates/stages/changelog-stage.yml
   - template: templates/stages/nightly-deploy-stage.yml
   - template: templates/stages/notify-failure-stage.yml

--- a/.azure-pipelines/templates/stages/changelog-stage.yml
+++ b/.azure-pipelines/templates/stages/changelog-stage.yml
@@ -3,13 +3,13 @@ stages:
     jobs:
       - job: prepare
         pool:
-          vmImage: windows-2019
+          vmImage: ubuntu-latest
         steps:
           # If we change the output filename from `release_notes.md`, it should also be changed in tools/create_github_release.py
           - bash: |
               set -e
               CERTBOT_VERSION="$(cd certbot/src && python -c "import certbot; print(certbot.__version__)" && cd ~-)"
-              "${BUILD_REPOSITORY_LOCALPATH}\tools\extract_changelog.py" "${CERTBOT_VERSION}" >> "${BUILD_ARTIFACTSTAGINGDIRECTORY}/release_notes.md"
+              "${BUILD_REPOSITORY_LOCALPATH}/tools/extract_changelog.py" "${CERTBOT_VERSION}" >> "${BUILD_ARTIFACTSTAGINGDIRECTORY}/release_notes.md"
             displayName: Prepare changelog
           - task: PublishPipelineArtifact@1
             inputs:

--- a/tools/extract_changelog.py
+++ b/tools/extract_changelog.py
@@ -12,8 +12,10 @@ NEW_SECTION_PATTERN = re.compile(r'^##\s*[\d.]+\s*-\s*[\d-]+$')
 
 def main():
     version = sys.argv[1]
+    if version.endswith('.dev0'):
+        version = version[:-5]
 
-    section_pattern = re.compile(r'^##\s*{0}\s*-\s*[\d-]+$'
+    section_pattern = re.compile(r'^##\s*{0}\s*-\s*.*$'
                                  .format(version.replace('.', '\\.')))
 
     with open(os.path.join(CERTBOT_ROOT, 'certbot', 'CHANGELOG.md')) as file_h:


### PR DESCRIPTION
it seems like we're probably not going to do 4.1.2 release, but just in case, i realized last night that we never added this release process fix to the 4.1.x branch

let's get this over there now before we/i forget again, we go to do a release, and it fails in the middle of the process

here's the original [issue](https://github.com/certbot/certbot/issues/10328) and [PR](https://github.com/certbot/certbot/pull/10349) here

i don't think this PR requires two reviews