### PR TITLE
use a static string when creating self-signed certs

### DIFF
--- a/certbot-nginx/src/certbot_nginx/_internal/configurator.py
+++ b/certbot-nginx/src/certbot_nginx/_internal/configurator.py
@@ -716,7 +716,13 @@ class NginxConfigurator(common.Configurator):
         assert isinstance(cryptography_key, rsa.RSAPrivateKey)
         cert = acme_crypto_util.make_self_signed_cert(
             cryptography_key,
-            domains=[socket.gethostname()]
+            # we used to use socket.gethostname here, but that sometimes
+            # resulted in strings over 64 characters long which would error
+            # on the validation introduced in
+            # https://github.com/pyca/cryptography/pull/11201. the ".invalid"
+            # TLD comes from RFC2606 (and was also used in the tls-sni-01
+            # challenge in early versions of the ACME spec)
+            domains=['temp-certbot-nginx.invalid']
         )
         cert_pem = cert.public_bytes(serialization.Encoding.PEM)
         cert_file, cert_path = util.unique_file(

--- a/newsfragments/10447.fixed
+++ b/newsfragments/10447.fixed
@@ -1,0 +1,1 @@
+certbot-nginx no longer uses socket.gethostname when generating self-signed certificates for use as a temporary step of installing certificates as it would sometimes result in strings that are too long to be used in the common name of a certificate. The static domain "temp-certbot-nginx.invalid" is now used instead.


### PR DESCRIPTION
this is the quickest somewhat sane fix for the current CI problem that i could think of

the domain being used in the self-signed cert really seems irrelevant. on my main test VPS, socket.gethostname returns "brad-certbot-dev". on my laptop, it's "MacBookPro". i manually tested this branch a bit on my VPS and nginx seems content

using a simple static string like this seems unlikely to break anything to me and i think helps clearly identify where the self-signed cert is coming from if ever causes a problem for anyone in the future