### PR TITLE
Remove unnecessary code from release script

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -101,12 +101,6 @@ git checkout "$RELEASE_BRANCH"
 towncrier build --version "$version" --yes
 git commit -m "Update changelog for $version release"
 
-for pkg_dir in $SUBPKGS certbot-compatibility-test
-do
-  sed -i 's/\.dev0//' "$pkg_dir/setup.py"
-  git add "$pkg_dir/setup.py"
-done
-
 SetVersion() {
     ver="$1"
     # bumping Certbot's version number is done differently


### PR DESCRIPTION
This code [never did anything](https://github.com/certbot/certbot/pull/10417#issuecomment-3190266418), and it is not now. Let's remove it so we don't have to keep taking it into account.