### PR TITLE
Add certbot-dns-dnscale to list of third-party plugins

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -336,6 +336,7 @@ pkcs12_                 N    Y    Install certificates as PKCS#12 archives
 dns-hetzner-cloud_      Y    N    DNS Authentication for Hetzner Cloud DNS
 dns-czechia_            Y    N    DNS Authentication for czechia.com
 dns-eurodns_            Y    N    DNS Authentication for EuroDNS
+dns-dnscale_            Y    N    DNS Authenticator for DNScale
 ======================= ==== ==== =================================================================
 
 .. _haproxy: https://github.com/greenhost/certbot-haproxy
@@ -373,6 +374,7 @@ dns-eurodns_            Y    N    DNS Authentication for EuroDNS
 .. _dns-hetzner-cloud: https://github.com/rolschewsky/certbot-dns-hetzner-cloud
 .. _dns-czechia: https://github.com/CZECHIA-COM/certbot-dns-czechia
 .. _dns-eurodns: https://pypi.org/project/certbot-dns-eurodns/
+.. _dns-dnscale: https://github.com/dnscaleou/certbot-dns-dnscale
 
 If you're interested, you can also :ref:`write your own plugin <dev-plugin>`.
 


### PR DESCRIPTION
This PR adds `certbot-dns-dnscale` to the list of third-party plugins in the documentation.

`certbot-dns-dnscale` enables DNS-01 challenge automation for domains managed with the DNScale DNS service (https://dnscale.eu). The plugin is Apache 2.0 licensed.

PyPI: https://pypi.org/project/certbot-dns-dnscale/
Source: https://github.com/dnscaleou/certbot-dns-dnscale

Verified with `pip install certbot-dns-dnscale`.