### PR TITLE
warn about missing server during ARI checks

### DIFF
--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -393,8 +393,8 @@ def should_autorenew(config: configuration.NamespaceConfig,
         renewal_time, _ = acme.renewal_time(cert_pem)
     else:
         renewal_conf_file = storage.renewal_filename_for_lineagename(config, lineage.lineagename)
-        logger.warning(f"Skipping ARI check because {renewal_conf_file} has no 'server' field. "
-                        "This issue will not prevent certificate renewal.")
+        logger.warning("Skipping ARI check because %s has no 'server' field. This issue will not "
+                       "prevent certificate renewal.", renewal_conf_file)
 
     now = datetime.datetime.now(datetime.timezone.utc)
 

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -392,8 +392,9 @@ def should_autorenew(config: configuration.NamespaceConfig,
         # Attempt to get the ARI-defined renewal time
         renewal_time, _ = acme.renewal_time(cert_pem)
     else:
-        logger.info("Certificate has no 'server' field configured, unable to "
-                    "perform ACME Renewal Information (ARI) request.")
+        renewal_conf_file = storage.renewal_filename_for_lineagename(config, lineage.lineagename)
+        logger.warning("Skipping ARI check because {renewal_conf_file} has no 'server' field. "
+                       "This issue will not prevent certificate renewal.")
 
     now = datetime.datetime.now(datetime.timezone.utc)
 

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -393,8 +393,8 @@ def should_autorenew(config: configuration.NamespaceConfig,
         renewal_time, _ = acme.renewal_time(cert_pem)
     else:
         renewal_conf_file = storage.renewal_filename_for_lineagename(config, lineage.lineagename)
-        logger.warning("Skipping ARI check because {renewal_conf_file} has no 'server' field. "
-                       "This issue will not prevent certificate renewal.")
+        logger.warning(f"Skipping ARI check because {renewal_conf_file} has no 'server' field. "
+                        "This issue will not prevent certificate renewal.")
 
     now = datetime.datetime.now(datetime.timezone.utc)
 

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -394,7 +394,7 @@ def should_autorenew(config: configuration.NamespaceConfig,
     else:
         renewal_conf_file = storage.renewal_filename_for_lineagename(config, lineage.lineagename)
         logger.warning("Skipping ARI check because %s has no 'server' field. This issue will not "
-                       "prevent certificate renewal.", renewal_conf_file)
+                       "prevent certificate renewal", renewal_conf_file)
 
     now = datetime.datetime.now(datetime.timezone.utc)
 

--- a/certbot/src/certbot/_internal/tests/renewal_test.py
+++ b/certbot/src/certbot/_internal/tests/renewal_test.py
@@ -418,7 +418,11 @@ class RenewalTest(test_util.ConfigTestCase):
             mock_ocsp.return_value = True
             assert renewal.should_autorenew(self.config, mock_rc, acme_clients)
             mock_rc.server = None
-            assert renewal.should_autorenew(self.config, mock_rc, acme_clients)
+            with mock.patch('certbot._internal.renewal.logger.warning') as mock_warning:
+                assert renewal.should_autorenew(self.config, mock_rc, acme_clients)
+            # Ensure we warned about skipping ARI checks when server is None
+            assert any(call.args[0].startswith('Skipping ARI') for call in
+                       mock_warning.call_args_list)
 
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):


### PR DESCRIPTION
this is part of https://github.com/certbot/certbot/issues/10336

on my test server, the output of `certbot renew` after deleting the server field looks like:
<img width="1815" height="398" alt="Screenshot 2025-07-17 at 12 06 07 PM" src="https://github.com/user-attachments/assets/537bcc39-eb59-43b4-912f-d30ac22baae8" />
