### PR TITLE
add changelog entry about IP refactoring

### DIFF
--- a/newsfragments/10468.changed
+++ b/newsfragments/10468.changed
@@ -1,0 +1,1 @@
+While nothing significant should have changed from the user's perspective, we've been doing a lot of internal refactoring in preparation for soon adding support for IP address certificates to Certbot.

--- a/newsfragments/10478.changed
+++ b/newsfragments/10478.changed
@@ -1,0 +1,1 @@
+While nothing significant should have changed from the user's perspective, we've been doing a lot of internal refactoring in preparation for soon adding support for IP address certificates to Certbot.


### PR DESCRIPTION
if you dislike the general idea of this PR, feel free to just close it, but i'm scheduled to release the next version of certbot a week from today and i personally didn't like how [newsfragments](https://github.com/certbot/certbot/tree/main/newsfragments) is so empty despite us having done a lot of work on certbot lately

this PR just adds a simple newsfragment highlighting/teasing the work jsha has been leading on support for IP address certificates which i imagine would be of interest to some people in the community

```
$ towncrier build --draft --version 5.2.0
Loading template...
Finding news fragments...
Rendering news fragments...
Draft only -- nothing has been written.
What is seen below is what would be written.

## 5.2.0 - 2025-11-25

### Added

- Support for Python 3.14 was added.
  ([#10477](https://github.com/certbot/certbot/issues/10477))

### Changed

- While nothing significant should have changed from the user's perspective,
  we've been doing a lot of internal refactoring in preparation for soon adding
  support for IP address certificates to Certbot.
  ([#10468](https://github.com/certbot/certbot/issues/10468),
  [#10478](https://github.com/certbot/certbot/issues/10478))
```