### PR TITLE
Have oldest tests inherit environment from python tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,9 @@ commands = {[testenv:py]commands}
 # This version should be kept in sync with the one declared in
 # tools/pinning/oldest/pyproject.toml.
 basepython = python3.10
-setenv = CERTBOT_OLDEST=1
+setenv =
+    {[testenv:py]setenv}
+    CERTBOT_OLDEST=1
 commands = {[testenv:py]commands}
 
 [testenv:cover]


### PR DESCRIPTION
With `tox-wat` applied:

```
$ tox -r -e oldest
[...]
8 workers [12 items]    
............
================================================== 12 passed in 1.44s ===================================================
  oldest: OK (27.17=setup[25.40]+cmd[1.77] seconds)
  congratulations :) (27.27 seconds)
```
replacing `--numprocesses auto` with `-s`:
```
$ tox -r -e oldest
[...]                                                                                 
certbot-apache/src/certbot_apache/_internal/tests/autohsts_test.py I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.

================================================== 12 passed in 1.71s ===================================================
  oldest: OK (27.47=setup[25.39]+cmd[2.09] seconds)
  congratulations :) (27.57 seconds)

$ tox -r -e py
[..]
certbot-apache/src/certbot_apache/_internal/tests/autohsts_test.py I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.I'm printing
.

================================================== 12 passed in 1.68s ===================================================
  py: OK (27.72=setup[25.72]+cmd[1.99] seconds)
  congratulations :) (27.79 seconds)
```

