### PR TITLE
Add instructions for renaming certificate to docs

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -768,6 +768,82 @@ commands into your individual environment.
   you will need to use the ``--deploy-hook`` since the exit status will be 0 both on successful renewal
   and when renewal is not necessary.
 
+.. _renaming:
+
+Renaming certificates
+------------------------------------------------------------
+
+While certbot does not have an internal rename function, it is possible to rename certs by
+requesting a new certificate using certbot's ``--cert-name`` flag.
+
+1. View certificates with ``certbot certificates``
+
+   The output might be something like::
+
+    Found the following certs:
+      Certificate Name: yourdomain.com-0001
+        Serial Number: 2ce74f4e2b822211dd7648ea26c8927bdef6
+        Key Type: ECDSA
+        Domains: yourdomain.com subdomain.yourdomain.com
+        Expiry Date: 2025-11-16 20:27:27+00:00 (INVALID: TEST_CERT)
+        Certificate Path: /etc/letsencrypt/live/yourdomain.com-0001/fullchain.pem
+        Private Key Path: /etc/letsencrypt/live/yourdomain.com-0001/privkey.pem
+      Certificate Name: yourdomain.com
+        Serial Number: 2c72aa8cf58aa9fe9a33208d82304642d9ed
+        Key Type: ECDSA
+        Domains: yourdomain.com
+        Expiry Date: 2025-11-16 19:22:47+00:00 (INVALID: TEST_CERT)
+        Certificate Path: /etc/letsencrypt/live/yourdomain.com/fullchain.pem
+        Private Key Path: /etc/letsencrypt/live/yourdomain.com/privkey.pem
+
+   In this example, we will rename certificate ``yourdomain.com-0001`` to ``yourdomain.com``.
+
+2. If the name you want is in use and you're not using that cert, delete it using the instructions
+   in the `Deleting certificates`_ section.
+
+   You'll then have::
+
+    Found the following certs:
+      Certificate Name: yourdomain.com-0001
+        Serial Number: 2ce74f4e2b822211dd7648ea26c8927bdef6
+        Key Type: ECDSA
+        Domains: yourdomain.com subdomain.yourdomain.com
+        Expiry Date: 2025-11-16 20:27:27+00:00 (INVALID: TEST_CERT)
+        Certificate Path: /etc/letsencrypt/live/yourdomain.com-0001/fullchain.pem
+        Private Key Path: /etc/letsencrypt/live/yourdomain.com-0001/privkey.pem
+
+3. If you're not sure how you set the cert up initially, note relevant configuration options by
+   inspecting ``/etc/letsencrypt/renewal/yourdomain.com-0001.conf``
+
+   It will look something like::
+
+    version = 4.2.0
+    archive_dir = /etc/letsencrypt/archive/yourdomain.com-0001
+    cert = /etc/letsencrypt/live/yourdomain.com-0001/cert.pem
+    privkey = /etc/letsencrypt/live/yourdomain.com-0001/privkey.pem
+    chain = /etc/letsencrypt/live/yourdomain.com-0001/chain.pem
+    fullchain = /etc/letsencrypt/live/yourdomain.com-0001/fullchain.pem
+    [renewalparams]
+    account = abcdef12345678910
+    server = https://acme-staging-v02.api.letsencrypt.org/directory
+    authenticator = standalone
+    key_type = ecdsa
+    post_hook = "echo 'shut down server'"
+
+   You'll want to note the authenticator, installer, server, any hooks, etc.
+
+4. Create a new cert with the options and name you want by running
+   ``certbot certonly --cert-name yourdomain.com -d yourdomain.com -d otherdomain.com --any-other-options``.
+   The value for ``--cert-name`` can be anything you want; by default it is the first domain
+   listed on the cert.
+
+5. Make sure that any links to your certificates are updated. If you're using certbot to manage
+   the installation of certs on your webserver, you can run
+   ``certbot install --cert-name yourdomain.com``.
+
+6. Restart your webserver, if applicable.
+
+
 .. _renewal-config-file:
 .. _Modifying the Renewal Configuration File:
 

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -843,6 +843,7 @@ requesting a new certificate using certbot's ``--cert-name`` flag.
 
 6. Restart your webserver, if applicable.
 
+7. You can now delete the old certificate, again using the `Deleting certificates`_ section.
 
 .. _renewal-config-file:
 .. _Modifying the Renewal Configuration File:


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/10431

The updated section is under "Managing certificates."
<img width="342" height="463" alt="Screenshot 2025-08-18 at 3 59 51 PM" src="https://github.com/user-attachments/assets/2d64f43f-3b42-4a1d-ae03-c826d22a8e6d" />

The compiled text looks as follows:

<img width="908" height="658" alt="Screenshot 2025-08-18 at 3 58 39 PM" src="https://github.com/user-attachments/assets/56ae378b-229e-4b67-b6c2-28d7e90c0517" />
<img width="903" height="809" alt="Screenshot 2025-08-18 at 3 58 56 PM" src="https://github.com/user-attachments/assets/2ece2c19-a72b-4431-b8d3-4cdded2a4753" />
<img width="888" height="272" alt="Screenshot 2025-08-18 at 4 04 15 PM" src="https://github.com/user-attachments/assets/047ee50d-ee69-4c54-8c65-7d492056cfe6" />

