### PR TITLE
Add temp remote and fetch temp from release folder in release script

### DIFF
--- a/tools/_release.sh
+++ b/tools/_release.sh
@@ -103,6 +103,7 @@ tools/pip_install.py build towncrier uv virtualenv
 
 root_without_le="$version.$$"
 root="$RELEASE_DIR/le.$root_without_le"
+REPO_ROOT="$(pwd)"
 
 echo "Cloning into fresh copy at $root"  # clean repo = no artifacts
 git clone . $root
@@ -217,3 +218,7 @@ if [ "$RELEASE_BRANCH" = candidate-"$version" ] ; then
     SetVersion "$nextversion".dev0
     git commit -m "Bump version to $nextversion"
 fi
+
+cd $REPO_ROOT
+git remote rm temp || :
+git remote add temp $root && git fetch temp


### PR DESCRIPTION
I don't understand why this wasn't already in the release script, and can see no reason to not add it. This doesn't do anything publicly or permanently, it just fetches the branch from the release folder. If we need to add the previous temp, it's right there in a `releases.*.bak` folder.

This is step 8 of the release process, and should be deleted when this is merged.

I did test this and it worked.