### PR TITLE
Massively speed up macOS tests

### DIFF
--- a/acme/src/acme/_internal/tests/standalone_test.py
+++ b/acme/src/acme/_internal/tests/standalone_test.py
@@ -20,7 +20,9 @@ class HTTP01ServerTest(unittest.TestCase):
     """Tests for acme.standalone.HTTP01Server."""
 
 
-    def setUp(self):
+    @mock.patch('socket.getfqdn')
+    def setUp(self, mock_fdqn):
+        mock_fdqn.return_value = "server_name"
         self.account_key = jose.JWK.load(
             test_util.load_vector('rsa1024_key.pem'))
         self.resources: Set = set()
@@ -67,7 +69,9 @@ class HTTP01ServerTest(unittest.TestCase):
     def test_http01_not_found(self):
         assert not self._test_http01(add=False)
 
-    def test_timely_shutdown(self):
+    @mock.patch('socket.getfqdn')
+    def test_timely_shutdown(self, mock_fdqn):
+        mock_fdqn.return_value = "server_name"
         from acme.standalone import HTTP01Server
         with HTTP01Server(('', 0), resources=set(), timeout=0.05) as server:
             server_thread = threading.Thread(target=server.serve_forever)
@@ -151,7 +155,9 @@ class BaseDualNetworkedServersTest(unittest.TestCase):
 class HTTP01DualNetworkedServersTest(unittest.TestCase):
     """Tests for acme.standalone.HTTP01DualNetworkedServers."""
 
-    def setUp(self):
+    @mock.patch('socket.getfqdn')
+    def setUp(self, mock_fdqn):
+        mock_fdqn.return_value = "server_name"
         self.account_key = jose.JWK.load(
             test_util.load_vector('rsa1024_key.pem'))
         self.resources: Set = set()

--- a/certbot/src/certbot/_internal/tests/client_test.py
+++ b/certbot/src/certbot/_internal/tests/client_test.py
@@ -69,7 +69,9 @@ class RegisterTest(test_util.ConfigTestCase):
         self.tos_cb = mock.MagicMock()
         display_obj.set_display(MagicMock())
 
-    def _call(self):
+    @mock.patch('socket.getfqdn')
+    def _call(self, mock_fqdn):
+        mock_fqdn.return_value = "server_name"
         from certbot._internal.client import register
         return register(self.config, self.account_storage, self.tos_cb)
 

--- a/certbot/src/certbot/_internal/tests/display/ops_test.py
+++ b/certbot/src/certbot/_internal/tests/display/ops_test.py
@@ -78,7 +78,9 @@ class GetEmailTest(unittest.TestCase):
 
 class ChooseAccountTest(test_util.TempDirTestCase):
     """Tests for certbot.display.ops.choose_account."""
-    def setUp(self):
+    @mock.patch('socket.getfqdn')
+    def setUp(self, mock_fqdn):
+        mock_fqdn.return_value = "server_name"
         super().setUp()
 
         display_obj.set_display(display_obj.FileDisplay(sys.stdout, False))

--- a/certbot/src/certbot/_internal/tests/plugins/standalone_test.py
+++ b/certbot/src/certbot/_internal/tests/plugins/standalone_test.py
@@ -28,7 +28,9 @@ class ServerManagerTest(unittest.TestCase):
     def test_init(self):
         assert self.mgr.http_01_resources is self.http_01_resources
 
-    def _test_run_stop(self, challenge_type):
+    @mock.patch('socket.getfqdn')
+    def _test_run_stop(self, challenge_type, mock_fdqn):
+        mock_fdqn.return_value = "server_name"
         server = self.mgr.run(port=0, challenge_type=challenge_type)
         port = server.getsocknames()[0][1]
         assert self.mgr.running() == {port: server}
@@ -38,7 +40,9 @@ class ServerManagerTest(unittest.TestCase):
     def test_run_stop_http_01(self):
         self._test_run_stop(challenges.HTTP01)
 
-    def test_run_idempotent(self):
+    @mock.patch('socket.getfqdn')
+    def test_run_idempotent(self, mock_fdqn):
+        mock_fdqn.return_value = "server_name"
         server = self.mgr.run(port=0, challenge_type=challenges.HTTP01)
         port = server.getsocknames()[0][1]
         server2 = self.mgr.run(port=port, challenge_type=challenges.HTTP01)
@@ -47,7 +51,9 @@ class ServerManagerTest(unittest.TestCase):
         self.mgr.stop(port)
         assert self.mgr.running() == {}
 
-    def test_run_bind_error(self):
+    @mock.patch('socket.getfqdn')
+    def test_run_bind_error(self, mock_fdqn):
+        mock_fdqn.return_value = "server_name"
         some_server = socket.socket(socket.AF_INET6)
         some_server.bind(("", 0))
         port = some_server.getsockname()[1]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = {cover,lint}-posix,mypy
 skipsdist = true
 
 [base]
-pytest = python -m pytest {posargs}
+pytest = python -m pytest {posargs} --durations=5
 # Paths are listed on one line because tox seems to have inconsistent
 # behavior with substitutions that contain line continuations, see
 # https://github.com/tox-dev/tox/issues/2069 for more info.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = {cover,lint}-posix,mypy
 skipsdist = true
 
 [base]
-pytest = python -m pytest {posargs} --durations=5
+pytest = python -m pytest {posargs}
 # Paths are listed on one line because tox seems to have inconsistent
 # behavior with substitutions that contain line continuations, see
 # https://github.com/tox-dev/tox/issues/2069 for more info.


### PR DESCRIPTION
I got sick of waiting for tests to finish. This is the same underlying problem as https://github.com/certbot/certbot/pull/8575/, just fixed in more places. I found those places by adding "--durations=10" to our pytest invocation in `tox.ini`, and then profiling using pyinstrument, with `pyinstrument -m pytest [filename]` locally.

I've removed the change I made to `tox.ini` to show durations since it does seem to slow down tests a little, but if you want the current top ten tests, they're visible at https://dev.azure.com/certbot/certbot/_build/results?buildId=9469&view=logs&j=1ae398a1-7dc9-5ade-0f59-912b32975b53&t=0ec28dfb-4593-5e04-05b6-bb502ec0a017. The 5 second one is a sleep 5 which we could fix but seemed fine tbh. Previously the bad tests were all taking about 70 seconds each.

You can now see a test macos-cover duration more in line with our linux tests at https://dev.azure.com/certbot/certbot/_build/results?buildId=9470&view=results.