### PR TITLE
Remove deprecated domain attribute from achallenges

### DIFF
--- a/certbot-compatibility-test/src/certbot_compatibility_test/test_driver.py
+++ b/certbot-compatibility-test/src/certbot_compatibility_test/test_driver.py
@@ -113,7 +113,10 @@ def _create_achalls(plugin: common.Proxy) -> list[achallenges.AnnotatedChallenge
                 challb = acme_util.chall_to_challb(
                     chall, messages.STATUS_PENDING)
                 achall = achallenges.KeyAuthorizationAnnotatedChallenge(
-                    challb=challb, domain=domain, account_key=util.JWK)
+                    challb=challb,
+                    identifier=messages.Identifier(
+                        typ=messages.IDENTIFIER_FQDN, value=domain),
+                    account_key=util.JWK)
                 achalls.append(achall)
 
     return achalls

--- a/certbot/src/certbot/achallenges.py
+++ b/certbot/src/certbot/achallenges.py
@@ -10,7 +10,9 @@ and :class:`.ChallengeBody` (denoted by ``challb``)::
 
   chall = challenges.DNS(token='foo')
   challb = messages.ChallengeBody(chall=chall)
-  achall = achallenges.DNS(chall=challb, domain='example.com')
+  achall = achallenges.DNS(
+      challb=challb,
+      identifier=messages.Identifier(typ=messages.IDENTIFIER_FQDN, value='example.com'))
 
 Note, that all annotated challenges act as a proxy objects::
 
@@ -19,14 +21,11 @@ Note, that all annotated challenges act as a proxy objects::
 """
 import logging
 from typing import Any
-import warnings
 
 import josepy as jose
 
-from acme import challenges, messages
+from acme import challenges
 from acme.challenges import Challenge
-
-from certbot import errors
 
 logger = logging.getLogger(__name__)
 
@@ -46,47 +45,10 @@ class AnnotatedChallenge(jose.ImmutableMap):
     def __getattr__(self, name: str) -> Any:
         return getattr(self.challb, name)
 
-    def __getattribute__(self, name: str) -> Any:
-        if name == 'domain':
-            warnings.warn("The domain attribute is deprecated and will be removed in "
-                        "an upcoming release. Access the AnnotatedChallenge.identifier.value "
-                        "attribute instead",
-                        DeprecationWarning)
-        return super().__getattribute__(name)
-
-    def __hash__(self) -> int:
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', 'the domain attribute is deprecated')
-            return super().__hash__()
-
-    def __eq__(self, other: Any) -> bool:
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', 'the domain attribute is deprecated')
-            return super().__eq__(other)
-
-    def __init__(self, **kwargs: Any) -> None:
-        if 'domain' in kwargs:
-            if 'identifier' in kwargs:
-                raise errors.Error("AnnotatedChallenge takes either domain or identifier, not both")
-            warnings.warn("The domain attribute is deprecated and will be removed in "
-                          "an upcoming release. Replace domain=<domain> with "
-                          "identifier=messages.Identifier(typ=messages.IDENTIFIER_FQDN, "
-                          "value=<domain>)",
-                          DeprecationWarning)
-        if 'identifier' not in kwargs:
-            kwargs['identifier'] = messages.Identifier(
-                typ=messages.IDENTIFIER_FQDN, value=kwargs['domain'])
-        if 'domain' not in kwargs:
-            if kwargs['identifier'].typ == messages.IDENTIFIER_FQDN:
-                kwargs['domain'] = kwargs['identifier'].value
-            else:
-                kwargs['domain'] = None
-        super().__init__(**kwargs)
-
 
 class KeyAuthorizationAnnotatedChallenge(AnnotatedChallenge):
     """Client annotated `KeyAuthorizationChallenge` challenge."""
-    __slots__ = ('challb', 'domain', 'account_key', 'identifier') # pylint: disable=redefined-slots-in-subclass
+    __slots__ = ('challb', 'account_key', 'identifier') # pylint: disable=redefined-slots-in-subclass
 
     def response_and_validation(self, *args: Any, **kwargs: Any
         ) -> tuple['challenges.KeyAuthorizationChallengeResponse', Any]:
@@ -97,10 +59,10 @@ class KeyAuthorizationAnnotatedChallenge(AnnotatedChallenge):
 
 class DNS(AnnotatedChallenge):
     """Client annotated "dns" ACME challenge."""
-    __slots__ = ('challb', 'domain', 'identifier') # pylint: disable=redefined-slots-in-subclass
+    __slots__ = ('challb', 'identifier') # pylint: disable=redefined-slots-in-subclass
     acme_type = challenges.DNS
 
 class Other(AnnotatedChallenge):
     """Client annotated ACME challenge of an unknown type."""
-    __slots__ = ('challb', 'domain', 'identifier') # pylint: disable=redefined-slots-in-subclass
+    __slots__ = ('challb', 'identifier') # pylint: disable=redefined-slots-in-subclass
     acme_type = challenges.Challenge


### PR DESCRIPTION
Fixes #10640 

The domain field on AnnotatedChallenge and its subclasses was deprecated in #10491 in favor of the identifier field, which can represent both domain names and IP addresses.

This removes the deprecation shim entirely: the custom __init__, __getattribute__, __hash__, and __eq__ overrides, plus the 'domain' entry from __slots__ on
  KeyAuthorizationAnnotatedChallenge, DNS, and Other. The lone remaining caller in the compatibility test driver is migrated to pass identifier=messages.Identifier(...) instead.