### PR TITLE
Remove `vhost_combined` override from Apache conf

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -124,6 +124,7 @@ Authors
 * [James Balazs](https://github.com/jamesbalazs)
 * [James Kasten](https://github.com/jdkasten)
 * [Jason Grinblat](https://github.com/ptychomancer)
+* [Jason Owen](https://github.com/jasonaowen)
 * [Jawshua](https://github.com/jawshua)
 * [Jay Faulkner](https://github.com/jayofdoom)
 * [J.C. Jones](https://github.com/jcjones)

--- a/certbot-apache/src/certbot_apache/_internal/constants.py
+++ b/certbot-apache/src/certbot_apache/_internal/constants.py
@@ -34,6 +34,8 @@ ALL_SSL_OPTIONS_HASHES: list[str] = [
     '3fd812e3e87fe5c645d3682a511b2a06c8286f19594f28e280f17cd6af1301b5',
     '27155797e160fe43b6951354a0a0ca4d829e9e605b3b41fc223c20bf2f6cb3c6',
     '3a6881d0a7e5740b039ec550c916105259f53b577a3d38d0ed11bd675bfeab88',
+    '0f3d9c62d4274aca0406925dc4ee0919599c397e7463bce792a915b60060d004',
+    '95f7367d4905a1cd0932a35ce476b4a639e2108dbd1eedf924a5ea9e51fecaf7',
 ]
 """SHA256 hashes of the contents of previous versions of all versions of MOD_SSL_CONF_SRC"""
 

--- a/certbot-apache/src/certbot_apache/_internal/tls_configs/current-options-ssl-apache.conf
+++ b/certbot-apache/src/certbot_apache/_internal/tls_configs/current-options-ssl-apache.conf
@@ -14,7 +14,3 @@ SSLHonorCipherOrder     off
 SSLSessionTickets       off
 
 SSLOptions +StrictRequire
-
-# Add vhost name to log entries:
-LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" vhost_combined
-LogFormat "%v %h %l %u %t \"%r\" %>s %b" vhost_common

--- a/certbot-apache/src/certbot_apache/_internal/tls_configs/old-options-ssl-apache.conf
+++ b/certbot-apache/src/certbot_apache/_internal/tls_configs/old-options-ssl-apache.conf
@@ -16,7 +16,3 @@ SSLCipherSuite          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA25
 SSLHonorCipherOrder     off
 
 SSLOptions +StrictRequire
-
-# Add vhost name to log entries:
-LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" vhost_combined
-LogFormat "%v %h %l %u %t \"%r\" %>s %b" vhost_common

--- a/newsfragments/9769.fixed
+++ b/newsfragments/9769.fixed
@@ -1,0 +1,1 @@
+Removed `vhost_combined` and `vhost_common` log formats from included Apache configuration file.


### PR DESCRIPTION
The Apache configuration `Include`d in automatically created `[sitename]-le-ssl.conf` files was redefining the `vhost_combined` `LogFormat`, but contrary to the comment before the redefinition, did not include the virtual host server name in the log format. This is particularly confusing because this redefinition is hard to find when debugging logging issues, as log formats are not related to SSL/TLS configuration, and the included configuration file is outside of `/etc/apache2`.

Additionally, a `vhost_common` `LogFormat` was defined, but not used anywhere.

The `LogFormat` directives were introduced in commit 68f85d9f1abc2b66a6a9a0bd970d42f37395f217. Several other directives that do not directly pertain to configuring SSL/TLS were added in that commit, and have gradually been removed over the years. This should be the last such removal.

Delete the `LogFormat` directives from the Apache configuration files (both old and current), and update the `ALL_SSL_OPTIONS_HASHES`.

Fixes #9769 File 'options-ssl-apache.conf' included in autocreated '[sitename]-le-ssl.conf' has potentially problematic vhost_combined LogFormat

## Pull Request Checklist

- [ ] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), add a description of your change to the `newsfragments` directory. This should be a file called `<title>.<type>`, where `<title>` is either a GitHub issue number or some other unique name starting with `+`, and `<type>` is either `changed`, `fixed`, or `added`.
  * For example, if you fixed a bug for issue number 42, create a file called `42.fixed` and put a description of your change in that file.
- [ ] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.
