### PR TITLE
use pep585 types in certbot-apache

### DIFF
--- a/certbot-apache/src/certbot_apache/_internal/apache_util.py
+++ b/certbot-apache/src/certbot_apache/_internal/apache_util.py
@@ -7,11 +7,8 @@ import logging
 import re
 import subprocess
 from contextlib import ExitStack
-from typing import Dict
 from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 from certbot import errors
 from certbot import util
@@ -20,7 +17,7 @@ from certbot.compat import os
 logger = logging.getLogger(__name__)
 
 
-def get_mod_deps(mod_name: str) -> List[str]:
+def get_mod_deps(mod_name: str) -> list[str]:
     """Get known module dependencies.
 
     .. note:: This does not need to be accurate in order for the client to
@@ -68,7 +65,7 @@ def get_internal_aug_path(vhost_path: str) -> str:
     return _split_aug_path(vhost_path)[1]
 
 
-def _split_aug_path(vhost_path: str) -> Tuple[str, str]:
+def _split_aug_path(vhost_path: str) -> tuple[str, str]:
     """Splits an Augeas path into a file path and an internal path.
 
     After removing "/files", this function splits vhost_path into the
@@ -82,7 +79,7 @@ def _split_aug_path(vhost_path: str) -> Tuple[str, str]:
     """
     # Strip off /files
     file_path = vhost_path[6:]
-    internal_path: List[str] = []
+    internal_path: list[str] = []
 
     # Remove components from the end of file_path until it becomes valid
     while not os.path.exists(file_path):
@@ -92,7 +89,7 @@ def _split_aug_path(vhost_path: str) -> Tuple[str, str]:
     return file_path, "/".join(reversed(internal_path))
 
 
-def parse_define_file(filepath: str, varname: str) -> Dict[str, str]:
+def parse_define_file(filepath: str, varname: str) -> dict[str, str]:
     """ Parses Defines from a variable in configuration file
 
     :param str filepath: Path of file to parse
@@ -102,7 +99,7 @@ def parse_define_file(filepath: str, varname: str) -> Dict[str, str]:
     :rtype: `dict`
 
     """
-    return_vars: Dict[str, str] = {}
+    return_vars: dict[str, str] = {}
     # Get list of words in the variable
     a_opts = util.get_var_from_file(varname, filepath).split()
     for i, v in enumerate(a_opts):
@@ -137,7 +134,7 @@ def included_in_paths(filepath: str, paths: Iterable[str]) -> bool:
     return any(fnmatch.fnmatch(filepath, path) for path in paths)
 
 
-def parse_defines(define_cmd: List[str]) -> Dict[str, str]:
+def parse_defines(define_cmd: list[str]) -> dict[str, str]:
     """
     Gets Defines from httpd process and returns a dictionary of
     the defined variables.
@@ -148,7 +145,7 @@ def parse_defines(define_cmd: List[str]) -> Dict[str, str]:
     :rtype: dict
     """
 
-    variables: Dict[str, str] = {}
+    variables: dict[str, str] = {}
     matches = parse_from_subprocess(define_cmd, r"Define: ([^ \n]*)")
     try:
         matches.remove("DUMP_RUN_CFG")
@@ -164,7 +161,7 @@ def parse_defines(define_cmd: List[str]) -> Dict[str, str]:
     return variables
 
 
-def parse_includes(inc_cmd: List[str]) -> List[str]:
+def parse_includes(inc_cmd: list[str]) -> list[str]:
     """
     Gets Include directives from httpd process and returns a list of
     their values.
@@ -178,7 +175,7 @@ def parse_includes(inc_cmd: List[str]) -> List[str]:
     return parse_from_subprocess(inc_cmd, r"\(.*\) (.*)")
 
 
-def parse_modules(mod_cmd: List[str]) -> List[str]:
+def parse_modules(mod_cmd: list[str]) -> list[str]:
     """
     Get loaded modules from httpd process, and return the list
     of loaded module names.
@@ -192,7 +189,7 @@ def parse_modules(mod_cmd: List[str]) -> List[str]:
     return parse_from_subprocess(mod_cmd, r"(.*)_module")
 
 
-def parse_from_subprocess(command: List[str], regexp: str) -> List[str]:
+def parse_from_subprocess(command: list[str], regexp: str) -> list[str]:
     """Get values from stdout of subprocess command
 
     :param list command: Command to run
@@ -206,7 +203,7 @@ def parse_from_subprocess(command: List[str], regexp: str) -> List[str]:
     return re.compile(regexp).findall(stdout)
 
 
-def _get_runtime_cfg(command: List[str]) -> str:
+def _get_runtime_cfg(command: list[str]) -> str:
     """
     Get runtime configuration info.
 

--- a/certbot-apache/src/certbot_apache/_internal/apacheparser.py
+++ b/certbot-apache/src/certbot_apache/_internal/apacheparser.py
@@ -1,9 +1,7 @@
 """ apacheconfig implementation of the ParserNode interfaces """
 from typing import Any
 from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 from certbot_apache._internal import assertions
 from certbot_apache._internal import interfaces
@@ -31,7 +29,7 @@ class ApacheParserNode(interfaces.ParserNode):
     def save(self, msg: str) -> None:
         pass  # pragma: no cover
 
-    def find_ancestors(self, name: str) -> List["ApacheParserNode"]:  # pylint: disable=unused-variable
+    def find_ancestors(self, name: str) -> list["ApacheParserNode"]:  # pylint: disable=unused-variable
         """Find ancestor BlockNodes with a given name"""
         return [ApacheBlockNode(name=assertions.PASS,
                                 parameters=assertions.PASS,
@@ -90,7 +88,7 @@ class ApacheBlockNode(ApacheDirectiveNode):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.children: Tuple[ApacheParserNode, ...] = ()
+        self.children: tuple[ApacheParserNode, ...] = ()
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, self.__class__):
@@ -105,7 +103,7 @@ class ApacheBlockNode(ApacheDirectiveNode):
         return False  # pragma: no cover
 
     # pylint: disable=unused-argument
-    def add_child_block(self, name: str, parameters: Optional[List[str]] = None,
+    def add_child_block(self, name: str, parameters: Optional[list[str]] = None,
                         position: Optional[int] = None) -> "ApacheBlockNode":  # pragma: no cover
         """Adds a new BlockNode to the sequence of children"""
         new_block = ApacheBlockNode(name=assertions.PASS,
@@ -117,7 +115,7 @@ class ApacheBlockNode(ApacheDirectiveNode):
         return new_block
 
     # pylint: disable=unused-argument
-    def add_child_directive(self, name: str, parameters: Optional[List[str]] = None,
+    def add_child_directive(self, name: str, parameters: Optional[list[str]] = None,
                             position: Optional[int] = None
     ) -> ApacheDirectiveNode:  # pragma: no cover
         """Adds a new DirectiveNode to the sequence of children"""
@@ -142,7 +140,7 @@ class ApacheBlockNode(ApacheDirectiveNode):
         self.children += (new_comment,)
         return new_comment
 
-    def find_blocks(self, name: str, exclude: bool = True) -> List["ApacheBlockNode"]:  # pylint: disable=unused-argument
+    def find_blocks(self, name: str, exclude: bool = True) -> list["ApacheBlockNode"]:  # pylint: disable=unused-argument
         """Recursive search of BlockNodes from the sequence of children"""
         return [ApacheBlockNode(name=assertions.PASS,
                                 parameters=assertions.PASS,
@@ -150,7 +148,7 @@ class ApacheBlockNode(ApacheDirectiveNode):
                                 filepath=assertions.PASS,
                                 metadata=self.metadata)]
 
-    def find_directives(self, name: str, exclude: bool = True) -> List[ApacheDirectiveNode]:  # pylint: disable=unused-argument
+    def find_directives(self, name: str, exclude: bool = True) -> list[ApacheDirectiveNode]:  # pylint: disable=unused-argument
         """Recursive search of DirectiveNodes from the sequence of children"""
         return [ApacheDirectiveNode(name=assertions.PASS,
                                     parameters=assertions.PASS,
@@ -159,7 +157,7 @@ class ApacheBlockNode(ApacheDirectiveNode):
                                     metadata=self.metadata)]
 
     # pylint: disable=unused-argument
-    def find_comments(self, comment: str, exact: bool = False) -> List[ApacheCommentNode]:
+    def find_comments(self, comment: str, exact: bool = False) -> list[ApacheCommentNode]:
         """Recursive search of DirectiveNodes from the sequence of children"""
         return [ApacheCommentNode(comment=assertions.PASS,  # pragma: no cover
                                   ancestor=self,
@@ -170,11 +168,11 @@ class ApacheBlockNode(ApacheDirectiveNode):
         """Deletes a ParserNode from the sequence of children"""
         return  # pragma: no cover
 
-    def unsaved_files(self) -> List[str]:
+    def unsaved_files(self) -> list[str]:
         """Returns a list of unsaved filepaths"""
         return [assertions.PASS]  # pragma: no cover
 
-    def parsed_paths(self) -> List[str]:
+    def parsed_paths(self) -> list[str]:
         """Returns a list of parsed configuration file paths"""
         return [assertions.PASS]
 

--- a/certbot-apache/src/certbot_apache/_internal/assertions.py
+++ b/certbot-apache/src/certbot_apache/_internal/assertions.py
@@ -2,7 +2,6 @@
 import fnmatch
 from typing import Any
 from typing import Iterable
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -103,7 +102,7 @@ def isPassComment(comment: CommentNode) -> bool:
     return False
 
 
-def isPassNodeList(nodelist: List[Union[DirectiveNode, CommentNode]]) -> bool:  # pragma: no cover
+def isPassNodeList(nodelist: list[Union[DirectiveNode, CommentNode]]) -> bool:  # pragma: no cover
     """ Checks if a ParserNode in the nodelist should pass the assertion,
     this function is used for results of find_* methods. Unimplemented find_*
     methods should return a sequence containing a single ParserNode instance

--- a/certbot-apache/src/certbot_apache/_internal/augeasparser.py
+++ b/certbot-apache/src/certbot_apache/_internal/augeasparser.py
@@ -66,12 +66,8 @@ Translates over to:
 """
 from typing import Any
 from typing import cast
-from typing import Dict
 from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Set
-from typing import Tuple
 from typing import Union
 
 from certbot import errors
@@ -109,7 +105,7 @@ class AugeasParserNode(interfaces.ParserNode):
     def save(self, msg: Iterable[str]) -> None:
         self.parser.save(msg)
 
-    def find_ancestors(self, name: str) -> List["AugeasParserNode"]:
+    def find_ancestors(self, name: str) -> list["AugeasParserNode"]:
         """
         Searches for ancestor BlockNodes with a given name.
 
@@ -119,7 +115,7 @@ class AugeasParserNode(interfaces.ParserNode):
         :rtype: list of AugeasParserNode
         """
 
-        ancestors: List["AugeasParserNode"] = []
+        ancestors: list["AugeasParserNode"] = []
 
         parent = self.metadata["augeaspath"]
         while True:
@@ -143,7 +139,7 @@ class AugeasParserNode(interfaces.ParserNode):
         """
 
         name: str = self._aug_get_name(path)
-        metadata: Dict[str, Union[parser.ApacheParser, str]] = {
+        metadata: dict[str, Union[parser.ApacheParser, str]] = {
             "augeasparser": self.parser, "augeaspath": path
         }
 
@@ -236,7 +232,7 @@ class AugeasDirectiveNode(AugeasParserNode):
             self.parser.aug.set(param_path, param)
 
     @property
-    def parameters(self) -> Tuple[str, ...]:
+    def parameters(self) -> tuple[str, ...]:
         """
         Fetches the parameters from Augeas tree, ensuring that the sequence always
         represents the current state
@@ -246,7 +242,7 @@ class AugeasDirectiveNode(AugeasParserNode):
         """
         return tuple(self._aug_get_params(self.metadata["augeaspath"]))
 
-    def _aug_get_params(self, path: str) -> List[str]:
+    def _aug_get_params(self, path: str) -> list[str]:
         """Helper function to get parameters for DirectiveNodes and BlockNodes"""
 
         arg_paths = self.parser.aug.match(path + "/arg")
@@ -259,7 +255,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.children: Tuple["AugeasBlockNode", ...] = ()
+        self.children: tuple["AugeasBlockNode", ...] = ()
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, self.__class__):
@@ -275,7 +271,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
 
     # pylint: disable=unused-argument
     def add_child_block(self, name: str,  # pragma: no cover
-                        parameters: Optional[List[str]] = None,
+                        parameters: Optional[list[str]] = None,
                         position: Optional[int] = None) -> "AugeasBlockNode":
         """Adds a new BlockNode to the sequence of children"""
 
@@ -283,7 +279,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
             name,
             position
         )
-        new_metadata: Dict[str, Any] = {"augeasparser": self.parser, "augeaspath": realpath}
+        new_metadata: dict[str, Any] = {"augeasparser": self.parser, "augeaspath": realpath}
 
         # Create the new block
         self.parser.aug.insert(insertpath, name, before)
@@ -305,7 +301,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
 
     # pylint: disable=unused-argument
     def add_child_directive(self, name: str,  # pragma: no cover
-                            parameters: Optional[List[str]] = None,
+                            parameters: Optional[list[str]] = None,
                             position: Optional[int] = None) -> AugeasDirectiveNode:
         """Adds a new DirectiveNode to the sequence of children"""
 
@@ -346,7 +342,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
             "#comment",
             position
         )
-        new_metadata: Dict[str, Any] = {
+        new_metadata: dict[str, Any] = {
             "augeasparser": self.parser, "augeaspath": realpath,
         }
 
@@ -362,10 +358,10 @@ class AugeasBlockNode(AugeasDirectiveNode):
             metadata=new_metadata,
         )
 
-    def find_blocks(self, name: str, exclude: bool = True) -> List["AugeasBlockNode"]:
+    def find_blocks(self, name: str, exclude: bool = True) -> list["AugeasBlockNode"]:
         """Recursive search of BlockNodes from the sequence of children"""
 
-        nodes: List["AugeasBlockNode"] = []
+        nodes: list["AugeasBlockNode"] = []
         paths: Iterable[str] = self._aug_find_blocks(name)
         if exclude:
             paths = self.parser.exclude_dirs(paths)
@@ -374,14 +370,14 @@ class AugeasBlockNode(AugeasDirectiveNode):
 
         return nodes
 
-    def find_directives(self, name: str, exclude: bool = True) -> List["AugeasDirectiveNode"]:
+    def find_directives(self, name: str, exclude: bool = True) -> list["AugeasDirectiveNode"]:
         """Recursive search of DirectiveNodes from the sequence of children"""
 
         nodes = []
         ownpath = self.metadata.get("augeaspath")
 
         directives = self.parser.find_dir(name, start=ownpath, exclude=exclude)
-        already_parsed: Set[str] = set()
+        already_parsed: set[str] = set()
         for directive in directives:
             # Remove the /arg part from the Augeas path
             directive = directive.partition("/arg")[0]
@@ -393,14 +389,14 @@ class AugeasBlockNode(AugeasDirectiveNode):
 
         return nodes
 
-    def find_comments(self, comment: str) -> List["AugeasCommentNode"]:
+    def find_comments(self, comment: str) -> list["AugeasCommentNode"]:
         """
         Recursive search of DirectiveNodes from the sequence of children.
 
         :param str comment: Comment content to search for.
         """
 
-        nodes: List["AugeasCommentNode"] = []
+        nodes: list["AugeasCommentNode"] = []
         ownpath = self.metadata.get("augeaspath")
 
         comments = self.parser.find_comments(comment, start=ownpath)
@@ -422,11 +418,11 @@ class AugeasBlockNode(AugeasDirectiveNode):
                  "seem to exist.").format(child.metadata["augeaspath"])
             )
 
-    def unsaved_files(self) -> Set[str]:
+    def unsaved_files(self) -> set[str]:
         """Returns a list of unsaved filepaths"""
         return self.parser.unsaved_files()
 
-    def parsed_paths(self) -> List[str]:
+    def parsed_paths(self) -> list[str]:
         """
         Returns a list of file paths that have currently been parsed into the parser
         tree. The returned list may include paths with wildcard characters, for
@@ -437,7 +433,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
         :returns: list of file paths of files that have been parsed
         """
 
-        res_paths: List[str] = []
+        res_paths: list[str] = []
 
         paths = self.parser.existing_paths
         for directory in paths:
@@ -463,7 +459,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
         """Helper function to create a DirectiveNode from Augeas path"""
 
         name = self.parser.get_arg(path)
-        metadata: Dict[str, Union[parser.ApacheParser, str]] = {
+        metadata: dict[str, Union[parser.ApacheParser, str]] = {
             "augeasparser": self.parser, "augeaspath": path,
         }
 
@@ -477,12 +473,12 @@ class AugeasBlockNode(AugeasDirectiveNode):
                                    filepath=apache_util.get_file_path(path),
                                    metadata=metadata)
 
-    def _aug_find_blocks(self, name: str) -> Set[str]:
+    def _aug_find_blocks(self, name: str) -> set[str]:
         """Helper function to perform a search to Augeas DOM tree to search
         configuration blocks with a given name"""
 
         # The code here is modified from configurator.get_virtual_hosts()
-        blk_paths: Set[str] = set()
+        blk_paths: set[str] = set()
         for vhost_path in list(self.parser.parser_paths):
             paths = self.parser.aug.match(
                 ("/files%s//*[label()=~regexp('%s')]" %
@@ -492,7 +488,7 @@ class AugeasBlockNode(AugeasDirectiveNode):
         return blk_paths
 
     def _aug_resolve_child_position(
-        self, name: str, position: Optional[int]) -> Tuple[str, str, bool]:
+        self, name: str, position: Optional[int]) -> tuple[str, str, bool]:
         """
         Helper function that iterates through the immediate children and figures
         out the insertion path for a new AugeasParserNode.

--- a/certbot-apache/src/certbot_apache/_internal/configurator.py
+++ b/certbot-apache/src/certbot_apache/_internal/configurator.py
@@ -10,15 +10,9 @@ import time
 from typing import Any
 from typing import Callable
 from typing import cast
-from typing import DefaultDict
-from typing import Dict
 from typing import Iterable
-from typing import List
 from typing import Optional
 from typing import Sequence
-from typing import Set
-from typing import Tuple
-from typing import Type
 from typing import Union
 
 from acme import challenges
@@ -63,10 +57,10 @@ class OsOptions:
                  vhost_files: str = "*",
                  logs_root: str = "/var/log/apache2",
                  ctl: str = "apache2ctl",
-                 version_cmd: Optional[List[str]] = None,
-                 restart_cmd: Optional[List[str]] = None,
-                 restart_cmd_alt: Optional[List[str]] = None,
-                 conftest_cmd: Optional[List[str]] = None,
+                 version_cmd: Optional[list[str]] = None,
+                 restart_cmd: Optional[list[str]] = None,
+                 restart_cmd_alt: Optional[list[str]] = None,
+                 conftest_cmd: Optional[list[str]] = None,
                  enmod: Optional[str] = None,
                  dismod: Optional[str] = None,
                  le_vhost_ext: str = "-le-ssl.conf",
@@ -253,32 +247,32 @@ class ApacheConfigurator(common.Configurator):
         super().__init__(*args, **kwargs)
 
         # Add name_server association dict
-        self.assoc: Dict[str, obj.VirtualHost] = {}
+        self.assoc: dict[str, obj.VirtualHost] = {}
         # Outstanding challenges
-        self._chall_out: Set[achallenges.AnnotatedChallenge] = set()
+        self._chall_out: set[achallenges.AnnotatedChallenge] = set()
         # List of vhosts configured per wildcard domain on this run.
         # used by deploy_cert() and enhance()
-        self._wildcard_vhosts: Dict[str, List[obj.VirtualHost]] = {}
+        self._wildcard_vhosts: dict[str, list[obj.VirtualHost]] = {}
         # Maps enhancements to vhosts we've enabled the enhancement for
-        self._enhanced_vhosts: DefaultDict[str, Set[obj.VirtualHost]] = defaultdict(set)
+        self._enhanced_vhosts: defaultdict[str, set[obj.VirtualHost]] = defaultdict(set)
         # Temporary state for AutoHSTS enhancement
-        self._autohsts: Dict[str, Dict[str, Union[int, float]]] = {}
+        self._autohsts: dict[str, dict[str, Union[int, float]]] = {}
         # Reverter save notes
         self.save_notes: str = ""
         # Should we use ParserNode implementation instead of the old behavior
         self.USE_PARSERNODE = use_parsernode
         # Saves the list of file paths that were parsed initially, and
         # not added to parser tree by self.conf("vhost-root") for example.
-        self.parsed_paths: List[str] = []
+        self.parsed_paths: list[str] = []
         # These will be set in the prepare function
         self._prepared: bool = False
         self.parser: parser.ApacheParser
         self.parser_root: Optional[dualparser.DualBlockNode] = None
         self.version = version
         self._openssl_version: Optional[str] = openssl_version
-        self.vhosts: List[obj.VirtualHost]
+        self.vhosts: list[obj.VirtualHost]
         self.options = copy.deepcopy(self.OS_DEFAULTS)
-        self._enhance_func: Dict[str, Callable[[obj.VirtualHost, Any], None]] = {
+        self._enhance_func: dict[str, Callable[[obj.VirtualHost, Any], None]] = {
             "redirect": self._enable_redirect,
             "ensure-http-header": self._set_http_header,
             "staple-ocsp": self._enable_ocsp_stapling,
@@ -486,7 +480,7 @@ class ApacheConfigurator(common.Configurator):
         return parser.ApacheParser(
             self.options.server_root, self, self.conf("vhost-root"), version=self.version)
 
-    def get_parsernode_root(self, metadata: Dict[str, Any]) -> dualparser.DualBlockNode:
+    def get_parsernode_root(self, metadata: dict[str, Any]) -> dualparser.DualBlockNode:
         """Initializes the ParserNode parser root instance."""
 
         if HAS_APACHECONFIG:
@@ -535,7 +529,7 @@ class ApacheConfigurator(common.Configurator):
             display_util.notify("Successfully deployed certificate for {} to {}"
                                 .format(domain, vhost.filep))
 
-    def choose_vhosts(self, domain: str, create_if_no_ssl: bool = True) -> List[obj.VirtualHost]:
+    def choose_vhosts(self, domain: str, create_if_no_ssl: bool = True) -> list[obj.VirtualHost]:
         """
         Finds VirtualHosts that can be used with the provided domain
 
@@ -557,14 +551,14 @@ class ApacheConfigurator(common.Configurator):
         else:
             return [self.choose_vhost(domain, create_if_no_ssl)]
 
-    def _vhosts_for_wildcard(self, domain: str) -> List[obj.VirtualHost]:
+    def _vhosts_for_wildcard(self, domain: str) -> list[obj.VirtualHost]:
         """
         Get VHost objects for every VirtualHost that the user wants to handle
         with the wildcard certificate.
         """
 
         # Collect all vhosts that match the name
-        matched: Set[obj.VirtualHost] = set()
+        matched: set[obj.VirtualHost] = set()
         for vhost in self.vhosts:
             for name in vhost.get_names():
                 if self._in_wildcard_scope(name, domain):
@@ -599,11 +593,11 @@ class ApacheConfigurator(common.Configurator):
         return None
 
     def _choose_vhosts_wildcard(self, domain: str, create_ssl: bool = True
-                                ) -> List[obj.VirtualHost]:
+                                ) -> list[obj.VirtualHost]:
         """Prompts user to choose vhosts to install a wildcard certificate for"""
 
         # Get all vhosts that are covered by the wildcard domain
-        vhosts: List[obj.VirtualHost] = self._vhosts_for_wildcard(domain)
+        vhosts: list[obj.VirtualHost] = self._vhosts_for_wildcard(domain)
 
         # Go through the vhosts, making sure that we cover all the names
         # present, but preferring the SSL vhosts
@@ -661,7 +655,7 @@ class ApacheConfigurator(common.Configurator):
         self._add_dummy_ssl_directives(vhost.path)
         self._clean_vhost(vhost)
 
-        path: Dict[str, Any] = {
+        path: dict[str, Any] = {
             "cert_path": self.parser.find_dir("SSLCertificateFile", None, vhost.path),
             "cert_key": self.parser.find_dir("SSLCertificateKeyFile", None, vhost.path),
         }
@@ -815,7 +809,7 @@ class ApacheConfigurator(common.Configurator):
         return self._find_best_vhost(target, filtered_vhosts, filter_defaults)
 
     def _find_best_vhost(
-        self, target_name: str, vhosts: Optional[List[obj.VirtualHost]] = None,
+        self, target_name: str, vhosts: Optional[list[obj.VirtualHost]] = None,
         filter_defaults: bool = True
     ) -> Optional[obj.VirtualHost]:
         """Finds the best vhost for a target_name.
@@ -878,13 +872,13 @@ class ApacheConfigurator(common.Configurator):
 
         return best_candidate
 
-    def _non_default_vhosts(self, vhosts: List[obj.VirtualHost]) -> List[obj.VirtualHost]:
+    def _non_default_vhosts(self, vhosts: list[obj.VirtualHost]) -> list[obj.VirtualHost]:
         """Return all non _default_ only vhosts."""
         return [vh for vh in vhosts if not all(
             addr.get_addr() == "_default_" for addr in vh.addrs
         )]
 
-    def get_all_names(self) -> Set[str]:
+    def get_all_names(self) -> set[str]:
         """Returns all names found in the Apache Configuration.
 
         :returns: All ServerNames, ServerAliases, and reverse DNS entries for
@@ -892,7 +886,7 @@ class ApacheConfigurator(common.Configurator):
         :rtype: set
 
         """
-        all_names: Set[str] = set()
+        all_names: set[str] = set()
 
         vhost_macro = []
 
@@ -937,7 +931,7 @@ class ApacheConfigurator(common.Configurator):
 
         return ""
 
-    def _get_vhost_names(self, path: Optional[str]) -> Tuple[Optional[str], List[Optional[str]]]:
+    def _get_vhost_names(self, path: Optional[str]) -> tuple[Optional[str], list[Optional[str]]]:
         """Helper method for getting the ServerName and
         ServerAlias values from vhost in path
 
@@ -989,7 +983,7 @@ class ApacheConfigurator(common.Configurator):
         :rtype: :class:`~certbot_apache._internal.obj.VirtualHost`
 
         """
-        addrs: Set[obj.Addr] = set()
+        addrs: set[obj.Addr] = set()
         try:
             args = self.parser.aug.match(path + "/arg")
         except RuntimeError:
@@ -1026,7 +1020,7 @@ class ApacheConfigurator(common.Configurator):
         self._add_servernames(vhost)
         return vhost
 
-    def get_virtual_hosts(self) -> List[obj.VirtualHost]:
+    def get_virtual_hosts(self) -> list[obj.VirtualHost]:
         """
         Temporary wrapper for legacy and ParserNode version for
         get_virtual_hosts. This should be replaced with the ParserNode
@@ -1049,7 +1043,7 @@ class ApacheConfigurator(common.Configurator):
             return v2_vhosts
         return v1_vhosts
 
-    def get_virtual_hosts_v1(self) -> List[obj.VirtualHost]:
+    def get_virtual_hosts_v1(self) -> list[obj.VirtualHost]:
         """Returns list of virtual hosts found in the Apache configuration.
 
         :returns: List of :class:`~certbot_apache._internal.obj.VirtualHost`
@@ -1058,8 +1052,8 @@ class ApacheConfigurator(common.Configurator):
 
         """
         # Search base config, and all included paths for VirtualHosts
-        file_paths: Dict[str, str] = {}
-        internal_paths: DefaultDict[str, Set[str]] = defaultdict(set)
+        file_paths: dict[str, str] = {}
+        internal_paths: defaultdict[str, set[str]] = defaultdict(set)
         vhs = []
         # Make a list of parser paths because the parser_paths
         # dictionary may be modified during the loop.
@@ -1102,7 +1096,7 @@ class ApacheConfigurator(common.Configurator):
                     vhs.append(new_vhost)
         return vhs
 
-    def get_virtual_hosts_v2(self) -> List[obj.VirtualHost]:
+    def get_virtual_hosts_v2(self) -> list[obj.VirtualHost]:
         """Returns list of virtual hosts found in the Apache configuration using
         ParserNode interface.
         :returns: List of :class:`~certbot_apache.obj.VirtualHost`
@@ -1247,7 +1241,7 @@ class ApacheConfigurator(common.Configurator):
         else:
             self._add_listens_http(listen_dirs, listens, port)
 
-    def _add_listens_http(self, listens: Set[str], listens_orig: List[str], port: str) -> None:
+    def _add_listens_http(self, listens: set[str], listens_orig: list[str], port: str) -> None:
         """Helper method for ensure_listen to figure out which new
         listen statements need adding for listening HTTP on port
 
@@ -1272,7 +1266,7 @@ class ApacheConfigurator(common.Configurator):
                 self.save_notes += (f"Added Listen {listen} directive to "
                                     f"{self.parser.loc['listen']}\n")
 
-    def _add_listens_https(self, listens: Set[str], listens_orig: List[str], port: str) -> None:
+    def _add_listens_https(self, listens: set[str], listens_orig: list[str], port: str) -> None:
         """Helper method for ensure_listen to figure out which new
         listen statements need adding for listening HTTPS on port
 
@@ -1305,7 +1299,7 @@ class ApacheConfigurator(common.Configurator):
                 self.save_notes += (f"Added Listen {listen} directive to "
                                     f"{self.parser.loc['listen']}\n")
 
-    def _has_port_already(self, listens: List[str], port: str) -> Optional[bool]:
+    def _has_port_already(self, listens: list[str], port: str) -> Optional[bool]:
         """Helper method for prepare_server_https to find out if user
         already has an active Listen statement for the port we need
 
@@ -1420,7 +1414,7 @@ class ApacheConfigurator(common.Configurator):
 
         return ssl_vhost
 
-    def _get_new_vh_path(self, orig_matches: List[str], new_matches: List[str]) -> Optional[str]:
+    def _get_new_vh_path(self, orig_matches: list[str], new_matches: list[str]) -> Optional[str]:
         """ Helper method for make_vhost_ssl for matching augeas paths. Returns
         VirtualHost path from new_matches that's not present in orig_matches.
 
@@ -1536,11 +1530,11 @@ class ApacheConfigurator(common.Configurator):
         self.parser.aug.set("/augeas/files%s/mtime" % (self._escape(ssl_fp)), "0")
         self.parser.aug.set("/augeas/files%s/mtime" % (self._escape(vhost.filep)), "0")
 
-    def _sift_rewrite_rules(self, contents: Iterable[str]) -> Tuple[List[str], bool]:
+    def _sift_rewrite_rules(self, contents: Iterable[str]) -> tuple[list[str], bool]:
         """ Helper function for _copy_create_ssl_vhost_skeleton to prepare the
         new HTTPS VirtualHost contents. Currently disabling the rewrites """
 
-        result: List[str] = []
+        result: list[str] = []
         sift: bool = False
         contents = iter(contents)
 
@@ -1597,7 +1591,7 @@ class ApacheConfigurator(common.Configurator):
                     result.append('\n'.join(chunk))
         return result, sift
 
-    def _get_vhost_block(self, vhost: obj.VirtualHost) -> List[str]:
+    def _get_vhost_block(self, vhost: obj.VirtualHost) -> list[str]:
         """ Helper method to get VirtualHost contents from the original file.
         This is done with help of augeas span, which returns the span start and
         end positions
@@ -1620,7 +1614,7 @@ class ApacheConfigurator(common.Configurator):
         self._remove_closing_vhost_tag(vh_contents)
         return vh_contents
 
-    def _remove_closing_vhost_tag(self, vh_contents: List[str]) -> None:
+    def _remove_closing_vhost_tag(self, vh_contents: list[str]) -> None:
         """Removes the closing VirtualHost tag if it exists.
 
         This method modifies vh_contents directly to remove the closing
@@ -1639,9 +1633,9 @@ class ApacheConfigurator(common.Configurator):
                     vh_contents[content_index] = line[:line_index]
                 break
 
-    def _update_ssl_vhosts_addrs(self, vh_path: str) -> Set[obj.Addr]:
-        ssl_addrs: Set[obj.Addr] = set()
-        ssl_addr_p: List[str] = self.parser.aug.match(vh_path + "/arg")
+    def _update_ssl_vhosts_addrs(self, vh_path: str) -> set[obj.Addr]:
+        ssl_addrs: set[obj.Addr] = set()
+        ssl_addr_p: list[str] = self.parser.aug.match(vh_path + "/arg")
 
         for addr in ssl_addr_p:
             old_addr = obj.Addr.fromstring(
@@ -1660,7 +1654,7 @@ class ApacheConfigurator(common.Configurator):
         # remove all problematic directives
         self._remove_directives(vhost.path, ["SSLCertificateChainFile"])
 
-    def _deduplicate_directives(self, vh_path: Optional[str], directives: List[str]) -> None:
+    def _deduplicate_directives(self, vh_path: Optional[str], directives: list[str]) -> None:
         for directive in directives:
             while len(self.parser.find_dir(directive, None,
                                            vh_path, False)) > 1:
@@ -1668,7 +1662,7 @@ class ApacheConfigurator(common.Configurator):
                                                       vh_path, False)
                 self.parser.aug.remove(re.sub(r"/\w*$", "", directive_path[0]))
 
-    def _remove_directives(self, vh_path: Optional[str], directives: List[str]) -> None:
+    def _remove_directives(self, vh_path: Optional[str], directives: list[str]) -> None:
         for directive in directives:
             while self.parser.find_dir(directive, None, vh_path, False):
                 directive_path = self.parser.find_dir(directive, None,
@@ -1790,12 +1784,12 @@ class ApacheConfigurator(common.Configurator):
     ######################################################################
     # Enhancements
     ######################################################################
-    def supported_enhancements(self) -> List[str]:
+    def supported_enhancements(self) -> list[str]:
         """Returns currently supported enhancements."""
         return ["redirect", "ensure-http-header", "staple-ocsp"]
 
     def enhance(self, domain: str, enhancement: str,
-                options: Optional[Union[List[str], str]] = None) -> None:
+                options: Optional[Union[list[str], str]] = None) -> None:
         """Enhance configuration.
 
         :param str domain: domain to enhance
@@ -2133,7 +2127,7 @@ class ApacheConfigurator(common.Configurator):
         # There can be other RewriteRule directive lines in vhost config.
         # rewrite_args_dict keys are directive ids and the corresponding value
         # for each is a list of arguments to that directive.
-        rewrite_args_dict: DefaultDict[str, List[str]] = defaultdict(list)
+        rewrite_args_dict: defaultdict[str, list[str]] = defaultdict(list)
         pat = r'(.*directive\[\d+\]).*'
         for match in rewrite_path:
             m = re.match(pat, match)
@@ -2398,7 +2392,7 @@ class ApacheConfigurator(common.Configurator):
         except errors.SubprocessError as err:
             raise errors.MisconfigurationError(str(err))
 
-    def get_version(self) -> Tuple[int, ...]:
+    def get_version(self) -> tuple[int, ...]:
         """Return version of Apache Server.
 
         Version is returned as tuple. (ie. 2.4.7 = (2, 4, 7))
@@ -2444,12 +2438,12 @@ class ApacheConfigurator(common.Configurator):
     ###########################################################################
     # Challenges Section
     ###########################################################################
-    def get_chall_pref(self, unused_domain: str) -> Sequence[Type[challenges.HTTP01]]:
+    def get_chall_pref(self, unused_domain: str) -> Sequence[type[challenges.HTTP01]]:
         """Return list of challenge preferences."""
         return [challenges.HTTP01]
 
-    def perform(self, achalls: List[achallenges.AnnotatedChallenge]
-                ) -> List[challenges.ChallengeResponse]:
+    def perform(self, achalls: list[achallenges.AnnotatedChallenge]
+                ) -> list[challenges.ChallengeResponse]:
         """Perform the configuration related challenge.
 
         This function currently assumes all challenges will be fulfilled.
@@ -2458,7 +2452,7 @@ class ApacheConfigurator(common.Configurator):
 
         """
         self._chall_out.update(achalls)
-        responses: List[Optional[challenges.ChallengeResponse]] = [None] * len(achalls)
+        responses: list[Optional[challenges.ChallengeResponse]] = [None] * len(achalls)
         http_doer = http_01.ApacheHttp01(self)
 
         for i, achall in enumerate(achalls):
@@ -2487,8 +2481,8 @@ class ApacheConfigurator(common.Configurator):
 
     def _update_responses(
         self,
-        responses: List[Optional[challenges.ChallengeResponse]],
-        chall_response: List[challenges.KeyAuthorizationChallengeResponse],
+        responses: list[Optional[challenges.ChallengeResponse]],
+        chall_response: list[challenges.KeyAuthorizationChallengeResponse],
         chall_doer: http_01.ApacheHttp01
     ) -> None:
         # Go through all of the challenges and assign them to the proper
@@ -2497,7 +2491,7 @@ class ApacheConfigurator(common.Configurator):
         for i, resp in enumerate(chall_response):
             responses[chall_doer.indices[i]] = resp
 
-    def cleanup(self, achalls: List[achallenges.AnnotatedChallenge]) -> None:
+    def cleanup(self, achalls: list[achallenges.AnnotatedChallenge]) -> None:
         """Revert all challenges."""
         self._chall_out.difference_update(achalls)
 
@@ -2523,7 +2517,7 @@ class ApacheConfigurator(common.Configurator):
         return common.install_version_controlled_file(
             options_ssl, options_ssl_digest, apache_config_path, constants.ALL_SSL_OPTIONS_HASHES)
 
-    def enable_autohsts(self, _unused_lineage: RenewableCert, domains: List[str]) -> None:
+    def enable_autohsts(self, _unused_lineage: RenewableCert, domains: list[str]) -> None:
         """
         Enable the AutoHSTS enhancement for defined domains
 
@@ -2535,7 +2529,7 @@ class ApacheConfigurator(common.Configurator):
         """
 
         self._autohsts_fetch_state()
-        _enhanced_vhosts: List[obj.VirtualHost] = []
+        _enhanced_vhosts: list[obj.VirtualHost] = []
         for d in domains:
             matched_vhosts = self.choose_vhosts(d, create_if_no_ssl=False)
             # We should be handling only SSL vhosts for AutoHSTS
@@ -2661,7 +2655,7 @@ class ApacheConfigurator(common.Configurator):
             # No autohsts enabled for any vhost
             return
 
-        vhosts: List[obj.VirtualHost] = []
+        vhosts: list[obj.VirtualHost] = []
         affected_ids = []
         # Copy, as we are removing from the dict inside the loop
         for id_str, config in list(self._autohsts.items()):

--- a/certbot-apache/src/certbot_apache/_internal/constants.py
+++ b/certbot-apache/src/certbot_apache/_internal/constants.py
@@ -2,8 +2,6 @@
 import atexit
 import importlib.resources
 from contextlib import ExitStack
-from typing import Dict
-from typing import List
 
 
 MOD_SSL_CONF_DEST = "options-ssl-apache.conf"
@@ -16,7 +14,7 @@ UPDATED_MOD_SSL_CONF_DIGEST = ".updated-options-ssl-apache-conf-digest.txt"
 in `certbot.configuration.NamespaceConfig.config_dir`."""
 
 # NEVER REMOVE A SINGLE HASH FROM THIS LIST UNLESS YOU KNOW EXACTLY WHAT YOU ARE DOING!
-ALL_SSL_OPTIONS_HASHES: List[str] = [
+ALL_SSL_OPTIONS_HASHES: list[str] = [
     '2086bca02db48daf93468332543c60ac6acdb6f0b58c7bfdf578a5d47092f82a',
     '4844d36c9a0f587172d9fa10f4f1c9518e3bcfa1947379f155e16a70a728c21a',
     '5a922826719981c0a234b1fbcd495f3213e49d2519e845ea0748ba513044b65b',
@@ -49,27 +47,27 @@ def _generate_augeas_lens_dir_static() -> str:
 AUGEAS_LENS_DIR = _generate_augeas_lens_dir_static()
 """Path to the Augeas lens directory"""
 
-REWRITE_HTTPS_ARGS: List[str] = [
+REWRITE_HTTPS_ARGS: list[str] = [
     "^", "https://%{SERVER_NAME}%{REQUEST_URI}", "[END,NE,R=permanent]"]
 """Apache version >= 2.3.9 rewrite rule arguments used for redirections to
     https vhost"""
 
-OLD_REWRITE_HTTPS_ARGS: List[List[str]] = [
+OLD_REWRITE_HTTPS_ARGS: list[list[str]] = [
     ["^", "https://%{SERVER_NAME}%{REQUEST_URI}", "[L,QSA,R=permanent]"],
     ["^", "https://%{SERVER_NAME}%{REQUEST_URI}", "[END,QSA,R=permanent]"],
     ["^", "https://%{SERVER_NAME}%{REQUEST_URI}", "[L,NE,R=permanent]"]]
 
-HSTS_ARGS: List[str] = ["always", "set", "Strict-Transport-Security",
+HSTS_ARGS: list[str] = ["always", "set", "Strict-Transport-Security",
              "\"max-age=31536000\""]
 """Apache header arguments for HSTS"""
 
-UIR_ARGS: List[str] = ["always", "set", "Content-Security-Policy", "upgrade-insecure-requests"]
+UIR_ARGS: list[str] = ["always", "set", "Content-Security-Policy", "upgrade-insecure-requests"]
 
-HEADER_ARGS: Dict[str, List[str]] = {
+HEADER_ARGS: dict[str, list[str]] = {
     "Strict-Transport-Security": HSTS_ARGS, "Upgrade-Insecure-Requests": UIR_ARGS,
 }
 
-AUTOHSTS_STEPS: List[int] = [60, 300, 900, 3600, 21600, 43200, 86400]
+AUTOHSTS_STEPS: list[int] = [60, 300, 900, 3600, 21600, 43200, 86400]
 """AutoHSTS increase steps: 1min, 5min, 15min, 1h, 6h, 12h, 24h"""
 
 AUTOHSTS_PERMANENT: int = 31536000

--- a/certbot-apache/src/certbot_apache/_internal/display_ops.py
+++ b/certbot-apache/src/certbot_apache/_internal/display_ops.py
@@ -1,10 +1,8 @@
 """Contains UI methods for Apache operations."""
 import logging
 from typing import Iterable
-from typing import List
 from typing import Optional
 from typing import Sequence
-from typing import Tuple
 
 from certbot import errors
 from certbot.compat import os
@@ -14,7 +12,7 @@ from certbot_apache._internal.obj import VirtualHost
 logger = logging.getLogger(__name__)
 
 
-def select_vhost_multiple(vhosts: Optional[List[VirtualHost]]) -> List[VirtualHost]:
+def select_vhost_multiple(vhosts: Optional[list[VirtualHost]]) -> list[VirtualHost]:
     """Select multiple Vhosts to install the certificate for
 
     :param vhosts: Available Apache VirtualHosts
@@ -38,7 +36,7 @@ def select_vhost_multiple(vhosts: Optional[List[VirtualHost]]) -> List[VirtualHo
     return []
 
 
-def _reversemap_vhosts(names: Iterable[str], vhosts: Iterable[VirtualHost]) -> List[VirtualHost]:
+def _reversemap_vhosts(names: Iterable[str], vhosts: Iterable[VirtualHost]) -> list[VirtualHost]:
     """Helper function for select_vhost_multiple for mapping string
     representations back to actual vhost objects"""
     return_vhosts = []
@@ -70,7 +68,7 @@ def select_vhost(domain: str, vhosts: Sequence[VirtualHost]) -> Optional[Virtual
     return None
 
 
-def _vhost_menu(domain: str, vhosts: Iterable[VirtualHost]) -> Tuple[str, int]:
+def _vhost_menu(domain: str, vhosts: Iterable[VirtualHost]) -> tuple[str, int]:
     """Select an appropriate Apache Vhost.
 
     :param vhosts: Available Apache Virtual Hosts

--- a/certbot-apache/src/certbot_apache/_internal/dualparser.py
+++ b/certbot-apache/src/certbot_apache/_internal/dualparser.py
@@ -2,10 +2,7 @@
 from typing import Any
 from typing import Generic
 from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Set
-from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
@@ -53,12 +50,12 @@ class DualNodeBase(Generic[GenericAugeasParserNode, GenericApacheParserNode]):
             assertions.assertEqualSimple(firstval, secondval)
         return firstval
 
-    def find_ancestors(self, name: str) -> List["DualBlockNode"]:
+    def find_ancestors(self, name: str) -> list["DualBlockNode"]:
         """ Traverses the ancestor tree and returns ancestors matching name """
         return self._find_helper(DualBlockNode, "find_ancestors", name)
 
     def _find_helper(self, nodeclass: type[GenericDualNode], findfunc: str, search: str,
-                     **kwargs: Any) -> List[GenericDualNode]:
+                     **kwargs: Any) -> list[GenericDualNode]:
         """A helper for find_* functions. The function specific attributes should
         be passed as keyword arguments.
 
@@ -203,7 +200,7 @@ class DualBlockNode(DualNodeBase[augeasparser.AugeasBlockNode,
 
         assertions.assertEqual(self.primary, self.secondary)
 
-    def add_child_block(self, name: str, parameters: Optional[List[str]] = None,
+    def add_child_block(self, name: str, parameters: Optional[list[str]] = None,
                         position: Optional[int] = None) -> "DualBlockNode":
         """ Creates a new child BlockNode, asserts that both implementations
         did it in a similar way, and returns a newly created DualBlockNode object
@@ -214,7 +211,7 @@ class DualBlockNode(DualNodeBase[augeasparser.AugeasBlockNode,
         assertions.assertEqual(primary_new, secondary_new)
         return DualBlockNode(primary=primary_new, secondary=secondary_new)
 
-    def add_child_directive(self, name: str, parameters: Optional[List[str]] = None,
+    def add_child_directive(self, name: str, parameters: Optional[list[str]] = None,
                             position: Optional[int] = None) -> DualDirectiveNode:
         """ Creates a new child DirectiveNode, asserts that both implementations
         did it in a similar way, and returns a newly created DualDirectiveNode
@@ -238,7 +235,7 @@ class DualBlockNode(DualNodeBase[augeasparser.AugeasBlockNode,
 
     def _create_matching_list(self, primary_list: Iterable[interfaces.ParserNode],
                               secondary_list: Iterable[interfaces.ParserNode]
-                              ) -> List[Tuple[interfaces.ParserNode, interfaces.ParserNode]]:
+                              ) -> list[tuple[interfaces.ParserNode, interfaces.ParserNode]]:
         """ Matches the list of primary_list to a list of secondary_list and
         returns a list of tuples. This is used to create results for find_
         methods.
@@ -265,7 +262,7 @@ class DualBlockNode(DualNodeBase[augeasparser.AugeasBlockNode,
                 raise AssertionError("Could not find a matching node.")
         return matched
 
-    def find_blocks(self, name: str, exclude: bool = True) -> List["DualBlockNode"]:
+    def find_blocks(self, name: str, exclude: bool = True) -> list["DualBlockNode"]:
         """
         Performs a search for BlockNodes using both implementations and does simple
         checks for results. This is built upon the assumption that unimplemented
@@ -277,7 +274,7 @@ class DualBlockNode(DualNodeBase[augeasparser.AugeasBlockNode,
         return self._find_helper(DualBlockNode, "find_blocks", name,
                                  exclude=exclude)
 
-    def find_directives(self, name: str, exclude: bool = True) -> List[DualDirectiveNode]:
+    def find_directives(self, name: str, exclude: bool = True) -> list[DualDirectiveNode]:
         """
         Performs a search for DirectiveNodes using both implementations and
         checks the results. This is built upon the assumption that unimplemented
@@ -289,7 +286,7 @@ class DualBlockNode(DualNodeBase[augeasparser.AugeasBlockNode,
         return self._find_helper(DualDirectiveNode, "find_directives", name,
                                  exclude=exclude)
 
-    def find_comments(self, comment: str) -> List[DualCommentNode]:
+    def find_comments(self, comment: str) -> list[DualCommentNode]:
         """
         Performs a search for CommentNodes using both implementations and
         checks the results. This is built upon the assumption that unimplemented
@@ -308,7 +305,7 @@ class DualBlockNode(DualNodeBase[augeasparser.AugeasBlockNode,
         self.primary.delete_child(child.primary)
         self.secondary.delete_child(child.secondary)
 
-    def unsaved_files(self) -> Set[str]:
+    def unsaved_files(self) -> set[str]:
         """ Fetches the list of unsaved file paths and asserts that the lists
         match """
         primary_files = self.primary.unsaved_files()
@@ -317,7 +314,7 @@ class DualBlockNode(DualNodeBase[augeasparser.AugeasBlockNode,
 
         return primary_files
 
-    def parsed_paths(self) -> List[str]:
+    def parsed_paths(self) -> list[str]:
         """
         Returns a list of file paths that have currently been parsed into the parser
         tree. The returned list may include paths with wildcard characters, for

--- a/certbot-apache/src/certbot_apache/_internal/entrypoint.py
+++ b/certbot-apache/src/certbot_apache/_internal/entrypoint.py
@@ -1,6 +1,4 @@
 """ Entry point for Apache Plugin """
-from typing import Dict
-from typing import Type
 
 from certbot import util
 from certbot_apache._internal import configurator
@@ -14,7 +12,7 @@ from certbot_apache._internal import override_gentoo
 from certbot_apache._internal import override_suse
 from certbot_apache._internal import override_void
 
-OVERRIDE_CLASSES: Dict[str, Type[configurator.ApacheConfigurator]] = {
+OVERRIDE_CLASSES: dict[str, type[configurator.ApacheConfigurator]] = {
     "alpine": override_alpine.AlpineConfigurator,
     "arch": override_arch.ArchConfigurator,
     "cloudlinux": override_centos.CentOSConfigurator,
@@ -43,7 +41,7 @@ OVERRIDE_CLASSES: Dict[str, Type[configurator.ApacheConfigurator]] = {
 }
 
 
-def get_configurator() -> Type[configurator.ApacheConfigurator]:
+def get_configurator() -> type[configurator.ApacheConfigurator]:
     """ Get correct configurator class based on the OS fingerprint """
     os_name, os_version = util.get_os_info()
     os_name = os_name.lower()

--- a/certbot-apache/src/certbot_apache/_internal/http_01.py
+++ b/certbot-apache/src/certbot_apache/_internal/http_01.py
@@ -1,8 +1,6 @@
 """A class that performs HTTP-01 challenges for Apache"""
 import errno
 import logging
-from typing import List
-from typing import Set
 from typing import TYPE_CHECKING
 
 from acme.challenges import KeyAuthorizationChallengeResponse
@@ -48,9 +46,9 @@ class ApacheHttp01(common.ChallengePerformer):
         self.challenge_dir = os.path.join(
             self.configurator.config.work_dir,
             "http_challenges")
-        self.moded_vhosts: Set[VirtualHost] = set()
+        self.moded_vhosts: set[VirtualHost] = set()
 
-    def perform(self) -> List[KeyAuthorizationChallengeResponse]:
+    def perform(self) -> list[KeyAuthorizationChallengeResponse]:
         """Perform all HTTP-01 challenges."""
         if not self.achalls:
             return []
@@ -79,7 +77,7 @@ class ApacheHttp01(common.ChallengePerformer):
                     self.configurator.enable_mod(mod, temp=True)
 
     def _mod_config(self) -> None:
-        selected_vhosts: List[VirtualHost] = []
+        selected_vhosts: list[VirtualHost] = []
         http_port = str(self.configurator.config.http01_port)
 
         # Search for VirtualHosts matching by name
@@ -120,7 +118,7 @@ class ApacheHttp01(common.ChallengePerformer):
         with open(self.challenge_conf_post, "w") as new_conf:
             new_conf.write(config_text_post)
 
-    def _matching_vhosts(self, domain: str) -> List[VirtualHost]:
+    def _matching_vhosts(self, domain: str) -> list[VirtualHost]:
         """Return all VirtualHost objects that have the requested domain name or
         a wildcard name that would match the domain in ServerName or ServerAlias
         directive.
@@ -134,9 +132,9 @@ class ApacheHttp01(common.ChallengePerformer):
 
         return matching_vhosts
 
-    def _relevant_vhosts(self) -> List[VirtualHost]:
+    def _relevant_vhosts(self) -> list[VirtualHost]:
         http01_port = str(self.configurator.config.http01_port)
-        relevant_vhosts: List[VirtualHost] = []
+        relevant_vhosts: list[VirtualHost] = []
         for vhost in self.configurator.vhosts:
             if any(a.is_wildcard() or a.get_port() == http01_port for a in vhost.addrs):
                 if not vhost.ssl:
@@ -150,11 +148,11 @@ class ApacheHttp01(common.ChallengePerformer):
 
         return relevant_vhosts
 
-    def _unnamed_vhosts(self) -> List[VirtualHost]:
+    def _unnamed_vhosts(self) -> list[VirtualHost]:
         """Return all VirtualHost objects with no ServerName"""
         return [vh for vh in self.configurator.vhosts if vh.name is None]
 
-    def _set_up_challenges(self) -> List[KeyAuthorizationChallengeResponse]:
+    def _set_up_challenges(self) -> list[KeyAuthorizationChallengeResponse]:
         if not os.path.isdir(self.challenge_dir):
             with filesystem.temp_umask(0o022):
                 try:

--- a/certbot-apache/src/certbot_apache/_internal/interfaces.py
+++ b/certbot-apache/src/certbot_apache/_internal/interfaces.py
@@ -100,10 +100,7 @@ For this reason the internal representation of data should not ignore the case.
 """
 import abc
 from typing import Any
-from typing import Dict
-from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import TypeVar
 
 GenericParserNode = TypeVar("GenericParserNode", bound="ParserNode")
@@ -154,7 +151,7 @@ class ParserNode(metaclass=abc.ABCMeta):
     ancestor: Optional["ParserNode"]
     dirty: bool
     filepath: Optional[str]
-    metadata: Dict[str, Any]
+    metadata: dict[str, Any]
 
     @abc.abstractmethod
     def __init__(self, **kwargs: Any) -> None:
@@ -200,7 +197,7 @@ class ParserNode(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def find_ancestors(self: GenericParserNode, name: str) -> List[GenericParserNode]:
+    def find_ancestors(self: GenericParserNode, name: str) -> list[GenericParserNode]:
         """
         Traverses the ancestor tree up, searching for BlockNodes with a specific
         name.
@@ -286,7 +283,7 @@ class DirectiveNode(ParserNode, metaclass=abc.ABCMeta):
     """
     enabled: bool
     name: Optional[str]
-    parameters: Tuple[str, ...]
+    parameters: tuple[str, ...]
 
     @abc.abstractmethod
     def __init__(self, **kwargs: Any) -> None:
@@ -327,7 +324,7 @@ class DirectiveNode(ParserNode, metaclass=abc.ABCMeta):
         )
 
     @abc.abstractmethod
-    def set_parameters(self, parameters: List[str]) -> None:
+    def set_parameters(self, parameters: list[str]) -> None:
         """
         Sets the sequence of parameters for this ParserNode object without
         whitespaces. While the whitespaces for parameters are discarded when using
@@ -378,10 +375,10 @@ class BlockNode(DirectiveNode, metaclass=abc.ABCMeta):
     children: Tuple[ParserNode, ...]
 
     """
-    children: Tuple[ParserNode, ...]
+    children: tuple[ParserNode, ...]
 
     @abc.abstractmethod
-    def add_child_block(self, name: str, parameters: Optional[List[str]] = None,
+    def add_child_block(self, name: str, parameters: Optional[list[str]] = None,
                         position: Optional[int] = None) -> "BlockNode":
         """
         Adds a new BlockNode child node with provided values and marks the callee
@@ -402,7 +399,7 @@ class BlockNode(DirectiveNode, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def add_child_directive(self, name: str, parameters: Optional[List[str]] = None,
+    def add_child_directive(self, name: str, parameters: Optional[list[str]] = None,
                             position: Optional[int] = None) -> DirectiveNode:
         """
         Adds a new DirectiveNode child node with provided values and marks the
@@ -444,7 +441,7 @@ class BlockNode(DirectiveNode, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def find_blocks(self, name: str, exclude: bool = True) -> List["BlockNode"]:
+    def find_blocks(self, name: str, exclude: bool = True) -> list["BlockNode"]:
         """
         Find a configuration block by name. This method walks the child tree of
         ParserNodes under the instance it was called from. This way it is possible
@@ -461,7 +458,7 @@ class BlockNode(DirectiveNode, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def find_directives(self, name: str, exclude: bool = True) -> List[DirectiveNode]:
+    def find_directives(self, name: str, exclude: bool = True) -> list[DirectiveNode]:
         """
         Find a directive by name. This method walks the child tree of ParserNodes
         under the instance it was called from. This way it is possible to search
@@ -479,7 +476,7 @@ class BlockNode(DirectiveNode, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def find_comments(self, comment: str) -> List[CommentNode]:
+    def find_comments(self, comment: str) -> list[CommentNode]:
         """
         Find comments with value containing the search term.
 
@@ -505,7 +502,7 @@ class BlockNode(DirectiveNode, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def unsaved_files(self) -> List[str]:
+    def unsaved_files(self) -> list[str]:
         """
         Returns a list of file paths that have been changed since the last save
         (or the initial configuration parse). The intended use for this method
@@ -518,7 +515,7 @@ class BlockNode(DirectiveNode, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def parsed_paths(self) -> List[str]:
+    def parsed_paths(self) -> list[str]:
         """
         Returns a list of file paths that have currently been parsed into the parser
         tree. The returned list may include paths with wildcard characters, for

--- a/certbot-apache/src/certbot_apache/_internal/obj.py
+++ b/certbot-apache/src/certbot_apache/_internal/obj.py
@@ -3,7 +3,6 @@ import re
 from typing import Any
 from typing import Iterable
 from typing import Optional
-from typing import Set
 from typing import Union
 
 from certbot.plugins import common
@@ -127,8 +126,8 @@ class VirtualHost:
     # ?: is used for not returning enclosed characters
     strip_name: re.Pattern[str] = re.compile(r"^(?:.+://)?([^ :$]*)")
 
-    def __init__(self, filepath: str, path: str, addrs: Set["Addr"], ssl: bool,
-                 enabled: bool, name: Optional[str] = None, aliases: Optional[Set[str]] = None,
+    def __init__(self, filepath: str, path: str, addrs: set["Addr"], ssl: bool,
+                 enabled: bool, name: Optional[str] = None, aliases: Optional[set[str]] = None,
                  modmacro: bool = False, ancestor: Optional["VirtualHost"] = None,
                  node: Optional[Union[ApacheBlockNode, AugeasBlockNode, DualBlockNode]] = None
                  ) -> None:
@@ -145,9 +144,9 @@ class VirtualHost:
         self.ancestor = ancestor
         self.node = node
 
-    def get_names(self) -> Set[str]:
+    def get_names(self) -> set[str]:
         """Return a set of all names."""
-        all_names: Set[str] = set()
+        all_names: set[str] = set()
         all_names.update(self.aliases)
         # Strip out any scheme:// and <port> field from servername
         if self.name is not None:
@@ -244,7 +243,7 @@ class VirtualHost:
 
         # already_found acts to keep everything very conservative.
         # Don't allow multiple ip:ports in same set.
-        already_found: Set[str] = set()
+        already_found: set[str] = set()
 
         for addr in vhost.addrs:
             for local_addr in self.addrs:

--- a/certbot-apache/src/certbot_apache/_internal/parsernode_util.py
+++ b/certbot-apache/src/certbot_apache/_internal/parsernode_util.py
@@ -1,14 +1,12 @@
 """ParserNode utils"""
 from typing import Any
-from typing import Dict
 from typing import Iterable
 from typing import Optional
-from typing import Tuple
 
 from certbot_apache._internal.interfaces import ParserNode
 
 
-def validate_kwargs(kwargs: Dict[str, Any], required_names: Iterable[str]) -> Dict[str, Any]:
+def validate_kwargs(kwargs: dict[str, Any], required_names: Iterable[str]) -> dict[str, Any]:
     """
     Ensures that the kwargs dict has all the expected values. This function modifies
     the kwargs dictionary, and hence the returned dictionary should be used instead
@@ -18,7 +16,7 @@ def validate_kwargs(kwargs: Dict[str, Any], required_names: Iterable[str]) -> Di
     :param list required_names: List of required parameter names.
     """
 
-    validated_kwargs: Dict[str, Any] = {}
+    validated_kwargs: dict[str, Any] = {}
     for name in required_names:
         try:
             validated_kwargs[name] = kwargs.pop(name)
@@ -32,8 +30,8 @@ def validate_kwargs(kwargs: Dict[str, Any], required_names: Iterable[str]) -> Di
     return validated_kwargs
 
 
-def parsernode_kwargs(kwargs: Dict[str, Any]
-                      ) -> Tuple[Optional[ParserNode], bool, Optional[str], Dict[str, Any]]:
+def parsernode_kwargs(kwargs: dict[str, Any]
+                      ) -> tuple[Optional[ParserNode], bool, Optional[str], dict[str, Any]]:
     """
     Validates keyword arguments for ParserNode. This function modifies the kwargs
     dictionary, and hence the returned dictionary should be used instead in the
@@ -63,7 +61,7 @@ def parsernode_kwargs(kwargs: Dict[str, Any]
     return kwargs["ancestor"], kwargs["dirty"], kwargs["filepath"], kwargs["metadata"]
 
 
-def commentnode_kwargs(kwargs: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, str]]:
+def commentnode_kwargs(kwargs: dict[str, Any]) -> tuple[Optional[str], dict[str, str]]:
     """
     Validates keyword arguments for CommentNode and sets the default values for
     optional kwargs. This function modifies the kwargs dictionary, and hence the
@@ -98,8 +96,8 @@ def commentnode_kwargs(kwargs: Dict[str, Any]) -> Tuple[Optional[str], Dict[str,
     return comment, kwargs
 
 
-def directivenode_kwargs(kwargs: Dict[str, Any]
-                         ) -> Tuple[Optional[str], Tuple[str, ...], bool, Dict[str, Any]]:
+def directivenode_kwargs(kwargs: dict[str, Any]
+                         ) -> tuple[Optional[str], tuple[str, ...], bool, dict[str, Any]]:
     """
     Validates keyword arguments for DirectiveNode and BlockNode and sets the
     default values for optional kwargs. This function modifies the kwargs

--- a/certbot-apache/src/certbot_apache/_internal/tests/augeasnode_test.py
+++ b/certbot-apache/src/certbot_apache/_internal/tests/augeasnode_test.py
@@ -1,6 +1,5 @@
 """Tests for AugeasParserNode classes"""
 import os
-from typing import List
 from unittest import mock
 
 import pytest
@@ -111,7 +110,7 @@ class AugeasParserNodeTest(util.ApacheTest):  # pylint: disable=too-many-public-
 
     def test_set_parameters(self):
         servernames = self.config.parser_root.find_directives("servername")
-        names: List[str] = []
+        names: list[str] = []
         for servername in servernames:
             names += servername.parameters
         assert "going_to_set_this" not in names

--- a/certbot-apache/src/certbot_apache/_internal/tests/http_01_test.py
+++ b/certbot-apache/src/certbot_apache/_internal/tests/http_01_test.py
@@ -1,7 +1,6 @@
 """Test for certbot_apache._internal.http_01."""
 import errno
 import sys
-from typing import List
 from unittest import mock
 
 import pytest
@@ -25,7 +24,7 @@ class ApacheHttp01Test(util.ApacheTest):
         super().setUp(*args, **kwargs)
 
         self.account_key = self.rsa512jwk
-        self.achalls: List[achallenges.KeyAuthorizationAnnotatedChallenge] = []
+        self.achalls: list[achallenges.KeyAuthorizationAnnotatedChallenge] = []
         vh_truth = util.get_vh_truth(
             self.temp_dir, "debian_apache_2_4/multiple_vhosts")
         # Takes the vhosts for encryption-example.demo, certbot.demo

--- a/certbot-apache/src/certbot_apache/_internal/tests/util.py
+++ b/certbot-apache/src/certbot_apache/_internal/tests/util.py
@@ -1,8 +1,6 @@
 """Common utilities for certbot_apache."""
 import shutil
-from typing import List
 from typing import Optional
-from typing import Tuple
 import unittest
 from unittest import mock
 
@@ -79,7 +77,7 @@ class ParserTest(ApacheTest):
 
 def get_apache_configurator(
         config_path: str, vhost_path: str,
-        config_dir: str, work_dir: str, version: Tuple[int, int, int] = (2, 4, 7),
+        config_dir: str, work_dir: str, version: tuple[int, int, int] = (2, 4, 7),
         os_info: str = "generic",
         conf_vhost_path: Optional[str] = None,
         use_parsernode: bool = False,
@@ -129,7 +127,7 @@ def get_apache_configurator(
     return config
 
 
-def get_vh_truth(temp_dir: str, config_name: str) -> Optional[List[obj.VirtualHost]]:
+def get_vh_truth(temp_dir: str, config_name: str) -> Optional[list[obj.VirtualHost]]:
     """Return the ground truth for the specified directory."""
     if config_name == "debian_apache_2_4/multiple_vhosts":
         prefix = os.path.join(


### PR DESCRIPTION
this is another part of https://github.com/certbot/certbot/issues/10195

these changes were done automatically with the command:

```
ruff check --fix --extend-select UP006 --unsafe-fixes certbot-apache
```