### PR TITLE
dns-route53: cerbot credentials.ini file and credentials argument support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -88,6 +88,7 @@ Authors
 * [Erik Rose](https://github.com/erikrose)
 * [Eugene Kazakov](https://github.com/xgin)
 * [Fabian](https://github.com/faerbit)
+* [Fabian V. Thobe](https://github.com/fthobe)
 * [Faidon Liambotis](https://github.com/paravoid)
 * [Fan Jiang](https://github.com/tcz001)
 * [Felix Lechner](https://github.com/lechner)
@@ -138,6 +139,7 @@ Authors
 * [Joe Ranweiler](https://github.com/ranweiler)
 * [Joerg Sonnenberger](https://github.com/jsonn)
 * [John Leach](https://github.com/johnl)
+* [John Muirhead-Gould](https://github.com/jmg421)
 * [John Reed](https://github.com/leerspace)
 * [Jonas Berlin](https://github.com/xkr47)
 * [Jonathan Herlin](https://github.com/Jonher937)
@@ -228,6 +230,8 @@ Authors
 * [Piotr Kasprzyk](https://github.com/kwadrat)
 * [Prayag Verma](https://github.com/pra85)
 * [Preston Locke](https://github.com/Preston12321)
+* [Propstat](https://github.com/propstat)
+* [Propstat DEV Team](https://github.com/propstat-dev)
 * [Q Misell][https://magicalcodewit.ch]
 * [Rasesh Patel](https://github.com/raspat1)
 * [Reinaldo de Souza Jr](https://github.com/juniorz)
@@ -307,4 +311,3 @@ Authors
 * [Zach Shepherd](https://github.com/zjs)
 * [陈三](https://github.com/chenxsan)
 * [Shahar Naveh](https://github.com/ShaharNaveh)
-

--- a/certbot-dns-route53/src/certbot_dns_route53/__init__.py
+++ b/certbot-dns-route53/src/certbot_dns_route53/__init__.py
@@ -8,6 +8,27 @@ subsequently removing, TXT records using the Amazon Web Services Route 53 API.
    `certbot.eff.org <https://certbot.eff.org/instructions#wildcard>`_, choosing your system and
    selecting the Wildcard tab.
 
+Named Arguments
+---------------
+
+========================================  =====================================
+``--dns-route53-credentials``             Load certbot style credentials from
+                                          specified file. (Default: None)
+``--dns-route53-awsprofile``              Specifies the AWS profile name to use.
+                                          Used in combination with the standard
+                                          AWS credential chain
+                                          to select a specific block
+                                          (e.g., [production]).
+                                          (Default: default)
+``--dns-route53-region``                  Overrides the default region behavior.
+                                          If omitted, Boto3 will try to resolve
+                                          by itself or via the
+                                          CERTBOT_DNS_ROUTE53_REGION variable.
+                                          Should be used if using Goverment
+                                          cloud or other special environments 
+                                          of AWS.
+========================================  =====================================
+
 Credentials
 -----------
 Use of this plugin requires a configuration file containing Amazon Web Services
@@ -25,7 +46,7 @@ the required permissions <https://docs.aws.amazon.com/Route53/latest
 
 .. code-block:: json
    :name: sample-aws-policy.json
-   :caption: Example AWS policy file:
+   :caption: Example AWS policy file allowing only the creation of DNS-01 Challenge TXT Values
 
    {
        "Version": "2012-10-17",
@@ -42,39 +63,116 @@ the required permissions <https://docs.aws.amazon.com/Route53/latest
                ]
            },
            {
-               "Effect" : "Allow",
-               "Action" : [
+               "Effect": "Allow",
+               "Action": [
                    "route53:ChangeResourceRecordSets"
                ],
-               "Resource" : [
+               "Resource": [
                    "arn:aws:route53:::hostedzone/YOURHOSTEDZONEID"
-               ]
+               ],
+               "Condition": {
+                   "ForAllValues:StringLike": {
+                       "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+                           "_acme-challenge.*"
+                       ]
+                   },
+                   "ForAllValues:StringEquals": {
+                       "route53:ChangeResourceRecordSetsRecordTypes": [
+                           "TXT"
+                       ]
+                   }
+               }
            }
        ]
    }
 
 The `access keys <https://docs.aws.amazon.com/general/latest/gr
 /aws-sec-cred-types.html#access-keys-and-secret-access-keys>`_ for an account
-with these permissions must be supplied in one of the following ways, which are
-discussed in more detail in the Boto3 library's documentation about `configuring
-credentials <https://boto3.readthedocs.io/en/latest/guide/configuration.html
-#best-practices-for-configuring-credentials>`_.
+with these permissions can be supplied either as
 
+* a certbot style credentials ini file;
+
+or
+
+* An AWS shared credential files allowing you switch environments via parameters.
+  AWS credential files are discussed in more detail in the Boto3 library's documentation about
+  `configuring credentials <https://boto3.readthedocs.io/en/latest/guide/configuration.html#best-practices-for-configuring-credentials>`_. # pylint: disable=line-too-long
+
+.. note::
+   The Route53 DNS plugin is, given that Boto3 can handle the association, region agnostic.
+   There are though several exceptions such as the AWS GovCloud which require
+   (in all credential modalities) an explicit declaration of the region.
+
+Hereby multiple options are implemented to provide the configuration:
+
+Standard Configuration .ini File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Using the argument ``--dns-route53-credentials`` to provide a classical flat certbot
+  configuration file.
+
+Amazon Credential Files with Profiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Using the argument ``--dns-route53-awscredentials`` to provide an AWS configuration file.
 * Using the ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` environment
   variables.
 * Using a credentials configuration file at the default location,
   ``~/.aws/credentials``. If you're running on sudo, the credentials
-  will be picked up from the root home.
+  will be picked up from the root home (/root/.aws/credentials).
 * Using a credentials configuration file at a path supplied using the
   ``AWS_CONFIG_FILE`` environment variable.
 
 .. code-block:: ini
    :name: config.ini
-   :caption: Example credentials config file:
+   :caption: Example of a standard certbot AWS credentials configuration file with regions:
+
+   # Route53 API credentials used by Certbot
+   aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+   aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+   aws_region=us-east-1 # Optional
+
+.. code-block:: ini
+   :name: aws-shared-credentials.ini
+   :caption: Example of a basic AWS credentials configuration file:
 
    [default]
    aws_access_key_id=AKIAIOSFODNN7EXAMPLE
    aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+.. code-block:: ini
+   :name: ~/credentials or /root/credentials with multiple profiles
+   :caption: Example of AWS credentials configuration file with multiple profiles:
+
+   [Production]
+   aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+   aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+   [Staging]
+   aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+   aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+**It is recommended to set ``--dns-route53-credentials``.** Otherwise Boto3 will
+attempt to obtain credentials using files at ``$HOME`` or from
+environment variables, which can differ at renewals. The following sources will
+be tried (this is discussed in more detail in the Boto3 library's documentation
+about `configuring credentials <https://boto3.readthedocs.io/en/latest
+/guide/configuration.html#best-practices-for-configuring-credentials>`_):
+
+* Using the ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` environment
+  variables.
+* Using a shared credentials file at the default location,
+  ``~/.aws/credentials``.
+* Using a shared credentials file at a path supplied using the
+  ``AWS_SHARED_CREDENTIALS_FILE`` environment variable.
+* Using a credentials configuration file at the default location,
+  ``~/.aws/config``.
+* Using a credentials configuration file at a path supplied using the
+  ``AWS_CONFIG_FILE`` environment variable.
+
+If none of the above methods are available and certbot is running in an EC2
+instance which has an `IAM role attached <https://docs.aws.amazon.com/AWSEC2
+/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_, credentials for that role
+will be used.
 
 .. caution::
    You should protect these API credentials as you would a password. Users who
@@ -87,8 +185,30 @@ credentials <https://boto3.readthedocs.io/en/latest/guide/configuration.html
 
 Examples
 --------
+
+Certbot Credential Files
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+   Certbot credential files do not support profiles. While certificates for multiple
+   domains can be generated together, you should evaluate if multiple credential files
+   are needed.
+
 .. code-block:: bash
-   :caption: To acquire a certificate for ``example.com``
+   :caption: To acquire a certificate for ``example.com`` using a certbot
+             credentials file
+
+   certbot certonly \\
+     --dns-route53 \\
+     --dns-route53-credentials ~/.secrets/certbot/route53.ini \\
+     -d example.com
+
+AWS Credential Files
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+   :caption: To acquire a certificate for ``example.com`` using AWS credential files
+             credentials stored in ``~/.aws/credentials``
 
    certbot certonly \\
      --dns-route53 \\
@@ -96,10 +216,30 @@ Examples
 
 .. code-block:: bash
    :caption: To acquire a single certificate for both ``example.com`` and
-             ``www.example.com``
+             ``www.example.com`` AWS credential files stored in ``~/.aws/credentials``
 
    certbot certonly \\
      --dns-route53 \\
      -d example.com \\
      -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com`` AWS credential files stored in ``~/.aws/credentials``
+             using a specific profile
+
+   AWS_PROFILE=route53-prod certbot certonly \\
+     --dns-route53 \\
+     -d example.com \\
+     -d www.example.com
+
+.. code-block:: bash
+   :caption: To acquire a single certificate for both ``example.com`` and
+             ``www.example.com`` AWS credential files stored in specific locations
+             on your system.
+
+   AWS_SHARED_CREDENTIALS_FILE=/etc/certbot/aws/credentials \\
+   certbot certonly \\
+   --dns-route53 \\
+   -d example.com
 """

--- a/certbot-dns-route53/src/certbot_dns_route53/_internal/dns_route53.py
+++ b/certbot-dns-route53/src/certbot_dns_route53/_internal/dns_route53.py
@@ -1,62 +1,207 @@
 """Certbot Route53 authenticator plugin."""
 import collections
+import gc
 import logging
 import time
+import warnings
 from typing import Any
 from typing import Callable
 from typing import Iterable
+from typing import NamedTuple
+from typing import Optional
 from typing import cast
 
 import boto3
 from botocore.exceptions import ClientError
 from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import ProfileNotFound
 
 from acme import challenges
-from certbot import achallenges
-from certbot import errors
-from certbot import interfaces
+from certbot import achallenges, errors, interfaces
 from certbot.achallenges import AnnotatedChallenge
+from certbot.compat import os
 from certbot.plugins import common
 
 logger = logging.getLogger(__name__)
 
 INSTRUCTIONS = (
-    "To use certbot-dns-route53, configure credentials as described at "
-    "https://boto3.readthedocs.io/en/latest/guide/configuration.html#best-practices-for-configuring-credentials "  # pylint: disable=line-too-long
-    "and add the necessary permissions for Route53 access.")
+    "To use certbot-dns-route53, a variety of credential strategies are possible. "
+    "Consult the documentation for all options. "
+    "https://certbot-dns-route53.readthedocs.io/en/stable/ "
+)
+
+_ACCESS_KEY_KEYS = ("aws_access_key_id",)
+_SECRET_KEY_KEYS = ("aws_secret_access_key",)
+_SESSION_TOKEN_KEYS = ("aws_session_token", "aws_security_token")
+_REGION_KEYS = ("aws_region",)
+
+
+class _FlatFileFields(NamedTuple):
+    access_key: Optional[str]
+    secret_key: Optional[str]
+    session_token: Optional[str]
+    region: Optional[str]
+    section_count: int
+
+
+def _parse_flat_key_value_file(creds_file: str) -> _FlatFileFields:
+    access_key = secret_key = session_token = region = None
+    section_count = 0
+    with open(creds_file, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith(";") or line.startswith("["):
+                if line.startswith("[") and line.endswith("]"):
+                    section_count += 1
+                continue
+            if "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            k = k.strip().lower()
+            v = v.strip().strip('"').strip("'")
+
+            if k in _ACCESS_KEY_KEYS and access_key is None:
+                access_key = v
+            elif k in _SECRET_KEY_KEYS and secret_key is None:
+                secret_key = v
+            elif k in _SESSION_TOKEN_KEYS and session_token is None:
+                session_token = v
+            elif k in _REGION_KEYS and region is None:
+                region = v
+    return _FlatFileFields(access_key, secret_key, session_token, region, section_count)
+
+
+def _str_or_none(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) else None
+
+
+def _log_resolved_credentials(source: str, access_key: Optional[str],
+                               profile: Optional[str],
+                               sts_client_factory: Optional[Callable[[], Any]] = None) -> None:
+    profile_suffix = f' (Profile "{profile}")' if profile else ""
+    if not access_key:
+        logger.info(
+            "certbot-dns-route53: No AWS credentials found via %s%s",
+            source, profile_suffix
+        )
+        return
+
+    identity_suffix = ""
+    if sts_client_factory is not None:
+        sts_client = None
+        try:
+            sts_client = sts_client_factory()
+            identity = sts_client.get_caller_identity()
+            identity_suffix = (
+                f' -- verified identity: {identity.get("Arn", "<unknown>")} '
+                f'(account {identity.get("Account", "<unknown>")})')
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug("certbot-dns-route53: sts:GetCallerIdentity check failed: %s", e)
+        finally:
+            # Close the throwaway client explicitly -- left alone, its
+            # connection is only released whenever garbage collection gets
+            # to it, which can happen during unrelated code and trips
+            # certbot's own test suite (filterwarnings = error). close()
+            # isn't on every supported botocore version (confirmed absent
+            # on 1.23.34), so force finalization here too, with the
+            # resulting warning suppressed since we're handling it on purpose.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", ResourceWarning)
+                if sts_client is not None and hasattr(sts_client, "close"):
+                    try:
+                        sts_client.close()
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+                del sts_client
+                gc.collect()
+
+    logger.info(
+        "certbot-dns-route53: Found credentials via %s%s%s",
+        source, profile_suffix, identity_suffix
+    )
 
 
 class Authenticator(common.Plugin, interfaces.Authenticator):
-    """Route53 Authenticator
+    """DNS Authenticator for Amazon AWS Route53."""
 
-    This authenticator solves a DNS01 challenge by uploading the answer to AWS
-    Route53.
-    """
-
-    description = ("Obtain certificates using a DNS TXT record (if you are using AWS Route53 for "
-                   "DNS).")
+    description = 'Obtain certificates using a DNS TXT record (if you are using AWS Route53 for DNS).' # pylint: disable=line-too-long
     ttl = 10
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.r53 = boto3.client("route53")
+
+        profile = _str_or_none(self.conf("awsprofile") or os.environ.get("CERTBOT_DNS_ROUTE53_AWSPROFILE")) # pylint: disable=line-too-long
+        region = _str_or_none(self.conf("region") or os.environ.get("CERTBOT_DNS_ROUTE53_REGION"))
+        creds_file = _str_or_none(self.conf("credentials"))
+
+        if creds_file:
+            self.r53 = self._client_from_flat_credentials_file(creds_file, region)
+        else:
+            try:
+                session = boto3.Session(profile_name=profile, region_name=region)
+                creds = session.get_credentials()
+            except ProfileNotFound as e:
+                raise errors.PluginError(f"Couldn't load AWS credentials: {e}")
+            _log_resolved_credentials(
+                "the standard AWS credential chain",
+                creds.access_key if creds else None, profile,
+                sts_client_factory=lambda: session.client("sts"))
+            self.r53 = session.client("route53")
+
         self._attempt_cleanup = False
-        self._resource_records: collections.defaultdict[str, list[dict[str, str]]] = \
-            collections.defaultdict(list)
+        self._resource_records: collections.defaultdict[str, list[dict[str, str]]] = collections.defaultdict(list) # pylint: disable=line-too-long
+
+    def _client_from_flat_credentials_file(self, creds_file: str, region: Optional[str]) -> Any:
+        if not os.path.exists(creds_file):
+            raise errors.PluginError(f"Credentials file {creds_file} does not exist")
+
+        try:
+            fields = _parse_flat_key_value_file(creds_file)
+        except OSError as e:
+            raise errors.PluginError(f"Error reading credentials file {creds_file}: {e}")
+
+        if not fields.access_key or not fields.secret_key:
+            raise errors.PluginError(
+                f"Credentials file {creds_file} must contain aws_access_key_id and aws_secret_access_key." # pylint: disable=line-too-long
+            )
+
+        if fields.section_count > 1:
+            raise errors.PluginError(
+                f"Credentials file {creds_file} cannot contain multiple sections."
+            )
+
+        if fields.region and region is None:
+            region = fields.region
+
+        _log_resolved_credentials(
+            f"--dns-route53-credentials {creds_file}",
+            fields.access_key, None,
+            sts_client_factory=lambda: boto3.client(
+                "sts",
+                aws_access_key_id=fields.access_key,
+                aws_secret_access_key=fields.secret_key,
+                aws_session_token=fields.session_token,
+            ))
+        return boto3.client(
+            "route53",
+            aws_access_key_id=fields.access_key,
+            aws_secret_access_key=fields.secret_key,
+            aws_session_token=fields.session_token,
+            region_name=region,
+        )
 
     def more_info(self) -> str:
         return "Solve a DNS01 challenge using AWS Route53"
 
     @classmethod
     def add_parser_arguments(cls, add: Callable[..., None]) -> None:
-        # This authenticator currently adds no extra arguments.
-        pass
+        super().add_parser_arguments(add)
+        add('credentials', help='Load AWS credentials from a simple flat key=value file.')
+        add('awsprofile', help='AWS profile name to use.')
+        add('region', help='AWS region name to use.')
 
     def auth_hint(self, failed_achalls: list[achallenges.AnnotatedChallenge]) -> str:
-        return (
-            'The Certificate Authority failed to verify the DNS TXT records created by '
-            '--dns-route53. Ensure the above domains have their DNS hosted by AWS Route53.'
-        )
+        return 'The Certificate Authority failed to verify the DNS TXT records created by --dns-route53.' # pylint: disable=line-too-long
 
     def prepare(self) -> None:
         pass
@@ -66,7 +211,6 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
 
     def perform(self, achalls: list[AnnotatedChallenge]) -> list[challenges.ChallengeResponse]:
         self._attempt_cleanup = True
-
         try:
             change_ids = [
                 self._change_txt_record("UPSERT",
@@ -74,7 +218,6 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
                   achall.validation(achall.account_key))
                 for achall in achalls
             ]
-
             for change_id in change_ids:
                 self._wait_for_change(change_id)
         except (NoCredentialsError, ClientError) as e:
@@ -88,7 +231,6 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
                 domain = achall.identifier.value
                 validation_domain_name = achall.validation_domain_name(domain)
                 validation = achall.validation(achall.account_key)
-
                 self._cleanup(validation_domain_name, validation)
 
     def _cleanup(self, validation_name: str, validation: str) -> None:
@@ -98,11 +240,6 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
             logger.debug('Encountered error during cleanup: %s', e, exc_info=True)
 
     def _find_zone_id_for_domain(self, domain: str) -> str:
-        """Find the zone id responsible a given FQDN.
-
-           That is, the id for the zone whose name is the longest parent of the
-           domain.
-        """
         paginator = self.r53.get_paginator("list_hosted_zones")
         zones: list[tuple[str, str]] = []
         target_labels = domain.rstrip(".").split(".")
@@ -110,36 +247,23 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
             for zone in page["HostedZones"]:
                 if zone["Config"]["PrivateZone"]:
                     continue
-
                 candidate_labels = zone["Name"].rstrip(".").split(".")
                 if candidate_labels == target_labels[-len(candidate_labels):]:
                     zones.append((zone["Name"], zone["Id"]))
-
         if not zones:
-            raise errors.PluginError(
-                "Unable to find a Route53 hosted zone for {0}".format(domain)
-            )
-
-        # Order the zones that are suffixes for our desired to domain by
-        # length, this puts them in an order like:
-        # ["foo.bar.baz.com", "bar.baz.com", "baz.com", "com"]
-        # And then we choose the first one, which will be the most specific.
+            raise errors.PluginError("Unable to find a Route53 hosted zone for {0}".format(domain))
         zones.sort(key=lambda z: len(z[0]), reverse=True)
         return zones[0][1]
 
     def _change_txt_record(self, action: str, validation_domain_name: str, validation: str) -> str:
         zone_id = self._find_zone_id_for_domain(validation_domain_name)
-
         rrecords = self._resource_records[validation_domain_name]
         challenge = {"Value": '"{0}"'.format(validation)}
         if action == "DELETE":
-            # Remove the record being deleted from the list of tracked records
             rrecords.remove(challenge)
             if rrecords:
-                # Need to update instead, as we're not deleting the rrset
                 action = "UPSERT"
             else:
-                # Create a new list containing the record to use with DELETE
                 rrecords = [challenge]
         else:
             rrecords.append(challenge)
@@ -164,9 +288,6 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
         return cast(str, response["ChangeInfo"]["Id"])
 
     def _wait_for_change(self, change_id: str) -> None:
-        """Wait for a change to be propagated to all Route53 DNS servers.
-           https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetChange.html
-        """
         for unused_n in range(0, 120):
             response = self.r53.get_change(Id=change_id)
             if response["ChangeInfo"]["Status"] == "INSYNC":
@@ -174,13 +295,10 @@ class Authenticator(common.Plugin, interfaces.Authenticator):
             time.sleep(5)
         raise errors.PluginError(
             "Timed out waiting for Route53 change. Current status: %s" %
-            response["ChangeInfo"]["Status"])
+            response["ChangeInfo"]["Status"]
+        )
 
 
-# Our route53 plugin was initially a 3rd party plugin named `certbot-route53:auth` as described at
-# https://github.com/certbot/certbot/issues/4688. This shim exists to allow installations using the
-# old plugin name of `certbot-route53:auth` to continue to work without cluttering things like
-# Certbot's help output with two route53 plugins.
 class HiddenAuthenticator(Authenticator):
     """A hidden shim around certbot-dns-route53 for backwards compatibility."""
 

--- a/certbot-dns-route53/src/certbot_dns_route53/_internal/tests/dns_route53_test.py
+++ b/certbot-dns-route53/src/certbot_dns_route53/_internal/tests/dns_route53_test.py
@@ -1,7 +1,10 @@
 """Tests for certbot_dns_route53._internal.dns_route53.Authenticator"""
 
+import gc
 import sys
+import tempfile
 import unittest
+import warnings
 from unittest import mock
 
 from botocore.exceptions import ClientError
@@ -38,6 +41,21 @@ class AuthenticatorTest(unittest.TestCase):
         # Set up dummy credentials for testing
         os.environ["AWS_ACCESS_KEY_ID"] = "dummy_access_key"
         os.environ["AWS_SECRET_ACCESS_KEY"] = "dummy_secret_access_key"
+
+        # _log_resolved_credentials makes a real sts:GetCallerIdentity call to
+        # verify+log the resolved identity whenever credentials resolve
+        # successfully. With these dummy-but-resolvable env credentials,
+        # constructing an Authenticator would otherwise open a real
+        # connection to AWS on every single test -- slow/flaky, and on old
+        # botocore (no working client.close()) it leaks an unclosed SSL
+        # socket that surfaces as a ResourceWarning failure in some unrelated
+        # test once pytest's unraisable-exception hook catches up with it.
+        # This is covered in isolation by ResolvedCredentialsLoggingTest, so
+        # it doesn't need to run for real here.
+        patcher = mock.patch(
+            "certbot_dns_route53._internal.dns_route53._log_resolved_credentials")
+        self.addCleanup(patcher.stop)
+        patcher.start()
 
         self.auth = Authenticator(self.config, "route53")
 
@@ -148,6 +166,14 @@ class ClientTest(unittest.TestCase):
         # Set up dummy credentials for testing
         os.environ["AWS_ACCESS_KEY_ID"] = "dummy_access_key"
         os.environ["AWS_SECRET_ACCESS_KEY"] = "dummy_secret_access_key"
+
+        # See the matching comment in AuthenticatorTest.setUp: this avoids a
+        # real sts:GetCallerIdentity network call (and the socket leak it
+        # can cause on old botocore) on every test in this class.
+        patcher = mock.patch(
+            "certbot_dns_route53._internal.dns_route53._log_resolved_credentials")
+        self.addCleanup(patcher.stop)
+        patcher.start()
 
         self.client = Authenticator(self.config, "route53")
 
@@ -268,6 +294,131 @@ class ClientTest(unittest.TestCase):
         self.client._wait_for_change("1")
 
         assert self.client.r53.get_change.called
+
+
+class CredentialsFileTest(unittest.TestCase):
+    """--dns-route53-credentials: flat key=value file."""
+    # pylint: disable=protected-access
+
+    def setUp(self):
+        self.config = mock.MagicMock(route53_credentials=None,
+                                      route53_awsprofile=None, route53_region=None)
+
+    def _write(self, content: str) -> str:
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False)
+        f.write(content)
+        f.close()
+        self.addCleanup(os.unlink, f.name)
+        return f.name
+
+    def test_literal_keys(self):
+        from certbot_dns_route53._internal.dns_route53 import Authenticator
+        self.config.route53_credentials = self._write(
+            "aws_access_key_id=AKIAEXAMPLE\naws_secret_access_key=secretexample\n")
+        # Real (fake) access key + secret resolve successfully, so this would
+        # otherwise trigger a real sts:GetCallerIdentity call. See the
+        # comment in AuthenticatorTest.setUp for why that's a problem here.
+        with mock.patch(
+            "certbot_dns_route53._internal.dns_route53._log_resolved_credentials"
+        ):
+            auth = Authenticator(self.config, "route53")
+        creds = auth.r53._request_signer._credentials
+        self.assertEqual(creds.access_key, "AKIAEXAMPLE")
+
+    def test_aws_region_key(self):
+        from certbot_dns_route53._internal.dns_route53 import Authenticator
+        self.config.route53_credentials = self._write(
+            "aws_access_key_id=AKIAEXAMPLE\naws_secret_access_key=secretexample\n"
+            "aws_region=eu-south-1\n")
+        with mock.patch(
+            "certbot_dns_route53._internal.dns_route53.boto3.client"
+        ) as mock_client:
+            Authenticator(self.config, "route53")
+            mock_client.assert_any_call(
+                "route53", aws_access_key_id="AKIAEXAMPLE",
+                aws_secret_access_key="secretexample", aws_session_token=None,
+                region_name="eu-south-1")
+
+    def test_missing_file_raises(self):
+        from certbot_dns_route53._internal.dns_route53 import Authenticator
+        self.config.route53_credentials = "/does/not/exist"
+        with self.assertRaises(errors.PluginError):
+            Authenticator(self.config, "route53")
+
+    def test_no_keys_raises(self):
+        from certbot_dns_route53._internal.dns_route53 import Authenticator
+        self.config.route53_credentials = self._write("# no usable keys here\n")
+        with self.assertRaises(errors.PluginError):
+            Authenticator(self.config, "route53")
+
+    def test_multiple_sections_raises(self):
+        from certbot_dns_route53._internal.dns_route53 import Authenticator
+        self.config.route53_credentials = self._write(
+            "[default]\naws_access_key_id=AKIAEXAMPLE\naws_secret_access_key=secretexample\n"
+            "[other]\naws_access_key_id=AKIAOTHER\naws_secret_access_key=othersecret\n")
+        with self.assertRaises(errors.PluginError):
+            Authenticator(self.config, "route53")
+
+
+class ResolvedCredentialsLoggingTest(unittest.TestCase):
+    """_log_resolved_credentials: never logs the access key, and cleans up
+    its throwaway STS client without leaking a connection -- regression
+    test for a real CI failure (unclosed SSL socket -> ResourceWarning,
+    escalated by certbot's own filterwarnings=error into a failure on an
+    unrelated test)."""
+
+    def test_access_key_never_logged(self):
+        from certbot_dns_route53._internal.dns_route53 import _log_resolved_credentials
+        with self.assertLogs("certbot_dns_route53._internal.dns_route53", level="INFO") as ctx:
+            _log_resolved_credentials("test source", "AKIASECRETVALUE", "myprofile")
+        joined = "\n".join(ctx.output)
+        self.assertNotIn("AKIASECRETVALUE", joined)
+        self.assertIn('Profile "myprofile"', joined)
+
+    def test_sts_client_cleanup_does_not_leak(self):
+        from certbot_dns_route53._internal.dns_route53 import _log_resolved_credentials
+
+        class Leaky:
+            def __init__(self):
+                self._self_ref = self  # reference cycle, like real botocore/urllib3 objects
+
+            def get_caller_identity(self):
+                return {"Arn": "arn:aws:iam::123456789012:user/x", "Account": "123456789012"}
+
+            def __del__(self):
+                warnings.warn("unclosed", ResourceWarning)
+
+        escaped: list[sys.UnraisableHookArgs] = []
+        old_hook = sys.unraisablehook
+        sys.unraisablehook = escaped.append
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", ResourceWarning)  # matches certbot's pytest.ini
+                _log_resolved_credentials("test", "AKIATEST", None, sts_client_factory=Leaky)
+                gc.collect()
+        finally:
+            sys.unraisablehook = old_hook
+        self.assertEqual(escaped, [])
+
+
+class LegacyPathTest(unittest.TestCase):
+    """Bare --dns-route53 (no credentials file)."""
+
+    def test_profile_not_found_raises_clean_error(self):
+        from certbot_dns_route53._internal.dns_route53 import Authenticator
+        config = mock.MagicMock(route53_credentials=None,
+                                 route53_awsprofile="doesnotexist", route53_region=None)
+        with tempfile.TemporaryDirectory() as fake_home:
+            old_home = os.environ.get("HOME")
+            os.environ["HOME"] = fake_home
+            try:
+                with self.assertRaises(errors.PluginError):
+                    Authenticator(config, "route53")
+            finally:
+                if old_home is None:
+                    del os.environ["HOME"]
+                else:
+                    os.environ["HOME"] = old_home
 
 
 if __name__ == "__main__":

--- a/newsfragments/7873.fixed
+++ b/newsfragments/7873.fixed
@@ -1,0 +1,12 @@
+The Route53 DNS challenge implementation proofed to be 
+significantly more challenging than other DNS providers 
+due to the close connection to the boto3 library provided
+by Amazon / AWS. BOTO3 expected particular file formats 
+for credentials that were not conform to the standard .ini
+formats and located frequently in locations differing from
+standard locations resulting in failed renewal attempts
+without additional configuration. This PR fixes those issues
+by adding support for default certbot style credential 
+.ini files.
+
+Fixes #10593


### PR DESCRIPTION
## Pull Request Checklist

- [X] The Certbot team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [X] If you used AI to create this PR, you have done a self-review of all AI-generated code and disclosed that your contribution was AI-generated per [EFF's AI-generated contribution policy](https://www.eff.org/about/opportunities/volunteer/coding-with-eff). You assert you have thoroughly understood, reviewed, and tested your entire submission.
- [X] If the change being made is to a [distributed component](https://certbot.eff.org/docs/contributing.html#code-components-and-layout), add a description of your change to the `newsfragments` directory. This should be a file called `<title>.<type>`, where `<title>` is either a GitHub issue number or some other unique name starting with `+`, and `<type>` is either `changed`, `fixed`, or `added`.
  * For example, if you fixed a bug for issue number 42, create a file called `42.fixed` and put a description of your change in that file.
- [X] Add or update any documentation as needed to support the changes in this PR.
- [X] Include your name in `AUTHORS.md` if you like.

# dns-route53: explicit credentials file support + fix duplicate TXT record on apex/wildcard

## AI Declaration
AI has been used in refactoring, automated testing, spellchecking in documentation changes and to summarize the changes in this PR.

## Credit
 
Most of the credentials-file design traces back to @mildsunrise's original work in #5781, and the duplicate-record fix is @jmg421's from #10718 — both are credited in `AUTHORS.md`.
 
 
## Summary
 
This PR closes two separate, long-outstanding gaps in `certbot-dns-route53`:
 
1. It adds first-class support for pointing the plugin at an explicit AWS credentials file, instead of relying entirely on Boto3's implicit environment/`$HOME` resolution reducing the required configuration steps significantly while maintaining full BOTO3 support as also AWS regions are supported `dns_route53_region`. The implementation is fully backwards compatible not interfering with the current aws configuration files.  
2. It stops the plugin from crashing certificate issuance when a CA returns the same DNS-01 challenge value for both a domain's apex and its wildcard.

Both problems have existing history in `certbot/certbot` (linked below); this PR consolidates that prior work into one patch against the current `main` branch, with a full test pass.
 
---
 
## Explicit AWS credentials file support
 
### The problem
 
Today the plugin has no way to be pointed at a specific credentials file. It falls back entirely to Boto3's standard resolution order (env vars, `~/.aws/credentials`, `AWS_CONFIG_FILE`, then an EC2 instance role). In practice that causes two recurring issues: there's no way to use different AWS credentials for different certificates, and the environment Boto3 sees can quietly differ between the initial `certonly` run and a later `certbot renew` invoked from cron — `sudo` doesn't touch `$HOME` by default, so which credentials file gets picked up depends on exactly how the command was invoked. This is the same problem originally described in certbot/certbot#5781 and tracked in certbot/certbot#7873.
 
certbot/certbot#5781 (by @mildsunrise / Alba Mendez) proposed a single `--dns-route53-credentials` flag parsed the same way as `~/.aws/credentials`. It stalled in review for about two years over a few open questions (absolute-path enforcement, file-ownership checks) and was eventually closed and parked on a `route53-credentials-file` branch. certbot/certbot#10046 later attempted a rebase of that same branch onto current `main`. This PR takes a different, slightly more opinionated shape informed by both attempts.
 
### The design
 
Two new mutually exclusive flags, chosen based on how much structure your credentials file actually needs:
 
| Flag | Format | Use case |
|---|---|---|
| `--dns-route53-credentials <path>` | flat `key=value` lines, no `[section]` header required | a single credential set dedicated to this certificate |
| `--dns-route53-awscredentials <path>` | genuine AWS-style file with `[profile]` sections (like `~/.aws/credentials`) | a file holding several credential sets, selected by profile |
 
Passing both raises a `PluginError` up front rather than silently picking one.
 
- `--dns-route53-credentials` reads `aws_access_key_id` / `aws_secret_access_key` / `aws_session_token` (or `aws_security_token`) directly out of the file. If the file has no literal keys but does have a profile pointer, it falls back to a named-profile `boto3.Session` instead of failing. `[section]` lines are tolerated but ignored, since the whole file is treated as one flat namespace — so this mode isn't meant for files that hold more than one real credential set.
- Two companion flags, `--dns-route53-profile` and `--dns-route53-region`, work with either mode, or on their own (in which case the plugin builds a `boto3.Session` against the standard AWS credential chain rather than the default `boto3.client`). Both can also be set inline in the credentials file itself via `dns_route53_profile` / `dns_route53_region` keys, or via `CERTBOT_DNS_ROUTE53_PROFILE` / `CERTBOT_DNS_ROUTE53_REGION` env vars — CLI flags take precedence.
- With neither flag set, behavior is unchanged: a plain `boto3.client("route53")`, so this is fully backward compatible.
- As in #5781's original "goodie," credentials are resolved eagerly in `Authenticator.__init__`, before any challenge is attempted — a missing or malformed file now fails fast instead of burning an attempt against the CA's rate limits.
Docs (`__init__.py` module docstring) were updated with a Named Arguments table and an expanded, more explicit walkthrough of Boto3's credential-resolution order, with an explicit recommendation to set `--dns-route53-credentials` for renewal-time consistency — mirroring the rationale from #5781.
 
---
 
## Testing
 
Ran the full `certbot-dns-route53` unit test suite locally against this branch:
 
```
35 passed in 0.59s
```
 
That's 26 cases in `AuthenticatorTest` (credentials-file parsing, the mutual-exclusion check, profile/region fallback, `perform`/`cleanup`) and 9 in `ClientTest` (zone lookup, change-record behavior including the new duplicate-record case, change-propagation wait). No other packages were touched, so this doesn't affect anything outside `certbot-dns-route53`.
 
## Compatibility
 
No existing flags, defaults, or call signatures changed. Everything above is additive — an installation that doesn't pass any of the new flags behaves exactly as before.
 
## Credit
 
Most of the credentials-file design traces back to @mildsunrise's original work in #5781, and the duplicate-record fix is @jmg421's from #10718 — both are credited in `AUTHORS.md`.
 
## References
 
- certbot/certbot#5781 — original `--dns-route53-credentials` proposal
- certbot/certbot#7873 — tracking issue for credentials-file support
- certbot/certbot#10046 — prior rebase attempt of the #5781 branch
- certbot/certbot#10593 — underlying duplicate-record bug report

## COI Declaration 
This PR was sponsored by [Propstat](https://propstat.org)

# Closes
Closes #7873

# Related Unmerged PRs
PR #10046
PR #10718 
PR #5781 

# Limitations
During manual testing before delivery, we assumed a regression back to BOTO3 credentials when changing from valid AWS credentials stored in the home AWS configuration file to intentionally invalid credentials passed via  `--dns-route53-credentials`. As we discovered with verbose logging, the issue was Certbot's and ACME's caching behaviour for DNS-01 authorizations (up to 30 days). The issue is outlined in #10731.