### PR TITLE
Switch readme.rst badge to GHA nightly workflow status

### DIFF
--- a/certbot/README.rst
+++ b/certbot/README.rst
@@ -2,9 +2,9 @@
 
 |build-status|
 
-.. |build-status| image:: https://img.shields.io/azure-devops/build/certbot/ba534f81-a483-4b9b-9b4e-a60bec8fee72/5/main
-   :target: https://dev.azure.com/certbot/certbot/_build?definitionId=5
-   :alt: Azure Pipelines CI status
+.. |build-status| image:: https://img.shields.io/github/actions/workflow/status/certbot/certbot/nightly.yml
+   :target: https://github.com/certbot/certbot/actions/workflows/nightly.yml
+   :alt: GitHub Actions nightly CI status
 
 .. image:: https://raw.githubusercontent.com/EFForg/design/master/logos/certbot/eff-certbot-lockup.png
   :width: 200


### PR DESCRIPTION
You can see what it will look like by clicking `...` --> "View File", or this link should work: https://github.com/certbot/certbot/blob/975be14d85dd365e5b145ad5136e37e9347ee94c/certbot/README.rst