### PR TITLE
Use python warning filters from pytest.ini during integration tests 

### DIFF
--- a/certbot-ci/src/certbot_integration_tests/nginx_tests/nginx_config.py
+++ b/certbot-ci/src/certbot_integration_tests/nginx_tests/nginx_config.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """General purpose nginx test configuration generator."""
 import atexit
-import getpass
 import importlib.resources
 from contextlib import ExitStack
 from typing import Optional

--- a/certbot-ci/src/certbot_integration_tests/utils/certbot_call.py
+++ b/certbot-ci/src/certbot_integration_tests/utils/certbot_call.py
@@ -91,7 +91,7 @@ def _prepare_environ(workspace: str) -> dict[str, str]:
     # Certbot's is located in its root directory. Let's just walk up the tree from this file.
     # In case we can't find it, we still do want to error, so add a default. It's fine to have
     # error in there twice. Also, ignore the unverified HTTPS request specifically for this call.
-    warning_filters: list = [
+    warning_filters: list[str]= [
         'error',
         "ignore:Unverified HTTPS request is being made to host 'localhost'",
         ]


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/10180.

So first of all, the core issue here is that [pyca deliberately chose](https://github.com/pyca/cryptography/blob/ec80c1c2894320d30fd674ea2c6103d91b4e777e/src/cryptography/utils.py#L15-L18) to override the default python functionality and make deprecation warnings appear by default. This isn't common. If they'd actually used a `DeprecationWarning`, it wouldn't have shown up to users, at least. That being said, we should still try to catch it, as we do in fact want to know about deprecation warnings for our own updates.

To do that, this PR searches upwards for a `pytest.ini` file from the file's location. If found, it reads the warnings from the file, and passes them using the `PYTHONWARNINGS` env variable. It also explicitly sets warnings to `error` always in case we can't find the `pytest.ini`, and ignores the subsequent unverified-https-on-localhost warning. It also fixes a warning in our test nginx config that seemed reasonable to address.

I tested this by adding a temporary warning, which I then removed, but since it turned out there were two other warnings, that wasn't actually necessary.

Options I considered and rejected:

- Switch from `atexit` to calling `main` directly. To do this, we'd have to switch our `main` function to something like a try-finally. That's complicated by the fact that we call `atexit` from other places in the code. Also, `exc_info` isn't availabe in `finally` while it is in `at_exit`, so it's not as versatile. But mostly if we wanted to do this, we'd have to implement a custom atexit handler, basically, and that seems worse than this option.
- Looking into pytest-forked. It's apparently buggy and not being maintained. Not even sure this is what it's for anyway.
- Multiple [-W](https://docs.python.org/3/using/cmdline.html#cmdoption-W) options can be given instead of an env variable. The env version seemed cleaner.
- More closely mimicking [how pytest finds ini files](https://docs.pytest.org/en/stable/reference/customize.html#finding-the-rootdir). It seemed unnecessary to me.

Potential drawbacks:
- If we move or rename the `pytest.ini` file and for some reason don't do a reasonable grep for `pytest.ini`, we will no longer catch any additional `ignore`s in there. But imo we're likely to do that grep, and also a missing ignore will then show up when we run the tests.