### PR TITLE
Catch acme.errors.ClientError in acme.client.ClientV2.renewal_time

### DIFF
--- a/acme/src/acme/client.py
+++ b/acme/src/acme/client.py
@@ -359,7 +359,7 @@ class ClientV2:
         ari_url = renewal_info_base_url + '/' + _renewal_info_path_component(cert)
         try:
             resp = self.net.get(ari_url, content_type='application/json')
-        except (requests.exceptions.RequestException, messages.Error) as error:
+        except (requests.exceptions.RequestException, messages.Error, errors.ClientError) as error:
             logger.info("failed to fetch renewal_info URL (%s): %s", ari_url, error)
             return None, now + default_retry_after
 


### PR DESCRIPTION
`ClientNetwork.get` calls `ClientNetwork._check_response`, which can also raise `acme.errors.ClientError`. We don't want one of those getting passed through and making certbot fail due to an ARI check either, so let's catch that as well

Fixes https://github.com/certbot/certbot/issues/10357