### PR TITLE
Fix removed domain diff in certificate update prompt

### DIFF
--- a/certbot/src/certbot/_internal/main.py
+++ b/certbot/src/certbot/_internal/main.py
@@ -420,8 +420,11 @@ def _get_added_removed(after: Iterable[T], before: Iterable[T]) -> tuple[list[T]
     """Get lists of items removed from `before`
     and a lists of items added to `after`
     """
-    added = list(set(after) - set(before))
-    removed = list(set(before) - set(after))
+    after_set = set(after)
+    before_set = set(before)
+
+    added = list(after_set - before_set)
+    removed = list(before_set - after_set)
     added.sort()
     removed.sort()
     return added, removed

--- a/certbot/src/certbot/_internal/tests/main_test.py
+++ b/certbot/src/certbot/_internal/tests/main_test.py
@@ -47,6 +47,16 @@ P256_KEY_PATH = test_util.vector_path('p256_key.pem')
 SS_CERT_PATH = test_util.vector_path('cert_2048.pem')
 
 
+def test_get_added_removed_with_iterators():
+    after = map(str, [san.DNSName("example.com"), san.DNSName("new.example.com")])
+    before = map(str, [san.DNSName("example.com"), san.DNSName("old.example.com")])
+
+    added, removed = main._get_added_removed(after, before)
+
+    assert added == ["new.example.com"]
+    assert removed == ["old.example.com"]
+
+
 class TestHandleCerts(unittest.TestCase):
     """Test for certbot._internal.main._handle_* methods"""
     @mock.patch("certbot._internal.main._handle_unexpected_key_type_migration")

--- a/newsfragments/10767.fixed
+++ b/newsfragments/10767.fixed
@@ -1,0 +1,1 @@
+Fixed removed domains being omitted from the certificate update confirmation prompt.


### PR DESCRIPTION
## AI Assistance Disclosure

Codex generated the patch and regression test from a user-provided contribution guide. I reviewed the diff, confirmed the root cause, and verified the behavior with the tests and checks listed below.

## Certbot Team Priority Evidence

This is a narrowly scoped UI correctness fix for the confirmed bug reported in #10767. It changes only the generic diff helper, adds focused regression coverage, and does not affect certificate issuance.

## Newsfragments Filename

10767.fixed

## Summary

Fix the certificate update confirmation so removed SANs are displayed correctly when `_get_added_removed()` receives one-shot iterables.

## Problem

`_ask_user_to_confirm_new_sans()` passes `map` objects into `_get_added_removed()`.

The helper previously traversed each iterable twice:

```python
added = list(set(after) - set(before))
removed = list(set(before) - set(after))
```

The first calculation exhausts both `map` iterators, causing the second calculation to incorrectly produce an empty removed-domain list.

As a result, a certificate change such as:

```text
old:
example.com
old.example.com

new:
example.com
new.example.com
```

could be shown as:

```text
+ new.example.com

removed:
(None)
```

even though `old.example.com` is removed from the newly issued certificate.

## Fix

Materialize each iterable into a set once before calculating both set differences. This makes `_get_added_removed()` behave correctly for one-shot `Iterable` inputs while preserving deduplication and sorted output.

## Tests

Added `test_get_added_removed_with_iterators`, which uses the same `map(str, san.SAN)` shape as the production caller and verifies both the added and removed results.

Local checks:

- `python -m pytest certbot/src/certbot/_internal/tests/main_test.py -k test_get_added_removed_with_iterators -vv`
- `python -m pytest certbot/src/certbot/_internal/tests/main_test.py -q` (`156 passed`)
- `python -m pylint --reports=n --rcfile=.pylintrc certbot/src/certbot/_internal/main.py certbot/src/certbot/_internal/tests/main_test.py`
- `ruff check certbot/src/certbot/_internal/main.py certbot/src/certbot/_internal/tests/main_test.py`
- `mypy --follow-imports=skip certbot/src/certbot/_internal/main.py certbot/src/certbot/_internal/tests/main_test.py`
- `towncrier build --draft --version 99.99.0`

The full tox environments could not be executed locally because their Windows command construction splits this workspace path at its space. GitHub Actions will run the repository's Linux environments.

Fixes #10767
