### PR TITLE
Increase snap build timeout to 39600 minutes to account for launchpad delays

### DIFF
--- a/.azure-pipelines/advanced-test.yml
+++ b/.azure-pipelines/advanced-test.yml
@@ -9,7 +9,7 @@ variables:
   # We don't publish our Docker images in this pipeline, but when building them
   # for testing, let's use the nightly tag.
   dockerTag: nightly
-  snapBuildTimeout: 5400
+  snapBuildTimeout: 39600
 
 stages:
   - template: templates/stages/test-and-package-stage.yml

--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -11,7 +11,7 @@ schedules:
 
 variables:
   dockerTag: nightly
-  snapBuildTimeout: 19800
+  snapBuildTimeout: 39600
 
 stages:
   - template: templates/stages/test-and-package-stage.yml

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -8,7 +8,7 @@ pr: none
 
 variables:
   dockerTag: ${{variables['Build.SourceBranchName']}}
-  snapBuildTimeout: 19800
+  snapBuildTimeout: 39600
 
 stages:
   - template: templates/stages/test-and-package-stage.yml


### PR DESCRIPTION
This might let us release?