### PR TITLE
Fix docstring :param: names that do not match the signatures

### DIFF
--- a/certbot/src/certbot/_internal/auth_handler.py
+++ b/certbot/src/certbot/_internal/auth_handler.py
@@ -240,7 +240,7 @@ class AuthHandler:
     def _get_chall_pref(self, identifier: str) -> list[type[challenges.Challenge]]:
         """Return list of challenge preferences.
 
-        :param str domain: domain for which you are requesting preferences
+        :param str identifier: domain for which you are requesting preferences
 
         """
         chall_prefs = []
@@ -369,7 +369,7 @@ def challb_to_achall(challb: messages.ChallengeBody, account_key: josepy.JWK,
 
     :param .ChallengeBody challb: ChallengeBody
     :param .JWK account_key: Authorized Account Key
-    :param str domain: Domain of the challb
+    :param str identifier: Domain of the challb
 
     :returns: Appropriate AnnotatedChallenge
     :rtype: :class:`certbot.achallenges.AnnotatedChallenge`

--- a/certbot/src/certbot/_internal/cert_manager.py
+++ b/certbot/src/certbot/_internal/cert_manager.py
@@ -118,8 +118,8 @@ def find_duplicative_certs(config: configuration.NamespaceConfig,
 
     :param config: Configuration.
     :type config: :class:`certbot._internal.configuration.NamespaceConfig`
-    :param domains: List of domain names
-    :type domains: `list` of `str`
+    :param sans: List of domain names
+    :type sans: `list` of `str`
 
     :returns: lineages representing the identically matching cert and the
         largest subset if they exist

--- a/certbot/src/certbot/_internal/display/obj.py
+++ b/certbot/src/certbot/_internal/display/obj.py
@@ -369,7 +369,7 @@ class FileDisplay:
     def _get_valid_int_ans(self, max_: int) -> tuple[str, int]:
         """Get a numerical selection.
 
-        :param int max: The maximum entry (len of choices), must be positive
+        :param int max_: The maximum entry (len of choices), must be positive
 
         :returns: tuple of the form (`code`, `selection`) where
             `code` - str display exit code ('ok' or cancel')

--- a/certbot/src/certbot/_internal/main.py
+++ b/certbot/src/certbot/_internal/main.py
@@ -1493,8 +1493,8 @@ def _csr_get_and_save_cert(config: configuration.NamespaceConfig,
     :param config: Configuration object
     :type config: configuration.NamespaceConfig
 
-    :param client: Client object
-    :type client: client.Client
+    :param le_client: Client object
+    :type le_client: client.Client
 
     :returns: `cert_path`, `chain_path` and `fullchain_path` as absolute
               paths to the actual files, or None for each if it's a dry-run.

--- a/certbot/src/certbot/_internal/plugins/apache/configurator.py
+++ b/certbot/src/certbot/_internal/plugins/apache/configurator.py
@@ -1164,8 +1164,8 @@ class ApacheConfigurator(common.Configurator):
 
     def _populate_vhost_names_v2(self, vhost: obj.VirtualHost) -> None:
         """Helper function that populates the VirtualHost names.
-        :param host: In progress vhost whose names will be added
-        :type host: :class:`~certbot._internal.plugins.apache.obj.VirtualHost`
+        :param vhost: In progress vhost whose names will be added
+        :type vhost: :class:`~certbot._internal.plugins.apache.obj.VirtualHost`
         """
         if not vhost.node:
             raise errors.PluginError("Current VirtualHost has no node.")  # pragma: no cover
@@ -2288,7 +2288,7 @@ class ApacheConfigurator(common.Configurator):
     def _get_proposed_addrs(self, vhost: obj.VirtualHost, port: str = "80") -> Iterable[obj.Addr]:
         """Return all addrs of vhost with the port replaced with the specified.
 
-        :param obj.VirtualHost ssl_vhost: Original Vhost
+        :param obj.VirtualHost vhost: Original Vhost
         :param str port: Desired port for new addresses
 
         :returns: `set` of :class:`~obj.Addr`

--- a/certbot/src/certbot/_internal/plugins/apache/parser.py
+++ b/certbot/src/certbot/_internal/plugins/apache/parser.py
@@ -376,8 +376,6 @@ class ApacheParser:
 
         :param str aug_conf_path: Augeas configuration path
         :param str mod: module ie. mod_ssl.c
-        :param bool beginning: If the IfModule should be created to the beginning
-            of augeas path DOM tree.
 
         :returns: Augeas path of the requested IfModule directive that pre-existed
             or was created during the process. The path may be dynamic,
@@ -620,7 +618,7 @@ class ApacheParser:
         """Determine if directive passes a filter.
 
         :param str match: Augeas path
-        :param list filter: list of tuples of form
+        :param list filter_: list of tuples of form
             [("lowercase if directive", set of relevant parameters)]
 
         """

--- a/certbot/src/certbot/_internal/plugins/nginx/configurator.py
+++ b/certbot/src/certbot/_internal/plugins/nginx/configurator.py
@@ -617,7 +617,7 @@ class NginxConfigurator(common.Configurator):
         """Tests whether a vhost has an address listening on a port with SSL enabled or disabled.
 
         :param `obj.VirtualHost` vhost: The vhost whose addresses will be tested
-        :param port str: The port number as a string that the address should be bound to
+        :param str port: The port number as a string that the address should be bound to
         :param bool ssl: Whether SSL should be enabled or disabled on the address
 
         :returns: Whether the vhost has an address listening on the port and protocol.

--- a/certbot/src/certbot/_internal/plugins/nginx/http_01.py
+++ b/certbot/src/certbot/_internal/plugins/nginx/http_01.py
@@ -30,13 +30,6 @@ class NginxHttp01(common.ChallengePerformer):
         class:`~certbot.achallenges.KeyAuthorizationAnnotatedChallenge`
         challenges
 
-    :param list indices: Meant to hold indices of challenges in a
-        larger array. NginxHttp01 is capable of solving many challenges
-        at once which causes an indexing issue within NginxConfigurator
-        who must return all responses in order. Imagine
-        NginxConfigurator maintaining state about where all of the
-        challenges, possibly of different types, belong in the response
-        array. This is an optional utility.
 
     """
 

--- a/certbot/src/certbot/_internal/plugins/nginx/obj.py
+++ b/certbot/src/certbot/_internal/plugins/nginx/obj.py
@@ -31,12 +31,12 @@ class Addr(common.Addr):
     .. todo:: Old-style nginx configs define SSL vhosts in a separate
               block instead of using 'ssl' in the listen directive.
 
-    :param str addr: addr part of vhost address, may be hostname, IPv4, IPv6,
+    :param str host: addr part of vhost address, may be hostname, IPv4, IPv6,
         "", or "\*"
     :param str port: port number or "\*" or ""
     :param bool ssl: Whether the directive includes 'ssl'
     :param bool default: Whether the directive includes 'default_server'
-    :param bool default: Whether this is an IPv6 address
+    :param bool ipv6: Whether this is an IPv6 address
     :param bool ipv6only: Whether the directive includes 'ipv6only=on'
 
     """

--- a/certbot/src/certbot/_internal/tests/plugins/apache/util.py
+++ b/certbot/src/certbot/_internal/tests/plugins/apache/util.py
@@ -86,7 +86,6 @@ def get_apache_configurator(
         openssl_version: str = "1.1.1a") -> configurator.ApacheConfigurator:
     """Create an Apache Configurator with the specified options.
 
-    :param conf: Function that returns binary paths. self.conf in Configurator
 
     """
     backups = os.path.join(work_dir, "backups")

--- a/certbot/src/certbot/display/ops.py
+++ b/certbot/src/certbot/display/ops.py
@@ -232,7 +232,7 @@ def success_installation(domains: list[str]) -> None:
 def success_renewal(unused_domains: list[str]) -> None:
     """Display a box confirming the renewal of an existing certificate.
 
-    :param list domains: domain names which were renewed
+    :param list unused_domains: domain names which were renewed
 
     """
     display_util.notify(

--- a/certbot/src/certbot/plugins/dns_common.py
+++ b/certbot/src/certbot/plugins/dns_common.py
@@ -110,7 +110,7 @@ class DNSAuthenticator(common.Plugin, interfaces.Authenticator, metaclass=abc.AB
         Performs a dns-01 challenge by creating a DNS TXT record.
 
         :param str domain: The domain being validated.
-        :param str validation_domain_name: The validation record domain name.
+        :param str validation_name: The validation record domain name.
         :param str validation: The validation record content.
         :raises errors.PluginError: If the challenge cannot be performed
         """
@@ -125,7 +125,7 @@ class DNSAuthenticator(common.Plugin, interfaces.Authenticator, metaclass=abc.AB
         Fails gracefully if no such record exists.
 
         :param str domain: The domain being validated.
-        :param str validation_domain_name: The validation record domain name.
+        :param str validation_name: The validation record domain name.
         :param str validation: The validation record content.
         """
         raise NotImplementedError()


### PR DESCRIPTION
Sixteen `:param:` fields name something the callable does not take. Docstrings only — no code, no behaviour, no tests.

Thirteen are renames:

| Where | Documented | Actual |
|---|---|---|
| `challb_to_achall`, `_get_chall_pref` | `domain` | `identifier` |
| `_search_lineages` caller in `cert_manager` | `domains` | `sans` |
| `_get_valid_int_ans` | `max` | `max_` |
| `renew_cert` in `main` | `client` | `le_client` |
| `_populate_vhost_names_v2` | `host` | `vhost` |
| `_get_proposed_addrs` | `ssl_vhost` | `vhost` |
| `_pass_filter` (apache parser) | `filter` | `filter_` |
| `Addr` (nginx) | `addr` | `host` |
| `success_renewal` | `domains` | `unused_domains` |
| `_perform_cleanup` and `_perform` (dns_common) | `validation_domain_name` | `validation_name` |

Where a `:type:` line accompanied the entry it was renamed with it.

Two had the field itself malformed:

- `_has_certbot_addr` in the nginx configurator writes `:param port str:` — type and name are the wrong way round, so Sphinx renders a parameter called `str`.
- `Addr` in `nginx/obj.py` has `:param bool default:` twice. The second one describes "Whether this is an IPv6 address", so it is `ipv6`. That one my checker could not see, since both names exist in the signature — I noticed it while reading the block.

The remaining three document an argument that is gone: `beginning` in `add_mod`, `indices` in the `NginxHttp01` class, and `conf` in the apache test helper.

Two I deliberately left: `certbot.plugins.common.Addr` documents `addr` and `port`, and its `__init__` takes `(tup, ipv6)`. The two names are the halves of `tup`, so dropping them would remove the only description of what goes in there — that reads like a case for a different fix than a rename.

Every entry was opened and read against its signature.
