### PR TITLE
update dns-azure URL

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -350,7 +350,7 @@ dns-czechia_            Y    N    DNS Authentication for czechia.com
 .. _dns-clouddns: https://github.com/vshosting/certbot-dns-clouddns
 .. _dns-lightsail: https://github.com/noi/certbot-dns-lightsail
 .. _dns-inwx: https://github.com/oGGy990/certbot-dns-inwx/
-.. _dns-azure: https://github.com/binkhq/certbot-dns-azure
+.. _dns-azure: https://github.com/terricain/certbot-dns-azure
 .. _dns-godaddy: https://github.com/miigotu/certbot-dns-godaddy
 .. _dns-yandexcloud: https://github.com/PykupeJIbc/certbot-dns-yandexcloud
 .. _dns-bunny: https://github.com/mwt/certbot-dns-bunny


### PR DESCRIPTION
until sometime in the last year, https://github.com/binkhq/certbot-dns-azure redirected to https://github.com/terricain/certbot-dns-azure according to https://web.archive.org/web/20250901000000*/https://github.com/binkhq/certbot-dns-azure. since then, that redirect was broken/removed

this has [caused confusion](https://github.com/certbot/certbot/pull/8727#issuecomment-3880163261) and since [terricain expressed interest in their plugin being listed](https://github.com/certbot/certbot/pull/8727#issuecomment-815287041), let's fix up that link