### PR TITLE
Remove unnecessary time.sleep from certbot-ci

### DIFF
--- a/certbot-ci/src/certbot_integration_tests/certbot_tests/test_main.py
+++ b/certbot-ci/src/certbot_integration_tests/certbot_tests/test_main.py
@@ -6,7 +6,6 @@ from os.path import join
 import re
 import shutil
 import subprocess
-import time
 from typing import Generator
 
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
@@ -960,9 +959,6 @@ def test_ocsp_status_live(context: IntegrationTestsContext) -> None:
 
     # OSCP 2: Check live certificate OCSP status (REVOKED)
     context.certbot(['revoke', '--cert-name', cert, '--no-delete-after-revoke'])
-    # Sometimes in oldest tests (using openssl binary and not cryptography), the OCSP status is
-    # not seen immediately by Certbot as invalid. Waiting few seconds solves this transient issue.
-    time.sleep(5)
     stdout, _ = context.certbot(['certificates'])
 
     assert stdout.count('INVALID') == 1, 'Expected {0} to be INVALID'.format(cert)


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/10450

Discussion when originally added is [here](https://github.com/certbot/certbot/pull/6989/files#r283050165). Further notes are "The problem is transient, only observed on Travis so far, not locally. I not know how to recreate a reliable pattern and find precisely what needs to be done." So it's possible we weren't even hitting this anymore anyway. Regardless, I ran the test a few times in CI just to make sure it's not breaking.

Runs:
https://dev.azure.com/certbot/certbot/_build/results?buildId=9686&view=results (pass)
https://dev.azure.com/certbot/certbot/_build/results?buildId=9688&view=results (pass)
https://dev.azure.com/certbot/certbot/_build/results?buildId=9689&view=results (pass)
https://dev.azure.com/certbot/certbot/_build/results?buildId=9690&view=results (pass)
https://dev.azure.com/certbot/certbot/_build/results?buildId=9691&view=results (pass)