### PR TITLE
use pep585 types in public certbot files

### DIFF
--- a/certbot/src/certbot/achallenges.py
+++ b/certbot/src/certbot/achallenges.py
@@ -19,8 +19,6 @@ Note, that all annotated challenges act as a proxy objects::
 """
 import logging
 from typing import Any
-from typing import Tuple
-from typing import Type
 
 import josepy as jose
 
@@ -40,7 +38,7 @@ class AnnotatedChallenge(jose.ImmutableMap):
 
     """
     __slots__ = ('challb',)
-    _acme_type: Type[Challenge] = NotImplemented
+    _acme_type: type[Challenge] = NotImplemented
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.challb, name)
@@ -51,7 +49,7 @@ class KeyAuthorizationAnnotatedChallenge(AnnotatedChallenge):
     __slots__ = ('challb', 'domain', 'account_key') # pylint: disable=redefined-slots-in-subclass
 
     def response_and_validation(self, *args: Any, **kwargs: Any
-        ) -> Tuple['challenges.KeyAuthorizationChallengeResponse', Any]:
+        ) -> tuple['challenges.KeyAuthorizationChallengeResponse', Any]:
         """Generate response and validation."""
         return self.challb.chall.response_and_validation(
             self.account_key, *args, **kwargs)

--- a/certbot/src/certbot/compat/filesystem.py
+++ b/certbot/src/certbot/compat/filesystem.py
@@ -6,7 +6,6 @@ import errno
 import os  # pylint: disable=os-module-forbidden
 import stat
 from typing import Any
-from typing import Dict
 from typing import Generator
 from typing import Optional
 
@@ -609,7 +608,7 @@ def _generate_dacl(user_sid: Any, mode: int, mask: Optional[int] = None) -> Any:
     return dacl
 
 
-def _analyze_mode(mode: int) -> Dict[str, Dict[str, int]]:
+def _analyze_mode(mode: int) -> dict[str, dict[str, int]]:
     return {
         'user': {
             'read': mode & stat.S_IRUSR,
@@ -652,7 +651,7 @@ def _copy_win_mode(src: str, dst: str) -> None:
     win32security.SetFileSecurity(dst, win32security.DACL_SECURITY_INFORMATION, security_dst)
 
 
-def _generate_windows_flags(rights_desc: Dict[str, int]) -> int:
+def _generate_windows_flags(rights_desc: dict[str, int]) -> int:
     # Some notes about how each POSIX right is interpreted.
     #
     # For the rights read and execute, we have a pretty bijective relation between

--- a/certbot/src/certbot/compat/misc.py
+++ b/certbot/src/certbot/compat/misc.py
@@ -9,7 +9,6 @@ import select
 import subprocess
 import sys
 from typing import Optional
-from typing import Tuple
 
 from certbot import errors
 from certbot.compat import os
@@ -136,7 +135,7 @@ def underscores_for_unsupported_characters_in_path(path: str) -> str:
 
 
 def execute_command_status(cmd_name: str, shell_cmd: str,
-                           env: Optional[dict] = None) -> Tuple[int, str, str]:
+                           env: Optional[dict] = None) -> tuple[int, str, str]:
     """
     Run a command:
         - on Linux command will be run by the standard shell selected with

--- a/certbot/src/certbot/configuration.py
+++ b/certbot/src/certbot/configuration.py
@@ -4,8 +4,6 @@ import copy
 import enum
 import logging
 from typing import Any
-from typing import Dict
-from typing import List
 from typing import Optional
 from urllib import parse
 
@@ -73,7 +71,7 @@ class NamespaceConfig:
         # Check command line parameters sanity, and error out in case of problem.
         _check_config_sanity(self)
 
-    def set_argument_sources(self, argument_sources: Dict[str, ArgumentSource]) -> None:
+    def set_argument_sources(self, argument_sources: dict[str, ArgumentSource]) -> None:
         """
         Associate the NamespaceConfig with a dictionary describing where each of
         its arguments came from, e.g. `{ 'email': ArgumentSource.CONFIG_FILE }`.
@@ -133,7 +131,7 @@ class NamespaceConfig:
 
         return False
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Returns a dictionary mapping all argument names to their values
         """
@@ -152,7 +150,7 @@ class NamespaceConfig:
                 del self._previously_accessed_mutables[name]
 
     @property
-    def argument_sources(self) -> Optional[Dict[str, ArgumentSource]]:
+    def argument_sources(self) -> Optional[dict[str, ArgumentSource]]:
         """Returns _argument_sources after handling any changes to accessed mutable values."""
         # We keep values in _previously_accessed_mutables until we've detected a modification to try
         # to provide up-to-date information when argument_sources is accessed. Once a mutable object
@@ -326,7 +324,7 @@ class NamespaceConfig:
         return self.namespace.https_port
 
     @property
-    def pref_challs(self) -> List[str]:
+    def pref_challs(self) -> list[str]:
         """List of user specified preferred challenges.
 
         Sorted with the most preferred challenge listed first.

--- a/certbot/src/certbot/crypto_util.py
+++ b/certbot/src/certbot/crypto_util.py
@@ -8,10 +8,7 @@ import datetime
 import hashlib
 import logging
 import re
-from typing import List
 from typing import Optional
-from typing import Set
-from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
 
@@ -100,7 +97,7 @@ def generate_key(key_size: int, key_dir: Optional[str], key_type: str = "rsa",
     return util.Key(key_path, key_pem)
 
 
-def generate_csr(privkey: util.Key, names: Union[List[str], Set[str]], path: Optional[str],
+def generate_csr(privkey: util.Key, names: Union[list[str], set[str]], path: Optional[str],
                  must_staple: bool = False, strict_permissions: bool = True) -> util.CSR:
     """Initialize a CSR with the given private key.
 
@@ -173,7 +170,7 @@ def csr_matches_pubkey(csr: bytes, privkey: bytes) -> bool:
 
 def import_csr_file(
     csrfile: str, data: bytes
-) -> Tuple[acme_crypto_util.Format, util.CSR, List[str]]:
+) -> tuple[acme_crypto_util.Format, util.CSR, list[str]]:
     """Import a CSR file, which can be either PEM or DER.
 
     :param str csrfile: CSR filename
@@ -390,7 +387,7 @@ def verify_fullchain(renewable_cert: interfaces.RenewableCert) -> None:
 
 def get_sans_from_cert(
     cert: bytes, typ: Union[acme_crypto_util.Format, int] = acme_crypto_util.Format.PEM
-) -> List[str]:
+) -> list[str]:
     """Get a list of Subject Alternative Names from a certificate.
 
     :param str cert: Certificate (encoded).
@@ -419,7 +416,7 @@ def get_sans_from_cert(
 
 def get_names_from_cert(
     cert: bytes, typ: Union[acme_crypto_util.Format, int] = acme_crypto_util.Format.PEM
-) -> List[str]:
+) -> list[str]:
     """Get a list of domains from a cert, including the CN if it is set.
 
     :param str cert: Certificate (encoded).
@@ -442,7 +439,7 @@ def get_names_from_cert(
 
 def get_names_from_req(
     csr: bytes, typ: Union[acme_crypto_util.Format, int] = acme_crypto_util.Format.PEM
-) -> List[str]:
+) -> list[str]:
     """Get a list of domains from a CSR, including the CN if it is set.
 
     :param str csr: CSR (encoded).
@@ -517,7 +514,7 @@ CERT_PEM_REGEX = re.compile(
 )
 
 
-def cert_and_chain_from_fullchain(fullchain_pem: str) -> Tuple[str, str]:
+def cert_and_chain_from_fullchain(fullchain_pem: str) -> tuple[str, str]:
     """Split fullchain_pem into cert_pem and chain_pem
 
     :param str fullchain_pem: concatenated cert + chain
@@ -538,7 +535,7 @@ def cert_and_chain_from_fullchain(fullchain_pem: str) -> Tuple[str, str]:
 
     # Second pass: for each certificate found, parse it using cryptography and re-encode it,
     # with the effect of normalizing any encoding variations (e.g. CRLF, whitespace).
-    certs_normalized: List[str] = []
+    certs_normalized: list[str] = []
     for cert_pem in certs:
         cert = x509.load_pem_x509_certificate(cert_pem)
         cert_pem = cert.public_bytes(Encoding.PEM)
@@ -561,7 +558,7 @@ def get_serial_from_cert(cert_path: str) -> int:
     return cert.serial_number
 
 
-def find_chain_with_issuer(fullchains: List[str], issuer_cn: str,
+def find_chain_with_issuer(fullchains: list[str], issuer_cn: str,
                            warn_on_no_match: bool = False) -> str:
     """Chooses the first certificate chain from fullchains whose topmost
     intermediate has an Issuer Common Name matching issuer_cn (in other words

--- a/certbot/src/certbot/display/ops.py
+++ b/certbot/src/certbot/display/ops.py
@@ -4,9 +4,7 @@ from textwrap import indent
 from typing import Any
 from typing import Callable
 from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 from certbot import errors
 from certbot import interfaces
@@ -48,7 +46,7 @@ def get_email(invalid: bool = False, **kwargs: Any) -> str:
         invalid_prefix = "There is a problem with your email address. "
 
 
-def choose_account(accounts: List[account.Account]) -> Optional[account.Account]:
+def choose_account(accounts: list[account.Account]) -> Optional[account.Account]:
     """Choose an account.
 
     :param list accounts: Containing at least one
@@ -64,7 +62,7 @@ def choose_account(accounts: List[account.Account]) -> Optional[account.Account]
     return None
 
 
-def choose_values(values: List[str], question: Optional[str] = None) -> List[str]:
+def choose_values(values: list[str], question: Optional[str] = None) -> list[str]:
     """Display screen to let user pick one or multiple values from the provided
     list.
 
@@ -82,7 +80,7 @@ def choose_values(values: List[str], question: Optional[str] = None) -> List[str
 
 
 def choose_names(installer: Optional[interfaces.Installer],
-                 question: Optional[str] = None) -> List[str]:
+                 question: Optional[str] = None) -> list[str]:
     """Display screen to select domains to validate.
 
     :param installer: An installer object
@@ -111,7 +109,7 @@ def choose_names(installer: Optional[interfaces.Installer],
     return []
 
 
-def get_valid_domains(domains: Iterable[str]) -> List[str]:
+def get_valid_domains(domains: Iterable[str]) -> list[str]:
     """Helper method for choose_names that implements basic checks
      on domain names
 
@@ -119,7 +117,7 @@ def get_valid_domains(domains: Iterable[str]) -> List[str]:
     :return: List of valid domains
     :rtype: list
     """
-    valid_domains: List[str] = []
+    valid_domains: list[str] = []
     for domain in domains:
         try:
             valid_domains.append(util.enforce_domain_sanity(domain))
@@ -128,7 +126,7 @@ def get_valid_domains(domains: Iterable[str]) -> List[str]:
     return valid_domains
 
 
-def _sort_names(FQDNs: Iterable[str]) -> List[str]:
+def _sort_names(FQDNs: Iterable[str]) -> list[str]:
     """Sort FQDNs by SLD (and if many, by their subdomains)
 
     :param list FQDNs: list of domain names
@@ -140,7 +138,7 @@ def _sort_names(FQDNs: Iterable[str]) -> List[str]:
 
 
 def _filter_names(names: Iterable[str],
-                  override_question: Optional[str] = None) -> Tuple[str, List[str]]:
+                  override_question: Optional[str] = None) -> tuple[str, list[str]]:
     """Determine which names the user would like to select from a list.
 
     :param list names: domain names
@@ -165,7 +163,7 @@ def _filter_names(names: Iterable[str],
     return code, [str(s) for s in names]
 
 
-def _choose_names_manually(prompt_prefix: str = "") -> List[str]:
+def _choose_names_manually(prompt_prefix: str = "") -> list[str]:
     """Manually input names for those without an installer.
 
     :param str prompt_prefix: string to prepend to prompt for domains
@@ -219,7 +217,7 @@ def _choose_names_manually(prompt_prefix: str = "") -> List[str]:
     return []
 
 
-def success_installation(domains: List[str]) -> None:
+def success_installation(domains: list[str]) -> None:
     """Display a box confirming the installation of HTTPS.
 
     :param list domains: domain names which were enabled
@@ -231,7 +229,7 @@ def success_installation(domains: List[str]) -> None:
     )
 
 
-def success_renewal(unused_domains: List[str]) -> None:
+def success_renewal(unused_domains: list[str]) -> None:
     """Display a box confirming the renewal of an existing certificate.
 
     :param list domains: domain names which were renewed
@@ -273,7 +271,7 @@ def report_executed_command(command_name: str, returncode: int, stdout: str, std
         logger.warning("%s ran with error output:\n%s", command_name, indent(err_s, ' '))
 
 
-def _gen_https_names(domains: List[str]) -> str:
+def _gen_https_names(domains: list[str]) -> str:
     """Returns a string of the https domains.
 
     Domains are formatted nicely with ``https://`` prepended to each.
@@ -294,9 +292,9 @@ def _gen_https_names(domains: List[str]) -> str:
     return ""
 
 
-def _get_validated(method: Callable[..., Tuple[str, str]],
+def _get_validated(method: Callable[..., tuple[str, str]],
                    validator: Callable[[str], Any], message: str,
-                   default: Optional[str] = None, **kwargs: Any) -> Tuple[str, str]:
+                   default: Optional[str] = None, **kwargs: Any) -> tuple[str, str]:
     if default is not None:
         try:
             validator(default)
@@ -324,7 +322,7 @@ def _get_validated(method: Callable[..., Tuple[str, str]],
 
 
 def validated_input(validator: Callable[[str], Any],
-                    *args: Any, **kwargs: Any) -> Tuple[str, str]:
+                    *args: Any, **kwargs: Any) -> tuple[str, str]:
     """Like `~certbot.display.util.input_text`, but with validation.
 
     :param callable validator: A method which will be called on the
@@ -339,7 +337,7 @@ def validated_input(validator: Callable[[str], Any],
 
 
 def validated_directory(validator: Callable[[str], Any],
-                        *args: Any, **kwargs: Any) -> Tuple[str, str]:
+                        *args: Any, **kwargs: Any) -> tuple[str, str]:
     """Like `~certbot.display.util.directory_select`, but with validation.
 
     :param callable validator: A method which will be called on the

--- a/certbot/src/certbot/display/util.py
+++ b/certbot/src/certbot/display/util.py
@@ -9,9 +9,7 @@ should be used whenever:
 Other messages can use the `logging` module. See `log.py`.
 
 """
-from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 
 from certbot._internal.display import obj
@@ -53,9 +51,9 @@ def notification(message: str, pause: bool = True, wrap: bool = True,
                                    force_interactive=force_interactive, decorate=decorate)
 
 
-def menu(message: str, choices: Union[List[str], List[Tuple[str, str]]],
+def menu(message: str, choices: Union[list[str], list[tuple[str, str]]],
          default: Optional[int] = None, cli_flag: Optional[str] = None,
-         force_interactive: bool = False) -> Tuple[str, int]:
+         force_interactive: bool = False) -> tuple[str, int]:
     """Display a menu.
 
     .. todo:: This doesn't enable the help label/button (I wasn't sold on
@@ -82,7 +80,7 @@ def menu(message: str, choices: Union[List[str], List[Tuple[str, str]]],
 
 
 def input_text(message: str, default: Optional[str] = None, cli_flag: Optional[str] = None,
-               force_interactive: bool = False) -> Tuple[str, str]:
+               force_interactive: bool = False) -> tuple[str, str]:
     """Accept input from the user.
 
     :param str message: message to display to the user
@@ -125,9 +123,9 @@ def yesno(message: str, yes_label: str = "Yes", no_label: str = "No",
                                    cli_flag=cli_flag, force_interactive=force_interactive)
 
 
-def checklist(message: str, tags: List[str], default: Optional[List[str]] = None,
+def checklist(message: str, tags: list[str], default: Optional[list[str]] = None,
               cli_flag: Optional[str] = None,
-              force_interactive: bool = False) -> Tuple[str, List[str]]:
+              force_interactive: bool = False) -> tuple[str, list[str]]:
     """Display a checklist.
 
     :param str message: Message to display to user
@@ -148,7 +146,7 @@ def checklist(message: str, tags: List[str], default: Optional[List[str]] = None
 
 
 def directory_select(message: str, default: Optional[str] = None, cli_flag: Optional[str] = None,
-                     force_interactive: bool = False) -> Tuple[str, str]:
+                     force_interactive: bool = False) -> tuple[str, str]:
     """Display a directory selection screen.
 
     :param str message: prompt to give the user

--- a/certbot/src/certbot/errors.py
+++ b/certbot/src/certbot/errors.py
@@ -1,5 +1,4 @@
 """Certbot client errors."""
-from typing import Set
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -55,7 +54,7 @@ class FailedChallenges(AuthorizationError):
     :ivar set failed_achalls: Failed `.AnnotatedChallenge` instances.
 
     """
-    def __init__(self, failed_achalls: Set['AnnotatedChallenge']) -> None:
+    def __init__(self, failed_achalls: set['AnnotatedChallenge']) -> None:
         assert failed_achalls
         self.failed_achalls = failed_achalls
         super().__init__()

--- a/certbot/src/certbot/interfaces.py
+++ b/certbot/src/certbot/interfaces.py
@@ -4,9 +4,7 @@ from abc import abstractmethod
 from argparse import ArgumentParser
 from typing import Any
 from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
 
@@ -29,7 +27,7 @@ class AccountStorage(metaclass=ABCMeta):
     """Accounts storage interface."""
 
     @abstractmethod
-    def find_all(self) -> List['Account']:  # pragma: no cover
+    def find_all(self) -> list['Account']:  # pragma: no cover
         """Find all accounts.
 
         :returns: All found accounts.
@@ -164,7 +162,7 @@ class Authenticator(Plugin):
     """
 
     @abstractmethod
-    def get_chall_pref(self, domain: str) -> Iterable[Type[Challenge]]:
+    def get_chall_pref(self, domain: str) -> Iterable[type[Challenge]]:
         """Return `collections.Iterable` of challenge preferences.
 
         :param str domain: Domain for which challenge preferences are sought.
@@ -178,7 +176,7 @@ class Authenticator(Plugin):
         """
 
     @abstractmethod
-    def perform(self, achalls: List[AnnotatedChallenge]) -> List[ChallengeResponse]:
+    def perform(self, achalls: list[AnnotatedChallenge]) -> list[ChallengeResponse]:
         """Perform the given challenge.
 
         :param list achalls: Non-empty (guaranteed) list of
@@ -199,7 +197,7 @@ class Authenticator(Plugin):
         """
 
     @abstractmethod
-    def cleanup(self, achalls: List[AnnotatedChallenge]) -> None:
+    def cleanup(self, achalls: list[AnnotatedChallenge]) -> None:
         """Revert changes and shutdown after challenges complete.
 
         This method should be able to revert all changes made by
@@ -255,7 +253,7 @@ class Installer(Plugin):
 
     @abstractmethod
     def enhance(self, domain: str, enhancement: str,
-                options: Optional[Union[List[str], str]] = None) -> None:
+                options: Optional[Union[list[str], str]] = None) -> None:
         """Perform a configuration enhancement.
 
         :param str domain: domain for which to provide enhancement
@@ -272,7 +270,7 @@ class Installer(Plugin):
         """
 
     @abstractmethod
-    def supported_enhancements(self) -> List[str]:
+    def supported_enhancements(self) -> list[str]:
         """Returns a `collections.Iterable` of supported enhancements.
 
         :returns: supported enhancements which should be a subset of
@@ -392,7 +390,7 @@ class RenewableCert(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def names(self) -> List[str]:
+    def names(self) -> list[str]:
         """What are the subject names of this certificate?
 
         :returns: the subject names

--- a/certbot/src/certbot/main.py
+++ b/certbot/src/certbot/main.py
@@ -1,12 +1,11 @@
 """Certbot main public entry point."""
-from typing import List
 from typing import Optional
 from typing import Union
 
 from certbot._internal import main as internal_main
 
 
-def main(cli_args: Optional[List[str]] = None) -> Optional[Union[str, int]]:
+def main(cli_args: Optional[list[str]] = None) -> Optional[Union[str, int]]:
     """Run Certbot.
 
     :param cli_args: command line to Certbot, defaults to ``sys.argv[1:]``

--- a/certbot/src/certbot/ocsp.py
+++ b/certbot/src/certbot/ocsp.py
@@ -7,7 +7,6 @@ import re
 import subprocess
 from subprocess import PIPE
 from typing import Optional
-from typing import Tuple
 import warnings
 
 from cryptography import x509
@@ -133,7 +132,7 @@ class RevocationChecker:
         return _translate_ocsp_query(cert_path, output, err)
 
 
-def _determine_ocsp_server(cert_path: str) -> Tuple[Optional[str], Optional[str]]:
+def _determine_ocsp_server(cert_path: str) -> tuple[Optional[str], Optional[str]]:
     """Extract the OCSP server host from a certificate.
 
     :param str cert_path: Path to the cert we're checking OCSP for

--- a/certbot/src/certbot/plugins/common.py
+++ b/certbot/src/certbot/plugins/common.py
@@ -10,11 +10,7 @@ import tempfile
 from typing import Any
 from typing import Callable
 from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Set
-from typing import Tuple
-from typing import Type
 from typing import TypeVar
 
 from acme import challenges
@@ -108,7 +104,7 @@ class Plugin(AbstractPlugin, metaclass=ABCMeta):
         """Find a configuration value for variable ``var``."""
         return getattr(self.config, self.dest(var))
 
-    def auth_hint(self, failed_achalls: List[achallenges.AnnotatedChallenge]) -> str:
+    def auth_hint(self, failed_achalls: list[achallenges.AnnotatedChallenge]) -> str:
         """Human-readable string to help the user troubleshoot the authenticator.
 
         Shown to the user if one or more of the attempted challenges were not a success.
@@ -146,7 +142,7 @@ class Installer(AbstractInstaller, Plugin, metaclass=ABCMeta):
         self.storage = PluginStorage(self.config, self.name)
         self.reverter = reverter.Reverter(self.config)
 
-    def add_to_checkpoint(self, save_files: Set[str], save_notes: str,
+    def add_to_checkpoint(self, save_files: set[str], save_notes: str,
                           temporary: bool = False) -> None:
         """Add files to a checkpoint.
 
@@ -256,12 +252,12 @@ class Addr:
     :param str port: port number or \*, or ""
 
     """
-    def __init__(self, tup: Tuple[str, str], ipv6: bool = False):
+    def __init__(self, tup: tuple[str, str], ipv6: bool = False):
         self.tup = tup
         self.ipv6 = ipv6
 
     @classmethod
-    def fromstring(cls: Type[GenericAddr], str_addr: str) -> GenericAddr:
+    def fromstring(cls: type[GenericAddr], str_addr: str) -> GenericAddr:
         """Initialize Addr from string."""
         if str_addr.startswith('['):
             # ipv6 addresses starts with [
@@ -280,7 +276,7 @@ class Addr:
             return "%s:%s" % self.tup
         return self.tup[0]
 
-    def normalized_tuple(self) -> Tuple[str, str]:
+    def normalized_tuple(self) -> tuple[str, str]:
         """Normalized representation of addr/port tuple
         """
         if self.ipv6:
@@ -310,7 +306,7 @@ class Addr:
         """Return new address object with same addr and new port."""
         return self.__class__((self.tup[0], port), self.ipv6)
 
-    def _normalize_ipv6(self, addr: str) -> List[str]:
+    def _normalize_ipv6(self, addr: str) -> list[str]:
         """Return IPv6 address in normalized form, helper function"""
         addr = addr.lstrip("[")
         addr = addr.rstrip("]")
@@ -322,7 +318,7 @@ class Addr:
             return ":".join(self._normalize_ipv6(self.tup[0]))
         return ""
 
-    def _explode_ipv6(self, addr: str) -> List[str]:
+    def _explode_ipv6(self, addr: str) -> list[str]:
         """Explode IPv6 address for comparison"""
         result = ['0', '0', '0', '0', '0', '0', '0', '0']
         addr_list = addr.split(":")
@@ -361,8 +357,8 @@ class ChallengePerformer:
 
     def __init__(self, configurator: Configurator):
         self.configurator = configurator
-        self.achalls: List[achallenges.KeyAuthorizationAnnotatedChallenge] = []
-        self.indices: List[int] = []
+        self.achalls: list[achallenges.KeyAuthorizationAnnotatedChallenge] = []
+        self.indices: list[int] = []
 
     def add_chall(self, achall: achallenges.KeyAuthorizationAnnotatedChallenge,
                   idx: Optional[int] = None) -> None:
@@ -377,7 +373,7 @@ class ChallengePerformer:
         if idx is not None:
             self.indices.append(idx)
 
-    def perform(self) -> List[challenges.KeyAuthorizationChallengeResponse]:
+    def perform(self) -> list[challenges.KeyAuthorizationChallengeResponse]:
         """Perform all added challenges.
 
         :returns: challenge responses
@@ -439,7 +435,7 @@ def install_version_controlled_file(dest_path: str, digest_path: str, src_path: 
 # "pragma: no cover") TODO: this might quickly lead to dead code (also
 # c.f. #383)
 
-def dir_setup(test_dir: str, pkg: str) -> Tuple[str, str, str]:  # pragma: no cover
+def dir_setup(test_dir: str, pkg: str) -> tuple[str, str, str]:  # pragma: no cover
     """Setup the directories necessary for the configurator."""
     def expanded_tempdir(prefix: str) -> str:
         """Return the real path of a temp directory with the specified prefix

--- a/certbot/src/certbot/plugins/dns_common.py
+++ b/certbot/src/certbot/plugins/dns_common.py
@@ -4,10 +4,8 @@ import logging
 from time import sleep
 from typing import Callable
 from typing import Iterable
-from typing import List
 from typing import Mapping
 from typing import Optional
-from typing import Type
 
 import configobj
 
@@ -46,7 +44,7 @@ class DNSAuthenticator(common.Plugin, interfaces.Authenticator, metaclass=abc.AB
             help='The number of seconds to wait for DNS to propagate before asking the ACME server '
                  'to verify the DNS record.')
 
-    def auth_hint(self, failed_achalls: List[achallenges.AnnotatedChallenge]) -> str:
+    def auth_hint(self, failed_achalls: list[achallenges.AnnotatedChallenge]) -> str:
         """See certbot.plugins.common.Plugin.auth_hint."""
         delay = self.conf('propagation-seconds')
         return (
@@ -56,7 +54,7 @@ class DNSAuthenticator(common.Plugin, interfaces.Authenticator, metaclass=abc.AB
             .format(name=self.name, secs=delay, suffix='s' if delay != 1 else '')
         )
 
-    def get_chall_pref(self, unused_domain: str) -> Iterable[Type[challenges.Challenge]]:  # pylint: disable=missing-function-docstring
+    def get_chall_pref(self, unused_domain: str) -> Iterable[type[challenges.Challenge]]:  # pylint: disable=missing-function-docstring
         return [challenges.DNS01]
 
     def prepare(self) -> None:  # pylint: disable=missing-function-docstring
@@ -65,8 +63,8 @@ class DNSAuthenticator(common.Plugin, interfaces.Authenticator, metaclass=abc.AB
     def more_info(self) -> str:  # pylint: disable=missing-function-docstring
         raise NotImplementedError()
 
-    def perform(self, achalls: List[achallenges.AnnotatedChallenge]
-                ) -> List[challenges.ChallengeResponse]: # pylint: disable=missing-function-docstring
+    def perform(self, achalls: list[achallenges.AnnotatedChallenge]
+                ) -> list[challenges.ChallengeResponse]: # pylint: disable=missing-function-docstring
         self._setup_credentials()
 
         self._attempt_cleanup = True
@@ -89,7 +87,7 @@ class DNSAuthenticator(common.Plugin, interfaces.Authenticator, metaclass=abc.AB
 
         return responses
 
-    def cleanup(self, achalls: List[achallenges.AnnotatedChallenge]) -> None:  # pylint: disable=missing-function-docstring
+    def cleanup(self, achalls: list[achallenges.AnnotatedChallenge]) -> None:  # pylint: disable=missing-function-docstring
         if self._attempt_cleanup:
             for achall in achalls:
                 domain = achall.domain
@@ -352,7 +350,7 @@ def validate_file_permissions(filename: str) -> None:
         logger.warning('Unsafe permissions on credentials configuration file: %s', filename)
 
 
-def base_domain_name_guesses(domain: str) -> List[str]:
+def base_domain_name_guesses(domain: str) -> list[str]:
     """Return a list of progressively less-specific domain names.
 
     One of these will probably be the domain name known to the DNS provider.

--- a/certbot/src/certbot/plugins/dns_common_lexicon.py
+++ b/certbot/src/certbot/plugins/dns_common_lexicon.py
@@ -5,11 +5,8 @@ import sys
 from types import ModuleType
 from typing import Any
 from typing import cast
-from typing import Dict
-from typing import List
 from typing import Mapping
 from typing import Optional
-from typing import Tuple
 from typing import Union
 import warnings
 
@@ -135,7 +132,7 @@ class LexiconClient:  # pragma: no cover
 
 def build_lexicon_config(lexicon_provider_name: str,
                          lexicon_options: Mapping[str, Any], provider_options: Mapping[str, Any]
-                         ) -> Union[ConfigResolver, Dict[str, Any]]:  # pragma: no cover
+                         ) -> Union[ConfigResolver, dict[str, Any]]:  # pragma: no cover
     """
     Convenient function to build a Lexicon 2.x/3.x config object.
 
@@ -148,7 +145,7 @@ def build_lexicon_config(lexicon_provider_name: str,
     .. deprecated:: 2.7.0
        Please use certbot.plugins.dns_common_lexicon.LexiconDNSAuthenticator instead.
     """
-    config_dict: Dict[str, Any] = {'provider_name': lexicon_provider_name}
+    config_dict: dict[str, Any] = {'provider_name': lexicon_provider_name}
     config_dict.update(lexicon_options)
     if ConfigResolver is None:
         # Lexicon 2.x
@@ -156,7 +153,7 @@ def build_lexicon_config(lexicon_provider_name: str,
         return config_dict
     else:
         # Lexicon 3.x
-        provider_config: Dict[str, Any] = {}
+        provider_config: dict[str, Any] = {}
         provider_config.update(provider_options)
         config_dict[lexicon_provider_name] = provider_config
         return ConfigResolver().with_dict(config_dict).with_env()
@@ -170,7 +167,7 @@ class LexiconDNSAuthenticator(dns_common.DNSAuthenticator):
 
     def __init__(self, config: configuration.NamespaceConfig, name: str):
         super().__init__(config, name)
-        self._provider_options: List[Tuple[str, str, str]] = []
+        self._provider_options: list[tuple[str, str, str]] = []
         self._credentials: dns_common.CredentialsConfiguration
 
     @property
@@ -298,7 +295,7 @@ class _DeprecationModule:
     def __delattr__(self, attr: str) -> Any:  # pragma: no cover
         delattr(self._module, attr)
 
-    def __dir__(self) -> List[str]:  # pragma: no cover
+    def __dir__(self) -> list[str]:  # pragma: no cover
         return ['_module'] + dir(self._module)
 
 

--- a/certbot/src/certbot/plugins/dns_test_common_lexicon.py
+++ b/certbot/src/certbot/plugins/dns_test_common_lexicon.py
@@ -5,9 +5,7 @@ from types import ModuleType
 from typing import Any
 from typing import cast
 from typing import Generator
-from typing import List
 from typing import Protocol
-from typing import Tuple
 from unittest import mock
 from unittest.mock import MagicMock
 import warnings
@@ -317,7 +315,7 @@ class BaseLexiconDNSAuthenticatorTest(dns_test_common.BaseAuthenticatorTest):
 
 
 @contextlib.contextmanager
-def _patch_lexicon_client() -> Generator[Tuple[MagicMock, MagicMock], None, None]:
+def _patch_lexicon_client() -> Generator[tuple[MagicMock, MagicMock], None, None]:
     with mock.patch('certbot.plugins.dns_common_lexicon.Client') as mock_client:
         mock_operations = MagicMock()
         mock_client.return_value.__enter__.return_value = mock_operations
@@ -348,7 +346,7 @@ class _DeprecationModule:
     def __delattr__(self, attr: str) -> Any:  # pragma: no cover
         delattr(self._module, attr)
 
-    def __dir__(self) -> List[str]:  # pragma: no cover
+    def __dir__(self) -> list[str]:  # pragma: no cover
         return ['_module'] + dir(self._module)
 
 

--- a/certbot/src/certbot/plugins/enhancements.py
+++ b/certbot/src/certbot/plugins/enhancements.py
@@ -2,10 +2,8 @@
 import abc
 from typing import Any
 from typing import Callable
-from typing import Dict
 from typing import Generator
 from typing import Iterable
-from typing import List
 from typing import Optional
 
 from certbot import configuration
@@ -25,7 +23,7 @@ List of expected options parameters:
 
 
 def enabled_enhancements(
-        config: configuration.NamespaceConfig) -> Generator[Dict[str, Any], None, None]:
+        config: configuration.NamespaceConfig) -> Generator[dict[str, Any], None, None]:
     """
     Generator to yield the enabled new style enhancements.
 
@@ -174,7 +172,7 @@ class AutoHSTSEnhancement(object, metaclass=abc.ABCMeta):
 # This is used to configure internal new style enhancements in Certbot. These
 # enhancement interfaces need to be defined in this file. Please do not modify
 # this list from plugin code.
-_INDEX: List[Dict[str, Any]] = [
+_INDEX: list[dict[str, Any]] = [
     {
         "name": "AutoHSTS",
         "cli_help": "Gradually increasing max-age value for HTTP Strict Transport "+

--- a/certbot/src/certbot/plugins/storage.py
+++ b/certbot/src/certbot/plugins/storage.py
@@ -2,7 +2,6 @@
 import json
 import logging
 from typing import Any
-from typing import Dict
 
 from certbot import configuration
 from certbot import errors
@@ -27,7 +26,7 @@ class PluginStorage:
         self._config = config
         self._classkey = classkey
         self._initialized = False
-        self._data: Dict
+        self._data: dict
         self._storagepath: str
 
     def _initialize_storage(self) -> None:
@@ -43,7 +42,7 @@ class PluginStorage:
 
         :raises .errors.PluginStorageError: when unable to open or read the file
         """
-        data: Dict[str, Any] = {}
+        data: dict[str, Any] = {}
         filedata = ""
         try:
             with open(self._storagepath, 'r') as fh:

--- a/certbot/src/certbot/plugins/util.py
+++ b/certbot/src/certbot/plugins/util.py
@@ -1,6 +1,5 @@
 """Plugin utilities."""
 import logging
-from typing import List
 
 from certbot import util
 from certbot.compat import os
@@ -9,7 +8,7 @@ from certbot.compat.misc import STANDARD_BINARY_DIRS
 logger = logging.getLogger(__name__)
 
 
-def get_prefixes(path: str) -> List[str]:
+def get_prefixes(path: str) -> list[str]:
     """Retrieves all possible path prefixes of a path, in descending order
     of length. For instance:
 
@@ -22,7 +21,7 @@ def get_prefixes(path: str) -> List[str]:
     :rtype: `list` of `str`
     """
     prefix = os.path.normpath(path)
-    prefixes: List[str] = []
+    prefixes: list[str] = []
     while prefix:
         prefixes.append(prefix)
         prefix, _ = os.path.split(prefix)

--- a/certbot/src/certbot/reverter.py
+++ b/certbot/src/certbot/reverter.py
@@ -6,10 +6,7 @@ import shutil
 import time
 import traceback
 from typing import Iterable
-from typing import List
-from typing import Set
 from typing import TextIO
-from typing import Tuple
 
 from certbot import configuration
 from certbot import errors
@@ -131,7 +128,7 @@ class Reverter:
                     "Unable to load checkpoint during rollback")
             rollback -= 1
 
-    def add_to_temp_checkpoint(self, save_files: Set[str], save_notes: str) -> None:
+    def add_to_temp_checkpoint(self, save_files: set[str], save_notes: str) -> None:
         """Add files to temporary checkpoint.
 
         :param set save_files: set of filepaths to save
@@ -141,7 +138,7 @@ class Reverter:
         self._add_to_checkpoint_dir(
             self.config.temp_checkpoint_dir, save_files, save_notes)
 
-    def add_to_checkpoint(self, save_files: Set[str], save_notes: str) -> None:
+    def add_to_checkpoint(self, save_files: set[str], save_notes: str) -> None:
         """Add files to a permanent checkpoint.
 
         :param set save_files: set of filepaths to save
@@ -153,7 +150,7 @@ class Reverter:
         self._add_to_checkpoint_dir(
             self.config.in_progress_dir, save_files, save_notes)
 
-    def _add_to_checkpoint_dir(self, cp_dir: str, save_files: Set[str], save_notes: str) -> None:
+    def _add_to_checkpoint_dir(self, cp_dir: str, save_files: set[str], save_notes: str) -> None:
         """Add save files to checkpoint directory.
 
         :param str cp_dir: Checkpoint directory filepath
@@ -198,7 +195,7 @@ class Reverter:
         with open(os.path.join(cp_dir, "CHANGES_SINCE"), "a") as notes_fd:
             notes_fd.write(save_notes)
 
-    def _read_and_append(self, filepath: str) -> Tuple[TextIO, List[str]]:
+    def _read_and_append(self, filepath: str) -> tuple[TextIO, list[str]]:
         """Reads the file lines and returns a file obj.
 
         Read the file returning the lines, and a pointer to the end of the file.
@@ -268,7 +265,7 @@ class Reverter:
                     logger.error(
                         "Unable to run undo command: %s", " ".join(command))
 
-    def _check_tempfile_saves(self, save_files: Set[str]) -> None:
+    def _check_tempfile_saves(self, save_files: set[str]) -> None:
         """Verify save isn't overwriting any temporary files.
 
         :param set save_files: Set of files about to be saved.

--- a/certbot/src/certbot/tests/acme_util.py
+++ b/certbot/src/certbot/tests/acme_util.py
@@ -1,7 +1,6 @@
 """ACME utilities for testing."""
 import datetime
 from typing import Any
-from typing import Dict
 from typing import Iterable
 
 import josepy as jose
@@ -67,7 +66,7 @@ def gen_authzr(authz_status: messages.Status, domain: str, challs: Iterable[chal
         chall_to_challb(chall, status)
         for chall, status in zip(challs, statuses)
     )
-    authz_kwargs: Dict[str, Any] = {
+    authz_kwargs: dict[str, Any] = {
         "identifier": messages.Identifier(
             typ=messages.IDENTIFIER_FQDN, value=domain),
         "challenges": challbs,

--- a/certbot/src/certbot/tests/util.py
+++ b/certbot/src/certbot/tests/util.py
@@ -16,7 +16,6 @@ from typing import Callable
 from typing import cast
 from typing import IO
 from typing import Iterable
-from typing import List
 from typing import Optional
 from typing import Union
 import unittest
@@ -51,10 +50,10 @@ class DummyInstaller(common.Installer):
         pass
 
     def enhance(self, domain: str, enhancement: str,
-                options: Optional[Union[List[str], str]] = None) -> None:
+                options: Optional[Union[list[str], str]] = None) -> None:
         pass
 
-    def supported_enhancements(self) -> List[str]:
+    def supported_enhancements(self) -> list[str]:
         return []
 
     def save(self, title: Optional[str] = None, temporary: bool = False) -> None:

--- a/certbot/src/certbot/util.py
+++ b/certbot/src/certbot/util.py
@@ -11,13 +11,9 @@ import subprocess
 import sys
 from typing import Any
 from typing import Callable
-from typing import Dict
 from typing import IO
-from typing import List
 from typing import NamedTuple
 from typing import Optional
-from typing import Set
-from typing import Tuple
 from typing import Union
 
 import configargparse
@@ -68,7 +64,7 @@ class LooseVersion:
 
         :param str version_string: version string
         """
-        components: List[Union[int, str]]
+        components: list[Union[int, str]]
         components = [x for x in _VERSION_COMPONENT_RE.split(version_string)
                               if x and x != '.']
         for i, obj in enumerate(components):
@@ -143,10 +139,10 @@ _INITIAL_PID = os.getpid()
 # the dict are attempted to be cleaned up at program exit. If the
 # program exits before the lock is cleaned up, it is automatically
 # released, but the file isn't deleted.
-_LOCKS: Dict[str, lock.LockFile] = {}
+_LOCKS: dict[str, lock.LockFile] = {}
 _VERSION_COMPONENT_RE = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
 
-def env_no_snap_for_external_calls() -> Dict[str, str]:
+def env_no_snap_for_external_calls() -> dict[str, str]:
     """
     When Certbot is run inside a Snap, certain environment variables
     are modified. But Certbot sometimes calls out to external programs,
@@ -177,7 +173,7 @@ def env_no_snap_for_external_calls() -> Dict[str, str]:
     return env
 
 
-def run_script(params: List[str], log: Callable[[str], None]=logger.error) -> Tuple[str, str]:
+def run_script(params: list[str], log: Callable[[str], None]=logger.error) -> tuple[str, str]:
     """Run the script with the given params.
 
     :param list params: List of parameters to pass to subprocess.run
@@ -306,16 +302,16 @@ def safe_open(path: str, mode: str = "w", chmod: Optional[int] = None) -> IO:
         if ``None``.
 
     """
-    open_args: Union[Tuple[()], Tuple[int]] = ()
+    open_args: Union[tuple[()], tuple[int]] = ()
     if chmod is not None:
         open_args = (chmod,)
-    fdopen_args: Union[Tuple[()], Tuple[int]] = ()
+    fdopen_args: Union[tuple[()], tuple[int]] = ()
     fd = filesystem.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, *open_args)
     return os.fdopen(fd, mode, *fdopen_args)
 
 
 def _unique_file(path: str, filename_pat: Callable[[int], str], count: int,
-                 chmod: int, mode: str) -> Tuple[IO, str]:
+                 chmod: int, mode: str) -> tuple[IO, str]:
     while True:
         current_path = os.path.join(path, filename_pat(count))
         try:
@@ -327,7 +323,7 @@ def _unique_file(path: str, filename_pat: Callable[[int], str], count: int,
         count += 1
 
 
-def unique_file(path: str, chmod: int = 0o777, mode: str = "w") -> Tuple[IO, str]:
+def unique_file(path: str, chmod: int = 0o777, mode: str = "w") -> tuple[IO, str]:
     """Safely finds a unique file.
 
     :param str path: path/filename.ext
@@ -344,7 +340,7 @@ def unique_file(path: str, chmod: int = 0o777, mode: str = "w") -> Tuple[IO, str
 
 
 def unique_lineage_name(path: str, filename: str, chmod: int = 0o644,
-                        mode: str = "w") -> Tuple[IO, str]:
+                        mode: str = "w") -> tuple[IO, str]:
     """Safely finds a unique file using lineage convention.
 
     :param str path: directory path
@@ -380,7 +376,7 @@ def safely_remove(path: str) -> None:
             raise
 
 
-def get_filtered_names(all_names: Set[str]) -> Set[str]:
+def get_filtered_names(all_names: set[str]) -> set[str]:
     """Removes names that aren't considered valid by Let's Encrypt.
 
     :param set all_names: all names found in the configuration
@@ -397,7 +393,7 @@ def get_filtered_names(all_names: Set[str]) -> Set[str]:
             logger.debug('Not suggesting name "%s"', name, exc_info=True)
     return filtered_names
 
-def get_os_info() -> Tuple[str, str]:
+def get_os_info() -> tuple[str, str]:
     """
     Get OS name and version
 
@@ -425,7 +421,7 @@ def get_os_info_ua() -> str:
         return " ".join(get_python_os_info(pretty=True))
     return os_info
 
-def get_systemd_os_like() -> List[str]:
+def get_systemd_os_like() -> list[str]:
     """
     Get a list of strings that indicate the distribution likeness to
     other distributions.
@@ -467,7 +463,7 @@ def _normalize_string(orig: str) -> str:
     """
     return orig.replace('"', '').replace("'", "").strip()
 
-def get_python_os_info(pretty: bool = False) -> Tuple[str, str]:
+def get_python_os_info(pretty: bool = False) -> tuple[str, str]:
     """
     Get Operating System type/distribution and major version
     using python platform module
@@ -722,7 +718,7 @@ def atexit_register(func: Callable, *args: Any, **kwargs: Any) -> None:
     atexit.register(_atexit_call, func, *args, **kwargs)
 
 
-def parse_loose_version(version_string: str) -> List[Union[int, str]]:
+def parse_loose_version(version_string: str) -> list[Union[int, str]]:
     """Parses a version string into its components.
     This code and the returned tuple is based on the now deprecated
     distutils.version.LooseVersion class from the Python standard library.


### PR DESCRIPTION
this is another part of https://github.com/certbot/certbot/issues/10195

these changes were done automatically with the commands:

```
ruff check --fix --extend-select UP006 --unsafe-fixes certbot
git checkout certbot/src/certbot/_internal
```

fixing up the files under certbot/src/certbot/_internal will be done in another PR