### PR TITLE
Drop stale plugin options from renewal config when switching plugins

### DIFF
--- a/certbot/src/certbot/_internal/storage.py
+++ b/certbot/src/certbot/_internal/storage.py
@@ -268,20 +268,32 @@ def _write_live_readme_to(readme_path: str, is_base_dir: bool = False) -> None:
                                     "certificates.\n".format(prefix=prefix))
 
 
-def _relevant(namespaces: Iterable[str], option: str) -> bool:
+def _relevant(namespaces: Iterable[str], used_namespaces: Iterable[str], option: str) -> bool:
     """
     Is this option one that could be restored for future renewal purposes?
 
+    Plugin-specific options (those prefixed by a plugin's dest namespace)
+    are only relevant if they belong to a plugin currently in use as the
+    authenticator or installer. This prevents stale options from a
+    previously used plugin from being persisted after switching plugins
+    (e.g. with ``certbot reconfigure``). See
+    https://github.com/certbot/certbot/issues/10736.
+
     :param namespaces: plugin namespaces for configuration options
     :type namespaces: `list` of `str`
+    :param used_namespaces: namespaces of the plugins currently in use
+    :type used_namespaces: `list` of `str`
     :param str option: the name of the option
 
     :rtype: bool
     """
     from certbot._internal import renewal
 
-    return (option in renewal.CONFIG_ITEMS or
-            any(option.startswith(namespace) for namespace in namespaces))
+    if option in renewal.CONFIG_ITEMS:
+        return True
+    if any(option.startswith(namespace) for namespace in namespaces):
+        return any(option.startswith(namespace) for namespace in used_namespaces)
+    return False
 
 
 def relevant_values(config: configuration.NamespaceConfig) -> dict[str, Any]:
@@ -296,11 +308,17 @@ def relevant_values(config: configuration.NamespaceConfig) -> dict[str, Any]:
     all_values = config.to_dict()
     plugins = plugins_disco.PluginsRegistry.find_all()
     namespaces = [plugins_common.dest_namespace(plugin) for plugin in plugins]
+    used_plugins = {
+        plugin_name for plugin_name in (all_values.get("authenticator"),
+                                        all_values.get("installer"))
+        if isinstance(plugin_name, str)
+    }
+    used_namespaces = [plugins_common.dest_namespace(plugin) for plugin in used_plugins]
 
     rv = {
         option: value
         for option, value in all_values.items()
-        if _relevant(namespaces, option) and config.set_by_user(option)
+        if _relevant(namespaces, used_namespaces, option) and config.set_by_user(option)
     }
     # We always save the server value to help with forward compatibility
     # and behavioral consistency when versions of Certbot with different

--- a/certbot/src/certbot/_internal/tests/storage_test.py
+++ b/certbot/src/certbot/_internal/tests/storage_test.py
@@ -51,8 +51,25 @@ class RelevantValuesTest(unittest.TestCase):
         mock_find_all.return_value = ["certbot-foo:bar"]
         self.mock_config.set_by_user.return_value = True
 
+        self.values["authenticator"] = "certbot-foo:bar"
         self.values["certbot_foo:bar_baz"] = 42
         assert self._call(self.values.copy()) == self.values
+
+    @mock.patch("certbot._internal.plugins.disco.PluginsRegistry.find_all")
+    def test_unused_plugin_namespace_dropped(self, mock_find_all):
+        # Options belonging to a plugin that is not the current authenticator
+        # or installer should not be persisted. See
+        # https://github.com/certbot/certbot/issues/10736
+        mock_find_all.return_value = ["certbot-foo:bar", "webroot"]
+        self.mock_config.set_by_user.return_value = True
+
+        self.values["authenticator"] = "certbot-foo:bar"
+        self.values["certbot_foo:bar_baz"] = 42
+        expected_relevant_values = self.values.copy()
+        self.values["webroot_path"] = ["/var/www/html"]
+        self.values["webroot_map"] = {"example.com": "/var/www/html"}
+
+        assert self._call(self.values.copy()) == expected_relevant_values
 
     def test_option_set(self):
         self.mock_config.set_by_user.return_value = True

--- a/newsfragments/10736.fixed
+++ b/newsfragments/10736.fixed
@@ -1,0 +1,5 @@
+When saving a renewal configuration, Certbot now only persists plugin-specific
+options belonging to the currently used authenticator and installer. Previously,
+commands like `certbot reconfigure --authenticator <new-plugin>` would leave
+stale options from the old plugin (e.g. `webroot_path` and `webroot_map`) in the
+renewal configuration file.


### PR DESCRIPTION
Fixes #10736.

## Problem

Running `certbot reconfigure --cert-name example.com --authenticator dns-dnsimple ...` on a cert previously using `--webroot` left the old `webroot_path` and `[[webroot_map]]` entries in the renewal configuration file, producing an amalgamation of both plugins' settings.

## Root cause

During `reconfigure`, `renewal.reconstitute()` restores the old plugin's options onto the config at runtime, which marks them as `set_by_user` (ArgumentSource.RUNTIME). When `storage.relevant_values()` later serializes the config, it kept any option under *any* installed plugin's namespace, so the stale webroot options were written back out even though the authenticator had changed.

## Fix

`storage._relevant()` now only treats a plugin-namespaced option as relevant if it belongs to the plugin(s) currently in use as the authenticator or installer. Options under an unused plugin's namespace are dropped when the renewal config is saved.

This also means a normal `renew`/`certonly` save won't persist options for plugins that aren't in use, which matches the restore-side behavior in `renewal._restore_plugin_configs()` (it only ever restores options prefixed by the current authenticator/installer).

## Testing

- Updated `RelevantValuesTest.test_namespace` to set the authenticator, and added `test_unused_plugin_namespace_dropped` as a regression test.
- Full `certbot/_internal` suite passes: 1526 passed, 30 skipped.


---

**AI disclosure:** This PR was AI-assisted — I used an AI coding tool to draft the changes. I have reviewed, understood, and tested the full diff myself. Apologies for not checking the disclosure box on submission; that was an oversight, not an attempt to hide it.