### PR TITLE
Make ACME directory fetches for ARI checks resilient

### DIFF
--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -10,13 +10,14 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-*
+* Catches and ignores errors during the directory fetch for ARI checking so that these
+  errors do not hinder the actual certificate issuance
 
 ### Fixed
 
-* Certbot now always uses the server value from the renewal configuration file                               
-  for ARI checks instead of the server value from the current invocation of                                                                                       
-  Certbot. This helps prevent ARI requests from going to the wrong server if        
+* Certbot now always uses the server value from the renewal configuration file
+  for ARI checks instead of the server value from the current invocation of
+  Certbot. This helps prevent ARI requests from going to the wrong server if
   the user changes CAs.
 * Previously, we claimed to set FAILED_DOMAINS and RENEWED_DOMAINS env variables for use by
   post-hooks when certificate renewals fail, but we were not actually setting them. Now, we are.

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -388,15 +388,12 @@ def should_autorenew(config: configuration.NamespaceConfig,
         # Creating a new ACME client makes a network request, so check if we have
         # one cached for this cert's server already
         if lineage.server not in acme_clients:
-            try:
-                acme_clients[lineage.server] = \
-                    client.create_acme_client(config, server_override=lineage.server)
-            except (messages.Error,
-                    acme_errors.ClientError,
-                    requests.exceptions.RequestException) as error:
-                logger.info("Could not fetch directory for server URL ({%s}), "
-                            "unable to perform ACME Renewal Information (ARI) request. "
-                            "Error is: {%s}", lineage.server, error)
+            try:    
+                acme_clients[lineage.server] = \                       
+                    client.create_acme_client(config, server_override=lineage.server)    
+            except Exception as error:  # pylint: disable=broad-except      
+                logger.info("Unable to connect to %s to request ACME Renewal Information (ARI). "    
+                            "Error was: %s", lineage.server, error)    
         acme = acme_clients.get(lineage.server, None)
 
         # Attempt to get the ARI-defined renewal time

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -21,8 +21,11 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography import x509
+import requests
 
 from acme import client as acme_client
+from acme import messages
+from acme import errors as acme_errors
 
 from certbot import configuration
 from certbot import crypto_util
@@ -385,12 +388,20 @@ def should_autorenew(config: configuration.NamespaceConfig,
         # Creating a new ACME client makes a network request, so check if we have
         # one cached for this cert's server already
         if lineage.server not in acme_clients:
-            acme_clients[lineage.server] = \
-                client.create_acme_client(config, server_override=lineage.server)
-        acme = acme_clients[lineage.server]
+            try:
+                acme_clients[lineage.server] = \
+                    client.create_acme_client(config, server_override=lineage.server)
+            except (messages.Error,
+                    acme_errors.ClientError,
+                    requests.exceptions.RequestException) as error:
+                logger.info("Could not fetch directory for server URL ({%s}), "
+                            "unable to perform ACME Renewal Information (ARI) request. "
+                            "Error is: {%s}", lineage.server, error)
+        acme = acme_clients.get(lineage.server, None)
 
         # Attempt to get the ARI-defined renewal time
-        renewal_time, _ = acme.renewal_time(cert_pem)
+        if acme:
+            renewal_time, _ = acme.renewal_time(cert_pem)
     else:
         logger.info("Certificate has no 'server' field configured, unable to "
                     "perform ACME Renewal Information (ARI) request.")

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -21,11 +21,8 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography import x509
-import requests
 
 from acme import client as acme_client
-from acme import messages
-from acme import errors as acme_errors
 
 from certbot import configuration
 from certbot import crypto_util
@@ -388,11 +385,11 @@ def should_autorenew(config: configuration.NamespaceConfig,
         # Creating a new ACME client makes a network request, so check if we have
         # one cached for this cert's server already
         if lineage.server not in acme_clients:
-            try:    
-                acme_clients[lineage.server] = \                       
-                    client.create_acme_client(config, server_override=lineage.server)    
-            except Exception as error:  # pylint: disable=broad-except      
-                logger.info("Unable to connect to %s to request ACME Renewal Information (ARI). "    
+            try:
+                acme_clients[lineage.server] = \
+                    client.create_acme_client(config, server_override=lineage.server)
+            except Exception as error:  # pylint: disable=broad-except
+                logger.info("Unable to connect to %s to request ACME Renewal Information (ARI). "
                             "Error was: %s", lineage.server, error)    
         acme = acme_clients.get(lineage.server, None)
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/10342

When doing ARI checks in acme.renewal_time, we catch RequestException and return a default value. That's so an unavailable ARI server doesn't cause issues.

Before we get to acme.renewal_time, we have to create an ACME client, and in the process fetch a directory. We should make the directory fetch similarly resilient.