### PR TITLE
update centos ami

### DIFF
--- a/letstest/targets/targets.yaml
+++ b/letstest/targets/targets.yaml
@@ -28,7 +28,7 @@ targets:
   #-----------------------------------------------------------------------------
   # CentOS
   # These AMI were found on https://centos.org/download/aws-images/.
-  - ami: ami-0685bf135ad24747f
+  - ami: ami-013db6d0c7167e046
     name: centos9stream
     type: centos
     virt: hvm


### PR DESCRIPTION
it looks like the one previously being used was deleted so i grabbed a new one from https://centos.org/download/aws-images/

you can see this passing at https://dev.azure.com/certbot/certbot/_build/results?buildId=9627&view=results after also reconfiguring CI to only run test farm tests