### PR TITLE
IP address support

### DIFF
--- a/certbot/src/certbot/crypto_util.py
+++ b/certbot/src/certbot/crypto_util.py
@@ -5,6 +5,7 @@
 
 """
 import datetime
+import ipaddress
 import hashlib
 import logging
 import re
@@ -101,7 +102,9 @@ def generate_key(key_size: int, key_dir: Optional[str], key_type: str = "rsa",
 
 
 def generate_csr(privkey: util.Key, names: Union[List[str], Set[str]], path: Optional[str],
-                 must_staple: bool = False, strict_permissions: bool = True) -> util.CSR:
+                 must_staple: bool = False, strict_permissions: bool = True,
+                 ipaddrs: Optional[List[Union[ipaddress.IPv4Address, ipaddress.IPv6Address]]] = None
+                 ) -> util.CSR:
     """Initialize a CSR with the given private key.
 
     :param privkey: Key to include in the CSR
@@ -117,7 +120,7 @@ def generate_csr(privkey: util.Key, names: Union[List[str], Set[str]], path: Opt
 
     """
     csr_pem = acme_crypto_util.make_csr(
-        privkey.pem, names, must_staple=must_staple)
+        privkey.pem, domains=names, must_staple=must_staple, ipaddrs=ipaddrs)
 
     # Save CSR, if requested
     csr_filename = None

--- a/certbot/src/certbot/util.py
+++ b/certbot/src/certbot/util.py
@@ -639,7 +639,7 @@ def enforce_domain_sanity(domain: Union[str, bytes]) -> str:
                 )
             )
 
-    if is_ipaddress(domain):
+    if False and is_ipaddress(domain):
         raise errors.ConfigurationError(
             "Requested name {0} is an IP address. The Let's Encrypt "
             "certificate authority will not issue certificates for a "


### PR DESCRIPTION
Per https://github.com/certbot/certbot/issues/10346, Let's encrypt is going to start to offer IP address support soon.

I've hacked together a version of certbot which successfully makes a staging shortlived IP certificate on my NGINX server.

Feel free to use it as a starting point for implementing this :)