### PR TITLE
auto-ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ snapcraft.cfg
 
 # pyenv files
 .python-version
+
+# macOS files
+.DS_Store

--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -658,10 +658,3 @@ current Certbot developers on macOS as of writing this:
 2. If you're using ``pyenv``, make sure you've set up your shell for it by
    following instructions like
    https://github.com/pyenv/pyenv?tab=readme-ov-file#set-up-your-shell-environment-for-pyenv.
-3. Configure ``git`` to ignore the ``.DS_Store`` files that are created by
-   macOS's file manager Finder by running something like:
-
-.. code-block:: shell
-
-   mkdir -p ~/.config/git
-   echo '.DS_Store' >> ~/.config/git/ignore


### PR DESCRIPTION
i'm creating this PR in response to https://github.com/certbot/certbot/pull/10495/changes/47c5c88fe13dfaf3702a954c17db67a490781457 where ohemorange manually deleted .DS_Store on jsha's PR

rather than doing that or having new certbot devs manually configure their system to ignore these files, let's just do it for them

i don't think this PR requires two reviews