### PR TITLE
[DOC] Update version support policy in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ Explanation on supported versions [here](https://github.com/certbot/certbot/wiki
 
 | Major Version | Support Level |
 | ------- | ------------------ |
-| >= 4.0  | Full Support |
-| 3.x     | Discretionary Backports |
-| <=2.x   | None |
+| >= 5.0  | Full Support |
+| 4.x     | Discretionary Backports |
+| <=3.x   | None |
 
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Keeping the version matrix consistent with our [policy](https://github.com/certbot/certbot/wiki/Architectural-Decision-Records-2025#-update-to-certbots-version-policy-and-end-of-life-support-on-previous-major-versions).

