### PR TITLE
Remove Azure references from contributing.rst

### DIFF
--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -156,7 +156,7 @@ adding the `-s` flag to `pytest` invocations.
 Running automated integration tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Generally it is sufficient to open a pull request and let Github and Azure Pipelines run
+Generally it is sufficient to open a pull request and let GitHub run
 integration tests for you. However, you may want to run them locally before submitting
 your pull request. You need Docker installed and working.
 
@@ -224,8 +224,8 @@ using an HTTP-01 challenge on a machine with Python 3:
 Running tests in CI
 ~~~~~~~~~~~~~~~~~~~
 
-Certbot uses Azure Pipelines to run continuous integration tests. If you are using our
-Azure setup, a branch whose name starts with `test-` will run all tests on that branch.
+Certbot uses GitHub Actions to run continuous integration tests. If you are using our
+GitHub Actions setup, a branch whose name starts with `test-` will run all tests on that branch.
 
 Code components and layout
 ==========================
@@ -526,7 +526,7 @@ Steps:
    containing your pull request to squash or amend commits. We use `squash
    merges <https://github.com/blog/2141-squash-your-commits>`_ on PRs and
    rewriting commits makes changes harder to track between reviews.
-7. Did your tests pass on Azure Pipelines? If they didn't, fix any errors.
+7. Did your tests pass on GitHub Actions? If they didn't, fix any errors.
 
 .. _ask for help:
 


### PR DESCRIPTION
```
$ git grep Azure
certbot-dns-google/src/certbot_dns_google/__init__.py:federation>`_. Instructions are generally available for most platforms, including `AWS or Azure
certbot/docs/using.rst:dns-azure_              Y    N    DNS Authentication using Azure DNS
```

<img width="872" height="163" alt="Screenshot 2026-06-10 at 5 11 36 PM" src="https://github.com/user-attachments/assets/fedfe9eb-17c7-430b-b4e1-60fb4a175649" />
<img width="831" height="141" alt="Screenshot 2026-06-10 at 5 11 45 PM" src="https://github.com/user-attachments/assets/2c25fee0-472f-47f2-beed-6ba334497372" />
<img width="652" height="61" alt="Screenshot 2026-06-10 at 5 11 56 PM" src="https://github.com/user-attachments/assets/38f9963e-57bc-4ca5-b673-5ae066a0480e" />
