### PR TITLE
Add note and warning about old-options-ssl-apache.conf not receiving updates

### DIFF
--- a/certbot-apache/src/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/src/certbot_apache/_internal/configurator.py
@@ -166,6 +166,10 @@ class ApacheConfigurator(common.Configurator):
         openssl_version = self.openssl_version(warn_on_no_mod_ssl)
         if self.version < (2, 4, 11) or not openssl_version or \
             util.parse_loose_version(openssl_version) < min_openssl_version:
+            logger.warning('Certbot has detected that apache version < 2.4.11 or compiled against '
+                'openssl < 1.0.2l. Since these are deprecated, the configuration file being '
+                'installed at %s will not receive future updates. To get the latest configuration '
+                'version, update apache.', self.mod_ssl_conf)
             return apache_util.find_ssl_apache_conf("old")
         return apache_util.find_ssl_apache_conf("current")
 

--- a/certbot-apache/src/certbot_apache/_internal/constants.py
+++ b/certbot-apache/src/certbot_apache/_internal/constants.py
@@ -34,6 +34,7 @@ ALL_SSL_OPTIONS_HASHES: List[str] = [
     '34783b9e2210f5c4a23bced2dfd7ec289834716673354ed7c7abf69fe30192a3',
     '61466bc2f98a623c02be8a5ee916ead1655b0ce883bdc936692076ea499ff5ce',
     '3fd812e3e87fe5c645d3682a511b2a06c8286f19594f28e280f17cd6af1301b5',
+    '27155797e160fe43b6951354a0a0ca4d829e9e605b3b41fc223c20bf2f6cb3c6',
 ]
 """SHA256 hashes of the contents of previous versions of all versions of MOD_SSL_CONF_SRC"""
 

--- a/certbot-apache/src/certbot_apache/_internal/tls_configs/old-options-ssl-apache.conf
+++ b/certbot-apache/src/certbot_apache/_internal/tls_configs/old-options-ssl-apache.conf
@@ -3,6 +3,10 @@
 # updates. Instead, Certbot will print and log an error message with a path to
 # the up-to-date file that you will need to refer to when manually updating
 # this file. Contents are based on https://ssl-config.mozilla.org
+#
+# This file is installed when apache < 2.4.11 or compiled against openssl < 1.0.2l. Since these
+# are deprecated, it is no longer receiving updates. To get the latest configuration
+# version, update apache.
 
 SSLEngine on
 


### PR DESCRIPTION
Part of #10183

> Option 4. Stop updating old files with security improvements. If people want to be on old software they can but then they're not getting the nice new things. We can either warn or not warn if we see people using them, either on certbot install (what, who's installing new certbot on these machines), new cert, cert renewal, or certbot update. The second two would require code changes, I'm pretty sure. I don't think we should warn too often because that's how we get people to silence all output. This is a little weird because we don't usually keep around deprecated things. We could also warn loudly and see if people complain. Or do some sort of brownout.

This PR warns every time certbot is run. We could make it run less often (only when a new config file is installed, probably), but that's a more extensive code change, and honestly I think it's probably fine? But I can change it.