### PR TITLE
Fix dns-google add_txt_record quoting when an RRset already exists

### DIFF
--- a/certbot-dns-google/src/certbot_dns_google/_internal/dns_google.py
+++ b/certbot-dns-google/src/certbot_dns_google/_internal/dns_google.py
@@ -147,7 +147,7 @@ class _GoogleClient:
             # The process was interrupted previously and validation token exists
             return
 
-        add_records.append(record_content)
+        add_records.append("\"" + record_content + "\"")
 
         data = {
             "kind": "dns#change",

--- a/certbot-dns-google/src/certbot_dns_google/_internal/tests/dns_google_test.py
+++ b/certbot-dns-google/src/certbot_dns_google/_internal/tests/dns_google_test.py
@@ -209,7 +209,7 @@ class GoogleClientTest(unittest.TestCase):
                     "kind": "dns#resourceRecordSet",
                     "type": "TXT",
                     "name": self.record_name + ".",
-                    "rrdatas": [self.record_content, ],
+                    "rrdatas": ["\"" + self.record_content + "\""],
                     "ttl": self.record_ttl,
                 },
             ],
@@ -218,6 +218,25 @@ class GoogleClientTest(unittest.TestCase):
         changes.create.assert_called_with(body=expected_body,
                                                managedZone=self.zone,
                                                project=PROJECT_ID)
+
+    @mock.patch('google.auth.load_credentials_from_file')
+    @mock.patch('certbot_dns_google._internal.dns_google.open',
+                mock.mock_open(read_data='{"project_id": "' + PROJECT_ID + '"}'), create=True)
+    def test_add_txt_record_existing_rrset_is_uniformly_quoted(self, credential_mock):
+        credential_mock.return_value = (mock.MagicMock(), PROJECT_ID)
+
+        client, changes = self._setUp_client_with_mock(
+            [{'managedZones': [{'id': self.zone, 'visibility': self.visibility}]}])
+        mock_get_rrs = "certbot_dns_google._internal.dns_google._GoogleClient.get_existing_txt_rrset"
+        with mock.patch(mock_get_rrs) as mock_rrs:
+            # Google's API returns TXT rrdatas as RFC 1035 quoted strings
+            mock_rrs.return_value = {"rrdatas": ["\"existing-token\""], "ttl": self.record_ttl}
+            client.add_txt_record(DOMAIN, self.record_name, self.record_content, self.record_ttl)
+
+        body = changes.create.call_args_list[0][1]["body"]
+        additions_rrdatas = body["additions"][0]["rrdatas"]
+        assert additions_rrdatas == ["\"existing-token\"",
+                                     "\"" + self.record_content + "\""]
 
     @mock.patch('google.auth.load_credentials_from_file')
     @mock.patch('certbot_dns_google._internal.dns_google.open',

--- a/newsfragments/10624.fixed
+++ b/newsfragments/10624.fixed
@@ -1,0 +1,1 @@
+Fixed the Google Cloud DNS plugin appending unquoted values onto the existing (quoted) rrdatas when adding a TXT record to a name with an existing RRset, which prevented later cleanup from matching and left stale _acme-challenge records in the zone.


### PR DESCRIPTION
Fixes #10624.

`_GoogleClient.add_txt_record` at dns_google.py line 150 appends the new TXT record content to `add_records` without quoting it, producing a mixed quoted/unquoted rrdatas payload whenever an RRset already exists at the challenge name. Because `del_txt_record` filters on the quoted form, records added through this path are stored unquoted, never match the deletion filter, and accumulate as stale `_acme-challenge` records.

Changes:

  - dns_google.py line 150: quote the appended value
  - test_add_txt_record: update the asserted rrdatas to the quoted form. The pre-change assertion was inconsistent with test_del_txt_record_multi_rrdatas in the same file, which correctly mocks the quoted form the API returns.
  - New test_add_txt_record_existing_rrset_is_uniformly_quoted covering the existing-rrset path to lock in that we never emit a mixed list again.

Disclosure: this change was AI-assisted. I reviewed every line, reproduced the bug against current main, and confirmed the fix against the full dns_google_test.py suite (32 passed). Per EFF's AI-generated contribution policy.
