### PR TITLE
Mock time.sleep for more modules to speed up tests

### DIFF
--- a/certbot-apache/src/certbot_apache/_internal/tests/conftest.py
+++ b/certbot-apache/src/certbot_apache/_internal/tests/conftest.py
@@ -1,0 +1,8 @@
+from unittest import mock
+
+import pytest
+
+@pytest.fixture(autouse=True)
+def mock_sleep():
+    with mock.patch("time.sleep") as mocked:
+        yield mocked

--- a/certbot-dns-route53/src/certbot_dns_route53/_internal/tests/conftest.py
+++ b/certbot-dns-route53/src/certbot_dns_route53/_internal/tests/conftest.py
@@ -1,0 +1,8 @@
+from unittest import mock
+
+import pytest
+
+@pytest.fixture(autouse=True)
+def mock_sleep():
+    with mock.patch("time.sleep") as mocked:
+        yield mocked


### PR DESCRIPTION
The extra 8 seconds isn't really relevant in the test farm, but is nice to have for local runs. This is based on what was done in https://github.com/certbot/certbot/pull/10419/.