### PR TITLE
Don't build epubs in readthedocs

### DIFF
--- a/acme/.readthedocs.yaml
+++ b/acme/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-cloudflare/.readthedocs.yaml
+++ b/certbot-dns-cloudflare/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-digitalocean/.readthedocs.yaml
+++ b/certbot-dns-digitalocean/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-dnsimple/.readthedocs.yaml
+++ b/certbot-dns-dnsimple/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-dnsmadeeasy/.readthedocs.yaml
+++ b/certbot-dns-dnsmadeeasy/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-gehirn/.readthedocs.yaml
+++ b/certbot-dns-gehirn/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-google/.readthedocs.yaml
+++ b/certbot-dns-google/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-linode/.readthedocs.yaml
+++ b/certbot-dns-linode/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-luadns/.readthedocs.yaml
+++ b/certbot-dns-luadns/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-nsone/.readthedocs.yaml
+++ b/certbot-dns-nsone/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-ovh/.readthedocs.yaml
+++ b/certbot-dns-ovh/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-rfc2136/.readthedocs.yaml
+++ b/certbot-dns-rfc2136/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-route53/.readthedocs.yaml
+++ b/certbot-dns-route53/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot-dns-sakuracloud/.readthedocs.yaml
+++ b/certbot-dns-sakuracloud/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub

--- a/certbot/.readthedocs.yaml
+++ b/certbot/.readthedocs.yaml
@@ -28,4 +28,3 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub


### PR DESCRIPTION
There's no way anyone is using these...

https://github.com/certbot/certbot/pull/9762 was just basing off of readthedocs' defaults.https://github.com/certbot/certbot/pull/9762 was just basing off of readthedocs' defaults.

Probably no one is using pdf either, but definitely no one is using epubs. This is the more cautious version of https://github.com/certbot/certbot/pull/10670

```
$ git grep epub
acme/docs/Makefile:.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
acme/docs/Makefile:     @echo "  epub       to make an epub"
acme/docs/Makefile:epub:
acme/docs/Makefile:     $(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
acme/docs/Makefile:     @echo "Build finished. The epub file is in $(BUILDDIR)/epub."
acme/docs/make.bat:     echo.  epub       to make an epub
acme/docs/make.bat:if "%1" == "epub" (
acme/docs/make.bat:     %SPHINXBUILD% -b epub %ALLSPHINXOPTS% %BUILDDIR%/epub
acme/docs/make.bat:     echo.Build finished. The epub file is in %BUILDDIR%/epub.
certbot/docs/Makefile:.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
certbot/docs/Makefile:  @echo "  epub       to make an epub"
certbot/docs/Makefile:epub:
certbot/docs/Makefile:  $(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
certbot/docs/Makefile:  @echo "Build finished. The epub file is in $(BUILDDIR)/epub."
certbot/docs/make.bat:  echo.  epub       to make an epub
certbot/docs/make.bat:if "%1" == "epub" (
certbot/docs/make.bat:  %SPHINXBUILD% -b epub %ALLSPHINXOPTS% %BUILDDIR%/epub
certbot/docs/make.bat:  echo.Build finished. The epub file is in %BUILDDIR%/epub.
```