### PR TITLE
Fix dns-route53 duplicate TXT record for apex + wildcard

### DIFF
--- a/certbot-dns-route53/src/certbot_dns_route53/_internal/dns_route53.py
+++ b/certbot-dns-route53/src/certbot_dns_route53/_internal/dns_route53.py
@@ -43,6 +43,7 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
         self._attempt_cleanup = False
         self._resource_records: collections.defaultdict[str, list[dict[str, str]]] = \
             collections.defaultdict(list)
+        self._resource_records_change_ids: dict[str, str] = {}
 
     def more_info(self) -> str:
         return "Solve a DNS01 challenge using AWS Route53"
@@ -142,6 +143,11 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
                 # Create a new list containing the record to use with DELETE
                 rrecords = [challenge]
         else:
+            if challenge in rrecords:
+                # Some ACME CAs return identical challenge values for apex and
+                # wildcard on the same domain. Route53 rejects duplicate resource
+                # records, so return the previous change ID without re-submitting.
+                return self._resource_records_change_ids[validation_domain_name]
             rrecords.append(challenge)
 
         response = self.r53.change_resource_record_sets(
@@ -161,7 +167,9 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
                 ]
             }
         )
-        return cast(str, response["ChangeInfo"]["Id"])
+        change_id = cast(str, response["ChangeInfo"]["Id"])
+        self._resource_records_change_ids[validation_domain_name] = change_id
+        return change_id
 
     def _wait_for_change(self, change_id: str) -> None:
         """Wait for a change to be propagated to all Route53 DNS servers.

--- a/certbot-dns-route53/src/certbot_dns_route53/_internal/tests/dns_route53_test.py
+++ b/certbot-dns-route53/src/certbot_dns_route53/_internal/tests/dns_route53_test.py
@@ -221,6 +221,21 @@ class ClientTest(unittest.TestCase):
         call_count = self.client.r53.change_resource_record_sets.call_count
         assert call_count == 1
 
+    def test_change_txt_record_duplicate(self):
+        self.client._find_zone_id_for_domain = mock.MagicMock() # type: ignore [method-assign, unused-ignore]
+        self.client.r53.change_resource_record_sets = mock.MagicMock(
+            return_value={"ChangeInfo": {"Id": "first-change-id"}})
+
+        # First call should go through
+        change_id = self.client._change_txt_record("UPSERT", DOMAIN, "same-value")
+        assert change_id == "first-change-id"
+        assert self.client.r53.change_resource_record_sets.call_count == 1
+
+        # Second call with same domain and value should return previous change ID
+        change_id = self.client._change_txt_record("UPSERT", DOMAIN, "same-value")
+        assert change_id == "first-change-id"
+        assert self.client.r53.change_resource_record_sets.call_count == 1
+
     def test_change_txt_record_delete(self):
         self.client._find_zone_id_for_domain = mock.MagicMock() # type: ignore[ method-assign, unused-ignore]
         self.client.r53.change_resource_record_sets = mock.MagicMock(

--- a/newsfragments/10593.fixed
+++ b/newsfragments/10593.fixed
@@ -1,0 +1,1 @@
+Fixed certbot-dns-route53 failing with "Duplicate Resource Record" when the ACME CA returns identical DNS-01 challenge values for apex and wildcard domains.


### PR DESCRIPTION
## Summary

Fixes #10593. When an ACME CA returns identical DNS-01 challenge values for both apex and wildcard domains (same `validation_domain_name` and same validation value), Route53 rejects the second UPSERT with `InvalidChangeBatch: Duplicate Resource Record`.

**Root cause:** `_change_txt_record` appends to `_resource_records` without checking for duplicate values.

**Fix:** Before appending, check if the challenge value already exists. If so, skip the Route53 API call and return the previously stored change ID.

## Changes
- Added `_resource_records_change_ids` dict to track the last change ID per validation domain
- Skip duplicate UPSERT when challenge value already exists in tracked records
- Added unit test `test_change_txt_record_duplicate`
- Added newsfragment

## Testing
- All 17 dns-route53 unit tests pass
- pylint: 10/10
- mypy --strict: clean

## AI Disclosure
This PR was developed with AI assistance (Kiro CLI). I have thoroughly reviewed, understood, and tested all code in this submission.

## Checklist
- [x] Certbot team expressed interest (issue #10593 is assigned to maintainer)
- [x] Newsfragment added (`10593.fixed`)
- [x] Tests pass