### PR TITLE
docs: add dns-feno to third-party plugins

### DIFF
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -337,6 +337,7 @@ dns-hetzner-cloud_      Y    N    DNS Authentication for Hetzner Cloud DNS
 dns-czechia_            Y    N    DNS Authentication for czechia.com
 dns-eurodns_            Y    N    DNS Authentication for EuroDNS
 dns-dnscale_            Y    N    DNS Authenticator for DNScale
+dns-feno_               Y    N    DNS Authentication using the FENO (feno.no) API for .no domains
 ======================= ==== ==== =================================================================
 
 .. _haproxy: https://github.com/greenhost/certbot-haproxy
@@ -375,6 +376,7 @@ dns-dnscale_            Y    N    DNS Authenticator for DNScale
 .. _dns-czechia: https://github.com/CZECHIA-COM/certbot-dns-czechia
 .. _dns-eurodns: https://pypi.org/project/certbot-dns-eurodns/
 .. _dns-dnscale: https://github.com/dnscaleou/certbot-dns-dnscale
+.. _dns-feno: https://github.com/mrerikcodes/certbot-dns-feno
 
 If you're interested, you can also :ref:`write your own plugin <dev-plugin>`.
 


### PR DESCRIPTION

Adds `dns-feno` to the third-party plugins table in `certbot/docs/using.rst`.

`certbot-dns-feno` is a DNS Authenticator plugin (Auth: Y, Inst: N) that completes the `dns-01` challenge through the FENO (feno.no) public API, for `.no` domains registered at FENO. Repository: https://github.com/mrerikcodes/certbot-dns-feno

Row appended at the end of the table and link added to the target list, matching the existing entries' format (GitHub repo link, same notes wording as neighbouring DNS plugins). No code changes.

## AI Assistance Disclosure

Claude (Anthropic) was used to prepare this docs change (locate the table, add the row and link target). The change was reviewed by the author for correctness.

## Certbot Team Priority Evidence

Documentation-only addition to the community-maintained third-party plugin list, following the same pattern as previous entries (e.g. dns-dnscale, dns-eurodns, dns-czechia). No review of plugin code is needed.

## Newsfragments Filename

No changes made to distributed components
