### PR TITLE
Add CN to subject

### DIFF
--- a/acme/src/acme/crypto_util.py
+++ b/acme/src/acme/crypto_util.py
@@ -88,7 +88,11 @@ def make_csr(
 
     builder = (
         x509.CertificateSigningRequestBuilder()
-        .subject_name(x509.Name([]))
+        .subject_name(
+            x509.Name([
+                x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, domains[0])
+            ])
+        )
         .add_extension(
             x509.SubjectAlternativeName(
                 [x509.DNSName(d) for d in domains]


### PR DESCRIPTION
This will add the first domain as the Common Name (CN) in the subject. This ensures compatibility with clients that depend on the CN being present for certificate validation.