### PR TITLE
build_remote.py: better detection of invalid snaps

### DIFF
--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -144,14 +144,17 @@ def _build_snap(
                 for arch in archs:
                     snap_path_list = glob.glob(join(workspace, f'{target}_*_{arch}.snap'))
                     assert len(snap_path_list) == 1
-                    with open(snap_path_list[0], 'r') as f:
+                    with open(snap_path_list[0], 'rb') as f:
+                        first_block = f.read(10)
+                        # 'hsqs' is the magic number that SquashFS files start with
+                        if first_block.startswith(b'hsqs'):
+                            continue
+                        failed_archs.add(arch)
                         try:
-                            first_line = f.readline().rstrip()
+                            first_block_str = first_block.decode()
                         except UnicodeDecodeError:
-                            first_line = ''
-                        if first_line == "<!DOCTYPE html>":
-                            failed_archs.add(arch)
-                            print(f'The {target} {arch} snap file contains html instead of a snap')
+                            first_block_str = first_block.hex()
+                        print(f'The {target} {arch} snap file began with invalid data: {first_block_str}')
                 dump_output = bool(failed_archs)
 
             if not dump_output:

--- a/tools/snap/build_remote.py
+++ b/tools/snap/build_remote.py
@@ -153,7 +153,7 @@ def _build_snap(
                         try:
                             first_block_str = first_block.decode()
                         except UnicodeDecodeError:
-                            first_block_str = first_block.hex()
+                            first_block_str = first_block.hex(sep=',')
                         print(f'The {target} {arch} snap file began with invalid data: {first_block_str}')
                 dump_output = bool(failed_archs)
 


### PR DESCRIPTION
Another attempt at fixing #10617. Seems the recent armhf builds resulted in slightly different HTML output, so instead of checking if the output matches a specific failure case, just check if we've actually got a SquashFS lookin file. According to https://dr-emann.github.io/squashfs/squashfs.html#_the_superblock, a SquashFS file starts with the magic number "hsqs".