### PR TITLE
Show --deploy-hook help info in certonly and run info, and add note that it will be run again later.

### DIFF
--- a/certbot/src/certbot/_internal/cli/__init__.py
+++ b/certbot/src/certbot/_internal/cli/__init__.py
@@ -428,9 +428,9 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: list[st
         default=flag_default("random_sleep_on_renew"), dest="random_sleep_on_renew",
         help=argparse.SUPPRESS)
     helpful.add(
-        ["renew", "reconfigure"], "--deploy-hook", action=_DeployHookAction,
+        ["certonly", "renew", "reconfigure", "run"], "--deploy-hook", action=_DeployHookAction,
         help='Command to be run in a shell once for each successfully'
-        ' issued certificate.'
+        ' issued certificate, including on subsequent renewals.'
         ' Unless --disable-hook-validation is used, the command’s first word'
         ' must be the absolute pathname of an executable or one found via the'
         ' PATH environment variable.'


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/6180.

New output:

```
  --deploy-hook DEPLOY_HOOK
                        Command to be run in a shell once for each successfully issued certificate, including on subsequent renewals. Unless --disable-hook-validation is
                        used, the command’s first word must be the absolute pathname of an executable or one found via the PATH environment variable. For this command, the
                        shell variable $RENEWED_LINEAGE will point to the config live subdirectory (for example, "/etc/letsencrypt/live/example.com") containing the new
                        certificates and keys; the shell variable $RENEWED_DOMAINS will contain a space-delimited list of renewed certificate domains (for example,
                        "example.com www.example.com") (default: None)
```

Pre and post hooks are still only shown in `renew` and `reconfigure` help, though perhaps there is less confusion over those so it's not necessary. 