### PR TITLE
update actions in response to pull_request_target concerns

### DIFF
--- a/.github/workflows/assigned.yaml
+++ b/.github/workflows/assigned.yaml
@@ -3,11 +3,22 @@ name: Issue Assigned
 on:
   issues:
     types: [assigned]
+permissions: {}  # let's not use any permissions we don't need here
 jobs:
   send-mattermost-message:
     runs-on: ubuntu-latest
     steps:
-    - uses: mattermost/action-mattermost-notify@master
+    # issue triggers in github actions can be dangerous like
+    # pull_request_target because they run with additional privileges in an
+    # environment containing values that can be controlled by an attacker.
+    # because of this, please take extra caution when modifying the steps taken
+    # by this workflow. for additional information, see
+    # https://github.com/certbot/certbot/pull/10490
+    #
+    # we pin this action to a version tested and audited by certbot's
+    # maintainers for extra security. the full hash is used as doing so is
+    # recommended by zizmor
+    - uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_ASSIGN_WEBHOOK }}
         TEXT: >

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -4,13 +4,23 @@ on:
   pull_request_target:
     types:
       - closed
-
+permissions: {}  # let's not use any permissions we don't need here
 jobs:
   if_merged:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-    - uses: mattermost/action-mattermost-notify@master
+    # github actions workflows triggered by pull_request_target can be
+    # dangerous because they run with additional privileges in an environment
+    # containing values that can be controlled by an attacker. because of
+    # this, please take extra caution when modifying the steps taken by this
+    # workflow. for additional information, see
+    # https://github.com/certbot/certbot/pull/10490
+    #
+    # we pin this action to a version tested and audited by certbot's
+    # maintainers for extra security. the full hash is used as doing so is
+    # recommended by zizmor
+    - uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_MERGE_WEBHOOK }}
         TEXT: >

--- a/.github/workflows/notify_weekly.yaml
+++ b/.github/workflows/notify_weekly.yaml
@@ -5,6 +5,7 @@ on:
     # Every week on Thursday @ 10:00
     - cron: "0 10 * * 4"
   workflow_dispatch:
+permissions: {}  # let's not use any permissions we don't need here
 jobs:
   send-mattermost-message:
     runs-on: ubuntu-latest
@@ -15,7 +16,10 @@ jobs:
         DATE=$(date --date="7 days ago" +"%Y-%m-%d")
         echo "ASSIGNED_PRS=https://github.com/pulls?q=is%3Apr+is%3Aopen+updated%3A%3E%3D${DATE}+assignee%3A*+user%3Acertbot" >> $GITHUB_ENV
         echo "UPDATED_URL=https://github.com/issues?q=is%3Aissue+is%3Aopen+sort%3Acomments-desc+updated%3A%3E%3D${DATE}+user%3Acertbot" >> $GITHUB_ENV
-    - uses: mattermost/action-mattermost-notify@master
+    # we pin this action to a version tested and audited by certbot's
+    # maintainers for extra security. the full hash is used as doing so is
+    # recommended by zizmor
+    - uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
         MATTERMOST_CHANNEL: private-certbot

--- a/.github/workflows/review_requested.yaml
+++ b/.github/workflows/review_requested.yaml
@@ -3,13 +3,24 @@ name: Review Requested
 on:
   pull_request_target:
     types: [review_requested]
+permissions: {}
 jobs:
   send-mattermost-message:
     # Don't notify for the interim step of certbot/eff-devs being assigned
     if: ${{ github.event.requested_reviewer.login != ''}}
     runs-on: ubuntu-latest
     steps:
-    - uses: mattermost/action-mattermost-notify@master
+    # github actions workflows triggered by pull_request_target can be
+    # dangerous because they run with additional privileges in an environment
+    # containing values that can be controlled by an attacker. because of
+    # this, please take extra caution when modifying the steps taken by this
+    # workflow. for additional information, see
+    # https://github.com/certbot/certbot/pull/10490
+    #
+    # we pin this action to a version tested and audited by certbot's
+    # maintainers for extra security. the full hash is used as doing so is
+    # recommended by zizmor
+    - uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_ASSIGN_WEBHOOK }}
         TEXT: >


### PR DESCRIPTION
this pr is in response to https://words.filippo.io/compromise-survey/.  ohemorange and i read this late on a friday to (speaking for myself at least) much panic as it has some very strong words to say about the github actions trigger pull_request_target which we use. looking into the issue more, i also found that the popular static analysis tool [zizmor](https://github.com/zizmorcore/zizmor) flags any github actions workflow that uses the pull_request_target trigger with the message:

```
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
pull_request_target is almost always used insecurely
```

this only added to my concern

the general problem with pull_request_target is that it runs with additional privileges (e.g. potential write access, access to secrets) in an environment containing values that can be set by an attacker. these values include things such as references to the arbitrary code contained in the triggering pr and pr titles which have been used to perform shell injection attacks. not carefully treating these values like the untrusted data it is while executing code in the privileged environment given to pull_request_target has resulted in many supply chain attacks

that's not to say that pull_request_target CAN'T be used securely. zizmor even has [an issue](https://github.com/zizmorcore/zizmor/issues/1168) brainstorming how to not warn about all uses of the trigger as some are clearly fine and the only way to accomplish what the user wants. i'm going to argue that our uses of the trigger are ok

looking through the links provided by filippo's blog and [zizmor's docs](https://docs.zizmor.sh/audits/#dangerous-triggers), i think we can break down attacks used against pull_request_target into roughly 2 categories:

1. shell injection: "Nx S1ingularity" and "Ultralytics" from filippo's blog
2. checking out and running a PR's code: "Kong Ingress Controller" and "Rspack" from filippo's blog and https://ptrpa.ws/nixpkgs-actions-abuse from zizmor docs

i think none of our pull_request_target workflows have these problems. none of them use a shell (the [zizmor issue](https://github.com/zizmorcore/zizmor/issues/1168) i linked earlier suggests that any pull_request_target workflow that uses a run block should always be flagged as insecure). instead, our workflows just call action-mattermost-notify which can be [pretty easily audited](https://github.com/mattermost/action-mattermost-notify/blob/2.0.0/src/main.js) (as all the other files in the repo are boilerplate). passing possible attacker controlled values directly to an action written in another language is one of the approaches for mitigating script injection [recommended by github](https://docs.github.com/en/actions/reference/security/secure-use#use-an-action-instead-of-an-inline-script).  our workflows also do not check out the triggering pr's code

despite all that, i took this opportunity to cleanup and harden things a bit.  i reduced the permissions for each workflow and confirmed they each still work on my fork. i also pinned the mattermost action to an exact version and added some inline documentation

with these changes, our github workflows trigger few to no warnings/errors when checked with zizmor, [octoscan](https://github.com/synacktiv/octoscan), and [openssf scorecard](https://github.com/ossf/scorecard)

if this pr is approved, i'll make similar changes to our josepy repo