### PR TITLE
Improve EAB UX: env var support and better error message

### DIFF
--- a/certbot/src/certbot/_internal/client.py
+++ b/certbot/src/certbot/_internal/client.py
@@ -229,13 +229,15 @@ def perform_registration(acme: acme_client.ClientV2, config: configuration.Names
     if not acme.net.key:
         raise errors.Error("acme client with no private key cannot register account.")
 
-    eab_credentials_supplied = config.eab_kid and config.eab_hmac_key
+    eab_kid = config.eab_kid or os.environ.get("CERTBOT_EAB_KID")
+    eab_hmac_key = config.eab_hmac_key or os.environ.get("CERTBOT_EAB_HMAC_KEY")
+    eab_credentials_supplied = eab_kid and eab_hmac_key
     eab: Optional[dict[str, Any]]
     if eab_credentials_supplied:
         account_public_key = acme.net.key.public_key()
         eab = messages.ExternalAccountBinding.from_data(account_public_key=account_public_key,
-                                                        kid=config.eab_kid,
-                                                        hmac_key=config.eab_hmac_key,
+                                                        kid=str(eab_kid),
+                                                        hmac_key=str(eab_hmac_key),
                                                         directory=acme.directory,
                                                         hmac_alg=config.eab_hmac_alg)
     else:
@@ -243,8 +245,11 @@ def perform_registration(acme: acme_client.ClientV2, config: configuration.Names
 
     if acme.external_account_required():
         if not eab_credentials_supplied:
-            msg = ("Server requires external account binding."
-                   " Please use --eab-kid and --eab-hmac-key.")
+            msg = ("Server at {0} requires External Account Binding (EAB). "
+                   "Please provide --eab-kid and --eab-hmac-key, or set the "
+                   "CERTBOT_EAB_KID and CERTBOT_EAB_HMAC_KEY environment variables. "
+                   "Obtain these credentials from your CA account portal."
+                   .format(config.server))
             raise errors.Error(msg)
 
     tos = acme.directory.meta.terms_of_service


### PR DESCRIPTION
## Summary

Two improvements to External Account Binding (EAB) support for enterprise ACME CAs:

### 1. Environment variable fallback for EAB credentials

Adds `CERTBOT_EAB_KID` and `CERTBOT_EAB_HMAC_KEY` as fallback sources when CLI flags are not provided.

```bash
export CERTBOT_EAB_KID=abc123
export CERTBOT_EAB_HMAC_KEY=base64encodedkey
certbot certonly --server https://ca.example.com/acme -d example.com
```

**Security benefit:** HMAC keys passed via `--eab-hmac-key` are visible in shell history (`~/.bash_history`) and process listings (`ps aux`). Environment variables are a standard pattern for sensitive credentials.

### 2. Actionable error message when EAB is required

Before:
```
Server requires external account binding. Please use --eab-kid and --eab-hmac-key.
```

After:
```
Server at https://ca.example.com/acme requires External Account Binding (EAB).
Please provide --eab-kid and --eab-hmac-key, or set the CERTBOT_EAB_KID and
CERTBOT_EAB_HMAC_KEY environment variables. Obtain these credentials from your
CA account portal.
```

## Testing
- All 1527 certbot unit tests pass
- pylint: 10/10, mypy: clean

## AI Disclosure
This PR was developed with AI assistance (Kiro CLI). I have thoroughly reviewed, understood, and tested all code in this submission.

## Checklist
- [x] Relates to #10566 (CA-neutral improvements)
- [x] Tests pass