### PR TITLE
disable towncrier wrapping

### DIFF
--- a/towncrier.toml
+++ b/towncrier.toml
@@ -5,7 +5,6 @@ filename = "certbot/CHANGELOG.md"
 title_format = "## {version} - {project_date}"
 issue_format = "[#{issue}](https://github.com/certbot/certbot/issues/{issue})"
 issue_pattern = "\\d+"
-wrap = true
 ignore = []
 
 # Our three custom news fragment types, declared in order of how we'd like them


### PR DESCRIPTION
this PR is a follow up to my comment at https://github.com/certbot/certbot/pull/10495#discussion_r2683527484

i dislike that jsha chose a slightly different column limit than towncrier which caused it to generate awkwardly short lines in our changelog. i also dislike contributors having to remember/know about towncrier's wrapping behavior when writing changelog entries. i'd like us to find a way to not have to worry about this

i initially looked into trying to set towncrier's line length limit to a much higher value, but after searching around https://towncrier.readthedocs.io/en/stable/configuration.html, i don't think it's configurable

instead, i'm proposing here that we remove the wrapping entirely. wrapping was added in response to the discussion at https://github.com/certbot/certbot/pull/10379#discussion_r2243799585. every markdown viewer i'm aware of automatically nicely handles wrapping of long lines in markdown. most also automatically merge manually wrapped lines to wrap based on the user's display/settings. finally, since the changelog is automatically edited, i think it'll be rare for certbot devs to have to manually edit the file

because of all this, i think whether the newsfragment was manually wrapped or not is largely irrelevant, we shouldn't worry about it, and we should let people wrap or their newsfragments or not as they see fit

i suppose alternatively we could just let towncrier double/awkwardly wrap entries since i'm making the case that the wrapping doesn't matter, but i personally have a slight preference for this approach. let me know what y'all think