### PR TITLE
make _DomainsAction an external attribute of _internal.cli.cli_utils

### DIFF
--- a/certbot/src/certbot/_internal/cli/__init__.py
+++ b/certbot/src/certbot/_internal/cli/__init__.py
@@ -23,7 +23,6 @@ from certbot._internal.cli.cli_constants import SHORT_USAGE
 from certbot._internal.cli.cli_constants import VAR_MODIFIERS
 from certbot._internal.cli.cli_constants import ZERO_ARG_ACTIONS
 from certbot._internal.cli.cli_utils import _DeployHookAction
-from certbot._internal.cli.cli_utils import _DomainsAction
 from certbot._internal.cli.cli_utils import _EncodeReasonAction
 from certbot._internal.cli.cli_utils import _PrefChallAction
 from certbot._internal.cli.cli_utils import _RenewHookAction
@@ -32,6 +31,7 @@ from certbot._internal.cli.cli_utils import add_domains
 from certbot._internal.cli.cli_utils import CaseInsensitiveList
 from certbot._internal.cli.cli_utils import config_help
 from certbot._internal.cli.cli_utils import CustomHelpFormatter
+from certbot._internal.cli.cli_utils import DomainsAction
 from certbot._internal.cli.cli_utils import flag_default
 from certbot._internal.cli.cli_utils import HelpfulArgumentGroup
 from certbot._internal.cli.cli_utils import nonnegative_int
@@ -115,7 +115,7 @@ def prepare_and_parse_args(plugins: plugins_disco.PluginsRegistry, args: list[st
     helpful.add(
         [None, "run", "certonly", "certificates", "enhance"],
         "-d", "--domains", "--domain", dest="domains",
-        metavar="DOMAIN", action=_DomainsAction,
+        metavar="DOMAIN", action=DomainsAction,
         default=flag_default("domains"),
         help="Domain names to include. For multiple domains you can use multiple -d flags "
              "or enter a comma separated list of domains as a parameter. All domains will "

--- a/certbot/src/certbot/_internal/cli/cli_utils.py
+++ b/certbot/src/certbot/_internal/cli/cli_utils.py
@@ -92,7 +92,7 @@ class CustomHelpFormatter(argparse.HelpFormatter):
         return helpstr
 
 
-class _DomainsAction(argparse.Action):
+class DomainsAction(argparse.Action):
     """Action class for parsing domains."""
 
     def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,

--- a/certbot/src/certbot/_internal/tests/plugins/webroot_test.py
+++ b/certbot/src/certbot/_internal/tests/plugins/webroot_test.py
@@ -20,7 +20,7 @@ from certbot import errors
 from certbot.compat import filesystem
 from certbot.compat import os
 from certbot.display import util as display_util
-from certbot._internal import cli
+from certbot._internal.cli import cli_utils
 from certbot.tests import acme_util
 from certbot.tests import util as test_util
 
@@ -322,7 +322,7 @@ class WebrootActionTest(unittest.TestCase):
         self.path = tempfile.mkdtemp()
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("-d", "--domains",
-                                 action=cli._DomainsAction, default=[])
+                                 action=cli_utils.DomainsAction, default=[])
         Authenticator.inject_parser_options(self.parser, "webroot")
 
     def test_webroot_map_action(self):


### PR DESCRIPTION
as i mentioned at https://github.com/certbot/certbot/pull/10509#discussion_r2601282033, i didn't love how the tests were using `_DomainsAction` when i think the leading underscore suggests the class is internal to the cli/cl_utils module

this PR fixes that

also, i don't think this PR requires two reviews