### PR TITLE
Specify fuse3:armhf to fix failing armhf tests

### DIFF
--- a/.github/workflows/snap_packaging_jobs.yml
+++ b/.github/workflows/snap_packaging_jobs.yml
@@ -140,8 +140,8 @@ jobs:
           run-on: ubuntu-24.04-arm
         - arch-name: amd64
           run-on: ubuntu-24.04
-        # - arch-name: armhf # temporarily turned off due to github's migration
-        #   run-on: ubuntu-24.04-arm
+        - arch-name: armhf
+          run-on: ubuntu-24.04-arm
     steps:
     - name: checkout
       uses: actions/checkout@v6.0.2
@@ -157,7 +157,7 @@ jobs:
         sudo apt-get update
         # apparmor will conflict with snapd:armhf dependency if not removed first
         sudo apt-get remove -y apparmor
-        sudo apt-get install -y --no-install-recommends snapd:armhf nginx-light
+        sudo apt-get install -y --no-install-recommends fuse3:armhf snapd:armhf nginx-light
     - name: Install non-armhf depdencies
       if: ${{ matrix.arch-name != 'armhf' }}
       run: |-
@@ -201,8 +201,8 @@ jobs:
           run-on: ubuntu-24.04-arm
         - arch-name: amd64
           run-on: ubuntu-24.04
-        # - arch-name: armhf # temporarily turned off due to github's migration
-        #   run-on: ubuntu-24.04-arm
+        - arch-name: armhf
+          run-on: ubuntu-24.04-arm
     steps:
     - name: checkout
       uses: actions/checkout@v6.0.2
@@ -215,7 +215,7 @@ jobs:
         sudo apt-get update
         # apparmor will conflict with snapd:armhf dependency if not removed first
         sudo apt-get remove -y apparmor
-        sudo apt-get install -y --no-install-recommends snapd:armhf
+        sudo apt-get install -y --no-install-recommends fuse3:armhf snapd:armhf
     - name: Install non-armhf depdencies
       if: ${{ matrix.arch-name != 'armhf' }}
       run: |-


### PR DESCRIPTION
These tests were turned off in https://github.com/certbot/certbot/pull/10665

See checks tab; full suite is passing with these changes.