### PR TITLE
renewal: factor out AriClientPool

### DIFF
--- a/certbot/src/certbot/_internal/main.py
+++ b/certbot/src/certbot/_internal/main.py
@@ -268,10 +268,9 @@ def _handle_identical_cert_request(config: configuration.NamespaceConfig,
     if is_key_type_changing:
         return "renew", lineage
 
-    acme_clients = {}
-    acme_clients[config.server] = client.create_acme_client(config)
+    ari_clients = renewal.AriClientPool(config)
 
-    if renewal.should_renew(config, lineage, acme_clients):
+    if renewal.should_renew(config, lineage, ari_clients):
         return "renew", lineage
 
     if config.reinstall:

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -369,8 +369,8 @@ def _ari_renewal_time(lineage: storage.RenewableCert,
     #
     # Fixes https://github.com/certbot/certbot/issues/10339
     if not lineage.server:
-        logger.warning("Skipping ARI check because config has no 'server' field. This issue will not "
-                       "prevent certificate renewal")
+        logger.warning("Skipping ARI check because %s has no 'server' field. This issue will not "
+                       "prevent certificate renewal", lineage.configfile.filename)
         return None
     try:
         ari_client = ari_clients.get(lineage.server)

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -69,7 +69,7 @@ class AriClientPool:
     """
     def __init__(self, cli_config: configuration.NamespaceConfig):
         self._verify_ssl = not cli_config.no_verify_ssl
-        self._user_agent = f"CertbotACMEClient/{certbot_version}"
+        self._user_agent = client.determine_user_agent(cli_config)
         self._pool: Dict[str, acme_client.ClientV2] = {}
 
     def get(self, server: str) -> acme_client.ClientV2:

--- a/certbot/src/certbot/_internal/renewal.py
+++ b/certbot/src/certbot/_internal/renewal.py
@@ -28,7 +28,6 @@ from certbot import configuration
 from certbot import crypto_util
 from certbot import errors
 from certbot import util
-from certbot import __version__ as certbot_version
 from certbot._internal import cli
 from certbot._internal import client
 from certbot._internal import constants
@@ -65,7 +64,8 @@ class AriClientPool:
     are all issued by the same server. To avoid redundant directory fetches, we create
     one acme.ClientV2 per server.
 
-    This takes a command line configuration object so it can observe the --no-verify-ssl flag.
+    This takes a command line configuration object so it can set the User-Agent header and
+    observe the --no-verify-ssl flag.
     """
     def __init__(self, cli_config: configuration.NamespaceConfig):
         self._verify_ssl = not cli_config.no_verify_ssl

--- a/certbot/src/certbot/_internal/tests/renewal_test.py
+++ b/certbot/src/certbot/_internal/tests/renewal_test.py
@@ -6,8 +6,6 @@ import tempfile
 import unittest
 from unittest import mock
 
-import argparse
-import configobj
 import pytest
 
 from acme import challenges

--- a/certbot/src/certbot/_internal/tests/renewal_test.py
+++ b/certbot/src/certbot/_internal/tests/renewal_test.py
@@ -352,7 +352,6 @@ class RenewalTest(test_util.ConfigTestCase):
                 sometime = datetime.datetime.fromtimestamp(current_time, datetime.timezone.utc)
                 mock_datetime.datetime.now.return_value = sometime
                 mock_renewable_cert.configuration = {"renew_before_expiry": interval}
-                mock_renewable_cert.configfile = {"renew_before_expiry": interval}
                 assert renewal.should_autorenew(mock_renewable_cert, acme_clients) == result, f"at {current_time}, with config '{interval}', ari response in future, expected {result}"
 
             # Now, test cases where ARI either fails (returns `(None, _)`) or
@@ -439,7 +438,6 @@ class RenewalTest(test_util.ConfigTestCase):
         ari_client_pool.get.side_effect = messages.Error()
         mock_rc = mock.MagicMock()
         mock_rc.server = ari_server
-        mock_rc.configfile = {}
         mock_rc.autorenewal_is_enabled.return_value = True
         mock_ocsp.return_value = True
 


### PR DESCRIPTION
Part of #10355.

This allows combining the NamespaceConfig object with a cache of ACME clients, so we don't have to make the whole large NamespaceConfig object available all the way down the renewal call stack.

The new AriClientPool is responsible for instantiating ACME clients for the purpose of ARI fetching. It provides only a simple user agent, listing the Certbot version. The only CLI flag it observes is --no-verify-ssl.