### PR TITLE
Remove deprecated domain attribute of certbot.AnnotatedChallenge

### DIFF
--- a/certbot-compatibility-test/src/certbot_compatibility_test/test_driver.py
+++ b/certbot-compatibility-test/src/certbot_compatibility_test/test_driver.py
@@ -113,7 +113,9 @@ def _create_achalls(plugin: common.Proxy) -> list[achallenges.AnnotatedChallenge
                 challb = acme_util.chall_to_challb(
                     chall, messages.STATUS_PENDING)
                 achall = achallenges.KeyAuthorizationAnnotatedChallenge(
-                    challb=challb, domain=domain, account_key=util.JWK)
+                    challb=challb, identifier=messages.Identifier(
+                        typ=messages.IDENTIFIER_FQDN, value=domain),
+                    account_key=util.JWK)
                 achalls.append(achall)
 
     return achalls

--- a/certbot/src/certbot/achallenges.py
+++ b/certbot/src/certbot/achallenges.py
@@ -10,7 +10,8 @@ and :class:`.ChallengeBody` (denoted by ``challb``)::
 
   chall = challenges.DNS(token='foo')
   challb = messages.ChallengeBody(chall=chall)
-  achall = achallenges.DNS(chall=challb, domain='example.com')
+  achall = achallenges.DNS(chall=challb, identifier=messages.Identifier(
+      typ=messages.IDENTIFIER_FQDN, value='example.com'))
 
 Note, that all annotated challenges act as a proxy objects::
 
@@ -19,14 +20,11 @@ Note, that all annotated challenges act as a proxy objects::
 """
 import logging
 from typing import Any
-import warnings
 
 import josepy as jose
 
-from acme import challenges, messages
+from acme import challenges
 from acme.challenges import Challenge
-
-from certbot import errors
 
 logger = logging.getLogger(__name__)
 
@@ -46,47 +44,10 @@ class AnnotatedChallenge(jose.ImmutableMap):
     def __getattr__(self, name: str) -> Any:
         return getattr(self.challb, name)
 
-    def __getattribute__(self, name: str) -> Any:
-        if name == 'domain':
-            warnings.warn("The domain attribute is deprecated and will be removed in "
-                        "an upcoming release. Access the AnnotatedChallenge.identifier.value "
-                        "attribute instead",
-                        DeprecationWarning)
-        return super().__getattribute__(name)
-
-    def __hash__(self) -> int:
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', 'the domain attribute is deprecated')
-            return super().__hash__()
-
-    def __eq__(self, other: Any) -> bool:
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', 'the domain attribute is deprecated')
-            return super().__eq__(other)
-
-    def __init__(self, **kwargs: Any) -> None:
-        if 'domain' in kwargs:
-            if 'identifier' in kwargs:
-                raise errors.Error("AnnotatedChallenge takes either domain or identifier, not both")
-            warnings.warn("The domain attribute is deprecated and will be removed in "
-                          "an upcoming release. Replace domain=<domain> with "
-                          "identifier=messages.Identifier(typ=messages.IDENTIFIER_FQDN, "
-                          "value=<domain>)",
-                          DeprecationWarning)
-        if 'identifier' not in kwargs:
-            kwargs['identifier'] = messages.Identifier(
-                typ=messages.IDENTIFIER_FQDN, value=kwargs['domain'])
-        if 'domain' not in kwargs:
-            if kwargs['identifier'].typ == messages.IDENTIFIER_FQDN:
-                kwargs['domain'] = kwargs['identifier'].value
-            else:
-                kwargs['domain'] = None
-        super().__init__(**kwargs)
-
 
 class KeyAuthorizationAnnotatedChallenge(AnnotatedChallenge):
     """Client annotated `KeyAuthorizationChallenge` challenge."""
-    __slots__ = ('challb', 'domain', 'account_key', 'identifier') # pylint: disable=redefined-slots-in-subclass
+    __slots__ = ('challb', 'account_key', 'identifier') # pylint: disable=redefined-slots-in-subclass
 
     def response_and_validation(self, *args: Any, **kwargs: Any
         ) -> tuple['challenges.KeyAuthorizationChallengeResponse', Any]:
@@ -97,10 +58,10 @@ class KeyAuthorizationAnnotatedChallenge(AnnotatedChallenge):
 
 class DNS(AnnotatedChallenge):
     """Client annotated "dns" ACME challenge."""
-    __slots__ = ('challb', 'domain', 'identifier') # pylint: disable=redefined-slots-in-subclass
+    __slots__ = ('challb', 'identifier') # pylint: disable=redefined-slots-in-subclass
     acme_type = challenges.DNS
 
 class Other(AnnotatedChallenge):
     """Client annotated ACME challenge of an unknown type."""
-    __slots__ = ('challb', 'domain', 'identifier') # pylint: disable=redefined-slots-in-subclass
+    __slots__ = ('challb', 'identifier') # pylint: disable=redefined-slots-in-subclass
     acme_type = challenges.Challenge

--- a/newsfragments/10640.removed
+++ b/newsfragments/10640.removed
@@ -1,0 +1,4 @@
+The deprecated `domain` attribute of `certbot.achallenges.AnnotatedChallenge` has
+been removed. Use `AnnotatedChallenge.identifier.value` instead, and pass
+`identifier=messages.Identifier(typ=messages.IDENTIFIER_FQDN, value=<domain>)`
+when constructing annotated challenges.


### PR DESCRIPTION
Fixes #10640.

Removes the `domain` attribute of `certbot.achallenges.AnnotatedChallenge`, deprecated in #10491:

- Dropped `domain` from `__slots__` of all subclasses, along with the `__init__`/`__getattribute__`/`__hash__`/`__eq__` deprecation shims (the class reverts to a plain `jose.ImmutableMap` proxy).
- Migrated the last in-tree caller (`certbot-compatibility-test/test_driver.py`) to `identifier=messages.Identifier(...)`.
- Updated the module docstring example and added a `newsfragments/10640.removed` entry.

All 708 core plugin/auth-handler tests plus route53 tests pass locally with `-W error::DeprecationWarning`.


---

**AI disclosure:** This PR was AI-assisted — I used an AI coding tool to draft the changes. I have reviewed, understood, and tested the full diff myself. Apologies for not checking the disclosure box on submission; that was an oversight, not an attempt to hide it.