### PR TITLE
Update DigitalOcean DNS docs: token scopes and URL

### DIFF
--- a/certbot-dns-digitalocean/src/certbot_dns_digitalocean/__init__.py
+++ b/certbot-dns-digitalocean/src/certbot_dns_digitalocean/__init__.py
@@ -26,8 +26,14 @@ Credentials
 -----------
 
 Use of this plugin requires a configuration file containing DigitalOcean API
-credentials, obtained from your DigitalOcean account's `Applications & API
-Tokens page <https://cloud.digitalocean.com/settings/api/tokens>`_.
+credentials, obtained from your DigitalOcean account's `API Tokens page
+<https://cloud.digitalocean.com/account/api/tokens>`_.
+
+The token requires the following scopes (under **domain**):
+
+- ``create``
+- ``read``
+- ``delete``
 
 .. code-block:: ini
    :name: credentials.ini


### PR DESCRIPTION
## Summary

Fixes #10577. Updates the DigitalOcean DNS plugin documentation:

1. **Fixed outdated API URL** — `cloud.digitalocean.com/settings/api/tokens` → `cloud.digitalocean.com/account/api/tokens`
2. **Added minimum required token scopes** — documents that the token needs `domain: create, read, delete` scopes, following the principle of least privilege

## Testing
- pylint: 10/10
- mypy --strict: clean
- Doc renders correctly (verified RST structure)

## AI Disclosure
This PR was developed with AI assistance (Kiro CLI). I have thoroughly reviewed, understood, and tested all code in this submission.

## Checklist
- [x] Certbot team expressed interest (issue #10577 is assigned to maintainer)
- [x] Documentation updated
- [x] No code changes requiring newsfragment