### PR TITLE
remove curses environment marker

### DIFF
--- a/certbot/pyproject.toml
+++ b/certbot/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
-    "Environment :: Console :: Curses",
     "Intended Audience :: System Administrators",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",


### PR DESCRIPTION
i noticed this when reviewing https://github.com/certbot/certbot/pull/10402

we stopped using curses ages ago and should probably remove this. see https://github.com/certbot/certbot/pull/3665
