### PR TITLE
Retrieve launchpad snaps in the same way as non-armhf snaps in deploy_snaps.yml

### DIFF
--- a/.github/workflows/deploy_snaps.yml
+++ b/.github/workflows/deploy_snaps.yml
@@ -53,13 +53,6 @@ jobs:
         sudo snap install --classic snapcraft
       shell: bash
     - name: Retrieve Certbot snaps
-      if: ${{ matrix.SNAP_ARCH == 'armhf' }}
-      uses: actions/download-artifact@v8.0.1
-      with:
-        name: snaps_${{ matrix.SNAP_ARCH }}
-        path: "${{ github.workspace }}/snap"
-    - name: Retrieve Certbot snaps
-      if: ${{ matrix.SNAP_ARCH != 'armhf' }}
       uses: actions/download-artifact@v8.0.1
       with:
         pattern: snap-*-${{ matrix.SNAP_ARCH }}


### PR DESCRIPTION
In https://github.com/certbot/certbot/pull/10675, launchpad artifacts were switched to the same format as non-launchpad snaps. `deploy_snaps.yml` still expected the old format of them bundled together. This PR updates `deploy_snaps.yml` to expect the single artifacts. This caused nightly builds to fail.

A nightly build on this fixed branch is here: https://github.com/certbot/certbot/actions/runs/31643107285