### PR TITLE
Clean up warning catching in `pytest.ini`

### DIFF
--- a/certbot-ci/pyproject.toml
+++ b/certbot-ci/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # This version is needed for "worker" attributes we currently use like
     # "workerinput". See https://github.com/pytest-dev/pytest-xdist/pull/268.
     "pytest-xdist>=1.22.1",
-    "python-dateutil",
+    "python-dateutil>=2.9.0", # https://github.com/dateutil/dateutil/issues/1314
     # This dependency needs to be added using environment markers to avoid its
     # installation on Linux.
     "pywin32>=300 ; sys_platform == \"win32\"",

--- a/certbot/pyproject.toml
+++ b/certbot/pyproject.toml
@@ -58,7 +58,7 @@ test = [
     "pip",
     "pylint",
     "pytest",
-    "pytest-cov",
+    "pytest-cov>=4.1.0", # https://github.com/pytest-dev/pytest-cov/pull/558
     "pytest-xdist",
     "ruff",
     "setuptools",

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,17 +13,12 @@
 # The current warnings being ignored are:
 # 1) pytest-cov uses deprecated functionality in pytest-xdist, to be resolved by
 #    https://github.com/pytest-dev/pytest-cov/issues/557.
-# 2) requests-toolbelt<0.10.1 can cause this warning to be raised during our
-#    unit tests. This warning should be ignored until our (transitive)
-#    dependency on requests-toolbelt is removed or our pinned version can be
-#    updated.
-# 3) Ignore DeprecationWarning for datetime.utcfromtimestamp() triggered
+# 2) Ignore DeprecationWarning for datetime.utcfromtimestamp() triggered
 #    from dateutil. See https://github.com/dateutil/dateutil/issues/1314.
-# 4) Planning to remove support for checking OCSP via OpenSSL binary.
+# 3) Planning to remove support for checking OCSP via OpenSSL binary.
 #     See https://github.com/certbot/certbot/issues/10291.
 filterwarnings =
     error
     ignore:.*rsyncdir:DeprecationWarning
-    ignore:'urllib3.contrib.pyopenssl:DeprecationWarning:requests_toolbelt
     ignore:.*datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:dateutil
     ignore:enforce_openssl_binary_usage parameter is deprecated:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,14 +11,11 @@
 # we release breaking changes.
 #
 # The current warnings being ignored are:
-# 1) pytest-cov uses deprecated functionality in pytest-xdist, to be resolved by
-#    https://github.com/pytest-dev/pytest-cov/issues/557.
-# 2) Ignore DeprecationWarning for datetime.utcfromtimestamp() triggered
+# 1) Ignore DeprecationWarning for datetime.utcfromtimestamp() triggered
 #    from dateutil. See https://github.com/dateutil/dateutil/issues/1314.
-# 3) Planning to remove support for checking OCSP via OpenSSL binary.
+# 2) Planning to remove support for checking OCSP via OpenSSL binary.
 #     See https://github.com/certbot/certbot/issues/10291.
 filterwarnings =
     error
-    ignore:.*rsyncdir:DeprecationWarning
     ignore:.*datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:dateutil
     ignore:enforce_openssl_binary_usage parameter is deprecated:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,11 +11,8 @@
 # we release breaking changes.
 #
 # The current warnings being ignored are:
-# 1) Ignore DeprecationWarning for datetime.utcfromtimestamp() triggered
-#    from dateutil. See https://github.com/dateutil/dateutil/issues/1314.
-# 2) Planning to remove support for checking OCSP via OpenSSL binary.
+# 1) Planning to remove support for checking OCSP via OpenSSL binary.
 #     See https://github.com/certbot/certbot/issues/10291.
 filterwarnings =
     error
-    ignore:.*datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:dateutil
     ignore:enforce_openssl_binary_usage parameter is deprecated:DeprecationWarning


### PR DESCRIPTION
Several of these have been fixed, so let's update the requirement if necessary and remove the warning catching.

`python-dateutil` 2.9.0 was released Feb 29, 2024, so it's not widely packaged in non-EOL major distros yet.
`pytest-cov` 4.1.0 was released May 24, 2023.