### PR TITLE
dynamically determine base branch name in mattermost notifications

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -27,4 +27,4 @@ jobs:
           [${{ github.repository }}] |
           [${{ github.event.pull_request.title }}
           #${{ github.event.number }}](https://github.com/${{ github.repository }}/pull/${{ github.event.number }})
-          was merged into main by ${{ github.actor }}
+          was merged into ${{ github.event.pull_request.base.ref }} by ${{ github.actor }}


### PR DESCRIPTION
previously, if we merged a PR into one of our point release branches, the mattermost notification would still say it was merged into main. this PR fixes that

you can see me testing this change on my fork with this [workflow file](https://github.com/bmw/letsencrypt/actions/runs/19588662936/workflow#L30) and this [output](https://github.com/bmw/letsencrypt/actions/runs/19588662936/job/56102625766#step:2:4)

if this PR is merged, i'll do the same thing in our josepy repo