### PR TITLE
dns-digitalocean: add API token scope docs and fix outdated URL

### DIFF
--- a/certbot-dns-digitalocean/src/certbot_dns_digitalocean/__init__.py
+++ b/certbot-dns-digitalocean/src/certbot_dns_digitalocean/__init__.py
@@ -31,10 +31,10 @@ Tokens page <https://cloud.digitalocean.com/account/api/tokens>`_.
 
 The API token requires the following scopes:
 
-- **domain** (read, create, update, delete)
+- **domain** (read, create, delete)
 
-These scopes allow Certbot to list your domains, create and delete TXT records
-for DNS challenges, and update domain TTL settings.
+These scopes allow Certbot to list your domains, and create and delete TXT records
+for DNS challenges.
 
 .. code-block:: ini
    :name: credentials.ini

--- a/certbot-dns-digitalocean/src/certbot_dns_digitalocean/__init__.py
+++ b/certbot-dns-digitalocean/src/certbot_dns_digitalocean/__init__.py
@@ -26,8 +26,15 @@ Credentials
 -----------
 
 Use of this plugin requires a configuration file containing DigitalOcean API
-credentials, obtained from your DigitalOcean account's `Applications & API
-Tokens page <https://cloud.digitalocean.com/settings/api/tokens>`_.
+credentials, obtained from your DigitalOcean account's `API
+Tokens page <https://cloud.digitalocean.com/account/api/tokens>`_.
+
+The API token requires the following scopes:
+
+- **domain** (read, create, update, delete)
+
+These scopes allow Certbot to list your domains, create and delete TXT records
+for DNS challenges, and update domain TTL settings.
 
 .. code-block:: ini
    :name: credentials.ini

--- a/newsfragments/10577.changed.md
+++ b/newsfragments/10577.changed.md
@@ -1,0 +1,2 @@
+Updated DigitalOcean DNS plugin documentation to list the required API token
+scopes and fix an outdated link to the DigitalOcean API token management page.

--- a/newsfragments/10577.changed.md
+++ b/newsfragments/10577.changed.md
@@ -1,2 +1,0 @@
-Updated DigitalOcean DNS plugin documentation to list the required API token
-scopes and fix an outdated link to the DigitalOcean API token management page.


### PR DESCRIPTION
## Summary

Update the DigitalOcean DNS plugin documentation to list the minimum required API token scopes and fix an outdated link.

## Motivation

The DigitalOcean DNS plugin docs currently do not mention what scopes a user needs when creating an API token. This leads to users either creating overly permissive tokens or getting confusing auth errors. The docs also link to an outdated DigitalOcean URL.

Fixes #10577

## Changes

- certbot-dns-digitalocean/src/certbot_dns_digitalocean/__init__.py: Added required scope documentation (domain: read, create, update, delete) and updated the API token page URL
- newsfragments/10577.changed.md: Added changelog entry

## Testing

Documentation-only change, no code changes.