### PR TITLE
Don't rerun standard tests during extended test run

### DIFF
--- a/.azure-pipelines/advanced-test.yml
+++ b/.azure-pipelines/advanced-test.yml
@@ -11,5 +11,6 @@ variables:
   dockerTag: nightly
   snapBuildTimeout: 5400
 
-stages:
-  - template: templates/stages/test-and-package-stage.yml
+jobs:
+  - template: templates/jobs/extended-tests-jobs.yml
+  - template: templates/jobs/packaging-jobs.yml


### PR DESCRIPTION
I never want this, and it just slows things down.