### PR TITLE
fix finish_release.py

### DIFF
--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -107,7 +107,7 @@ def get_snap_revisions(snap, channel, version):
     print('Getting revision numbers for', snap, version)
     cmd = ['snapcraft', 'status', snap]
     process = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True)
-    pattern = f'^\\s+{channel}\\s+{version}\\s+(\\d+)\\s*'
+    pattern = f'\\s+{channel}\\s+{version}\\s+(\\d+)\\s*'
     revisions = re.findall(pattern, process.stdout, re.MULTILINE)
     assert len(revisions) == SNAP_ARCH_COUNT, f'Unexpected number of snaps found for {channel} {snap} {version} (expected {SNAP_ARCH_COUNT}, found {len(revisions)})'
     return revisions


### PR DESCRIPTION
in https://github.com/canonical/snapcraft/pull/5720, snapcraft made a change. `snapcraft status certbot` output changed from something like this:
```
Track    Arch    Channel    Version     Revision    Progress
latest   amd64   stable     5.1.0       5057        -
                 candidate  ↑           ↑           -
                 beta       5.2.1       5214        -
                 edge       5.2.0.dev0  5210        -
         arm64   stable     5.1.0       5058        -
                 candidate  ↑           ↑           -
                 beta       5.2.1       5215        -
                 edge       5.2.0.dev0  5211        -
         armhf   stable     5.1.0       5056        -
                 candidate  ↑           ↑           -
                 beta       5.2.1       5213        -
                 edge       5.2.0.dev0  5212        -
```
to this:
```
Track    Arch    Channel    Version     Revision    Progress
latest   amd64   stable     5.1.0       5057        -
latest   amd64   candidate  ↑           ↑           -
latest   amd64   beta       5.2.1       5214        -
latest   amd64   edge       5.2.0.dev0  5210        -
latest   arm64   stable     5.1.0       5058        -
latest   arm64   candidate  ↑           ↑           -
latest   arm64   beta       5.2.1       5215        -
latest   arm64   edge       5.2.0.dev0  5211        -
latest   armhf   stable     5.1.0       5056        -
latest   armhf   candidate  ↑           ↑           -
latest   armhf   beta       5.2.1       5213        -
latest   armhf   edge       5.2.0.dev0  5212        -
```
when its output is captured like it is in finish_release.py in the lines above the code i'm modifying here

not matching on the beginning of lines makes this pattern a little less strict, but based on the rest of the pattern and the output here, i personally think this is fine

after carefully verifying this works with the current state of things, i went ahead and finished the release with this change and it worked just fine. instead, this PR proposes a way to fix things going forward