### PR TITLE
Add tests for is_ipaddress function

### DIFF
--- a/certbot/src/certbot/_internal/tests/util_test.py
+++ b/certbot/src/certbot/_internal/tests/util_test.py
@@ -490,6 +490,53 @@ class EnforceDomainSanityTest(unittest.TestCase):
         self._call('this.is.xn--ls8h.tld')
 
 
+class IsIpAddressTest(unittest.TestCase):
+    """Tests for is_ipaddress."""
+
+    def _call(self, address):
+        from certbot.util import is_ipaddress
+        return is_ipaddress(address)
+
+    def test_is_ipaddress(self):
+        cases = [
+            # IPv4
+            ("127.0.0.1", True),
+            ("192.168.1.1", True),
+            ("255.255.255.255", True),
+            ("0.0.0.0", True),
+            ("1.2.3.4 ", False),
+            (" 1.2.3.4", False),
+            ("1.2.3.256", False),
+            ("1.2.3", False),
+            ("1.2.3.4.5", False),
+            ("a.b.c.d", False),
+
+            # IPv6
+            ("::1", True),
+            ("fe80::1", True),
+            ("2001:db8::ff00:42:8329", True),
+            ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", True),
+            ("2001:db8:85a3:0:0:8a2e:370:7334", True),
+            ("2001:db8:85a3::8a2e:370:7334", True),
+            ("::", True),
+            ("::ffff:192.168.0.1", True),  # IPv4-mapped IPv6
+            ("2001:db8::1::1", False),    # Multiple double colons
+            ("2001:db8:g::1", False),     # Invalid hex
+            ("1:2:3:4:5:6:7:8:9", False), # Too many segments
+
+            # General
+            ("example.com", False),
+            ("", False),
+            (" ", False),
+            ("127.0.0.1/24", False),      # CIDR notation
+            ("2001:db8::/32", False),     # CIDR notation IPv6
+            ("[::1]", False),             # Bracketed IPv6
+        ]
+        for addr, expected in cases:
+            result = self._call(addr)
+            self.assertEqual(result, expected, f"is_ipaddress failed for {addr}")
+
+
 class IsWildcardDomainTest(unittest.TestCase):
     """Tests for is_wildcard_domain."""
 


### PR DESCRIPTION
Add unit tests for is_ipaddress function to validate IPv4 and IPv6 addresses.

## Pull Request Checklist

- [n/a] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ack - partially AI generated with human adjustments and testing] If you used AI to create this PR, you have done a self-review of all AI-generated code and disclosed that your contribution was AI-generated per [EFF's AI-generated contribution policy](https://www.eff.org/about/opportunities/volunteer/coding-with-eff). You assert you have thoroughly understood, reviewed, and tested your entire submission.
- [n/a] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), add a description of your change to the `newsfragments` directory. This should be a file called `<title>.<type>`, where `<title>` is either a GitHub issue number or some other unique name starting with `+`, and `<type>` is either `changed`, `fixed`, or `added`.
  * For example, if you fixed a bug for issue number 42, create a file called `42.fixed` and put a description of your change in that file.
- [n/a] Add or update any documentation as needed to support the changes in this PR.
- [n/a] Include your name in `AUTHORS.md` if you like.