### PR TITLE
List certbot-dns-eurodns as a third-party plugin

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -335,6 +335,7 @@ dns-synergy-wholesale_  Y    N    DNS Authentication using Synergy Wholesale DNS
 pkcs12_                 N    Y    Install certificates as PKCS#12 archives
 dns-hetzner-cloud_      Y    N    DNS Authentication for Hetzner Cloud DNS
 dns-czechia_            Y    N    DNS Authentication for czechia.com
+dns-eurodns_            Y    N    DNS Authentication for EuroDNS
 ======================= ==== ==== =================================================================
 
 .. _haproxy: https://github.com/greenhost/certbot-haproxy
@@ -371,6 +372,7 @@ dns-czechia_            Y    N    DNS Authentication for czechia.com
 .. _pkcs12: https://github.com/nasa-gcn/certbot-pkcs12
 .. _dns-hetzner-cloud: https://github.com/rolschewsky/certbot-dns-hetzner-cloud
 .. _dns-czechia: https://github.com/CZECHIA-COM/certbot-dns-czechia
+.. _dns-eurodns: https://pypi.org/project/certbot-dns-eurodns/
 
 If you're interested, you can also :ref:`write your own plugin <dev-plugin>`.
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/10603

The link to the github repo is 404'ing. I've asked for a current link, but the pypi link seems fine to me also. It was released yesterday so it does seem to still be in active development.

<img width="910" height="214" alt="Screenshot 2026-03-18 at 10 30 19 AM" src="https://github.com/user-attachments/assets/25208402-ebd1-4d9e-8c46-f1a3f5b83ec0" />
