### PR TITLE
Temporarily turn off failing tests so we don't get failure notifications

### DIFF
--- a/.github/workflows/snap_packaging_jobs.yml
+++ b/.github/workflows/snap_packaging_jobs.yml
@@ -140,8 +140,8 @@ jobs:
           run-on: ubuntu-24.04-arm
         - arch-name: amd64
           run-on: ubuntu-24.04
-        - arch-name: armhf
-          run-on: ubuntu-24.04-arm
+        # - arch-name: armhf # temporarily turned off due to github's migration
+        #   run-on: ubuntu-24.04-arm
     steps:
     - name: checkout
       uses: actions/checkout@v6.0.2
@@ -201,8 +201,8 @@ jobs:
           run-on: ubuntu-24.04-arm
         - arch-name: amd64
           run-on: ubuntu-24.04
-        - arch-name: armhf
-          run-on: ubuntu-24.04-arm
+        # - arch-name: armhf # temporarily turned off due to github's migration
+        #   run-on: ubuntu-24.04-arm
     steps:
     - name: checkout
       uses: actions/checkout@v6.0.2


### PR DESCRIPTION
These tests are failing because the runner migrated ownership to github, and that somehow broke it even though it wasn't supposed to. They're not responding to issues [other than](https://github.com/actions/runner-images/issues/14100) "a CVE or vulnerability" during the transition period (ends june 12). Let's just turn these off for now. We weren't even running this at all in azure, it's fine.