### PR TITLE
Upgrade action-mattermost-notify action to use node 24

### DIFF
--- a/.github/workflows/assigned.yaml
+++ b/.github/workflows/assigned.yaml
@@ -18,7 +18,7 @@ jobs:
     # we pin this action to a version tested and audited by certbot's
     # maintainers for extra security. the full hash is used as doing so is
     # recommended by zizmor
-    - uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
+    - uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_ASSIGN_WEBHOOK }}
         TEXT: >

--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -20,7 +20,7 @@ jobs:
     # we pin this action to a version tested and audited by certbot's
     # maintainers for extra security. the full hash is used as doing so is
     # recommended by zizmor
-    - uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
+    - uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_MERGE_WEBHOOK }}
         TEXT: >

--- a/.github/workflows/notify_nightly.yml
+++ b/.github/workflows/notify_nightly.yml
@@ -28,7 +28,7 @@ jobs:
         echo "result = $DURATION"
         echo "result=$DURATION" >> "$GITHUB_OUTPUT"
     - name: Send to mattermost
-      uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
+      uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_PUBLIC_CERTBOT_CHANNEL_WEBHOOK }}
         PAYLOAD: |-

--- a/.github/workflows/notify_weekly.yaml
+++ b/.github/workflows/notify_weekly.yaml
@@ -19,7 +19,7 @@ jobs:
     # we pin this action to a version tested and audited by certbot's
     # maintainers for extra security. the full hash is used as doing so is
     # recommended by zizmor
-    - uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
+    - uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
         MATTERMOST_CHANNEL: private-certbot

--- a/.github/workflows/review_requested.yaml
+++ b/.github/workflows/review_requested.yaml
@@ -20,7 +20,7 @@ jobs:
     # we pin this action to a version tested and audited by certbot's
     # maintainers for extra security. the full hash is used as doing so is
     # recommended by zizmor
-    - uses: mattermost/action-mattermost-notify@b7d118e440bf2749cd18a4a8c88e7092e696257a
+    - uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_ASSIGN_WEBHOOK }}
         TEXT: >


### PR DESCRIPTION
Makes the warnings about the upcoming Node 20 deprecation go away.

See warning here before this PR: https://github.com/certbot/certbot/actions/runs/26120147961

See no warning here: https://github.com/certbot/certbot/actions/runs/26122033390