### PR TITLE
renewal: use early return for empty lineage server

### DIFF
--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -337,31 +337,30 @@ def _ari_renewal_time(config: configuration.NamespaceConfig,
     # conf, i.e. `lineage.server`
     #
     # Fixes https://github.com/certbot/certbot/issues/10339
-    if lineage.server:
-        try:
-            # Creating a new ACME client makes a network request, so check if we have
-            # one cached for this cert's server already
-            if lineage.server not in acme_clients:
-                acme_clients[lineage.server] = \
-                    client.create_acme_client(config, server_override=lineage.server)
-            acme = acme_clients.get(lineage.server, None)
-
-            # Attempt to get the ARI-defined renewal time
-            if acme:
-                return acme.renewal_time(cert_pem)[0]
-        except Exception:  # pylint: disable=broad-except
-            # We want to stop errors around ARI preventing renewal so we catch all exceptions here
-            # with a warning asking users to tell us about any problems they are experiencing
-            logger.warning("An error occurred requesting ACME Renewal Information (ARI). If this "
-                           "problem persists and you think it's a bug in Certbot, please open an "
-                           "issue at https://github.com/certbot/certbot/issues/new/choose.")
-            logger.debug("Error while requesting ARI was:", exc_info=True)
-    else:
+    if not lineage.server:
         renewal_conf_file = storage.renewal_filename_for_lineagename(config, lineage.lineagename)
         logger.warning("Skipping ARI check because %s has no 'server' field. This issue will not "
                        "prevent certificate renewal", renewal_conf_file)
+        return None
+    try:
+        # Creating a new ACME client makes a network request, so check if we have
+        # one cached for this cert's server already
+        if lineage.server not in acme_clients:
+            acme_clients[lineage.server] = \
+                client.create_acme_client(config, server_override=lineage.server)
+        acme = acme_clients.get(lineage.server, None)
 
-    return None
+        # Attempt to get the ARI-defined renewal time
+        if acme:
+            return acme.renewal_time(cert_pem)[0]
+    except Exception:  # pylint: disable=broad-except
+        # We want to stop errors around ARI preventing renewal so we catch all exceptions here
+        # with a warning asking users to tell us about any problems they are experiencing
+        logger.warning("An error occurred requesting ACME Renewal Information (ARI). If this "
+                       "problem persists and you think it's a bug in Certbot, please open an "
+                       "issue at https://github.com/certbot/certbot/issues/new/choose.")
+        logger.debug("Error while requesting ARI was:", exc_info=True)
+        return None
 
 
 def _default_renewal_time(cert_pem: bytes) -> datetime.datetime:


### PR DESCRIPTION
This allows outdenting most of the logic for _ari_renewal_time.

Split from #10377.

cc @ohemorange 