### PR TITLE
Fix ConfigurationError when a certificate's Common Name is a bare IP address

### DIFF
--- a/acme/src/acme/crypto_util.py
+++ b/acme/src/acme/crypto_util.py
@@ -192,7 +192,19 @@ def get_identifiers_from_x509(
     else:
         # We only include the first CN, if there are multiple. This matches
         # the behavior of the previous implementation using pyOpenSSL.
-        return [cns[0]] + [d for d in dns_names if d != cns[0]], ip_addresses
+        cn = cns[0]
+        try:
+            # Some CAs copy an IPAddress SAN into the CN for compatibility
+            # with older clients that only look at the CN. If the CN is a
+            # bare IP address, classify it as an IP address rather than a
+            # DNS name, since it isn't a syntactically valid DNS name.
+            normalized_cn = str(ipaddress.ip_address(cn))
+        except ValueError:
+            return [cn] + [d for d in dns_names if d != cn], ip_addresses
+        else:
+            return dns_names, [normalized_cn] + [
+                ip for ip in ip_addresses if ip != normalized_cn
+            ]
 
 
 def _cryptography_cert_or_req_san(

--- a/certbot/src/certbot/_internal/san.py
+++ b/certbot/src/certbot/_internal/san.py
@@ -116,8 +116,8 @@ def display(sans: Iterable[SAN]) -> str:
 def from_x509(subject: x509.Name, exts: x509.Extensions) -> tuple[list[DNSName], list[IPAddress]]:
     """Get all DNS names and IP addresses, plus the first Common Name from subject.
 
-    The CN will be first in the list, if present. It will always be interpreted
-    as a DNS name.
+    The CN will be first in the list, if present. It is interpreted as an IP
+    address if it parses as one, and as a DNS name otherwise.
 
     :param subject: Name of the x509 object, which may include Common Name
     :type subject: `cryptography.x509.Name`

--- a/certbot/src/certbot/_internal/tests/san_test.py
+++ b/certbot/src/certbot/_internal/tests/san_test.py
@@ -150,3 +150,44 @@ class FromX509Test(unittest.TestCase):
             [san.DNSName("example.com")],
             [san.IPAddress("192.168.1.1")],
         )
+
+    def test_cn_ip_address(self) -> None:
+        """A bare IP address in the CN should be classified as an IP
+        address, not a DNS name. Regression test for
+        https://github.com/certbot/certbot/issues/10773.
+        """
+        key = ec.generate_private_key(ec.SECP256R1())
+        csr = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(x509.Name([
+                x509.NameAttribute(NameOID.COMMON_NAME, "10.5.0.5"),
+            ]))
+            .add_extension(
+                x509.SubjectAlternativeName(
+                    [x509.IPAddress(ipaddress.ip_address("10.5.0.5"))]
+                ),
+                critical=False,
+            )
+        ).sign(key, hashes.SHA256())
+        result = san.from_x509(csr.subject, csr.extensions)
+        assert result == (
+            [],
+            [san.IPAddress("10.5.0.5")],
+        )
+
+    def test_cn_ip_address_no_san(self) -> None:
+        """A bare IP address in the CN is classified as an IP address even
+        when there is no SubjectAlternativeName extension at all.
+        """
+        key = ec.generate_private_key(ec.SECP256R1())
+        csr = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(x509.Name([
+                x509.NameAttribute(NameOID.COMMON_NAME, "10.5.0.5"),
+            ]))
+        ).sign(key, hashes.SHA256())
+        result = san.from_x509(csr.subject, csr.extensions)
+        assert result == (
+            [],
+            [san.IPAddress("10.5.0.5")],
+        )

--- a/newsfragments/10773.fixed
+++ b/newsfragments/10773.fixed
@@ -1,0 +1,1 @@
+Fixed a bug where certificates whose Common Name is a bare IP address (e.g. copied from an IPAddress SAN for compatibility with older clients) would raise a ConfigurationError when deploying, since the CN was always treated as a DNS name.


### PR DESCRIPTION
### Summary

Fixes #10773.

Some ACME CAs copy an `IPAddress` SAN into a certificate's Common
Name (CN) field, for compatibility with older clients that only
consult the CN. `acme.crypto_util.get_identifiers_from_x509()`
unconditionally treats the CN as a DNS name. When the CN happens to
be a bare IP address string (e.g. `10.5.0.5`), this misclassification
propagates to `certbot._internal.san.from_x509()`, which wraps it in
a `DNSName`. `DNSName.__init__` calls `enforce_domain_sanity()`,
which rejects the string as an invalid domain and raises
`certbot.errors.ConfigurationError` -- even though the certificate
was issued and stored successfully. This surfaces during
`hooks.deploy_hook()` / `lineage.sans()`, right when the user expects
the cert to just work.

### Root cause

```python
# acme/src/acme/crypto_util.py
if not cns:
    return dns_names, ip_addresses
else:
    return [cns[0]] + [d for d in dns_names if d != cns[0]], ip_addresses
```

The CN is always prepended to `dns_names`, regardless of whether it's
syntactically a DNS name or an IP address.

### Fix

Classify the CN as an IP address (joining `ip_addresses`, deduplicated
against any existing entry) when it parses via `ipaddress.ip_address()`,
and only fall back to treating it as a DNS name otherwise. This is the
same pattern already used elsewhere in the codebase (e.g.
`certbot._internal.san.guess()`).

This fixes the bug at its single source, so it also corrects the
same misclassification in `acme.client.ClientV2.new_order()`, which
uses `get_identifiers_from_x509()` to build ACME order identifiers
from a CSR -- a CSR with an IP-address CN would previously have been
requested as an `IDENTIFIER_FQDN` instead of `IDENTIFIER_IP`.

Also updated the now-inaccurate docstring on
`certbot._internal.san.from_x509()`, which stated the CN "will always
be interpreted as a DNS name."

### Testing

Added `test_cn_ip_address` and `test_cn_ip_address_no_san` to
`san_test.py`, reproducing the reporter's scenario (CN is a bare IP
address, with and without a matching SAN). Confirmed both fail with
the exact `certbot.errors.ConfigurationError` from the report when
the fix is reverted, and pass with it applied. Ran the full
`san_test.py`, `crypto_util_test.py`, and `client_test.py` suites
(114 tests) -- all pass. `ruff check` and `mypy` clean on the changed
files.

Added a news fragment (`newsfragments/10773.fixed`).
