### PR TITLE
Generate and print post-release community forum post text in `finish_release.py`

### DIFF
--- a/tools/finish_release.py
+++ b/tools/finish_release.py
@@ -176,10 +176,34 @@ def fetch_version_number(major_version=None):
             return version
     raise ValueError('Release not found on Azure Pipelines!')
 
+def generate_community_forum_post(version: str):
+    print('Generating announcement text for community forum post')
+
+    cmd = f"gh release view v{version} --json body -t {{{{.body}}}}".split()
+
+    try:
+        process = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True)
+    except (subprocess.CalledProcessError, OSError):
+        print("Generating announcement text failed.")
+        sys.exit(1)
+
+    changelog = process.stdout
+
+    print('Subject:')
+    print()
+    print(f'Certbot {version} Release')
+    print()
+    print('Contents:')
+    print()
+    print(f'Certbot {version} has just been released. The changelog for the release is:')
+    print()
+    print(changelog)
+
 def main(args):
     parsed_args = parse_args(args)
     version = fetch_version_number()
     promote_snaps(ALL_SNAPS, 'beta', version)
+    generate_community_forum_post(version)
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
Item 5 of https://github.com/certbot/certbot/issues/10600

When this is merged, the setup section of the [release process](https://github.com/EFForg/certbot-misc/wiki/The-Mystical-Release-Process) should be modified.
- `gh` should be added to os packages for mac and debian
- A new step should be added: "Run `gh auth login` and log into a GitHub account." Technically any account should work here.

The contents of the step saying to post to the community forum should be shortened to say something like "copy the output from the terminal." We could add the link to the client-dev tag here, but personally I think it's easiest to just keep it in the release instructions.

Tested by commenting out `promote_snaps` call in `tools/finish_release.py`:

```
(venv) $ tools/finish_release.py 
Generating announcement text for community forum post
Subject:

Certbot 5.6.0 Release

Contents:

Certbot 5.6.0 has just been released. The changelog for the release is:

### Changed

- certbot now requires version 1.7+ of the library distro and certbot-dns-cloudflare requires 4.0+ of the Cloudflare Python library. ([#10587](https://github.com/certbot/certbot/issues/10587))

### Fixed

- The certbot-dns-ovh snap and docker image now properly delete any created TXT records after the challenge is completed by requiring dns-lexicon 3.25.1 which contains the fix. ([#10492](https://github.com/certbot/certbot/issues/10492))
- Our Docker images have been updated to use Python 3.14 and Alpine Linux 3.23. ([#10619](https://github.com/certbot/certbot/issues/10619))



(venv) $ gh auth logout
✓ Logged out of github.com account ohemorange
(venv) $ tools/finish_release.py 
Generating announcement text for community forum post
To get started with GitHub CLI, please run:  gh auth login
Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.
Generating announcement text failed.
(venv) $ 
```
