### PR TITLE
add support for setting CN in the subject as a legacy setting

### DIFF
--- a/acme/src/acme/_internal/tests/crypto_util_test.py
+++ b/acme/src/acme/_internal/tests/crypto_util_test.py
@@ -248,6 +248,20 @@ class MakeCSRTest(unittest.TestCase):
             x509.TLSFeatureType.status_request
         ]
 
+    def test_make_csr_legacy_cn(self):
+        csr_pem = self._call_with_key(["a.example", "b.example"], legacy_common_name=True)
+        assert b"--BEGIN CERTIFICATE REQUEST--" in csr_pem
+        assert b"--END CERTIFICATE REQUEST--" in csr_pem
+        csr = x509.load_pem_x509_csr(csr_pem)
+        assert csr.subject == x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, 'a.example')])
+
+    def test_make_csr_without_domains_legacy_cn_enabled(self):
+        with pytest.raises(ValueError):
+            self._call_with_key(
+                [],
+                ipaddrs=[ipaddress.ip_address("127.0.0.1"), ipaddress.ip_address("::1")],
+                legacy_common_name=True)
+
     def test_make_csr_without_hostname(self):
         with pytest.raises(ValueError):
             self._call_with_key()

--- a/acme/src/acme/crypto_util.py
+++ b/acme/src/acme/crypto_util.py
@@ -57,6 +57,7 @@ def make_csr(
     domains: Optional[Union[set[str], list[str]]] = None,
     must_staple: bool = False,
     ipaddrs: Optional[list[Union[ipaddress.IPv4Address, ipaddress.IPv6Address]]] = None,
+    legacy_common_name: bool = False
 ) -> bytes:
     """Generate a CSR containing domains or IPs as subjectAltNames.
 
@@ -69,11 +70,13 @@ def make_csr(
         OCSP Must Staple: https://tools.ietf.org/html/rfc7633).
     :param list ipaddrs: List of IPaddress(type ipaddress.IPv4Address or ipaddress.IPv6Address)
         names to include in subbjectAltNames of CSR.
+    :param bool legacy_common_name: Whether to add a CN to the CSR
 
     :returns: buffer PEM-encoded Certificate Signing Request.
 
     """
     private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    cn = ''
     if not isinstance(private_key, CertificateIssuerPrivateKeyTypesTpl):
         raise ValueError(f"Invalid private key type: {type(private_key)}")
     if domains is None:
@@ -84,10 +87,13 @@ def make_csr(
         raise ValueError(
             "At least one of domains or ipaddrs parameter need to be not empty"
         )
+    if legacy_common_name and not domains:
+        raise ValueError("At least one domain is required to set a legacy CN")
+    if legacy_common_name and domains:
+        cn = next(iter(domains))
 
     builder = (
         x509.CertificateSigningRequestBuilder()
-        .subject_name(x509.Name([]))
         .add_extension(
             x509.SubjectAlternativeName(
                 [x509.DNSName(d) for d in domains]
@@ -96,6 +102,14 @@ def make_csr(
             critical=False,
         )
     )
+
+    if legacy_common_name:
+        builder = builder.subject_name(
+            x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, cn)])
+        )
+    else:
+        builder = builder.subject_name(x509.Name([]))
+
     if must_staple:
         builder = builder.add_extension(
             # "status_request" is the feature commonly known as OCSP

--- a/certbot/src/certbot/_internal/cli/__init__.py
+++ b/certbot/src/certbot/_internal/cli/__init__.py
@@ -124,6 +124,12 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: list[st
              "already have a certificate with the same name. In the case of a name conflict, "
              "a number like -0001 will be appended to the certificate name. (default: Ask)")
     helpful.add(
+        [None, "run", "certonly", "certificates", "enhance"],
+        constants.LEGACY_COMMON_NAME_FLAG, action="store_true",
+        default=flag_default("legacy_common_name"),
+        help="Set the certificate subject common name to be the first domain "
+             "provided")
+    helpful.add(
         [None, "run", "certonly", "register"],
         "--eab-kid", dest="eab_kid",
         metavar="EAB_KID",

--- a/certbot/src/certbot/_internal/client.py
+++ b/certbot/src/certbot/_internal/client.py
@@ -411,7 +411,9 @@ class Client:
             )
             csr = util.CSR(file=None, form="pem",
                            data=acme_crypto_util.make_csr(
-                               key.pem, domains, self.config.must_staple))
+                               key.pem, domains,
+                               must_staple=self.config.must_staple,
+                               legacy_common_name=self.config.legacy_common_name))
         else:
             key = key or crypto_util.generate_key(
                 key_size=key_size,
@@ -421,7 +423,10 @@ class Client:
                 strict_permissions=self.config.strict_permissions,
             )
             csr = crypto_util.generate_csr(
-                key, domains, None, self.config.must_staple, self.config.strict_permissions)
+                key, domains, None,
+                self.config.must_staple,
+                self.config.strict_permissions,
+                self.config.legacy_common_name)
 
         try:
             orderr = self._get_order_and_authorizations(csr.data, self.config.allow_subset_of_names)

--- a/certbot/src/certbot/_internal/constants.py
+++ b/certbot/src/certbot/_internal/constants.py
@@ -32,6 +32,7 @@ CLI_DEFAULTS: dict[str, Any] = dict(  # pylint: disable=use-dict-literal
     noninteractive_mode=False,
     force_interactive=False,
     domains=[],
+    legacy_common_name=False,
     certname=None,
     dry_run=False,
     register_unsafely_without_email=False,
@@ -214,6 +215,9 @@ EFF_SUBSCRIBE_URI = "https://supporters.eff.org/subscribe/certbot"
 SSL_DHPARAMS_DEST = "ssl-dhparams.pem"
 """Name of the ssl_dhparams file as saved
 in `certbot.configuration.NamespaceConfig.config_dir`."""
+
+LEGACY_COMMON_NAME_FLAG = "--legacy-common-name"
+"""Flag to set the first domain provided to the subject common name."""
 
 def _generate_ssl_dhparams_src_static() -> str:
     # This code ensures that the resource is accessible as file for the lifetime of current

--- a/certbot/src/certbot/_internal/tests/client_test.py
+++ b/certbot/src/certbot/_internal/tests/client_test.py
@@ -378,7 +378,7 @@ class ClientTest(ClientTestCommon):
             strict_permissions=True,
         )
         mock_crypto_util.generate_csr.assert_called_once_with(
-            mock.sentinel.key, self.eg_domains, None, False, True)
+            mock.sentinel.key, self.eg_domains, None, False, True, False)
         mock_crypto_util.cert_and_chain_from_fullchain.assert_called_once_with(
             self.eg_order.fullchain_pem)
 
@@ -516,8 +516,8 @@ class ClientTest(ClientTestCommon):
         successful_domains = [d for d in self.eg_domains if d != 'example.com']
         assert mock_crypto_util.generate_key.call_count == 2
         mock_crypto_util.generate_csr.assert_has_calls([
-            mock.call(key, self.eg_domains, None, self.config.must_staple, self.config.strict_permissions),
-            mock.call(key, successful_domains, None, self.config.must_staple, self.config.strict_permissions)])
+            mock.call(key, self.eg_domains, None, self.config.must_staple, self.config.strict_permissions, self.config.legacy_common_name),
+            mock.call(key, successful_domains, None, self.config.must_staple, self.config.strict_permissions, self.config.legacy_common_name)])
         assert mock_crypto_util.cert_and_chain_from_fullchain.call_count == 1
 
     @mock.patch("certbot._internal.client.crypto_util")
@@ -608,8 +608,8 @@ class ClientTest(ClientTestCommon):
         successful_domains = [d for d in self.eg_domains if d != 'example.com']
         assert mock_crypto_util.generate_key.call_count == 2
         mock_crypto_util.generate_csr.assert_has_calls([
-            mock.call(key, self.eg_domains, None, self.config.must_staple, self.config.strict_permissions),
-            mock.call(key, successful_domains, None, self.config.must_staple, self.config.strict_permissions)])
+            mock.call(key, self.eg_domains, None, self.config.must_staple, self.config.strict_permissions, self.config.legacy_common_name),
+            mock.call(key, successful_domains, None, self.config.must_staple, self.config.strict_permissions, self.config.legacy_common_name)])
         assert mock_crypto_util.cert_and_chain_from_fullchain.call_count == 1
 
     @mock.patch("certbot._internal.client.crypto_util")
@@ -686,7 +686,9 @@ class ClientTest(ClientTestCommon):
             key_type=self.config.key_type,
         )
         mock_acme_crypto.make_csr.assert_called_once_with(
-            mock.sentinel.key_pem, self.eg_domains, self.config.must_staple)
+            mock.sentinel.key_pem, self.eg_domains,
+            must_staple=self.config.must_staple,
+            legacy_common_name=self.config.legacy_common_name)
         mock_crypto.generate_key.assert_not_called()
         mock_crypto.generate_csr.assert_not_called()
         assert mock_crypto.cert_and_chain_from_fullchain.call_count == 1

--- a/certbot/src/certbot/configuration.py
+++ b/certbot/src/certbot/configuration.py
@@ -456,6 +456,14 @@ class NamespaceConfig:
         """
         return self.namespace.new_key
 
+    @property
+    def legacy_common_name(self) -> bool:
+        """This option specifies whether Certbot should add the first
+        domain provided to the subject common name. This is to support
+        TLS clients which still check the common name first/only before
+        checking SANs."""
+        return self.namespace.legacy_common_name
+
     # Magic methods
 
     def __deepcopy__(self, _memo: Any) -> 'NamespaceConfig':

--- a/certbot/src/certbot/crypto_util.py
+++ b/certbot/src/certbot/crypto_util.py
@@ -98,7 +98,9 @@ def generate_key(key_size: int, key_dir: Optional[str], key_type: str = "rsa",
 
 
 def generate_csr(privkey: util.Key, names: Union[list[str], set[str]], path: Optional[str],
-                 must_staple: bool = False, strict_permissions: bool = True) -> util.CSR:
+                 must_staple: bool = False,
+                 strict_permissions: bool = True,
+                 legacy_common_name: bool = False) -> util.CSR:
     """Initialize a CSR with the given private key.
 
     :param privkey: Key to include in the CSR
@@ -108,13 +110,14 @@ def generate_csr(privkey: util.Key, names: Union[list[str], set[str]], path: Opt
     :param bool must_staple: If true, include the TLS Feature extension "OCSP Must-Staple"
     :param bool strict_permissions: If true and path exists, an exception is raised if
         the directory doesn't have 0755 permissions or isn't owned by the current user.
+    :param bool legacy_common_name: Whether to add a CN to the CSR
 
     :returns: CSR
     :rtype: :class:`certbot.util.CSR`
 
     """
     csr_pem = acme_crypto_util.make_csr(
-        privkey.pem, names, must_staple=must_staple)
+        privkey.pem, names, must_staple=must_staple, legacy_common_name=legacy_common_name)
 
     # Save CSR, if requested
     csr_filename = None


### PR DESCRIPTION
Hello, this is an attempt to put some money where the collective mouths are to support setting a common name in CSRs. This relates back to these issues/discussions:
https://github.com/certbot/certbot/issues/10269
https://github.com/certbot/certbot/issues/9543
https://github.com/certbot/certbot/issues/6463#issuecomment-652914365

My particular use case is @sekrause's second and third points in https://github.com/certbot/certbot/issues/6463#issuecomment-652914365. In our environment, we have services/clients expecting to see a CN and it would be great to use our internal PKI platform's ACME service to spur on some automation.

I understand not wanting to persist deprecated practices, but hopefully this is at least a middle ground where it's an explicit option to be enabled.

The first domain provided will be set as the subject. This allows for older clients which rely on CN being present to not fail cert validation.

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
