### PR TITLE
Fix FAILED_DOMAINS truncation in run_saved_post_hooks

### DIFF
--- a/certbot/src/certbot/_internal/hooks.py
+++ b/certbot/src/certbot/_internal/hooks.py
@@ -176,7 +176,7 @@ def run_saved_post_hooks(renewed_sans: list[san.SAN], failed_sans: list[san.SAN]
 
     if len(failed_sans_str) > 16_000:
         logger.warning("Limiting FAILED_DOMAINS environment variable to 16k characters")
-        renewed_sans_str = failed_sans_str[:16_000]
+        failed_sans_str = failed_sans_str[:16_000]
 
     for cmd in post_hooks:
         _run_hook(

--- a/certbot/src/certbot/_internal/tests/hook_test.py
+++ b/certbot/src/certbot/_internal/tests/hook_test.py
@@ -313,6 +313,24 @@ class RunSavedPostHooksTest(HookTest):
         assert mock_execute.call_args.kwargs['env']["RENEWED_DOMAINS"] == "success.org"
         assert mock_execute.call_args.kwargs['env']["FAILED_DOMAINS"] == "failed.org"
 
+    def test_env_truncation_oversize_failed(self):
+        self.eventually = ["foo"]
+        renewed = ["success.org"]
+        failed = [f"fail{i}.example.com" for i in range(1000)]
+        mock_execute = self._call_with_mock_execute_and_eventually(renewed, failed)
+        env = mock_execute.call_args.kwargs['env']
+        assert env["RENEWED_DOMAINS"] == "success.org"
+        assert len(env["FAILED_DOMAINS"]) <= 16_000
+
+    def test_env_truncation_oversize_renewed(self):
+        self.eventually = ["foo"]
+        renewed = [f"renew{i}.example.com" for i in range(1000)]
+        failed = ["failed.org"]
+        mock_execute = self._call_with_mock_execute_and_eventually(renewed, failed)
+        env = mock_execute.call_args.kwargs['env']
+        assert len(env["RENEWED_DOMAINS"]) <= 16_000
+        assert env["FAILED_DOMAINS"] == "failed.org"
+
 
 class RenewalHookTest(HookTest):
     """Common base class for testing deploy/renew hooks."""

--- a/newsfragments/10623.fixed
+++ b/newsfragments/10623.fixed
@@ -1,0 +1,1 @@
+Fixed run_saved_post_hooks truncating the wrong variable when the joined failed-domain string exceeds 16k characters, which corrupted RENEWED_DOMAINS and left FAILED_DOMAINS untruncated.


### PR DESCRIPTION
Fixes #10623.

hooks.py line 179 assigns the truncated failed-domain string to renewed_sans_str instead of failed_sans_str. When the joined failed list exceeds 16k characters, this overwrites RENEWED_DOMAINS with the first 16k of the failed list and leaves FAILED_DOMAINS untruncated.

One-word fix. Added two tests to RunSavedPostHooksTest covering the oversize-failed and oversize-renewed branches (none of the existing tests exercised either).

Disclosure: this change was AI-assisted. I reviewed every line, ran the new tests against current main to confirm they reproduce the bug, then against the fix to confirm the bug is gone and all existing RunSavedPostHooksTest cases continue to pass. Per EFF's AI-generated contribution policy.
