### PR TITLE
modify pyvenv.cfg instead of PYTHONPATH

### DIFF
--- a/newsfragments/10176.fixed
+++ b/newsfragments/10176.fixed
@@ -1,0 +1,1 @@
+The Certbot snap no longer sets the environment variable PYTHONPATH stopping it from picking up Python files in the current directory and polluting the environment for Certbot hooks written in Python.

--- a/newsfragments/10257.fixed
+++ b/newsfragments/10257.fixed
@@ -1,0 +1,1 @@
+The Certbot snap no longer sets the environment variable PYTHONPATH stopping it from picking up Python files in the current directory and polluting the environment for Certbot hooks written in Python.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,6 @@ environment:
   # https://github.com/certbot/certbot/issues/10055.
   OPENSSL_MODULES: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ossl-modules"
   PATH: "$SNAP/bin:$SNAP/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
-  PYTHONPATH: "$SNAP/lib/python3.12/site-packages:${PYTHONPATH}"
   # Disable FIPS mode detection. See
   # https://git.launchpad.net/ubuntu/+source/openssl/tree/debian/patches/fips/crypto-Add-kernel-FIPS-mode-detection.patch?h=applied/ubuntu/noble
   # for more on this flag, and https://github.com/certbot/certbot/issues/10044
@@ -62,7 +61,6 @@ parts:
       - ./certbot-nginx
     stage:
       - -usr/lib/python3.12/sitecustomize.py # maybe unnecessary
-      - -pyvenv.cfg
       # Old versions of this file used to unstage
       # lib/python3.8/site-packages/augeas.py to avoid conflicts between
       # python-augeas 0.5.0 which was pinned in snap-constraints.txt and
@@ -118,6 +116,8 @@ parts:
       python3 -m venv "${CRAFT_PART_INSTALL}"
       "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
       craftctl default
+      sed -i "${CRAFT_PART_INSTALL}/pyvenv.cfg" \
+          -e 's@^home = '"${CRAFT_PART_INSTALL}"'/usr/bin$@home = /snap/certbot/current/usr/bin@g'
     override-pull: |
       craftctl default
       grep -v python-augeas "${CRAFT_PART_SRC}/tools/requirements.txt" >> "${CRAFT_PART_SRC}/snap-constraints.txt"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -116,6 +116,8 @@ parts:
       python3 -m venv "${CRAFT_PART_INSTALL}"
       "${CRAFT_PART_INSTALL}/bin/python3" "${CRAFT_PART_SRC}/tools/pipstrap.py"
       craftctl default
+      # Workaround for misconfigured pyvenv.cfg; see discussion on snapcraft forum for more info
+      # https://forum.snapcraft.io/t/upgrading-classic-snap-to-core24-using-snapcraft-8-3-causes-python-3-12-errors-at-runtime/
       sed -i "${CRAFT_PART_INSTALL}/pyvenv.cfg" \
           -e 's@^home = '"${CRAFT_PART_INSTALL}"'/usr/bin$@home = /snap/certbot/current/usr/bin@g'
     override-pull: |


### PR DESCRIPTION
this fixes https://github.com/certbot/certbot/issues/10176 and fixes https://github.com/certbot/certbot/issues/10257. it is based on https://github.com/certbot/certbot/pull/10017 and ohemorange said it's fine for me to cherry-pick their commit here

this change accomplishes a few things:

* because PYTHONPATH is no longer set to `"$SNAP/lib/python3.12/site-packages:${PYTHONPATH}"` which evaluates to `"$SNAP/lib/python3.12/site-packages:"` if PYTHONPATH wasn't previously set, Certbot no longer searches for Python modules in the current working directory which was causing #10176. i was able to reproduce this problem with our currently released snap and verify that this change fixes that problem
* since we no longer set PYTHONPATH at all, it won't be set in user hooks which was causing https://github.com/certbot/certbot/issues/10257
* as an added bonus, scripts that start with `#!/usr/bin/env /snap/certbot/current/bin/python3` as suggested [here](https://github.com/certbot/certbot/issues/10257#issuecomment-2809421320) are still able to find and import certbot and its dependencies so those scripts should continue to work. i verified this is the case with manual testing

finally, i created two news fragments here based on the text at https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments which says

> You can associate multiple issue numbers with a news fragment by giving them the same contents.

when run on this PR `towncrier --draft` outputs:
```
Loading template...
Finding news fragments...
Rendering news fragments...
Draft only -- nothing has been written.
What is seen below is what would be written.

## 4.2.0.dev0 - 2025-07-31

### Changed

- Catches and ignores errors during the directory fetch for ARI checking so
  that these errors do not hinder the actual certificate issuance.
  ([#10342](https://github.com/certbot/certbot/issues/10342))
- Removed the dependency on `pytz`.
  ([#10350](https://github.com/certbot/certbot/issues/10350))

### Fixed

- The Certbot snap no longer sets the environment variable PYTHONPATH stopping
  it from picking up Python files in the current directory and polluting the
  environment for Certbot hooks written in Python.
  ([#10176](https://github.com/certbot/certbot/issues/10176),
  [#10257](https://github.com/certbot/certbot/issues/10257))
- Previously, we claimed to set FAILED_DOMAINS and RENEWED_DOMAINS env
  variables for use by post-hooks when certificate renewals fail, but we were
  not actually setting them. Now, we are.
  ([#10259](https://github.com/certbot/certbot/issues/10259))
- Added `--eab-hmac-alg` parameter to support custom HMAC algorithm for
  External Account Binding.
  ([#10281](https://github.com/certbot/certbot/issues/10281))
- Certbot now always uses the server value from the renewal configuration file
  for ARI checks instead of the server value from the current invocation of
  Certbot. This helps prevent ARI requests from going to the wrong server if
  the user changes CAs.
  ([#10339](https://github.com/certbot/certbot/issues/10339))



```