### PR TITLE
Speed up mac tests by using socket.gethostname instead of socket.getfqdn

### DIFF
--- a/certbot/src/certbot/_internal/account.py
+++ b/certbot/src/certbot/_internal/account.py
@@ -62,7 +62,7 @@ class Account:
         self.meta = self.Meta(
             # pyrfc3339 drops microseconds, make sure __eq__ is sane
             creation_dt=datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0),
-            creation_host=socket.getfqdn(),
+            creation_host=socket.gethostname(),
             register_to_eff=None) if meta is None else meta
 
         # try MD5, else use MD5 in non-security mode (e.g. for FIPS systems / RHEL)

--- a/certbot/src/certbot/_internal/tests/account_test.py
+++ b/certbot/src/certbot/_internal/tests/account_test.py
@@ -31,7 +31,7 @@ class AccountTest(unittest.TestCase):
         self.regr.__repr__ = mock.MagicMock(return_value="i_am_a_regr")
 
         with mock.patch("certbot._internal.account.socket") as mock_socket:
-            mock_socket.getfqdn.return_value = "test.certbot.org"
+            mock_socket.gethostname.return_value = "test.certbot.org"
             with mock.patch("certbot._internal.account.datetime") as mock_dt:
                 mock_dt.datetime.now.return_value = self.meta.creation_dt
                 self.acc_no_meta = Account(self.regr, KEY)


### PR DESCRIPTION
This automatically uses the built-in fallback behavior by combining the implementations of `socket.fqdn` and `BaseHTTPServer.HTTPServer.server_bind`, so it's unlikely to change things.

getfqdn implementation: https://github.com/python/cpython/blob/main/Lib/socket.py#L808
httpserver implementation: https://github.com/python/cpython/blob/main/Lib/http/server.py#L115

As mentioned in the [python bug](https://bugs.python.org/issue35164), the thing it's failing on is trying a reverse-dns query.