### PR TITLE
in release script, check that certbot's virtual environment isn't activated and deactivate it if it is

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -30,6 +30,18 @@ echo Releasing production version "$version"...
 nextversion="$2"
 RELEASE_BRANCH="candidate-$version"
 
+if [ -n "$VIRTUAL_ENV" ]; then
+    if [[ "$PATH" != $VIRTUAL_ENV* ]]; then
+        echo "Unexpected PATH and VIRTUAL_ENV value. Please deactivate any"
+        echo "Python virtual environments and try running this script again."
+        exit 1
+    fi
+    echo "Deactivating venv..."
+    export PATH="${PATH#*:}"
+    hash -r 2> /dev/null
+    unset VIRTUAL_ENV
+fi
+
 # If RELEASE_GPG_KEY isn't set, determine the key to use.
 if [ "$RELEASE_GPG_KEY" = "" ]; then
     TRUSTED_KEYS="

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -40,6 +40,13 @@ if [ -n "$SNAP_BUILD" ]; then
     exit 1
 fi
 
+if [ -n "$VIRTUAL_ENV" ]; then
+    echo "Deactivating venv..."
+    export PATH="${PATH#*:}"
+    hash -r 2> /dev/null
+    unset VIRTUAL_ENV
+fi
+
 export RELEASE_DIR="./releases"
 mv "$RELEASE_DIR" "$RELEASE_DIR.$(date +%s).bak" || true
 LOG_PATH="log"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -40,18 +40,6 @@ if [ -n "$SNAP_BUILD" ]; then
     exit 1
 fi
 
-if [ -n "$VIRTUAL_ENV" ]; then
-    if [[ "$PATH" != $VIRTUAL_ENV* ]]; then
-        echo "Unexpected PATH and VIRTUAL_ENV value. Please deactivate any"
-        echo "Python virtual environments and try running this script again."
-        exit 1
-    fi
-    echo "Deactivating venv..."
-    export PATH="${PATH#*:}"
-    hash -r 2> /dev/null
-    unset VIRTUAL_ENV
-fi
-
 export RELEASE_DIR="./releases"
 mv "$RELEASE_DIR" "$RELEASE_DIR.$(date +%s).bak" || true
 LOG_PATH="log"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -41,6 +41,11 @@ if [ -n "$SNAP_BUILD" ]; then
 fi
 
 if [ -n "$VIRTUAL_ENV" ]; then
+    if [[ "$PATH" != $VIRTUAL_ENV* ]]; then
+        echo "Unexpected PATH and VIRTUAL_ENV value. Please deactivate any"
+        echo "Python virtual environments and try running this script again."
+        exit 1
+    fi
     echo "Deactivating venv..."
     export PATH="${PATH#*:}"
     hash -r 2> /dev/null


### PR DESCRIPTION
Item 1 of https://github.com/certbot/certbot/issues/10600

Once this is merged, the [release instructions](https://github.com/EFForg/certbot-misc/wiki/The-Mystical-Release-Process) should be updated to no longer say "Make sure Certbot's virtual environment isn't activated."

Why in `release.sh` instead of `_release.sh`? This seemed to be the "check the environment status" file.

`venv/bin/activate` does several things.
1. create `deactivate` shell function
2. create `_OLD_VIRTUAL_PATH` and modify `PATH` to prepend `venv/bin` location. `_OLD_VIRTUAL_PATH` isn't exported.
3. unset `PYTHONHOME` and store the old `PYTHONHOME` in `_OLD_VIRTUAL_PYTHONHOME`, again not exported.
4. export `VIRTUAL_ENV_PROMPT`
5. call `hash -r 2> /dev/null` for some sort of edge case
6. set `VIRTUAL_ENV`
7. change the prompt appearance (PS1)

1, 4, and 7 don't need to be undone. 2, 4, and 6 are managed here manually.

3 is the hard one, since we don't have access to `_OLD_VIRTUAL_PYTHONHOME`, and there's not a great way of grabbing it from the shell. One thought I had was to modify `venv/bin/activate` in `venv.py` so that it is exported. That's possible, but at least for me, `PYTHONHOME` isn't set in the first place and so it doesn't seem worth doing that. Given that this script only needs to run on a few people's machines, I would say we can hold off on doing that if and until it becomes necessary.

Added some prints and an `exit 0` after the relevant code in the script to test:

```bash
$ RELEASE_GPG_KEY=dontmatter tools/release.sh 1.2.3 4.5.6
$ source venv/bin/activate
(venv) $ RELEASE_GPG_KEY=dontmatter tools/release.sh 1.2.3 4.5.6
Deactivating venv...
previous path:
/Users/erica/certbot/venv/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:[rest of path omitted]
new path:
/opt/homebrew/opt/coreutils/libexec/gnubin:[rest of path omitted]
(venv) $ printenv PATH
/Users/erica/certbot/venv/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:[rest of path omitted]
```

