### PR TITLE
improve ARI error handling and logging

### DIFF
--- a/acme/src/acme/_internal/tests/client_test.py
+++ b/acme/src/acme/_internal/tests/client_test.py
@@ -547,30 +547,6 @@ class ClientV2Test(unittest.TestCase):
         assert t <= datetime.datetime(2025, 3, 17, 1, 1, 1, tzinfo=datetime.timezone.utc)
 
     @mock.patch('acme.client.datetime')
-    def test_renewal_time_renewal_info_errors(self, dt_mock):
-        utc_now = datetime.datetime(2025, 3, 15, tzinfo=datetime.timezone.utc)
-        dt_mock.datetime.now.return_value = utc_now
-        self.client.directory = messages.Directory({
-            'renewalInfo': 'https://www.letsencrypt-demo.org/acme/renewal-info',
-        })
-        # Failure to fetch the 'renewalInfo' URL should return None
-        self.net.get.side_effect = requests.exceptions.RequestException
-
-        cert_pem = make_cert_for_renewal(
-            not_before=datetime.datetime(2025, 3, 12, 00, 00, 00),
-            not_after=datetime.datetime(2025, 3, 20, 00, 00, 00),
-        )
-        t, _ = self.client.renewal_time(cert_pem)
-        assert t == None
-
-        cert_pem = make_cert_for_renewal(
-            not_before=datetime.datetime(2025, 3, 12, 00, 00, 00),
-            not_after=datetime.datetime(2025, 3, 30, 00, 00, 00),
-        )
-        t, _ = self.client.renewal_time(cert_pem)
-        assert t == None
-
-    @mock.patch('acme.client.datetime')
     def test_renewal_time_returns_retry_after(self, dt_mock):
         def now(tzinfo=None):
             return datetime.datetime(2025, 3, 15, tzinfo=tzinfo)

--- a/acme/src/acme/client.py
+++ b/acme/src/acme/client.py
@@ -356,12 +356,7 @@ class ClientV2:
             return None, now + default_retry_after
 
         ari_url = renewal_info_base_url + '/' + _renewal_info_path_component(cert)
-        try:
-            resp = self.net.get(ari_url, content_type='application/json')
-        except (requests.exceptions.RequestException, messages.Error) as error:
-            logger.info("failed to fetch renewal_info URL (%s): %s", ari_url, error)
-            return None, now + default_retry_after
-
+        resp = self.net.get(ari_url, content_type='application/json')
         renewal_info: messages.RenewalInfo = messages.RenewalInfo.from_json(resp.json())
 
         start = renewal_info.suggested_window.start # pylint: disable=no-member

--- a/acme/src/acme/client.py
+++ b/acme/src/acme/client.py
@@ -365,7 +365,8 @@ class ClientV2:
         try:
             resp = self.net.get(ari_url, content_type='application/json')
         except Exception as e:  # pylint: disable=broad-except
-            raise errors.ARIError(now + default_retry_after) from e
+            error_msg = f'failed to fetch renewal_info URL {ari_url}'
+            raise errors.ARIError(error_msg, now + default_retry_after) from e
         renewal_info: messages.RenewalInfo = messages.RenewalInfo.from_json(resp.json())
 
         start = renewal_info.suggested_window.start # pylint: disable=no-member

--- a/acme/src/acme/errors.py
+++ b/acme/src/acme/errors.py
@@ -1,4 +1,5 @@
 """ACME errors."""
+import datetime
 import typing
 from typing import Any
 from typing import List
@@ -149,3 +150,10 @@ class ConflictError(ClientError):
 
 class WildcardUnsupportedError(Error):
     """Error for when a wildcard is requested but is unsupported by ACME CA."""
+
+
+class ARIError(ClientError):
+    """An error occurred during an ARI request and we want to suggest a Retry-After time."""
+    def __init__(self, retry_after: datetime.datetime, *args: Any) -> None:
+        super().__init__(*args)
+        self.retry_after = retry_after

--- a/acme/src/acme/errors.py
+++ b/acme/src/acme/errors.py
@@ -154,6 +154,6 @@ class WildcardUnsupportedError(Error):
 
 class ARIError(ClientError):
     """An error occurred during an ARI request and we want to suggest a Retry-After time."""
-    def __init__(self, retry_after: datetime.datetime, *args: Any) -> None:
-        super().__init__(*args)
+    def __init__(self, message: str, retry_after: datetime.datetime) -> None:
+        super().__init__(message, retry_after)
         self.retry_after = retry_after

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -355,7 +355,7 @@ def _ari_renewal_time(config: configuration.NamespaceConfig,
             logger.warning("An error occurred requesting ACME Renewal Information (ARI). If this "
                            "problem persists and you think it's a bug in Certbot, please open an "
                            "issue at https://github.com/certbot/certbot/issues/new/choose.")
-            logger.debug("Error was:", exc_info=True)
+            logger.debug("Error while requesting ARI was:", exc_info=True)
     else:
         renewal_conf_file = storage.renewal_filename_for_lineagename(config, lineage.lineagename)
         logger.warning("Skipping ARI check because %s has no 'server' field. This issue will not "

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -356,11 +356,13 @@ def _ari_renewal_time(config: configuration.NamespaceConfig,
             logger.warning("An error occurred requesting ACME Renewal Information (ARI). If this "
                            "problem persists and you think it's a bug in Certbot, please open an "
                            "issue at https://github.com/certbot/certbot/issues/new/choose.")
+            # While not strictly necessary, we unwrap any ARIErrors here to create slightly
+            # cleaner and easier to read logs
             if isinstance(exception, acme_errors.ARIError) and exception.__cause__ is not None:
-                # While not strictly necessary, we unwrap any ARIErrors here to create slightly
-                # cleaner and easier to read logs
-                exception = exception.__cause__
-            logger.debug("Error while requesting ARI was:", exc_info=exception)
+                exception_for_logs = exception.__cause__
+            else:
+                exception_for_logs = exception
+            logger.debug("Error while requesting ARI was:", exc_info=exception_for_logs)
     else:
         renewal_conf_file = storage.renewal_filename_for_lineagename(config, lineage.lineagename)
         logger.warning("Skipping ARI check because %s has no 'server' field. This issue will not "

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -23,6 +23,7 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography import x509
 
 from acme import client as acme_client
+from acme import errors as acme_errors
 
 from certbot import configuration
 from certbot import crypto_util
@@ -349,13 +350,17 @@ def _ari_renewal_time(config: configuration.NamespaceConfig,
             # Attempt to get the ARI-defined renewal time
             if acme:
                 return acme.renewal_time(cert_pem)[0]
-        except Exception:  # pylint: disable=broad-except
+        except Exception as exception:  # pylint: disable=broad-except
             # We want to stop errors around ARI preventing renewal so we catch all exceptions here
             # with a warning asking users to tell us about any problems they are experiencing
             logger.warning("An error occurred requesting ACME Renewal Information (ARI). If this "
                            "problem persists and you think it's a bug in Certbot, please open an "
                            "issue at https://github.com/certbot/certbot/issues/new/choose.")
-            logger.debug("Error while requesting ARI was:", exc_info=True)
+            if isinstance(exception, acme_errors.ARIError) and exception.__cause__ is not None:
+                # While not strictly necessary, we unwrap any ARIErrors here to create slightly
+                # cleaner and easier to read logs
+                exception = exception.__cause__
+            logger.debug("Error while requesting ARI was:", exc_info=exception)
     else:
         renewal_conf_file = storage.renewal_filename_for_lineagename(config, lineage.lineagename)
         logger.warning("Skipping ARI check because %s has no 'server' field. This issue will not "

--- a/certbot/src/certbot/_internal/tests/renewal_test.py
+++ b/certbot/src/certbot/_internal/tests/renewal_test.py
@@ -437,18 +437,16 @@ class RenewalTest(test_util.ConfigTestCase):
         mock_rc = mock.MagicMock()
         mock_rc.server = ari_server
         mock_rc.autorenewal_is_enabled.return_value = True
-        expected_error = messages.Error()
-        mock_create_acme.side_effect = expected_error
+        mock_create_acme.side_effect = messages.Error()
         mock_ocsp.return_value = True
 
         with mock.patch('certbot._internal.renewal.open', mock.mock_open(read_data=b'')):
             with mock.patch('certbot._internal.renewal.logger') as mock_logger:
                 assert renewal.should_autorenew(self.config, mock_rc, acme_clients)
         assert mock_renewal_time.call_count == 0
-        # Ensure we logged about skipping the ARI check and what the underlying exception was
+        # Ensure we logged about skipping the ARI check and the underlying exception
         assert any('ARI' in call.args[0] for call in mock_logger.warning.call_args_list)
-        assert any(call.kwargs.get('exc_info') is expected_error
-                   for call in mock_logger.debug.call_args_list)
+        assert any(call.kwargs.get('exc_info') for call in mock_logger.debug.call_args_list)
 
 
     @mock.patch('certbot._internal.storage.RenewableCert.ocsp_revoked')
@@ -457,8 +455,6 @@ class RenewalTest(test_util.ConfigTestCase):
 
         mock_acme = mock.MagicMock()
         ari_error = acme_errors.ARIError('some error', datetime.datetime.now())
-        underlying_error = ValueError()
-        ari_error.__cause__ = underlying_error
         ari_server = 'http://ari'
         mock_acme.renewal_time.side_effect = ari_error
         acme_clients = {}
@@ -468,14 +464,12 @@ class RenewalTest(test_util.ConfigTestCase):
         mock_rc.autorenewal_is_enabled.return_value = True
         mock_ocsp.return_value = True
 
-
         with mock.patch('certbot._internal.renewal.open', mock.mock_open(read_data=b'')):
             with mock.patch('certbot._internal.renewal.logger') as mock_logger:
                 assert renewal.should_autorenew(self.config, mock_rc, acme_clients)
-        # Ensure we logged about skipping the ARI check and what the underlying exception was
+        # Ensure we logged about skipping the ARI check and the underlying exception
         assert any('ARI' in call.args[0] for call in mock_logger.warning.call_args_list)
-        assert any(call.kwargs.get('exc_info') is underlying_error
-                   for call in mock_logger.debug.call_args_list)
+        assert any(call.kwargs.get('exc_info') for call in mock_logger.debug.call_args_list)
 
 
 class RestoreRequiredConfigElementsTest(test_util.ConfigTestCase):


### PR DESCRIPTION
fixes https://github.com/certbot/certbot/issues/10336 and fixes https://github.com/certbot/certbot/issues/10357 using the plan at https://github.com/certbot/certbot/issues/10336#issuecomment-3109192677

while this PR makes the renewal_time function slightly less nice, i think us catching and handling the exceptions in certbot makes the most sense so we can do exactly what we want around terminal and file logging

with this change, a output from a failed `sudo certbot renew` run looks like
```
$ sudo certbot renew
Saving debug log to /var/log/letsencrypt/letsencrypt.log

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
Processing /etc/letsencrypt/renewal/example.org.conf
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
An error occurred requesting ACME Renewal Information (ARI). If this problem persists and you think it's a bug in Certbot, please open an issue at https://github.com/certbot/certbot/issues/new/choose.
Certificate not yet due for renewal

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
The following certificates are not due for renewal yet:
  /etc/letsencrypt/live/example.org/fullchain.pem expires on 2025-10-23 (skipped)
No renewals were attempted.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
```
`sudo certbot renew -q` produces no output and the relevant messages in the log file look like:
```
2025-07-30 19:51:13,267:WARNING:certbot._internal.renewal:An error occurred requesting ACME Renewal Information (ARI). If this problem persists and you think it's a bug in Certbot, please open an issue at https://github.com/certbot/certbot/issues/new/choose.
2025-07-30 19:51:13,267:DEBUG:certbot._internal.renewal:Error while requesting ARI was:
Traceback (most recent call last):
  File "/home/brad/certbot/acme/src/acme/client.py", line 366, in renewal_time
    raise ValueError('im some error')
ValueError: im some error

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/brad/certbot/certbot/src/certbot/_internal/renewal.py", line 351, in _ari_renewal_time
    return acme.renewal_time(cert_pem)[0]
  File "/home/brad/certbot/acme/src/acme/client.py", line 370, in renewal_time
    raise errors.ARIError(error_msg, now + default_retry_after) from e
acme.errors.ARIError: ('failed to fetch renewal_info URL https://acme-staging-v02.api.letsencrypt.org/acme/renewal-info/oXQaBm1Qt4YtSizBfrSNiElszRY.LMjTHFS4HPbSRMOzLrA9OZId', datetime.datetime(2025, 7, 31, 1, 51, 13, 267088))

```