### PR TITLE
prep for 4.2.0 and fix changelog

### DIFF
--- a/acme/setup.py
+++ b/acme/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'cryptography>=43.0.0',

--- a/certbot-apache/setup.py
+++ b/certbot-apache/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     # We specify the minimum acme and certbot version as the current plugin

--- a/certbot-compatibility-test/setup.py
+++ b/certbot-compatibility-test/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'certbot',

--- a/certbot-dns-cloudflare/setup.py
+++ b/certbot-dns-cloudflare/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     # for now, do not upgrade to cloudflare>=2.20 to avoid deprecation warnings and the breaking

--- a/certbot-dns-digitalocean/setup.py
+++ b/certbot-dns-digitalocean/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'python-digitalocean>=1.11', # 1.15.0 or newer is recommended for TTL support

--- a/certbot-dns-dnsimple/setup.py
+++ b/certbot-dns-dnsimple/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     # This version of lexicon is required to address the problem described in

--- a/certbot-dns-dnsmadeeasy/setup.py
+++ b/certbot-dns-dnsmadeeasy/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-gehirn/setup.py
+++ b/certbot-dns-gehirn/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-google/setup.py
+++ b/certbot-dns-google/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'google-api-python-client>=1.6.5',

--- a/certbot-dns-linode/setup.py
+++ b/certbot-dns-linode/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-luadns/setup.py
+++ b/certbot-dns-luadns/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-nsone/setup.py
+++ b/certbot-dns-nsone/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-dns-ovh/setup.py
+++ b/certbot-dns-ovh/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.15.1',

--- a/certbot-dns-rfc2136/setup.py
+++ b/certbot-dns-rfc2136/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     # This version was chosen because it is the version packaged in RHEL 9 and Debian unstable. It

--- a/certbot-dns-route53/setup.py
+++ b/certbot-dns-route53/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'boto3>=1.15.15',

--- a/certbot-dns-sakuracloud/setup.py
+++ b/certbot-dns-sakuracloud/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     'dns-lexicon>=3.14.1',

--- a/certbot-nginx/setup.py
+++ b/certbot-nginx/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '5.0.0.dev0'
+version = '4.2.0.dev0'
 
 install_requires = [
     # We specify the minimum acme and certbot version as the current plugin

--- a/certbot/CHANGELOG.md
+++ b/certbot/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 Certbot adheres to [Semantic Versioning](https://semver.org/).
 
-## 5.0.0 - main
+## 4.2.0 - main
 
 ### Added
 
-*
+* Added `--eab-hmac-alg` parameter to support custom HMAC algorithm for External Account Binding.
 
 ### Changed
 
@@ -23,12 +23,6 @@ Certbot adheres to [Semantic Versioning](https://semver.org/).
   post-hooks when certificate renewals fail, but we were not actually setting them. Now, we are.
 
 More details about these changes can be found on our GitHub repo.
-
-## 4.2.0
-
-### Added
-
-* Added `--eab-hmac-alg` parameter to support custom HMAC algorithm for External Account Binding.
 
 ## 4.1.1 - 2025-06-12
 

--- a/certbot/src/certbot/__init__.py
+++ b/certbot/src/certbot/__init__.py
@@ -1,4 +1,4 @@
 """Certbot client."""
 
 # version number like 1.2.3a0, must have at least 2 parts, like 1.2
-__version__ = '5.0.0.dev0'
+__version__ = '4.2.0.dev0'


### PR DESCRIPTION
something weird happened to the changelog in https://github.com/certbot/certbot/pull/10319. a 4.2.0 entry was added below the entry for `5.0.0 - main` despite 4.2.0 not having been released. since it's sounding like we're expecting our next release to be 4.2.0 and not 5.0, i merged these two changelog entries into one for 4.2.0

i also modified our setup.py files to use 4.2.0.dev0 instead of 5.0.0.dev0 altho this isn't strictly necessary because our release script will automatically set all version numbers to whatever version we give it on the command line before building the release