### PR TITLE
Clarify manual DNS challenge prompts

### DIFF
--- a/certbot/src/certbot/_internal/plugins/manual.py
+++ b/certbot/src/certbot/_internal/plugins/manual.py
@@ -62,13 +62,19 @@ with the following value:
 
 {validation}
 """
+    _DNS_CONTINUE_INSTRUCTIONS = """
+You do not need to wait for this TXT record to be deployed yet. Continue setting
+up the remaining challenge tasks first.
+"""
     _DNS_VERIFY_INSTRUCTIONS = """
-Before continuing, verify the TXT record has been deployed. Depending on the DNS
-provider, this may take some time, from a few seconds to multiple minutes. You can
-check if it has finished deploying with aid of online tools, such as the Google
+All required DNS challenge TXT records have now been shown. Before continuing,
+verify that all of them have been deployed. Depending on the DNS provider, this may
+take some time, from a few seconds to multiple minutes. You can check if it has
+finished deploying with aid of online tools, such as the Google
 Admin Toolbox: https://toolbox.googleapps.com/apps/dig/#TXT/{domain}.
-Look for one or more bolded line(s) below the line ';ANSWER'. It should show the
-value(s) you've just added.
+Look for one or more bolded line(s) below the line ';ANSWER'. They should show the
+value(s) you have just added. Certbot will verify all of the DNS challenges when
+you continue from this prompt.
 """
     _HTTP_INSTRUCTIONS = """\
 Create a file containing just this data:
@@ -170,7 +176,7 @@ permitted by DNS standards.)
     def perform(self, achalls: list[achallenges.AnnotatedChallenge]
                 ) -> list[challenges.ChallengeResponse]:  # pylint: disable=missing-function-docstring
         responses = []
-        last_dns_achall = 0
+        last_dns_achall = None
         for i, achall in enumerate(achalls):
             if isinstance(achall.chall, challenges.DNS01):
                 last_dns_achall = i
@@ -178,7 +184,12 @@ permitted by DNS standards.)
             if self.conf('auth-hook'):
                 self._perform_achall_with_script(achall, achalls)
             else:
-                self._perform_achall_manually(achall, i == last_dns_achall)
+                dns_verification_domain = None
+                if last_dns_achall is not None and i == len(achalls) - 1:
+                    last_dns = achalls[last_dns_achall]
+                    dns_verification_domain = last_dns.validation_domain_name(
+                        last_dns.identifier.value)
+                self._perform_achall_manually(achall, dns_verification_domain)
             responses.append(achall.response(achall.account_key))
         return responses
 
@@ -204,7 +215,7 @@ permitted by DNS standards.)
         self.env[achall] = env
 
     def _perform_achall_manually(self, achall: achallenges.AnnotatedChallenge,
-                                 last_dns_achall: bool = False) -> None:
+                                 dns_verification_domain: str | None = None) -> None:
         identifier_value = achall.identifier.value
         validation = achall.validation(achall.account_key)
         if isinstance(achall.chall, challenges.HTTP01):
@@ -227,13 +238,14 @@ permitted by DNS standards.)
                 # instruct user not to remove any previous http-01 challenge
                 msg += self._SUBSEQUENT_CHALLENGE_INSTRUCTIONS
             self.subsequent_dns_challenge = True
-            if last_dns_achall:
-                # last dns-01 challenge
-                msg += self._DNS_VERIFY_INSTRUCTIONS.format(
-                    domain=achall.validation_domain_name(identifier_value))
+            if dns_verification_domain is None:
+                msg += self._DNS_CONTINUE_INSTRUCTIONS
         elif self.subsequent_any_challenge:
             # 2nd or later challenge of another type
             msg += self._SUBSEQUENT_CHALLENGE_INSTRUCTIONS
+        if dns_verification_domain is not None:
+            msg += self._DNS_VERIFY_INSTRUCTIONS.format(
+                domain=dns_verification_domain)
         display_util.notification(msg, wrap=False, force_interactive=True)
         self.subsequent_any_challenge = True
 

--- a/certbot/src/certbot/_internal/tests/plugins/manual_test.py
+++ b/certbot/src/certbot/_internal/tests/plugins/manual_test.py
@@ -114,6 +114,29 @@ class AuthenticatorTest(test_util.TempDirTestCase):
             assert achall.validation(achall.account_key) in args[0]
             assert kwargs['wrap'] is False
 
+        first_dns_message = self.mock_get_display().notification.call_args_list[1].args[0]
+        assert "do not need to wait" in first_dns_message
+        assert "All required DNS challenge" not in first_dns_message
+
+        last_dns_message = self.mock_get_display().notification.call_args_list[2].args[0]
+        assert "All required DNS challenge TXT records" in last_dns_message
+        assert "verify that all of them have been deployed" in last_dns_message
+        assert "verify all of the DNS challenges when" in last_dns_message
+        assert "do not need to wait" not in last_dns_message
+
+    def test_manual_perform_dns_before_http(self):
+        achalls = [self.dns_achall, self.http_achall]
+
+        self.auth.perform(achalls)
+
+        dns_message = self.mock_get_display().notification.call_args_list[0].args[0]
+        assert "do not need to wait" in dns_message
+        assert "All required DNS challenge" not in dns_message
+
+        http_message = self.mock_get_display().notification.call_args_list[1].args[0]
+        assert "All required DNS challenge TXT records" in http_message
+        assert "verify all of the DNS challenges when" in http_message
+
     def test_cleanup(self):
         self.config.manual_auth_hook = ('{0} -c "import sys; sys.stdout.write(\'foo\')"'
                                         .format(sys.executable))

--- a/newsfragments/9859.changed
+++ b/newsfragments/9859.changed
@@ -1,0 +1,1 @@
+Clarified when to wait for DNS propagation while completing multiple manual challenges.


### PR DESCRIPTION
## AI Assistance Disclosure

I used OpenAI Codex to help inspect the relevant control flow, draft the implementation and tests, and perform a review. I reviewed every change and ran the tests and checks listed below.

## Certbot Team Priority Evidence

In https://github.com/certbot/certbot/issues/9859#issuecomment-2587723504, @bmw scoped the requested improvement to a focused text change that distinguishes the final DNS verification prompt.

## Newsfragments Filename

`9859.changed`

## Summary

- tell users not to wait for propagation while more challenge tasks remain
- place the DNS propagation check on the final manual prompt, including when an HTTP challenge follows the last DNS challenge
- make it explicit that all displayed DNS challenges will be verified together

Fixes #9859.

## Testing

- `python -m tox run -e isolated-certbot -- certbot/src/certbot/_internal/tests/plugins/manual_test.py` (1015 passed, 30 skipped)
- pinned `ruff` on the changed Python files
- pinned `pylint` on the changed Python files (10.00/10)
- pinned `mypy` on the changed Python files
