### PR TITLE
Automatically create a candidate-`$VERSION-NUM` branch in the release script

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -30,6 +30,11 @@ echo Releasing production version "$version"...
 nextversion="$2"
 RELEASE_BRANCH="candidate-$version"
 
+if [ "$(git branch --show-current)" != "$RELEASE_BRANCH" ]; then
+    echo "Creating $RELEASE_BRANCH branch..."
+    git switch -c "$RELEASE_BRANCH"
+fi
+
 # If RELEASE_GPG_KEY isn't set, determine the key to use.
 if [ "$RELEASE_GPG_KEY" = "" ]; then
     TRUSTED_KEYS="
@@ -91,9 +96,6 @@ echo "Cloning into fresh copy at $root"  # clean repo = no artifacts
 git clone . $root
 git rev-parse HEAD
 cd $root
-if [ "$RELEASE_BRANCH" != "candidate-$version" ] ; then
-    git branch -f "$RELEASE_BRANCH"
-fi
 git checkout "$RELEASE_BRANCH"
 
 # Update changelog. `--yes` automatically clears out older newsfragments,


### PR DESCRIPTION
Item 3 of https://github.com/certbot/certbot/issues/10600

If this is merged, the [release instructions](https://github.com/EFForg/certbot-misc/wiki/The-Mystical-Release-Process) should be updated to no longer manually create the branch.

I intentionally do not add error checking to `git switch -c` because I think if the command fails, the script should fail, and we should manually fix the error, which will probably be something like `fatal: a branch named 'candidate-5.5.0' already exists` which is clear enough.

I do check if we're already on the intended branch, because we may want to be able to rerun the release script without having to switch back to main and delete the candidate branch each time.

I remove the check later on because I believe it is a holdover from a previous version where it was possible for `RELEASE_BRANCH` to be not equal to `candidate-$version`, but even in the existing code before the other change, that should not be possible.

Test results, created by adding `git status` before and after the new code, and adding `exit 0` right after:

```bash
$ RELEASE_GPG_KEY=dontmatter tools/release.sh 1.2.3 4.5.6 # no existing candidate branch
[...]
+ RELEASE_BRANCH=candidate-1.2.3
+ git status
On branch cand-create
Your branch is ahead of 'origin/cand-create' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
++ git branch --show-current
+ '[' cand-create '!=' candidate-1.2.3 ']'
+ echo 'Creating candidate-1.2.3 branch...'
Creating candidate-1.2.3 branch...
+ git switch -c candidate-1.2.3
Switched to a new branch 'candidate-1.2.3'
+ git status
On branch candidate-1.2.3
nothing to commit, working tree clean
+ exit 0
[...]

Script done, output file is log
$
$
$ RELEASE_GPG_KEY=dontmatter tools/release.sh 1.2.3 4.5.6 # already on candidate branch, should succeed
[...]
+ RELEASE_BRANCH=candidate-1.2.3
+ git status
On branch candidate-1.2.3
nothing to commit, working tree clean
++ git branch --show-current
+ '[' candidate-1.2.3 '!=' candidate-1.2.3 ']'
+ git status
On branch candidate-1.2.3
nothing to commit, working tree clean
+ exit 0
[...]

Script done, output file is log
$
$
$ git checkout cand-create 
Switched to branch 'cand-create'
Your branch is ahead of 'origin/cand-create' by 1 commit. # prints
  (use "git push" to publish your local commits)
$
$ RELEASE_GPG_KEY=dontmatter tools/release.sh 1.2.3 4.5.6 # candidate branch exists but we're not on it, should fail
[...]
+ RELEASE_BRANCH=candidate-1.2.3
+ git status
On branch cand-create
Your branch is ahead of 'origin/cand-create' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
++ git branch --show-current
+ '[' cand-create '!=' candidate-1.2.3 ']'
+ echo 'Creating candidate-1.2.3 branch...'
Creating candidate-1.2.3 branch...
+ git switch -c candidate-1.2.3
fatal: a branch named 'candidate-1.2.3' already exists
+ ExitWarning
+ exit_status=128
+ '[' 128 '!=' 0 ']'
+ set +x
******************************
*                            *
* THE RELEASE SCRIPT FAILED! *
*                            *
******************************
+ exit 128

Script done, output file is log
$ 
```