### PR TITLE
Truncate CERTBOT_AUTH_OUTPUT to prevent ARG_MAX failures in cleanup hooks

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -154,6 +154,7 @@ Authors
 * [Kenneth Skovhede](https://github.com/kenkendk)
 * [Kevin Burke](https://github.com/kevinburke)
 * [Kevin London](https://github.com/kevinlondon)
+* [Karl Hill](https://github.com/karlhillx)
 * [Kubilay Kocak](https://github.com/koobs)
 * [LeCoyote](https://github.com/LeCoyote)
 * [Lee Watson](https://github.com/TheReverend403)

--- a/certbot/docs/cli-help.txt
+++ b/certbot/docs/cli-help.txt
@@ -716,7 +716,8 @@ manual:
   resource requested when performing an HTTP-01 challenge. An additional
   cleanup script can also be provided and can use the additional variable
   $CERTBOT_AUTH_OUTPUT which contains the stdout output from the auth
-  script. For both authenticator and cleanup script, on HTTP-01 and DNS-01
+  script (truncated to 10 KB to avoid ARG_MAX limits in the cleanup hook).
+  For both authenticator and cleanup script, on HTTP-01 and DNS-01
   challenges, $CERTBOT_REMAINING_CHALLENGES will be equal to the number of
   challenges that remain after the current one, and $CERTBOT_ALL_IDENTIFIERS
   contains a comma-separated list of all identifiers that are challenged for

--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -1094,7 +1094,7 @@ variables to these scripts:
 
 Additionally for cleanup:
 
-- ``CERTBOT_AUTH_OUTPUT``: Whatever the auth script wrote to stdout
+- ``CERTBOT_AUTH_OUTPUT``: Whatever the auth script wrote to stdout (truncated to 10 KB to avoid ARG_MAX limits)
 
 Certbot also sets ``CERTBOT_DOMAIN`` and ``CERTBOT_ALL_DOMAINS`` to the same values as
 ``CERTBOT_IDENTIFIER`` and ``CERTBOT_ALL_IDENTIFIERS`` respectively for backwards compatibility,

--- a/certbot/src/certbot/_internal/plugins/manual.py
+++ b/certbot/src/certbot/_internal/plugins/manual.py
@@ -206,11 +206,12 @@ permitted by DNS standards.)
         os.environ.update(env)
         _, out = self._execute_hook('auth-hook', identifier_value)
         auth_output = out.strip()
-        if len(auth_output.encode('utf-8')) > _MAX_AUTH_OUTPUT_BYTES:
+        auth_output_bytes = auth_output.encode('utf-8')
+        if len(auth_output_bytes) > _MAX_AUTH_OUTPUT_BYTES:
             logger.warning(
                 'auth-hook output exceeded %d bytes; truncating CERTBOT_AUTH_OUTPUT '
                 'to avoid ARG_MAX limits in cleanup hook', _MAX_AUTH_OUTPUT_BYTES)
-            auth_output = auth_output.encode('utf-8')[:_MAX_AUTH_OUTPUT_BYTES].decode(
+            auth_output = auth_output_bytes[:_MAX_AUTH_OUTPUT_BYTES].decode(
                 'utf-8', errors='ignore')
         env['CERTBOT_AUTH_OUTPUT'] = auth_output
         self.env[achall] = env

--- a/certbot/src/certbot/_internal/plugins/manual.py
+++ b/certbot/src/certbot/_internal/plugins/manual.py
@@ -20,6 +20,11 @@ from certbot.plugins import common
 
 logger = logging.getLogger(__name__)
 
+# Maximum size of CERTBOT_AUTH_OUTPUT passed to cleanup hooks via environment.
+# auth-hook stdout beyond this is truncated to avoid exceeding ARG_MAX (E2BIG)
+# when the env dict is passed to subprocess.run(shell=True, env=...).
+_MAX_AUTH_OUTPUT_BYTES = 10 * 1024  # 10 KB
+
 
 class Authenticator(common.Plugin, interfaces.Authenticator):
     """Manual authenticator
@@ -200,7 +205,14 @@ permitted by DNS standards.)
             os.environ.pop('CERTBOT_TOKEN', None)
         os.environ.update(env)
         _, out = self._execute_hook('auth-hook', identifier_value)
-        env['CERTBOT_AUTH_OUTPUT'] = out.strip()
+        auth_output = out.strip()
+        if len(auth_output.encode('utf-8')) > _MAX_AUTH_OUTPUT_BYTES:
+            logger.warning(
+                'auth-hook output exceeded %d bytes; truncating CERTBOT_AUTH_OUTPUT '
+                'to avoid ARG_MAX limits in cleanup hook', _MAX_AUTH_OUTPUT_BYTES)
+            auth_output = auth_output.encode('utf-8')[:_MAX_AUTH_OUTPUT_BYTES].decode(
+                'utf-8', errors='ignore')
+        env['CERTBOT_AUTH_OUTPUT'] = auth_output
         self.env[achall] = env
 
     def _perform_achall_manually(self, achall: achallenges.AnnotatedChallenge,

--- a/certbot/src/certbot/_internal/plugins/manual.py
+++ b/certbot/src/certbot/_internal/plugins/manual.py
@@ -46,7 +46,8 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
         'is the validation string, and $CERTBOT_TOKEN is the filename of the '
         'resource requested when performing an HTTP-01 challenge. An additional '
         'cleanup script can also be provided and can use the additional variable '
-        '$CERTBOT_AUTH_OUTPUT which contains the stdout output from the auth script. '
+        '$CERTBOT_AUTH_OUTPUT which contains the stdout output from the auth script '
+        '(truncated to 10 KB to avoid ARG_MAX limits in the cleanup hook). '
         'For both authenticator and cleanup script, on HTTP-01 and DNS-01 challenges, '
         '$CERTBOT_REMAINING_CHALLENGES will be equal to the number of challenges that '
         'remain after the current one, and $CERTBOT_ALL_IDENTIFIERS contains a comma-separated '
@@ -206,12 +207,12 @@ permitted by DNS standards.)
         os.environ.update(env)
         _, out = self._execute_hook('auth-hook', identifier_value)
         auth_output = out.strip()
-        auth_output_bytes = auth_output.encode('utf-8')
-        if len(auth_output_bytes) > _MAX_AUTH_OUTPUT_BYTES:
+        encoded = auth_output.encode('utf-8')
+        if len(encoded) > _MAX_AUTH_OUTPUT_BYTES:
             logger.warning(
                 'auth-hook output exceeded %d bytes; truncating CERTBOT_AUTH_OUTPUT '
                 'to avoid ARG_MAX limits in cleanup hook', _MAX_AUTH_OUTPUT_BYTES)
-            auth_output = auth_output_bytes[:_MAX_AUTH_OUTPUT_BYTES].decode(
+            auth_output = encoded[:_MAX_AUTH_OUTPUT_BYTES].decode(
                 'utf-8', errors='ignore')
         env['CERTBOT_AUTH_OUTPUT'] = auth_output
         self.env[achall] = env

--- a/certbot/src/certbot/_internal/plugins/manual.py
+++ b/certbot/src/certbot/_internal/plugins/manual.py
@@ -207,7 +207,7 @@ permitted by DNS standards.)
         os.environ.update(env)
         _, out = self._execute_hook('auth-hook', identifier_value)
         auth_output = out.strip()
-        encoded = auth_output.encode('utf-8')
+        encoded = auth_output.encode('utf-8', errors='ignore')
         if len(encoded) > _MAX_AUTH_OUTPUT_BYTES:
             logger.warning(
                 'auth-hook output exceeded %d bytes; truncating CERTBOT_AUTH_OUTPUT '

--- a/certbot/src/certbot/_internal/tests/plugins/manual_test.py
+++ b/certbot/src/certbot/_internal/tests/plugins/manual_test.py
@@ -156,5 +156,26 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             'Ensure that you created these in the correct location.'
 
 
+    def test_auth_output_truncation(self):
+        """Test that CERTBOT_AUTH_OUTPUT is truncated when it exceeds the limit."""
+        from certbot._internal.plugins.manual import _MAX_AUTH_OUTPUT_BYTES
+        import tempfile
+        big_output = 'x' * (_MAX_AUTH_OUTPUT_BYTES + 1000)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as tmp:
+            tmp.write(big_output)
+            tmp_path = tmp.name
+        self.config.manual_auth_hook = (
+            '{0} -c "print(open(\'{1}\').read(), end=\'\')"'.format(
+                sys.executable, tmp_path))
+        self.config.manual_cleanup_hook = '# cleanup'
+        try:
+            self.auth.perform(self.achalls)
+            for achall in self.achalls:
+                stored = self.auth.env[achall]['CERTBOT_AUTH_OUTPUT']
+                assert len(stored.encode('utf-8')) <= _MAX_AUTH_OUTPUT_BYTES
+                assert len(stored) < len(big_output)
+        finally:
+            os.unlink(tmp_path)
+
 if __name__ == '__main__':
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/certbot/src/certbot/_internal/tests/plugins/manual_test.py
+++ b/certbot/src/certbot/_internal/tests/plugins/manual_test.py
@@ -161,12 +161,14 @@ class AuthenticatorTest(test_util.TempDirTestCase):
         from certbot._internal.plugins.manual import _MAX_AUTH_OUTPUT_BYTES
         import tempfile
         big_output = 'x' * (_MAX_AUTH_OUTPUT_BYTES + 1000)
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as tmp:
-            tmp.write(big_output)
-            tmp_path = tmp.name
-        self.config.manual_auth_hook = (
-            '{0} -c "print(open(\'{1}\').read(), end=\'\')"'.format(
-                sys.executable, tmp_path))
+        # Write a helper script to a temp file instead of embedding the path
+        # in a -c snippet to avoid Windows backslash escape issues.
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as script:
+            script.write('import sys\n')
+            script.write(f'data = "x" * {_MAX_AUTH_OUTPUT_BYTES + 1000}\n')
+            script.write('sys.stdout.write(data)\n')
+            script_path = script.name
+        self.config.manual_auth_hook = '{0} {1}'.format(sys.executable, script_path)
         self.config.manual_cleanup_hook = '# cleanup'
         try:
             self.auth.perform(self.achalls)
@@ -175,7 +177,7 @@ class AuthenticatorTest(test_util.TempDirTestCase):
                 assert len(stored.encode('utf-8')) <= _MAX_AUTH_OUTPUT_BYTES
                 assert len(stored) < len(big_output)
         finally:
-            os.unlink(tmp_path)
+            os.unlink(script_path)
 
 if __name__ == '__main__':
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/newsfragments/10724.fixed
+++ b/newsfragments/10724.fixed
@@ -1,0 +1,1 @@
+Fixed ``CERTBOT_AUTH_OUTPUT`` environment variable exceeding ``ARG_MAX`` limits when manual auth-hook produces large stdout output, which caused cleanup hooks to fail with ``E2BIG`` errors.


### PR DESCRIPTION
## Pull Request Checklist

- [x] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] If you used AI to create this PR, you have done a self-review of all AI-generated code and disclosed that your contribution was AI-generated per [EFF's AI-generated contribution policy](https://www.eff.org/about/opportunities/volunteer/coding-with-eff). You assert you have thoroughly understood, reviewed, and tested your entire submission.
- [x] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), add a description of your change to the `newsfragments` directory. This should be a file called `<title>.<type>`, where `<title>` is either a GitHub issue number or some other unique name starting with `+`, and `<type>` is either `changed`, `fixed`, or `added`.
- [x] Add or update any documentation as needed to support the changes in this PR.
- [x] Include your name in `AUTHORS.md` if you like.

## Problem

When a `--manual-auth-hook` script produces large stdout output, the entire output is stored in `CERTBOT_AUTH_OUTPUT` and passed through the environment to the cleanup hook via `subprocess.run(shell=True, env=env)`. If the combined environment + argv exceeds `ARG_MAX` (typically 1 MB on Linux), `execve` fails with `E2BIG` and the cleanup hook never runs.

The chain:

1. `manual.py:203` — `env['CERTBOT_AUTH_OUTPUT'] = out.strip()` stores full stdout
2. `manual.py:247` — `os.environ.update(env)` mutates the process environment
3. `_execute_hook` → `env_no_snap_for_external_calls()` → `os.environ.copy()` picks up the bloated var
4. `subprocess.run(shell=True, env=env)` → `execve` → `E2BIG`

Reported by @xkr47 in #10724 — their verbose auth-hook output caused cleanup hooks to silently fail with "Argument list too long".

## Fix

Truncate `CERTBOT_AUTH_OUTPUT` to 10 KB (well under `ARG_MAX` minus normal env overhead) with a logged warning when the limit is exceeded. The truncation uses `errors='ignore'` on decode to avoid splitting multi-byte UTF-8 sequences.

This is the simplest backward-compatible approach — no interface change, no new env vars. A temp-file variant (`CERTBOT_AUTH_OUTPUT_FILE`) was considered but would change the public interface.

## Changes

- `certbot/src/certbot/_internal/plugins/manual.py` — added `_MAX_AUTH_OUTPUT_BYTES` constant and truncation logic
- `certbot/src/certbot/_internal/tests/plugins/manual_test.py` — added `test_auth_output_truncation`
- `newsfragments/10724.fixed` — changelog entry

## Testing

All 9 existing tests pass plus the new truncation test. `ruff check` clean.

## AI Disclosure

The initial code analysis and patch were developed with AI assistance. I reviewed, understood, and tested all changes before submitting.