### PR TITLE
fix finish_release.py on the 5.2.x point release branch

### DIFF
--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -107,7 +107,7 @@ def get_snap_revisions(snap, channel, version):
     print('Getting revision numbers for', snap, version)
     cmd = ['snapcraft', 'status', snap]
     process = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True)
-    pattern = f'^\\s+{channel}\\s+{version}\\s+(\\d+)\\s*'
+    pattern = f'\\s+{channel}\\s+{version}\\s+(\\d+)\\s*'
     revisions = re.findall(pattern, process.stdout, re.MULTILINE)
     assert len(revisions) == SNAP_ARCH_COUNT, f'Unexpected number of snaps found for {channel} {snap} {version} (expected {SNAP_ARCH_COUNT}, found {len(revisions)})'
     return revisions


### PR DESCRIPTION
this PR just cherry picks https://github.com/certbot/certbot/pull/10503 to the 5.2.x branch in case we need to do a point release to fix https://github.com/certbot/certbot/issues/10506 or any other issues