### PR TITLE
try adding codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @certbot/eff-devs


### PR DESCRIPTION
this fixes https://github.com/certbot/certbot/issues/10462 and i personally think this is a nice change worth trying

now when people open (non-draft) PRs, one of us will automatically be assigned hopefully helping to both automate and speed up the review process

i personally don't think this PR requires two reviews