### PR TITLE
update centos pyenv deps

### DIFF
--- a/letstest/scripts/bootstrap_os_packages.sh
+++ b/letstest/scripts/bootstrap_os_packages.sh
@@ -23,8 +23,8 @@ elif [ -f /etc/redhat-release ]; then
   # the "codeready builder" repository must be enabled to install the
   # augeas-devel package needed to compile newer versions of python-augeas
   sudo yum config-manager --set-enabled crb
-  PYENV_DEPS="gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel \
-              tk-devel libffi-devel xz-devel git"
+  PYENV_DEPS="gcc make patch zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel \
+              openssl-devel tk-devel libffi-devel xz-devel git"
   ALL_DEPS="augeas-devel $PYENV_DEPS"
 
   if yum list installed "httpd" >/dev/null 2>&1; then


### PR DESCRIPTION
this PR fixes the recently nightly test failures by installing the updated [build dependencies needed by pyenv on centos](https://github.com/pyenv/pyenv/wiki#suggested-build-environment)

you can see tests passing with this change at https://dev.azure.com/certbot/certbot/_build/results?buildId=9958&view=results

fwiw, i don't think this PR requires two reviews