### PR TITLE
Make user-facing messages more CA-neutral

### DIFF
--- a/certbot/src/certbot/_internal/main.py
+++ b/certbot/src/certbot/_internal/main.py
@@ -73,8 +73,11 @@ def _suggest_donation_if_appropriate(config: configuration.NamespaceConfig) -> N
     # - renewing
     # - using the staging server (--staging or --dry-run)
     # - running with --quiet (display fd won't be available during atexit calls #8995)
+    # - using a non-Let's Encrypt ACME server
     assert config.verb != "renew"
     if config.staging or config.quiet:
+        return
+    if "letsencrypt.org" not in config.server:
         return
     util.atexit_register(
         display_util.notification,

--- a/certbot/src/certbot/util.py
+++ b/certbot/src/certbot/util.py
@@ -377,11 +377,11 @@ def safely_remove(path: str) -> None:
 
 
 def get_filtered_names(all_names: set[str]) -> set[str]:
-    """Removes names that aren't considered valid by Let's Encrypt.
+    """Removes names that aren't considered valid for certificate issuance.
 
     :param set all_names: all names found in the configuration
 
-    :returns: all found names that are considered valid by LE
+    :returns: all found names that are considered valid for the default CA
     :rtype: set
 
     """
@@ -565,14 +565,14 @@ def add_deprecated_argument(add_argument: Callable[..., None], argument_name: st
 
 
 def enforce_le_validity(domain: str) -> str:
-    """Checks that Let's Encrypt will consider domain to be valid.
+    """Checks that the default CA will consider domain to be valid.
 
     :param str domain: FQDN to check
     :type domain: `str`
     :returns: The domain cast to `str`, with ASCII-only contents
     :rtype: str
-    :raises ConfigurationError: for invalid domains and cases where Let's
-                                Encrypt currently will not issue certificates
+    :raises ConfigurationError: for invalid domains and cases where the
+                                default CA will not issue certificates
 
     """
 
@@ -637,9 +637,10 @@ def enforce_domain_sanity(domain: Union[str, bytes]) -> str:
 
     if is_ipaddress(domain):
         raise errors.ConfigurationError(
-            "Requested name {0} is an IP address. The Let's Encrypt "
-            "certificate authority will not issue certificates for a "
-            "bare IP address.".format(domain))
+            "Requested name {0} is an IP address. The default certificate "
+            "authority will not issue certificates for a bare IP address. "
+            "If your CA supports IP certificates, use --ip-address instead "
+            "of -d.".format(domain))
 
     # FQDN checks according to RFC 2181: domain name should be less than 255
     # octets (inclusive). And each label is 1 - 63 octets (inclusive).

--- a/newsfragments/10566.changed
+++ b/newsfragments/10566.changed
@@ -1,0 +1,1 @@
+Made user-facing messages more CA-neutral: suppress donation prompt when using non-Let's Encrypt servers, updated IP address error to mention --ip-address flag, and clarified docstrings.


### PR DESCRIPTION
## Summary

Contributes to #10566. Makes certbot's user-facing messages more appropriate when users configure alternative ACME CAs via `--server`.

## Changes

1. **Suppress donation prompt for non-LE servers** — When `--server` points to a non-Let's Encrypt ACME endpoint, the "Donate to ISRG / Let's Encrypt" message is no longer shown. Enterprise CA customers shouldn't see donation solicitations for a different organization.

2. **CA-neutral IP address error** — The error for IP address domains previously said "The Let's Encrypt certificate authority will not issue certificates for a bare IP address." Now it says "The default certificate authority will not issue..." and helpfully points users to `--ip-address` (which certbot already supports for CAs that issue IP certs).

3. **Updated docstrings** — `enforce_le_validity` and `get_filtered_names` docstrings now use generic language.

## Design Decisions

- Let's Encrypt remains the default server (no change)
- The donation message still shows for LE users (no change to default behavior)
- Detection is simple: `"letsencrypt.org" not in config.server`
- No functional changes to certificate issuance logic

## Testing
- All 1527 certbot unit tests pass
- pylint: 10/10
- mypy: clean

## AI Disclosure
This PR was developed with AI assistance (Kiro CLI). I have thoroughly reviewed, understood, and tested all code in this submission.

## Checklist
- [x] Issue #10566 has active interest and an existing (smaller) PR
- [x] Newsfragment added (`10566.changed`)
- [x] Tests pass